### PR TITLE
fix: make contributor tests server-safe

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,8 @@ This path is for maintainers and trusted collaborators.
 
 - **Runtime**: Bun (never `npm install`).
 - **Lint/format**: `bun run check` / `bun run format` (Biome).
-- **Tests**: `bun test`.
+- **Tests**: `bun test`. DB-backed search integration tests are explicit:
+  `DATABASE_URL=... bun run test:db`.
 - **Commit style**: conventional commits (`feat:`, `fix:`, `docs:`, etc.).
 
 ## Where to look

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "generate-assets": "bun scripts/generate-assets.ts",
     "auto-tag": "bun scripts/auto-tag.ts",
     "i18n:check": "bun scripts/i18n-check.ts",
-    "test": "bun test"
+    "test": "bun test",
+    "test:db": "bun test ./src/lib/pet-search.integration.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1041.0",

--- a/src/lib/install-script-render.ts
+++ b/src/lib/install-script-render.ts
@@ -1,0 +1,101 @@
+export type ResolvedPet = {
+  slug: string;
+  displayName: string;
+  petJsonUrl: string;
+  spritesheetUrl: string;
+  spriteExt: "webp" | "png";
+};
+
+export function posixInstallScript(pet: ResolvedPet): string {
+  const { slug, displayName, petJsonUrl, spritesheetUrl, spriteExt } = pet;
+  // POSIX hard-quote: wrap in single-quotes and replace each ' with '\''.
+  // After this every value, even something like
+  //   "'; rm -rf $HOME; echo '"
+  // is just an opaque string to /bin/sh.
+  const q = (s: string) => `'${String(s).replace(/'/g, "'\\''")}'`;
+  // Comment lines must also strip newlines so a displayName with a literal
+  // \n can't break out into a fresh shell command.
+  const safeName = String(displayName).replace(/[\r\n]+/g, " ");
+  // Filename within $PET_DIR — strict slug already, but pin the regex so a
+  // freak DB row can't produce path traversal.
+  const safeSlug = String(slug).replace(/[^a-z0-9-]/g, "");
+  const safeExt = spriteExt === "png" ? "png" : "webp";
+  return [
+    "#!/bin/sh",
+    "# Petdex installer",
+    `# https://petdex.crafter.run/pets/${safeSlug}`,
+    "",
+    "set -e",
+    "",
+    `PET_DIR="$HOME/.codex/pets/${safeSlug}"`,
+    "",
+    `echo "Installing ${safeName.replace(/"/g, "")} into $PET_DIR"`,
+    'mkdir -p "$PET_DIR"',
+    "",
+    `curl -fsSL -o "$PET_DIR/pet.json" ${q(petJsonUrl)}`,
+    `curl -fsSL -o "$PET_DIR/spritesheet.${safeExt}" ${q(spritesheetUrl)}`,
+    "",
+    `echo "Installed: ${safeName.replace(/"/g, "")}"`,
+    'echo "  Path: $PET_DIR"',
+    'echo ""',
+    'echo "Activate it inside Codex:"',
+    'echo "  Settings -> Appearance -> Pets -> select your pet"',
+    'echo ""',
+    'echo "Then use /pet inside Codex to wake or tuck it away."',
+    "",
+  ].join("\n");
+}
+
+export function powershellInstallScript(pet: ResolvedPet): string {
+  const { slug, displayName, petJsonUrl, spritesheetUrl, spriteExt } = pet;
+  // PowerShell single-quoted hard-quote: ' -> ''.
+  const q = (s: string) => `'${String(s).replace(/'/g, "''")}'`;
+  const safeSlug = String(slug).replace(/[^a-z0-9-]/g, "");
+  const safeExt = spriteExt === "png" ? "png" : "webp";
+  // Strip newlines / quotes from the display name before echoing.
+  const safeName = String(displayName).replace(/[\r\n"]+/g, " ");
+  return [
+    "# Petdex installer",
+    `# https://petdex.crafter.run/pets/${safeSlug}`,
+    "",
+    "$ErrorActionPreference = 'Stop'",
+    `$slug = ${q(safeSlug)}`,
+    "$petDir = Join-Path $HOME (Join-Path '.codex' (Join-Path 'pets' $slug))",
+    "",
+    `Write-Host ${q(`Installing ${safeName} into `)}$petDir`,
+    "New-Item -ItemType Directory -Force -Path $petDir | Out-Null",
+    "",
+    `Invoke-WebRequest -Uri ${q(petJsonUrl)} -OutFile (Join-Path $petDir 'pet.json') -UseBasicParsing`,
+    `Invoke-WebRequest -Uri ${q(spritesheetUrl)} -OutFile (Join-Path $petDir ${q(`spritesheet.${safeExt}`)}) -UseBasicParsing`,
+    "",
+    `Write-Host ${q(`Installed: ${safeName}`)}`,
+    'Write-Host "  Path: $petDir"',
+    'Write-Host ""',
+    'Write-Host "Activate it inside Codex:"',
+    'Write-Host "  Settings -> Appearance -> Pets -> select your pet"',
+    'Write-Host ""',
+    'Write-Host "Then use /pet inside Codex to wake or tuck it away."',
+    "",
+  ].join("\n");
+}
+
+export function posixNotFoundScript(slug: string): string {
+  const safe = String(slug).replace(/[^a-z0-9-]/g, "");
+  return [
+    "#!/bin/sh",
+    `echo "Pet '${safe}' not found in Petdex." >&2`,
+    'echo "Browse pets at https://petdex.crafter.run" >&2',
+    "exit 1",
+    "",
+  ].join("\n");
+}
+
+export function powershellNotFoundScript(slug: string): string {
+  const safe = String(slug).replace(/[^a-z0-9-]/g, "");
+  return [
+    `Write-Error "Pet '${safe}' not found in Petdex."`,
+    'Write-Error "Browse pets at https://petdex.crafter.run"',
+    "exit 1",
+    "",
+  ].join("\n");
+}

--- a/src/lib/install-script.ts
+++ b/src/lib/install-script.ts
@@ -1,14 +1,23 @@
+import "server-only";
+
 import { eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/db/client";
+import {
+  posixInstallScript,
+  posixNotFoundScript,
+  powershellInstallScript,
+  powershellNotFoundScript,
+  type ResolvedPet,
+} from "@/lib/install-script-render";
 import { isAllowedAssetUrl } from "@/lib/url-allowlist";
 
-export type ResolvedPet = {
-  slug: string;
-  displayName: string;
-  petJsonUrl: string;
-  spritesheetUrl: string;
-  spriteExt: "webp" | "png";
+export {
+  posixInstallScript,
+  posixNotFoundScript,
+  powershellInstallScript,
+  powershellNotFoundScript,
+  type ResolvedPet,
 };
 
 export async function resolveInstallablePet(
@@ -38,98 +47,4 @@ export async function resolveInstallablePet(
     spritesheetUrl: submitted.spritesheetUrl,
     spriteExt: submitted.spritesheetUrl.endsWith(".png") ? "png" : "webp",
   };
-}
-
-export function posixInstallScript(pet: ResolvedPet): string {
-  const { slug, displayName, petJsonUrl, spritesheetUrl, spriteExt } = pet;
-  // POSIX hard-quote: wrap in single-quotes and replace each ' with '\''.
-  // After this every value, even something like
-  //   "'; rm -rf $HOME; echo '"
-  // is just an opaque string to /bin/sh.
-  const q = (s: string) => `'${String(s).replace(/'/g, "'\\''")}'`;
-  // Comment lines must also strip newlines so a displayName with a literal
-  // \n can't break out into a fresh shell command.
-  const safeName = String(displayName).replace(/[\r\n]+/g, " ");
-  // Filename within $PET_DIR — strict slug already, but pin the regex so a
-  // freak DB row can't produce path traversal.
-  const safeSlug = String(slug).replace(/[^a-z0-9-]/g, "");
-  const safeExt = spriteExt === "png" ? "png" : "webp";
-  return [
-    "#!/bin/sh",
-    "# Petdex installer",
-    `# https://petdex.crafter.run/pets/${safeSlug}`,
-    "",
-    "set -e",
-    "",
-    `PET_DIR="$HOME/.codex/pets/${safeSlug}"`,
-    "",
-    `echo "Installing ${safeName.replace(/"/g, "")} into $PET_DIR"`,
-    'mkdir -p "$PET_DIR"',
-    "",
-    `curl -fsSL -o "$PET_DIR/pet.json" ${q(petJsonUrl)}`,
-    `curl -fsSL -o "$PET_DIR/spritesheet.${safeExt}" ${q(spritesheetUrl)}`,
-    "",
-    `echo "Installed: ${safeName.replace(/"/g, "")}"`,
-    'echo "  Path: $PET_DIR"',
-    'echo ""',
-    'echo "Activate it inside Codex:"',
-    'echo "  Settings -> Appearance -> Pets -> select your pet"',
-    'echo ""',
-    'echo "Then use /pet inside Codex to wake or tuck it away."',
-    "",
-  ].join("\n");
-}
-
-export function powershellInstallScript(pet: ResolvedPet): string {
-  const { slug, displayName, petJsonUrl, spritesheetUrl, spriteExt } = pet;
-  // PowerShell single-quoted hard-quote: ' -> ''.
-  const q = (s: string) => `'${String(s).replace(/'/g, "''")}'`;
-  const safeSlug = String(slug).replace(/[^a-z0-9-]/g, "");
-  const safeExt = spriteExt === "png" ? "png" : "webp";
-  // Strip newlines / quotes from the display name before echoing.
-  const safeName = String(displayName).replace(/[\r\n"]+/g, " ");
-  return [
-    "# Petdex installer",
-    `# https://petdex.crafter.run/pets/${safeSlug}`,
-    "",
-    "$ErrorActionPreference = 'Stop'",
-    `$slug = ${q(safeSlug)}`,
-    "$petDir = Join-Path $HOME (Join-Path '.codex' (Join-Path 'pets' $slug))",
-    "",
-    `Write-Host ${q(`Installing ${safeName} into `)}$petDir`,
-    "New-Item -ItemType Directory -Force -Path $petDir | Out-Null",
-    "",
-    `Invoke-WebRequest -Uri ${q(petJsonUrl)} -OutFile (Join-Path $petDir 'pet.json') -UseBasicParsing`,
-    `Invoke-WebRequest -Uri ${q(spritesheetUrl)} -OutFile (Join-Path $petDir ${q(`spritesheet.${safeExt}`)}) -UseBasicParsing`,
-    "",
-    `Write-Host ${q(`Installed: ${safeName}`)}`,
-    'Write-Host "  Path: $petDir"',
-    'Write-Host ""',
-    'Write-Host "Activate it inside Codex:"',
-    'Write-Host "  Settings -> Appearance -> Pets -> select your pet"',
-    'Write-Host ""',
-    'Write-Host "Then use /pet inside Codex to wake or tuck it away."',
-    "",
-  ].join("\n");
-}
-
-export function posixNotFoundScript(slug: string): string {
-  const safe = String(slug).replace(/[^a-z0-9-]/g, "");
-  return [
-    "#!/bin/sh",
-    `echo "Pet '${safe}' not found in Petdex." >&2`,
-    'echo "Browse pets at https://petdex.crafter.run" >&2',
-    "exit 1",
-    "",
-  ].join("\n");
-}
-
-export function powershellNotFoundScript(slug: string): string {
-  const safe = String(slug).replace(/[^a-z0-9-]/g, "");
-  return [
-    `Write-Error "Pet '${safe}' not found in Petdex."`,
-    'Write-Error "Browse pets at https://petdex.crafter.run"',
-    "exit 1",
-    "",
-  ].join("\n");
 }

--- a/src/lib/pet-search.integration.ts
+++ b/src/lib/pet-search.integration.ts
@@ -1,14 +1,23 @@
 // Integration tests for the gallery search / sort. Hits the real Postgres
 // instance pointed at by DATABASE_URL — same shape the API route uses.
 //
-// Run: bun test
+// Run: DATABASE_URL=... bun run test:db
 
 import { describe, expect, it } from "bun:test";
 
-import { searchPets } from "@/lib/pet-search";
+import type { searchPets as searchPetsFn } from "@/lib/pet-search";
+
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL is required for pet-search integration tests");
+}
+
+async function loadSearchPets(): Promise<typeof searchPetsFn> {
+  return (await import("@/lib/pet-search")).searchPets;
+}
 
 describe("searchPets", () => {
   it("returns pets and total > 0 with no filters", async () => {
+    const searchPets = await loadSearchPets();
     const out = await searchPets({});
     expect(out.pets.length).toBeGreaterThan(0);
     expect(out.total).toBeGreaterThanOrEqual(out.pets.length);
@@ -18,6 +27,7 @@ describe("searchPets", () => {
   });
 
   it("sort=installed orders by installCount descending (regression #11)", async () => {
+    const searchPets = await loadSearchPets();
     const out = await searchPets({ sort: "installed", limit: 60 });
     expect(out.pets.length).toBeGreaterThan(1);
     for (let i = 1; i < out.pets.length; i++) {
@@ -28,6 +38,7 @@ describe("searchPets", () => {
   });
 
   it("sort=popular orders by likeCount descending", async () => {
+    const searchPets = await loadSearchPets();
     const out = await searchPets({ sort: "popular", limit: 60 });
     expect(out.pets.length).toBeGreaterThan(1);
     for (let i = 1; i < out.pets.length; i++) {
@@ -38,6 +49,7 @@ describe("searchPets", () => {
   });
 
   it("sort=alpha orders pets by displayName ascending", async () => {
+    const searchPets = await loadSearchPets();
     const out = await searchPets({ sort: "alpha", limit: 60 });
     expect(out.pets.length).toBeGreaterThan(1);
     // Postgres asc(displayName) orders by raw byte order (ASCII first),
@@ -52,6 +64,7 @@ describe("searchPets", () => {
   });
 
   it("sort=curated puts featured pets first", async () => {
+    const searchPets = await loadSearchPets();
     const out = await searchPets({ sort: "curated", limit: 60 });
     let sawNonFeatured = false;
     for (const pet of out.pets) {
@@ -66,6 +79,7 @@ describe("searchPets", () => {
   });
 
   it("ties in sort=installed break by displayName ascending", async () => {
+    const searchPets = await loadSearchPets();
     const out = await searchPets({ sort: "installed", limit: 60 });
     for (let i = 1; i < out.pets.length; i++) {
       const a = out.pets[i - 1];
@@ -77,6 +91,7 @@ describe("searchPets", () => {
   });
 
   it("vibes filter only returns pets with that vibe", async () => {
+    const searchPets = await loadSearchPets();
     const out = await searchPets({ vibes: ["cozy"], limit: 60 });
     if (out.pets.length === 0) return; // skip if dataset has no cozy
     for (const pet of out.pets) {
@@ -85,6 +100,7 @@ describe("searchPets", () => {
   });
 
   it("kinds filter only returns pets of that kind", async () => {
+    const searchPets = await loadSearchPets();
     const out = await searchPets({ kinds: ["creature"], limit: 60 });
     if (out.pets.length === 0) return;
     for (const pet of out.pets) {
@@ -93,6 +109,7 @@ describe("searchPets", () => {
   });
 
   it("batches filter only returns pets from that approval month", async () => {
+    const searchPets = await loadSearchPets();
     const initial = await searchPets({ limit: 1 });
     const firstBatch = initial.facets.batches[0]?.key;
     if (!firstBatch) return;
@@ -104,14 +121,11 @@ describe("searchPets", () => {
   });
 
   it("q search hits displayName / description / tags", async () => {
+    const searchPets = await loadSearchPets();
     const out = await searchPets({ q: "otter", limit: 10 });
     if (out.pets.length === 0) return;
     for (const pet of out.pets) {
-      const haystack = [
-        pet.displayName,
-        pet.description,
-        ...pet.tags,
-      ]
+      const haystack = [pet.displayName, pet.description, ...pet.tags]
         .join(" ")
         .toLowerCase();
       expect(haystack).toContain("otter");
@@ -119,6 +133,7 @@ describe("searchPets", () => {
   });
 
   it("pagination cursor returns disjoint slices", async () => {
+    const searchPets = await loadSearchPets();
     const limit = 5;
     const first = await searchPets({ limit, sort: "alpha" });
     if (first.nextCursor == null) return; // dataset too small
@@ -134,6 +149,7 @@ describe("searchPets", () => {
   });
 
   it("limit is clamped to MAX_LIMIT", async () => {
+    const searchPets = await loadSearchPets();
     const out = await searchPets({ limit: 9999 });
     expect(out.pets.length).toBeLessThanOrEqual(60);
   });

--- a/src/lib/security.test.ts
+++ b/src/lib/security.test.ts
@@ -3,13 +3,14 @@
 // Run: bun test --env-file=.env.local
 
 import { describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
 
 import {
   posixInstallScript,
-  powershellInstallScript,
   posixNotFoundScript,
-} from "@/lib/install-script";
-import { validateSubmission } from "@/lib/submissions";
+  powershellInstallScript,
+} from "@/lib/install-script-render";
+import { validateSubmission } from "@/lib/submissions-validation";
 import {
   isAllowedAssetUrl,
   isAllowedAvatarUrl,
@@ -66,10 +67,12 @@ describe("isAllowedAssetUrl", () => {
   });
 
   it("blocks LAN / metadata IPs", () => {
-    expect(isAllowedAssetUrl("https://169.254.169.254/latest/meta-data/"))
-      .toBe(false);
-    expect(isAllowedAssetUrl("https://localhost:3000/api/admin/secret"))
-      .toBe(false);
+    expect(isAllowedAssetUrl("https://169.254.169.254/latest/meta-data/")).toBe(
+      false,
+    );
+    expect(isAllowedAssetUrl("https://localhost:3000/api/admin/secret")).toBe(
+      false,
+    );
   });
 
   it("rejects empty / undefined", () => {
@@ -110,8 +113,7 @@ describe("validateSubmission", () => {
   it("rejects shell-injection in petJsonUrl (off allowlist)", () => {
     const r = validateSubmission({
       ...BASE_INPUT,
-      petJsonUrl:
-        "https://evil.example.com/x'; rm -rf $HOME; echo 'pwned",
+      petJsonUrl: "https://evil.example.com/x'; rm -rf $HOME; echo 'pwned",
     });
     expect(r?.ok).toBe(false);
     if (r && r.ok === false) {
@@ -121,6 +123,8 @@ describe("validateSubmission", () => {
 });
 
 describe("posixInstallScript shell-injection", () => {
+  const shAvailable = spawnSync("sh", ["-c", "exit 0"]).status === 0;
+
   const safeBase = {
     slug: "boba",
     displayName: "Boba",
@@ -132,13 +136,14 @@ describe("posixInstallScript shell-injection", () => {
   };
 
   it("escapes single quotes in URLs (sh syntax-checks clean)", () => {
+    if (!shAvailable) return;
+
     // If our hard-quoting was wrong, the script wouldn't parse — `sh -n`
     // would surface a syntax error. We don't actually run it (would touch
     // the filesystem); we only prove the tokenization round-trips.
     const evilUrl = "https://x.com/a'; rm -rf /; echo '";
     const script = posixInstallScript({ ...safeBase, petJsonUrl: evilUrl });
-    const { spawnSync } = require("node:child_process") as typeof import("node:child_process");
-    const r = spawnSync("/bin/sh", ["-n"], { input: script, encoding: "utf8" });
+    const r = spawnSync("sh", ["-n"], { input: script, encoding: "utf8" });
     expect(r.status).toBe(0);
     expect(r.stderr).toBe("");
   });
@@ -184,7 +189,8 @@ describe("powershellInstallScript", () => {
 });
 
 describe("isSameOrigin (CSRF guard)", () => {
-  const { isSameOrigin } = require("@/lib/same-origin") as typeof import("@/lib/same-origin");
+  const { isSameOrigin } =
+    require("@/lib/same-origin") as typeof import("@/lib/same-origin");
 
   function reqWith(headers: Record<string, string>): Request {
     return new Request("https://petdex.crafter.run/api/x", {
@@ -200,13 +206,13 @@ describe("isSameOrigin (CSRF guard)", () => {
   });
 
   it("allows localhost dev", () => {
-    expect(isSameOrigin(reqWith({ origin: "http://localhost:3000" })))
-      .toBe(true);
+    expect(isSameOrigin(reqWith({ origin: "http://localhost:3000" }))).toBe(
+      true,
+    );
   });
 
   it("blocks attacker.com cross-origin POST", () => {
-    expect(isSameOrigin(reqWith({ origin: "https://evil.com" })))
-      .toBe(false);
+    expect(isSameOrigin(reqWith({ origin: "https://evil.com" }))).toBe(false);
   });
 
   it("blocks origin null (e.g. data: pages)", () => {
@@ -214,12 +220,12 @@ describe("isSameOrigin (CSRF guard)", () => {
   });
 
   it("uses Sec-Fetch-Site fallback when Origin missing", () => {
-    expect(
-      isSameOrigin(reqWith({ "sec-fetch-site": "same-origin" })),
-    ).toBe(true);
-    expect(
-      isSameOrigin(reqWith({ "sec-fetch-site": "cross-site" })),
-    ).toBe(false);
+    expect(isSameOrigin(reqWith({ "sec-fetch-site": "same-origin" }))).toBe(
+      true,
+    );
+    expect(isSameOrigin(reqWith({ "sec-fetch-site": "cross-site" }))).toBe(
+      false,
+    );
   });
 
   it("allows non-browser callers (no Origin, no Sec-Fetch)", () => {
@@ -238,14 +244,10 @@ describe("isAllowedAvatarUrl", () => {
   it("allows clerk and known socials", () => {
     expect(isAllowedAvatarUrl("https://img.clerk.com/eyJ...")).toBe(true);
     expect(
-      isAllowedAvatarUrl(
-        "https://avatars.githubusercontent.com/u/12345?v=4",
-      ),
+      isAllowedAvatarUrl("https://avatars.githubusercontent.com/u/12345?v=4"),
     ).toBe(true);
     expect(
-      isAllowedAvatarUrl(
-        "https://storage.googleapis.com/avatars/x.png",
-      ),
+      isAllowedAvatarUrl("https://storage.googleapis.com/avatars/x.png"),
     ).toBe(true);
   });
   it("rejects attacker-controlled host (tracking pixel)", () => {

--- a/src/lib/submissions-validation.ts
+++ b/src/lib/submissions-validation.ts
@@ -1,0 +1,94 @@
+import { isAllowedAssetUrl } from "@/lib/url-allowlist";
+
+export type SubmissionInput = {
+  zipUrl: string;
+  spritesheetUrl: string;
+  petJsonUrl: string;
+  displayName: string;
+  description: string;
+  petId: string;
+  spritesheetWidth: number;
+  spritesheetHeight: number;
+};
+
+export type SubmissionResult =
+  | { ok: true; id: string; slug: string }
+  | {
+      ok: false;
+      status: number;
+      error: string;
+      message?: string;
+      field?: string;
+      got?: unknown;
+    };
+
+export const REQUIRED_FIELDS: ReadonlyArray<keyof SubmissionInput> = [
+  "zipUrl",
+  "spritesheetUrl",
+  "petJsonUrl",
+  "displayName",
+  "description",
+  "petId",
+  "spritesheetWidth",
+  "spritesheetHeight",
+] as const;
+
+export const MIN_SPRITE_DIM = 256;
+
+const ASSET_URL_FIELDS: ReadonlyArray<
+  "zipUrl" | "spritesheetUrl" | "petJsonUrl"
+> = ["zipUrl", "spritesheetUrl", "petJsonUrl"];
+
+export function validateSubmission(
+  body: Partial<SubmissionInput>,
+): SubmissionResult | null {
+  for (const field of REQUIRED_FIELDS) {
+    if (!body[field]) {
+      return {
+        ok: false,
+        status: 400,
+        error: "missing_field",
+        field,
+      };
+    }
+  }
+  if (
+    !body.spritesheetWidth ||
+    !body.spritesheetHeight ||
+    body.spritesheetWidth < MIN_SPRITE_DIM ||
+    body.spritesheetHeight < MIN_SPRITE_DIM
+  ) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_spritesheet",
+      message: `Spritesheet seems too small. Got ${body.spritesheetWidth}x${body.spritesheetHeight}, expected at least ${MIN_SPRITE_DIM}x${MIN_SPRITE_DIM} (ideal 1536x1872).`,
+      got: { width: body.spritesheetWidth, height: body.spritesheetHeight },
+    };
+  }
+  // Reject any URL outside the allowlist. Without this, a malicious
+  // submission could land javascript:, attacker.com, or LAN IPs into the
+  // pet detail page (XSS) and the install script (RCE on every viewer who
+  // pipes it through sh).
+  for (const field of ASSET_URL_FIELDS) {
+    if (!isAllowedAssetUrl(body[field])) {
+      return {
+        ok: false,
+        status: 400,
+        error: "invalid_asset_url",
+        field,
+        message: `${field} must be hosted on the petdex R2 bucket.`,
+      };
+    }
+  }
+  return null;
+}
+
+export function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+}

--- a/src/lib/submissions.ts
+++ b/src/lib/submissions.ts
@@ -4,13 +4,28 @@
 // MUST come from a verified caller (Clerk session for web, OAuth bearer for
 // CLI) — never from request body — so this module accepts them as `principal`.
 
+import "server-only";
+
 import { eq } from "drizzle-orm";
 import { Resend } from "resend";
 
 import { db, schema } from "@/lib/db/client";
 import { renderNewSubmissionEmail } from "@/lib/email-templates/new-submission";
+import {
+  type SubmissionInput,
+  type SubmissionResult,
+  slugify,
+} from "@/lib/submissions-validation";
 import { getPreferredLocaleForUser } from "@/lib/user-locale";
-import { isAllowedAssetUrl } from "@/lib/url-allowlist";
+
+export {
+  MIN_SPRITE_DIM,
+  REQUIRED_FIELDS,
+  type SubmissionInput,
+  type SubmissionResult,
+  slugify,
+  validateSubmission,
+} from "@/lib/submissions-validation";
 
 export type SubmissionPrincipal = {
   userId: string;
@@ -22,89 +37,6 @@ export type SubmissionPrincipal = {
   /** Pre-computed external profile URL (X or GitHub) when available. */
   url?: string | null;
 };
-
-export type SubmissionInput = {
-  zipUrl: string;
-  spritesheetUrl: string;
-  petJsonUrl: string;
-  displayName: string;
-  description: string;
-  petId: string;
-  spritesheetWidth: number;
-  spritesheetHeight: number;
-};
-
-export type SubmissionResult =
-  | { ok: true; id: string; slug: string }
-  | {
-      ok: false;
-      status: number;
-      error: string;
-      message?: string;
-      field?: string;
-      got?: unknown;
-    };
-
-export const REQUIRED_FIELDS: ReadonlyArray<keyof SubmissionInput> = [
-  "zipUrl",
-  "spritesheetUrl",
-  "petJsonUrl",
-  "displayName",
-  "description",
-  "petId",
-  "spritesheetWidth",
-  "spritesheetHeight",
-] as const;
-
-export const MIN_SPRITE_DIM = 256;
-
-export function validateSubmission(
-  body: Partial<SubmissionInput>,
-): SubmissionResult | null {
-  for (const field of REQUIRED_FIELDS) {
-    if (!body[field]) {
-      return {
-        ok: false,
-        status: 400,
-        error: "missing_field",
-        field,
-      };
-    }
-  }
-  if (
-    !body.spritesheetWidth ||
-    !body.spritesheetHeight ||
-    body.spritesheetWidth < MIN_SPRITE_DIM ||
-    body.spritesheetHeight < MIN_SPRITE_DIM
-  ) {
-    return {
-      ok: false,
-      status: 400,
-      error: "invalid_spritesheet",
-      message: `Spritesheet seems too small. Got ${body.spritesheetWidth}x${body.spritesheetHeight}, expected at least ${MIN_SPRITE_DIM}x${MIN_SPRITE_DIM} (ideal 1536x1872).`,
-      got: { width: body.spritesheetWidth, height: body.spritesheetHeight },
-    };
-  }
-  // Reject any URL outside the allowlist. Without this, a malicious
-  // submission could land javascript:, attacker.com, or LAN IPs into the
-  // pet detail page (XSS) and the install script (RCE on every viewer who
-  // pipes it through sh).
-  for (const field of ASSET_URL_FIELDS) {
-    if (!isAllowedAssetUrl(body[field])) {
-      return {
-        ok: false,
-        status: 400,
-        error: "invalid_asset_url",
-        field,
-        message: `${field} must be hosted on the petdex R2 bucket.`,
-      };
-    }
-  }
-  return null;
-}
-
-const ASSET_URL_FIELDS: ReadonlyArray<"zipUrl" | "spritesheetUrl" | "petJsonUrl"> =
-  ["zipUrl", "spritesheetUrl", "petJsonUrl"];
 
 /** Persist a submission. Caller is responsible for authn/ratelimit.
  *  Slug collisions get suffixed (boba -> boba-2) by resolveUniqueSlug.
@@ -150,9 +82,7 @@ export async function persistSubmission(
     // SMTP header injection defense — strip control chars from anything
     // that could end up in a header. The Resend SDK probably escapes, but
     // we don't trust user-controlled fields anywhere near a header.
-    const safeName = body.displayName
-      .replace(/[\r\n\t]+/g, " ")
-      .slice(0, 80);
+    const safeName = body.displayName.replace(/[\r\n\t]+/g, " ").slice(0, 80);
     void (async () => {
       try {
         const resend = new Resend(resendKey);
@@ -201,15 +131,6 @@ export function creditFromPrincipal(p: SubmissionPrincipal): {
     url: p.url ?? null,
     imageUrl: p.imageUrl ?? null,
   };
-}
-
-export function slugify(value: string): string {
-  return value
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 40);
 }
 
 export async function resolveUniqueSlug(base: string): Promise<string> {


### PR DESCRIPTION
## Summary

This PR makes the default contributor test suite pass without requiring a Next server graph or a live database, while keeping server-only production modules protected.

- extracts pure install script rendering and submission validation helpers for unit tests
- keeps `install-script.ts` and `submissions.ts` as server-only modules with top-level DB imports
- moves DB-backed search coverage to an explicit `test:db` integration command
- makes the POSIX shell syntax test use `sh` from PATH instead of hardcoding `/bin/sh`
- documents the default and DB-backed test commands for contributors

## Why

`bun test` currently imports DB/server-only code through test files, which can fail before the useful regression tests run. The DB search tests also need a real `DATABASE_URL`, so keeping them in default discovery makes the local contributor path brittle.

## Validation

- `bun test` passes: 41 pass, 0 fail
- `bun --bun tsc --noEmit` passes
- touched-file Biome check passes
- `bun run test:db` fails explicitly without `DATABASE_URL`, as intended

`bun run build` compiles and completes TypeScript, then fails during page data collection because this local shell has no Neon `DATABASE_URL` configured.

`bun run check` still reports existing repo-wide CRLF/formatting and lint diagnostics outside this patch.
