### PR TITLE
feat(submit): show pets dir + copy-path button on upload zone

### DIFF
--- a/src/components/pet-submit-form.tsx
+++ b/src/components/pet-submit-form.tsx
@@ -291,7 +291,7 @@ export function PetSubmitForm() {
           upload.
         </span>
         <span className="mt-4 inline-flex items-center gap-2 text-xs text-[#5d5d66]">
-          Packages live in
+          Pet assets live in
           <code className="rounded bg-white/70 px-1.5 py-0.5 font-mono">
             {PETS_DIR}
           </code>

--- a/src/components/pet-submit-form.tsx
+++ b/src/components/pet-submit-form.tsx
@@ -8,7 +8,9 @@ import { track } from "@vercel/analytics";
 import JSZip from "jszip";
 import {
   AlertTriangle,
+  Check,
   CheckCircle2,
+  Copy,
   FileArchive,
   Loader2,
   Send,
@@ -41,6 +43,7 @@ type SubmissionResult =
   | { kind: "success"; slug: string; displayName: string };
 
 const REQUIRED = { width: 1536, height: 1872 } as const;
+const PETS_DIR = "~/.codex/pets";
 
 export function PetSubmitForm() {
   const { isSignedIn, isLoaded } = useUser();
@@ -287,6 +290,13 @@ export function PetSubmitForm() {
           ({REQUIRED.width}×{REQUIRED.height}). Validation runs locally before
           upload.
         </span>
+        <span className="mt-4 inline-flex items-center gap-2 text-xs text-[#5d5d66]">
+          Packages live in
+          <code className="rounded bg-white/70 px-1.5 py-0.5 font-mono">
+            {PETS_DIR}
+          </code>
+          <CopyPathButton path={PETS_DIR} />
+        </span>
         {!isLoaded ? null : !isSignedIn ? (
           <span className="mt-5 inline-flex items-center gap-2 rounded-full bg-amber-100/70 px-3 py-1 font-mono text-[10px] tracking-[0.18em] text-amber-900 uppercase">
             Sign in to submit
@@ -369,6 +379,28 @@ export function PetSubmitForm() {
         )}
       </aside>
     </div>
+  );
+}
+
+function CopyPathButton({ path }: { path: string }) {
+  const [copied, setCopied] = useState(false);
+
+  return (
+    <button
+      type="button"
+      aria-label={copied ? "Path copied" : "Copy path to clipboard"}
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        void navigator.clipboard.writeText(path);
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1500);
+      }}
+      className="inline-flex items-center gap-1 rounded-full border border-black/10 bg-white/70 px-2 py-0.5 text-[11px] font-medium text-[#3a3a44] transition hover:bg-white"
+    >
+      {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+      {copied ? "Copied" : "Copy"}
+    </button>
   );
 }
 


### PR DESCRIPTION
## Summary
- Shows the local pets directory (`~/.codex/pets`) inside the upload dropzone so users know where to grab the package from
- Adds a small "Copy" button that writes the path to the clipboard (with a 1.5s "Copied" affordance)

## Why not auto-open Finder?
Browsers can't launch native file managers — `file://` URIs are blocked from `https` origins, and there's no web API for it. Copy-to-clipboard is the closest UX win.

## Implementation notes
- The copy button lives inside the `<label>` that wraps the file input, so its click handler calls `event.preventDefault()` + `event.stopPropagation()` to avoid triggering the file picker
- Path stored as a `PETS_DIR` constant alongside `REQUIRED` so it has a single source of truth
- `~` form is shell-portable across macOS/Linux; copy-paste expands correctly in any POSIX shell

## Test plan
- [ ] Path renders inside the dropzone with the copy button next to it
- [ ] Click the copy button — clipboard contains `~/.codex/pets`, button shows "Copied" for ~1.5s, then resets
- [ ] Clicking the copy button does NOT open the file picker
- [ ] Clicking elsewhere on the dropzone still opens the file picker
- [ ] Drop / click flows still work as before