### PR TITLE
fix: Announcement modal dark contrast

### DIFF
--- a/src/components/announcement-modal.test.ts
+++ b/src/components/announcement-modal.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("./announcement-modal.tsx", import.meta.url),
+  "utf8",
+);
+
+describe("AnnouncementModal theme classes", () => {
+  it("does not hardcode a light modal surface while using theme text", () => {
+    expect(source).not.toContain("border-border-base bg-white");
+  });
+
+  it("keeps inline search examples readable in dark mode", () => {
+    const exampleClasses =
+      source.match(
+        /<span className="[^"]*bg-surface-muted[^"]*font-mono text-xs[^"]*">/g,
+      ) ?? [];
+
+    expect(exampleClasses).toHaveLength(2);
+    for (const className of exampleClasses) {
+      expect(className).toContain("text-foreground");
+      expect(className).not.toContain("text-stone-900");
+    }
+  });
+});

--- a/src/components/announcement-modal.tsx
+++ b/src/components/announcement-modal.tsx
@@ -51,7 +51,7 @@ export function AnnouncementModal({ onClose }: AnnouncementModalProps) {
       />
 
       <div
-        className={`relative w-full max-w-md overflow-hidden rounded-3xl border border-border-base bg-white shadow-[0_30px_80px_-20px_rgba(56,71,245,0.45)] transition-all duration-200 ${
+        className={`relative w-full max-w-md overflow-hidden rounded-3xl border border-border-base bg-surface text-foreground shadow-[0_30px_80px_-20px_rgba(56,71,245,0.45)] transition-all duration-200 ${
           closing ? "translate-y-2 opacity-0" : "translate-y-0 opacity-100"
         }`}
       >
@@ -88,20 +88,18 @@ export function AnnouncementModal({ onClose }: AnnouncementModalProps) {
           </h2>
           <p className="text-sm leading-6 text-muted-2">
             Type{" "}
-            <span className="rounded bg-surface-muted px-1.5 py-0.5 font-mono text-xs text-stone-900">
+            <span className="rounded bg-surface-muted px-1.5 py-0.5 font-mono text-xs text-foreground">
               cozy night programmer
             </span>{" "}
             or{" "}
-            <span className="rounded bg-surface-muted px-1.5 py-0.5 font-mono text-xs text-stone-900">
+            <span className="rounded bg-surface-muted px-1.5 py-0.5 font-mono text-xs text-foreground">
               fierce dragon
             </span>{" "}
             and Petdex finds the closest matches by vibe — not just keyword.
           </p>
           <p className="text-sm leading-6 text-muted-2">
             Doesn't find what you wanted?{" "}
-            <strong className="text-stone-900 dark:text-stone-100">
-              Request the pet
-            </strong>{" "}
+            <strong className="text-foreground">Request the pet</strong>{" "}
             and the community can upvote it. Most-asked land in the queue first.
           </p>
 


### PR DESCRIPTION
## Summary
- Updates the vibe-search announcement modal to use semantic surface and foreground tokens instead of hardcoded light-mode colors.
- Makes the inline example chips and emphasized text readable in both light and dark mode.
- Adds a regression test that guards against reintroducing the hardcoded light modal surface and dark chip text.

## Root Cause
The modal shell was hardcoded to `bg-white` while its body text used theme-aware color tokens. In dark mode, those tokens flip for dark surfaces, creating low-contrast text on a white modal. The example chips also forced `text-stone-900` on `bg-surface-muted`, which becomes a dark chip background in dark mode.

## Validation
- `bun test src/components/announcement-modal.test.ts`
- `bunx biome lint src/components/announcement-modal.tsx src/components/announcement-modal.test.ts`
- `bunx biome check src/components/announcement-modal.test.ts`
- `bunx tsc --noEmit --pretty false`

## Notes
This branch is based directly on `origin/main` and does not include the separate title-template fix from PR #90. Full local route rendering on `main` is currently blocked by that separate title-template issue, so I verified the visual state with an isolated dark-mode preview using the same announcement artwork and updated token choices.

## Before
<img width="585" height="717" alt="image" src="https://github.com/user-attachments/assets/f1234c29-d7aa-4c84-9d7a-75d5242fbeec" />

## Update
<img width="656" height="831" alt="{098846E5-2E80-4FEF-B845-C966E8FFC951}" src="https://github.com/user-attachments/assets/b4071988-067f-4eac-9ddf-12e45779481a" />

