### PR TITLE
fix(i18n): align pet state viewer placeholders

### DIFF
--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -448,8 +448,8 @@
   "petStateViewer": {
     "eyebrow": "State viewer",
     "frames": "{count} frames",
-    "rowFrames": "Row {row} - {frames} frames",
-    "animationLabel": "{name} {state} animation",
+    "rowFrames": "Row {row} - {count} frames",
+    "animationLabel": "{petName} {state} animation",
     "states": {
       "idle": {
         "label": "Idle",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -448,8 +448,8 @@
   "petStateViewer": {
     "eyebrow": "Visor de estados",
     "frames": "{count} frames",
-    "rowFrames": "Fila {row} - {frames} frames",
-    "animationLabel": "{name} animación {state}",
+    "rowFrames": "Fila {row} - {count} frames",
+    "animationLabel": "{petName} animación {state}",
     "states": {
       "idle": {
         "label": "Inactivo",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -497,8 +497,8 @@
   "petStateViewer": {
     "eyebrow": "状态查看器",
     "frames": "{count} 帧",
-    "rowFrames": "第 {row} 行 - {frames} 帧",
-    "animationLabel": "{name} {state} 动画",
+    "rowFrames": "第 {row} 行 - {count} 帧",
+    "animationLabel": "{petName} {state} 动画",
     "states": {
       "idle": {
         "label": "待机",


### PR DESCRIPTION
Please help with a CR. After adding the last i18n, the styles got messed up.
<img width="1371" height="732" alt="image" src="https://github.com/user-attachments/assets/f2cdaa17-96ff-44e6-98e4-07ea892edbf6" />
