### PR TITLE
feat(submit): accept drag & drop on pet package upload

### DIFF
--- a/src/components/pet-submit-form.tsx
+++ b/src/components/pet-submit-form.tsx
@@ -46,6 +46,7 @@ export function PetSubmitForm() {
   const { isSignedIn, isLoaded } = useUser();
   const [parsed, setParsed] = useState<ParsedPet | null>(null);
   const [isReading, setIsReading] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
   const [submission, setSubmission] = useState<SubmissionResult>({
     kind: "idle",
   });
@@ -266,7 +267,26 @@ export function PetSubmitForm() {
 
   return (
     <div className="grid gap-5 lg:grid-cols-[1fr_360px]">
-      <label className="glass-panel flex min-h-80 cursor-pointer flex-col items-center justify-center rounded-3xl p-8 text-center transition hover:bg-white/80">
+      <label
+        className={`glass-panel flex min-h-80 cursor-pointer flex-col items-center justify-center rounded-3xl p-8 text-center transition hover:bg-white/80 ${
+          isDragging ? "bg-white/90 ring-2 ring-black/40 ring-offset-2" : ""
+        }`}
+        onDragOver={(event) => {
+          event.preventDefault();
+          event.dataTransfer.dropEffect = "copy";
+          if (!isDragging) setIsDragging(true);
+        }}
+        onDragLeave={(event) => {
+          if (event.currentTarget.contains(event.relatedTarget as Node | null))
+            return;
+          setIsDragging(false);
+        }}
+        onDrop={(event) => {
+          event.preventDefault();
+          setIsDragging(false);
+          void handleFiles(event.dataTransfer.files);
+        }}
+      >
         <input
           type="file"
           multiple={false}


### PR DESCRIPTION
## Summary
- Adds drag-and-drop file handling to the pet package upload zone in `src/components/pet-submit-form.tsx`
- Reuses the existing `handleFiles` validation pipeline (zip filter, `pet.json` + `spritesheet.webp` checks, dimension verification)
- Adds a subtle ring highlight while a file is being dragged over the panel; click-to-pick via the hidden `<input>` continues to work

## Implementation notes
- `onDragOver` calls `preventDefault()` and sets `dropEffect = "copy"` (required so `onDrop` fires and the cursor reflects the action)
- `onDragLeave` uses `currentTarget.contains(relatedTarget)` to ignore bubbling events from child elements — prevents flicker. `Node.contains(null)` returns false per spec, so leaving the window also resets the highlight
- `onDrop` forwards `dataTransfer.files` to `handleFiles`, which already filters for `.zip`
- `if (!isDragging) setIsDragging(true)` guards the high-frequency `dragover` handler

## Test plan
- [ ] Drag a valid pet `.zip` from Finder onto the upload zone — preview + validation appear
- [ ] Drag a non-zip file — "Upload a ZIP file." issue is shown
- [ ] Drag over and leave (without dropping) — highlight clears
- [ ] Click-to-pick still works
- [ ] Drop while over a child element doesn't cause flicker