### PR TITLE
fix: Profile page correct name display

### DIFF
--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -10,7 +10,7 @@
   "metadata": {
     "root": {
       "titleDefault": "Petdex — Animated companions for Codex",
-      "titleTemplate": "{title} | Petdex",
+      "titleTemplate": "%s | Petdex",
       "description": "Petdex is the public gallery of animated companions for Codex. Browse open-source companions, preview their animations, and install one with a single command.",
       "ogTitle": "Petdex — Animated companions for Codex",
       "twitterTitle": "Petdex — Animated companions for Codex",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -10,7 +10,7 @@
   "metadata": {
     "root": {
       "titleDefault": "Petdex — Compañeros animados para Codex",
-      "titleTemplate": "{title} | Petdex",
+      "titleTemplate": "%s | Petdex",
       "description": "Petdex es la galería pública de compañeros animados para Codex. Explora compañeros open source, previsualiza sus animaciones e instala uno con un solo comando.",
       "ogTitle": "Petdex — Compañeros animados para Codex",
       "twitterTitle": "Petdex — Compañeros animados para Codex",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -12,7 +12,7 @@
   "metadata": {
     "root": {
       "titleDefault": "Petdex — 适用于 Codex 的动画伙伴",
-      "titleTemplate": "{title} | Petdex",
+      "titleTemplate": "%s | Petdex",
       "description": "Petdex 是面向 Codex 的公共动画伙伴图库。浏览开源伙伴，预览它们的动画，并用一条命令安装。",
       "description__fixme": true,
       "ogTitle": "Petdex — 适用于 Codex 的动画伙伴",

--- a/src/i18n/metadata.test.ts
+++ b/src/i18n/metadata.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+
+import en from "./messages/en.json";
+import es from "./messages/es.json";
+import zh from "./messages/zh.json";
+
+const messagesByLocale = { en, es, zh };
+
+describe("root metadata messages", () => {
+  it("uses Next title template placeholders for every locale", () => {
+    for (const [locale, messages] of Object.entries(messagesByLocale)) {
+      const titleTemplate = messages.metadata.root.titleTemplate;
+
+      expect(titleTemplate, locale).toContain("%s");
+      expect(titleTemplate, locale).not.toContain("{title}");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces locale root title templates from `{title} | Petdex` to `%s | Petdex` for English, Spanish, and Chinese.
- Adds a regression test so locale metadata templates keep using Next's supported title placeholder.

## Root Cause
Next's `metadata.title.template` interpolates child page titles with `%s`. The app passed localized `metadata.root.titleTemplate` directly into that API, but the messages used `{title}`, so pages rendered the literal browser title `{title} | Petdex`.

## Validation
- `bun test src/i18n/metadata.test.ts`
- `bun run i18n:check`
- `bunx biome check src/i18n/metadata.test.ts`
- `bun run build` compiled and passed TypeScript, then stopped during page-data collection because local `DATABASE_URL` is not set.

## Notes
Live checks before the fix showed the issue on `/u/nachoestevo`, `/docs`, and `/about`; the home page was unaffected because it uses the root default title.
