### PR TITLE
Add pinned pets reordering

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -6,12 +6,13 @@ import { and, eq, inArray, ne } from "drizzle-orm";
 import { db, schema } from "@/lib/db/client";
 import {
   dedupePins,
+  isPinOnlyProfilePatch,
   MAX_PINNED_PETS,
   normalizeProfileDisplayName,
   normalizeProfileHandle,
   validateProfileHandle,
 } from "@/lib/profiles";
-import { profileEditRatelimit } from "@/lib/ratelimit";
+import { profileEditRatelimit, profilePinRatelimit } from "@/lib/ratelimit";
 import { requireSameOrigin } from "@/lib/same-origin";
 
 import { defaultLocale, hasLocale, type Locale } from "@/i18n/config";
@@ -39,19 +40,22 @@ export async function PATCH(req: Request): Promise<Response> {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
 
-  const lim = await profileEditRatelimit.limit(userId);
-  if (!lim.success) {
-    return NextResponse.json(
-      { error: "rate_limited", retryAfter: lim.reset },
-      { status: 429 },
-    );
-  }
-
   let body: PatchBody;
   try {
     body = (await req.json()) as PatchBody;
   } catch {
     return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const limiter = isPinOnlyProfilePatch(body)
+    ? profilePinRatelimit
+    : profileEditRatelimit;
+  const lim = await limiter.limit(userId);
+  if (!lim.success) {
+    return NextResponse.json(
+      { error: "rate_limited", retryAfter: lim.reset },
+      { status: 429 },
+    );
   }
 
   const patch: {

--- a/src/components/pinned-reorder-grid.test.ts
+++ b/src/components/pinned-reorder-grid.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("./pinned-reorder-grid.tsx", import.meta.url),
+  "utf8",
+);
+
+describe("PinnedReorderGrid behavior contract", () => {
+  it("uses pointer events for desktop and touch drag", () => {
+    expect(source).toContain("onPointerDown");
+    expect(source).toContain("onPointerMove");
+    expect(source).toContain("onPointerUp");
+    expect(source).toContain("touch-none");
+  });
+
+  it("keeps reorder changes auto-saved instead of using an explicit save step", () => {
+    expect(source).toContain("Drops are saved automatically.");
+    expect(source).toContain("Done");
+    expect(source).not.toContain("Click Save");
+    expect(source).not.toContain(">Save<");
+  });
+
+  it("keeps failure recovery visible", () => {
+    expect(source).toContain("Could not save order");
+    expect(source).toContain("Retry");
+    expect(source).toContain("Restore saved order");
+  });
+});

--- a/src/components/pinned-reorder-grid.tsx
+++ b/src/components/pinned-reorder-grid.tsx
@@ -1,18 +1,18 @@
 "use client";
 
-// Owner-only reorderable pinned-pets grid for /u/<handle>. Wraps the
-// existing PetCard layout with native HTML5 drag-and-drop on desktop
-// plus left/right arrow controls for touch + keyboard. Saves via
-// PATCH /api/profile { featuredPetSlugs: [...] } with optimistic UI.
-//
-// Why HTML5 DnD vs a library: pinned grids cap at MAX_PINNED_PETS (6)
-// so we don't need keyboard sortable accessibility primitives or virtual
-// lists. Native DnD ships zero JS, and the keyboard fallback covers
-// users who can't drag.
+// Owner-only reorderable pinned-pets grid for /u/<handle>. The pinned
+// set is capped at 6, so pointer events give us desktop + touch drag
+// without adding a drag-and-drop dependency.
 
-import { useState, useTransition } from "react";
+import { useEffect, useRef, useState } from "react";
 
-import { ArrowLeft, ArrowRight, Check, GripVertical, X } from "lucide-react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Check,
+  GripVertical,
+  RefreshCcw,
+} from "lucide-react";
 
 import type { PetWithMetrics } from "@/lib/pets";
 import { MAX_PINNED_PETS } from "@/lib/profiles";
@@ -25,75 +25,239 @@ type PinnedReorderGridProps = {
   petStateCount: number;
 };
 
+type DragState = {
+  slug: string;
+  fromIndex: number;
+  targetIndex: number;
+  pointerId: number;
+  startX: number;
+  startY: number;
+  x: number;
+  y: number;
+};
+
+type SaveState = "idle" | "saving" | "saved" | "error";
+
+export function movePinnedPets<T>(items: T[], from: number, to: number): T[] {
+  if (
+    from === to ||
+    from < 0 ||
+    to < 0 ||
+    from >= items.length ||
+    to >= items.length
+  ) {
+    return items;
+  }
+  const next = items.slice();
+  const [item] = next.splice(from, 1);
+  next.splice(to, 0, item);
+  return next;
+}
+
 export function PinnedReorderGrid({
   pets,
   petStateCount,
 }: PinnedReorderGridProps) {
+  const itemRefs = useRef(new Map<string, HTMLDivElement>());
   const [order, setOrder] = useState<PetWithMetrics[]>(pets);
+  const [savedSlugs, setSavedSlugs] = useState<string[]>(
+    pets.map((pet) => pet.slug),
+  );
   const [editing, setEditing] = useState(false);
-  const [dragIndex, setDragIndex] = useState<number | null>(null);
-  const [overIndex, setOverIndex] = useState<number | null>(null);
+  const [drag, setDrag] = useState<DragState | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [isSaving, startSave] = useTransition();
+  const [saveState, setSaveState] = useState<SaveState>("idle");
 
-  const initialSlugs = pets.map((p) => p.slug).join(",");
-  const currentSlugs = order.map((p) => p.slug).join(",");
-  const dirty = editing && initialSlugs !== currentSlugs;
-
-  function move(from: number, to: number) {
-    if (from === to || from < 0 || to < 0 || to >= order.length) return;
-    setOrder((prev) => {
-      const next = prev.slice();
-      const [item] = next.splice(from, 1);
-      next.splice(to, 0, item);
-      return next;
-    });
-  }
-
-  function cancel() {
+  useEffect(() => {
+    const slugs = pets.map((pet) => pet.slug);
     setOrder(pets);
-    setEditing(false);
-    setDragIndex(null);
-    setOverIndex(null);
+    setSavedSlugs(slugs);
+    setDrag(null);
     setError(null);
+    setSaveState("idle");
+  }, [pets]);
+
+  const isSaving = saveState === "saving";
+  const activeSlug = drag?.slug ?? null;
+
+  function setItemRef(slug: string) {
+    return (node: HTMLDivElement | null) => {
+      if (node) {
+        itemRefs.current.set(slug, node);
+      } else {
+        itemRefs.current.delete(slug);
+      }
+    };
   }
 
-  function save() {
+  function orderFromSlugs(slugs: string[]): PetWithMetrics[] {
+    const bySlug = new Map(pets.map((pet) => [pet.slug, pet]));
+    return slugs
+      .map((slug) => bySlug.get(slug))
+      .filter((pet): pet is PetWithMetrics => Boolean(pet));
+  }
+
+  async function saveOrder(nextOrder: PetWithMetrics[]) {
+    setSaveState("saving");
     setError(null);
-    startSave(async () => {
-      try {
-        const res = await fetch("/api/profile", {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            featuredPetSlugs: order.map((p) => p.slug),
-          }),
-        });
-        if (!res.ok) {
-          const body = (await res.json().catch(() => ({}))) as {
-            error?: string;
-          };
-          throw new Error(body.error ?? `save failed (${res.status})`);
-        }
-        setEditing(false);
-      } catch (err) {
-        setError((err as Error).message);
+    try {
+      const slugs = nextOrder.map((pet) => pet.slug);
+      const res = await fetch("/api/profile", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ featuredPetSlugs: slugs }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        throw new Error(body.error ?? `save failed (${res.status})`);
       }
+      setSavedSlugs(slugs);
+      setSaveState("saved");
+    } catch (err) {
+      setSaveState("error");
+      setError((err as Error).message);
+    }
+  }
+
+  function restoreSavedOrder() {
+    setOrder(orderFromSlugs(savedSlugs));
+    setDrag(null);
+    setError(null);
+    setSaveState("idle");
+  }
+
+  function startEditing() {
+    setEditing(true);
+    setError(null);
+    setSaveState("idle");
+  }
+
+  function finishEditing() {
+    if (isSaving || saveState === "error") return;
+    setEditing(false);
+    setDrag(null);
+    setError(null);
+    setSaveState("idle");
+  }
+
+  function retrySave() {
+    if (isSaving) return;
+    void saveOrder(order);
+  }
+
+  function moveAndSave(from: number, to: number) {
+    if (isSaving) return;
+    const next = movePinnedPets(order, from, to);
+    if (next === order) return;
+    setOrder(next);
+    void saveOrder(next);
+  }
+
+  function targetIndexForPoint(clientX: number, clientY: number): number {
+    let targetIndex = drag?.targetIndex ?? 0;
+    let bestDistance = Number.POSITIVE_INFINITY;
+    for (const [index, pet] of order.entries()) {
+      if (pet.slug === drag?.slug) continue;
+      const rect = itemRefs.current.get(pet.slug)?.getBoundingClientRect();
+      if (!rect) continue;
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+      const distance = (clientX - centerX) ** 2 + (clientY - centerY) ** 2;
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        targetIndex = index;
+      }
+    }
+    return targetIndex;
+  }
+
+  function onHandlePointerDown(
+    event: React.PointerEvent<HTMLButtonElement>,
+    slug: string,
+    index: number,
+  ) {
+    if (!editing || isSaving) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    setError(null);
+    setSaveState("idle");
+    setDrag({
+      slug,
+      fromIndex: index,
+      targetIndex: index,
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      x: event.clientX,
+      y: event.clientY,
     });
   }
 
-  // Render the existing single-card layout when there's only one pin —
-  // there's nothing to reorder, but owners can still toggle edit mode
-  // for consistency with the multi-pet view.
+  function onHandlePointerMove(event: React.PointerEvent<HTMLButtonElement>) {
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    event.preventDefault();
+    const targetIndex = targetIndexForPoint(event.clientX, event.clientY);
+    setDrag((current) =>
+      current
+        ? {
+            ...current,
+            targetIndex,
+            x: event.clientX,
+            y: event.clientY,
+          }
+        : current,
+    );
+  }
+
+  function onHandlePointerUp(event: React.PointerEvent<HTMLButtonElement>) {
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    event.preventDefault();
+    const { fromIndex, targetIndex } = drag;
+    setDrag(null);
+    if (fromIndex !== targetIndex) {
+      const next = movePinnedPets(order, fromIndex, targetIndex);
+      setOrder(next);
+      void saveOrder(next);
+    }
+  }
+
+  function onHandlePointerCancel(event: React.PointerEvent<HTMLButtonElement>) {
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    setDrag(null);
+  }
+
   const oneOnly = order.length <= 1;
+  const statusLabel =
+    saveState === "saving"
+      ? "Saving..."
+      : saveState === "saved"
+        ? "Order updated"
+        : saveState === "error"
+          ? "Could not save order"
+          : null;
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <p className="font-mono text-[11px] tracking-[0.22em] text-brand uppercase">
           ★ Pinned
         </p>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          {statusLabel ? (
+            <span
+              className={`inline-flex h-7 items-center gap-1.5 rounded-full border px-3 text-[11px] font-medium ${
+                saveState === "error"
+                  ? "border-red-300 bg-red-50 text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300"
+                  : "border-border-base bg-surface text-muted-2"
+              }`}
+            >
+              {saveState === "saved" ? <Check className="size-3" /> : null}
+              {statusLabel}
+            </span>
+          ) : null}
           <p className="font-mono text-[10px] tracking-[0.18em] text-muted-4 uppercase">
             {order.length} of {MAX_PINNED_PETS}
           </p>
@@ -101,7 +265,7 @@ export function PinnedReorderGrid({
             order.length >= 2 ? (
               <button
                 type="button"
-                onClick={() => setEditing(true)}
+                onClick={startEditing}
                 className="inline-flex h-7 items-center gap-1.5 rounded-full border border-border-base bg-surface px-3 text-[11px] font-medium text-muted-2 transition hover:border-border-strong hover:text-foreground"
               >
                 <GripVertical className="size-3" />
@@ -109,39 +273,47 @@ export function PinnedReorderGrid({
               </button>
             ) : null
           ) : (
-            <div className="flex items-center gap-1.5">
-              <button
-                type="button"
-                onClick={cancel}
-                disabled={isSaving}
-                className="inline-flex h-7 items-center gap-1 rounded-full border border-border-base bg-surface px-3 text-[11px] font-medium text-muted-2 transition hover:border-border-strong disabled:opacity-50"
-              >
-                <X className="size-3" />
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={save}
-                disabled={!dirty || isSaving}
-                className="inline-flex h-7 items-center gap-1 rounded-full bg-inverse px-3 text-[11px] font-medium text-on-inverse transition hover:bg-inverse-hover disabled:opacity-50"
-              >
-                <Check className="size-3" />
-                {isSaving ? "Saving…" : "Save"}
-              </button>
-            </div>
+            <button
+              type="button"
+              onClick={finishEditing}
+              disabled={isSaving || saveState === "error"}
+              className="inline-flex h-7 items-center gap-1 rounded-full bg-inverse px-3 text-[11px] font-medium text-on-inverse transition hover:bg-inverse-hover disabled:opacity-50"
+            >
+              <Check className="size-3" />
+              Done
+            </button>
           )}
         </div>
       </div>
 
       {error ? (
-        <p className="rounded-2xl border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300">
-          {error}
-        </p>
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300">
+          <p>Could not save order: {error}</p>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={retrySave}
+              disabled={isSaving}
+              className="inline-flex h-7 items-center gap-1 rounded-full border border-red-300/70 bg-white/70 px-2.5 font-medium transition hover:bg-white disabled:opacity-50 dark:border-red-800 dark:bg-red-950/50"
+            >
+              <RefreshCcw className="size-3" />
+              Retry
+            </button>
+            <button
+              type="button"
+              onClick={restoreSavedOrder}
+              disabled={isSaving}
+              className="inline-flex h-7 items-center rounded-full border border-red-300/70 bg-white/70 px-2.5 font-medium transition hover:bg-white disabled:opacity-50 dark:border-red-800 dark:bg-red-950/50"
+            >
+              Restore saved order
+            </button>
+          </div>
+        </div>
       ) : null}
 
       {editing ? (
         <p className="text-xs text-muted-3">
-          Drag a pet to reorder, or use the arrows. Click Save when you're done.
+          Drag a pet by its handle to reorder. Drops are saved automatically.
         </p>
       ) : null}
 
@@ -153,60 +325,62 @@ export function PinnedReorderGrid({
         }
       >
         {order.map((pet, index) => {
-          const isDragging = dragIndex === index;
-          const isOver = overIndex === index && dragIndex !== index;
+          const isActive = activeSlug === pet.slug;
+          const isTarget =
+            editing &&
+            drag?.targetIndex === index &&
+            drag.fromIndex !== index &&
+            activeSlug !== pet.slug;
+          const translate =
+            isActive && drag
+              ? {
+                  transform: `translate3d(${drag.x - drag.startX}px, ${
+                    drag.y - drag.startY
+                  }px, 0) scale(1.03)`,
+                }
+              : undefined;
           return (
-            // biome-ignore lint/a11y/noStaticElementInteractions: drag wrapper; arrow buttons inside provide keyboard a11y
             <div
               key={pet.slug}
+              ref={setItemRef(pet.slug)}
+              style={translate}
               className={`relative h-full transition ${
-                editing ? "cursor-grab active:cursor-grabbing" : ""
-              } ${isDragging ? "scale-[0.98] opacity-40" : ""} ${
-                isOver
-                  ? "rounded-3xl ring-2 ring-brand ring-offset-2 ring-offset-background"
+                isActive
+                  ? "z-30 cursor-grabbing opacity-95 shadow-2xl shadow-blue-950/20"
+                  : ""
+              } ${
+                isTarget
+                  ? "rounded-3xl ring-2 ring-brand ring-offset-2 ring-offset-background after:absolute after:inset-0 after:rounded-3xl after:border-2 after:border-dashed after:border-brand/70 after:bg-brand/5"
                   : ""
               }`}
-              draggable={editing}
-              onDragStart={(e) => {
-                if (!editing) return;
-                setDragIndex(index);
-                e.dataTransfer.effectAllowed = "move";
-                // Firefox needs setData or the drag event aborts.
-                e.dataTransfer.setData("text/plain", String(index));
-              }}
-              onDragOver={(e) => {
-                if (!editing || dragIndex === null) return;
-                e.preventDefault();
-                e.dataTransfer.dropEffect = "move";
-                if (overIndex !== index) setOverIndex(index);
-              }}
-              onDragLeave={() => {
-                if (overIndex === index) setOverIndex(null);
-              }}
-              onDrop={(e) => {
-                if (!editing || dragIndex === null) return;
-                e.preventDefault();
-                move(dragIndex, index);
-                setDragIndex(null);
-                setOverIndex(null);
-              }}
-              onDragEnd={() => {
-                setDragIndex(null);
-                setOverIndex(null);
-              }}
             >
               <PetCard pet={pet} index={index} stateCount={petStateCount} />
 
               {editing ? (
                 <>
-                  <div className="absolute top-3 left-3 grid size-7 place-items-center rounded-full bg-surface/95 text-muted-2 shadow-sm ring-1 ring-black/5 dark:ring-white/10">
+                  <button
+                    type="button"
+                    onPointerDown={(event) =>
+                      onHandlePointerDown(event, pet.slug, index)
+                    }
+                    onPointerMove={onHandlePointerMove}
+                    onPointerUp={onHandlePointerUp}
+                    onPointerCancel={onHandlePointerCancel}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                    }}
+                    disabled={isSaving}
+                    aria-label={`Drag ${pet.displayName} to reorder`}
+                    className="absolute top-3 left-3 z-40 grid size-8 touch-none place-items-center rounded-full bg-surface/95 text-muted-2 shadow-sm ring-1 ring-black/5 transition hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50 dark:ring-white/10"
+                  >
                     <GripVertical className="size-3.5" />
-                  </div>
-                  <div className="absolute bottom-3 left-3 flex items-center gap-1">
+                  </button>
+                  <div className="absolute bottom-3 left-3 z-40 flex items-center gap-1">
                     <button
                       type="button"
-                      onClick={() => move(index, index - 1)}
-                      disabled={index === 0}
+                      onClick={() => moveAndSave(index, index - 1)}
+                      disabled={index === 0 || isSaving}
                       aria-label={`Move ${pet.displayName} left`}
                       className="grid size-7 place-items-center rounded-full bg-surface/95 text-muted-2 shadow-sm ring-1 ring-black/5 transition hover:text-foreground disabled:opacity-30 dark:ring-white/10"
                     >
@@ -214,8 +388,8 @@ export function PinnedReorderGrid({
                     </button>
                     <button
                       type="button"
-                      onClick={() => move(index, index + 1)}
-                      disabled={index === order.length - 1}
+                      onClick={() => moveAndSave(index, index + 1)}
+                      disabled={index === order.length - 1 || isSaving}
                       aria-label={`Move ${pet.displayName} right`}
                       className="grid size-7 place-items-center rounded-full bg-surface/95 text-muted-2 shadow-sm ring-1 ring-black/5 transition hover:text-foreground disabled:opacity-30 dark:ring-white/10"
                     >

--- a/src/lib/mock/db.ts
+++ b/src/lib/mock/db.ts
@@ -16,7 +16,22 @@ import { drizzle } from "drizzle-orm/pglite";
 import * as schema from "../db/schema";
 import { MOCK_USER } from "./index";
 
-let _db: ReturnType<typeof drizzle<typeof schema>> | null = null;
+type MockDbState = {
+  db: ReturnType<typeof drizzle<typeof schema>> | null;
+  initPromise: Promise<void> | null;
+};
+
+const globalMockDb = globalThis as typeof globalThis & {
+  __petdexMockDb?: MockDbState;
+};
+
+if (!globalMockDb.__petdexMockDb) {
+  globalMockDb.__petdexMockDb = {
+    db: null,
+    initPromise: null,
+  };
+}
+const state: MockDbState = globalMockDb.__petdexMockDb;
 
 async function bootstrap(client: PGlite): Promise<void> {
   // Drizzle migrations are SQL files. We run them in order, tolerating
@@ -81,6 +96,40 @@ async function bootstrap(client: PGlite): Promise<void> {
       "image_rejection_reason" text,
       "created_at" timestamp with time zone NOT NULL DEFAULT now(),
       "updated_at" timestamp with time zone NOT NULL DEFAULT now()
+    )`,
+    `CREATE TABLE IF NOT EXISTS "feedback" (
+      "id" text PRIMARY KEY NOT NULL,
+      "kind" text NOT NULL DEFAULT 'suggestion',
+      "status" text NOT NULL DEFAULT 'pending',
+      "message" text NOT NULL,
+      "email" text,
+      "page_url" text,
+      "user_agent" text,
+      "user_id" text,
+      "addressed_at" timestamp with time zone,
+      "archived_at" timestamp with time zone,
+      "admin_note" text,
+      "notify_email" boolean NOT NULL DEFAULT true,
+      "user_last_read_at" timestamp with time zone,
+      "admin_last_read_at" timestamp with time zone,
+      "created_at" timestamp with time zone NOT NULL DEFAULT now()
+    )`,
+    `CREATE TABLE IF NOT EXISTS "feedback_replies" (
+      "id" text PRIMARY KEY NOT NULL,
+      "feedback_id" text NOT NULL,
+      "author_kind" text NOT NULL,
+      "author_user_id" text,
+      "body" text NOT NULL,
+      "created_at" timestamp with time zone NOT NULL DEFAULT now()
+    )`,
+    `CREATE TABLE IF NOT EXISTS "notifications" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL,
+      "kind" text NOT NULL,
+      "payload" jsonb NOT NULL,
+      "href" text NOT NULL,
+      "read_at" timestamp with time zone,
+      "created_at" timestamp with time zone NOT NULL DEFAULT now()
     )`,
     `ALTER TABLE "submitted_pets" ADD COLUMN IF NOT EXISTS "source" text NOT NULL DEFAULT 'submit'`,
     `ALTER TABLE "submitted_pets" ADD COLUMN IF NOT EXISTS "dominant_color" text`,
@@ -193,14 +242,14 @@ async function seed(client: PGlite): Promise<void> {
 // Bootstrap+seed are run synchronously at module load via top-level
 // await. PGlite's underlying postgres-on-wasm queues exec calls so the
 // schema is fully ready before drizzle's first .select() runs.
-let _initPromise: Promise<void> | null = null;
-
 export function getMockDb() {
-  if (_db) return { db: _db, ready: _initPromise ?? Promise.resolve() };
+  if (state.db) {
+    return { db: state.db, ready: state.initPromise ?? Promise.resolve() };
+  }
 
   const client = new PGlite();
-  _db = drizzle(client, { schema });
-  _initPromise = (async () => {
+  state.db = drizzle(client, { schema });
+  state.initPromise = (async () => {
     await bootstrap(client);
     await seed(client);
     console.log(
@@ -208,13 +257,13 @@ export function getMockDb() {
     );
   })();
 
-  return { db: _db, ready: _initPromise };
+  return { db: state.db, ready: state.initPromise };
 }
 
 // Awaitable used by /src/lib/db/client.ts to block on first import.
 export const mockDbReady = (): Promise<void> => {
-  if (_initPromise) return _initPromise;
+  if (state.initPromise) return state.initPromise;
   // Side-effect of getMockDb seeds _initPromise; ignore the returned db.
   getMockDb();
-  return _initPromise ?? Promise.resolve();
+  return state.initPromise ?? Promise.resolve();
 };

--- a/src/lib/profiles.test.ts
+++ b/src/lib/profiles.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import {
+  isPinOnlyProfilePatch,
   normalizeProfileDisplayName,
   normalizeProfileHandle,
   validateProfileHandle,
@@ -27,5 +28,22 @@ describe("profile identity helpers", () => {
     expect(validateProfileHandle("my pets")).toBe("invalid_format");
     expect(validateProfileHandle("-kevwuzy")).toBe("invalid_format");
     expect(validateProfileHandle("admin")).toBe("reserved");
+  });
+
+  it("classifies pin-only profile patches", () => {
+    expect(isPinOnlyProfilePatch({ featuredPetSlugs: ["boba"] })).toBe(true);
+    expect(isPinOnlyProfilePatch({ pin: { slug: "boba" } })).toBe(true);
+    expect(isPinOnlyProfilePatch({ unpin: { slug: "boba" } })).toBe(true);
+  });
+
+  it("does not classify identity edits as pin-only patches", () => {
+    expect(
+      isPinOnlyProfilePatch({
+        featuredPetSlugs: ["boba"],
+        bio: "tiny pets",
+      }),
+    ).toBe(false);
+    expect(isPinOnlyProfilePatch({ displayName: "Petdex" })).toBe(false);
+    expect(isPinOnlyProfilePatch(null)).toBe(false);
   });
 });

--- a/src/lib/profiles.ts
+++ b/src/lib/profiles.ts
@@ -51,6 +51,19 @@ export function dedupePins(slugs: string[]): string[] {
   return out;
 }
 
+export function isPinOnlyProfilePatch(body: unknown): boolean {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return false;
+  const patch = body as Record<string, unknown>;
+  const hasPinMutation =
+    "featuredPetSlugs" in patch || "pin" in patch || "unpin" in patch;
+  const hasIdentityMutation =
+    "displayName" in patch ||
+    "handle" in patch ||
+    "bio" in patch ||
+    "preferredLocale" in patch;
+  return hasPinMutation && !hasIdentityMutation;
+}
+
 export function normalizeProfileDisplayName(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const normalized = value.replace(/\s+/g, " ").trim();

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -3,28 +3,26 @@ import { Redis } from "@upstash/redis";
 
 import { IS_MOCK } from "./mock";
 
-// In mock mode the contributor doesn't have Upstash credentials. Build a
-// stub that satisfies the Ratelimit constructor signature and always
-// returns success so rate-limited routes work end-to-end.
-const redis = IS_MOCK
-  ? ({
-      // biome-ignore lint/suspicious/noExplicitAny: shim must impersonate Redis client shape
-    } as any)
-  : Redis.fromEnv();
+const redis = Redis.fromEnv();
 
-// When mocked, override Ratelimit#limit to short-circuit before the
-// constructor tries to talk to Redis.
-if (IS_MOCK) {
-  (Ratelimit.prototype as unknown as { limit: unknown }).limit = async () => ({
-    success: true,
-    limit: Number.POSITIVE_INFINITY,
-    remaining: Number.POSITIVE_INFINITY,
-    reset: 0,
-    pending: Promise.resolve(),
-  });
+type RatelimitConfig = ConstructorParameters<typeof Ratelimit>[0];
+
+function createRatelimit(config: RatelimitConfig): Ratelimit {
+  if (IS_MOCK) {
+    return {
+      limit: async () => ({
+        success: true,
+        limit: Number.POSITIVE_INFINITY,
+        remaining: Number.POSITIVE_INFINITY,
+        reset: 0,
+        pending: Promise.resolve(),
+      }),
+    } as unknown as Ratelimit;
+  }
+  return new Ratelimit(config);
 }
 
-export const submitRatelimit = new Ratelimit({
+export const submitRatelimit = createRatelimit({
   redis,
   limiter: Ratelimit.slidingWindow(10, "24 h"),
   prefix: "petdex:submit",
@@ -33,7 +31,7 @@ export const submitRatelimit = new Ratelimit({
 
 // Withdrawals from /my-pets — generous so retries don't lock you out, but
 // stops a malicious automated loop.
-export const withdrawRatelimit = new Ratelimit({
+export const withdrawRatelimit = createRatelimit({
   redis,
   limiter: Ratelimit.slidingWindow(20, "10 m"),
   prefix: "petdex:withdraw",
@@ -41,7 +39,7 @@ export const withdrawRatelimit = new Ratelimit({
 
 // Claim attempts — anti-bruteforce for the cross-account flow even though
 // the verified-email check already blocks the actual data move.
-export const claimRatelimit = new Ratelimit({
+export const claimRatelimit = createRatelimit({
   redis,
   limiter: Ratelimit.slidingWindow(20, "1 h"),
   prefix: "petdex:claim",
@@ -49,14 +47,14 @@ export const claimRatelimit = new Ratelimit({
 
 // Public install-counter increments. Generous because a real user might
 // install dozens of pets, but caps obvious automation. Keyed by IP.
-export const installCounterRatelimit = new Ratelimit({
+export const installCounterRatelimit = createRatelimit({
   redis,
   limiter: Ratelimit.slidingWindow(60, "1 h"),
   prefix: "petdex:install-count",
 });
 
 // Zip-download tracker. Same shape as install-count.
-export const trackZipRatelimit = new Ratelimit({
+export const trackZipRatelimit = createRatelimit({
   redis,
   limiter: Ratelimit.slidingWindow(60, "1 h"),
   prefix: "petdex:track-zip",
@@ -64,7 +62,7 @@ export const trackZipRatelimit = new Ratelimit({
 
 // Likes — generous so legit users browsing the gallery never hit the cap,
 // but stops a 100-account brigade from inflating one pet to the top.
-export const likeRatelimit = new Ratelimit({
+export const likeRatelimit = createRatelimit({
   redis,
   limiter: Ratelimit.slidingWindow(60, "1 h"),
   prefix: "petdex:like",
@@ -72,7 +70,7 @@ export const likeRatelimit = new Ratelimit({
 
 // Pet requests + upvotes share a generous bucket — one user can shape the
 // roadmap up to 30 actions / 10 min before we slow them down.
-export const petRequestRatelimit = new Ratelimit({
+export const petRequestRatelimit = createRatelimit({
   redis,
   limiter: Ratelimit.slidingWindow(30, "10 m"),
   prefix: "petdex:requests",
@@ -81,7 +79,7 @@ export const petRequestRatelimit = new Ratelimit({
 // R2 presign requests. Without this, a logged-in attacker can request
 // thousands of presigned PUT URLs in a loop and waste R2 storage cost
 // even if they never call /api/submit/register afterwards.
-export const presignRatelimit = new Ratelimit({
+export const presignRatelimit = createRatelimit({
   redis,
   limiter: Ratelimit.slidingWindow(20, "1 h"),
   prefix: "petdex:presign",
@@ -89,7 +87,7 @@ export const presignRatelimit = new Ratelimit({
 
 // CLI bearer verification by IP — stops blind floods of bogus tokens
 // burning Clerk userinfo quota.
-export const cliVerifyRatelimit = new Ratelimit({
+export const cliVerifyRatelimit = createRatelimit({
   redis,
   limiter: Ratelimit.slidingWindow(120, "1 m"),
   prefix: "petdex:cli-verify",
@@ -98,16 +96,26 @@ export const cliVerifyRatelimit = new Ratelimit({
 // Owner edits to displayName/description/tags. Generous within the day so
 // the owner can iterate copy, but caps a malicious loop that floods the
 // admin queue with edit churn. Keyed by petId.
-export const editRatelimit = new Ratelimit({
+export const editRatelimit = createRatelimit({
   redis,
   limiter: Ratelimit.slidingWindow(5, "24 h"),
   prefix: "petdex:edit",
 });
 
-// User profile edits (bio, featured pet pin). Self-expression, no
-// admin review, so we only need to stop spam loops. Keyed by userId.
-export const profileEditRatelimit = new Ratelimit({
+// User profile identity edits (display name, handle, bio, locale).
+// Self-expression, no admin review, so we only need to stop spam loops.
+// Keyed by userId.
+export const profileEditRatelimit = createRatelimit({
   redis,
   limiter: Ratelimit.slidingWindow(10, "24 h"),
   prefix: "petdex:profile-edit",
+});
+
+// Pin and pinned-order edits can happen repeatedly while curating a
+// profile. Keep the abuse cap, but make it generous enough for drag
+// auto-save and one-click pin/unpin flows.
+export const profilePinRatelimit = createRatelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(60, "24 h"),
+  prefix: "petdex:profile-pin",
 });


### PR DESCRIPTION
## Summary
- Add owner-only pinned-pet reorder mode on profile pages
- Auto-save reordered `featuredPetSlugs` after drag/drop or move-button changes
- Preserve existing pin/unpin behavior, max pinned count, and public read-only display
- Add a more generous profile pin/order rate-limit bucket for pin-only profile mutations
- Stabilize mock DB setup for local profile QA

Closes #95

## Verification
- `bun test src/components/pinned-reorder-grid.test.ts src/lib/profiles.test.ts`
- `./node_modules/.bin/biome check src/lib/mock/db.ts src/lib/ratelimit.ts src/app/api/profile/route.ts src/components/pinned-reorder-grid.tsx src/components/pinned-reorder-grid.test.ts src/lib/profiles.ts src/lib/profiles.test.ts`
- `bun --env-file=.env.mock run build`
- Browser QA on `http://localhost:3000/u/contributor`: owner reorder mode, drag/drop, auto-save persistence after reload, and existing pin/unpin flow

## Notes
- Full `bun test` still fails on existing unrelated environment/import issues in `src/lib/security.test.ts` and `src/lib/pet-search.test.ts`.
- Full `bun run check` still reports existing repo-wide Biome diagnostics outside this feature scope.
- `bun run build` without `.env.mock` requires production DB/Redis environment variables.