### PR TITLE
perf(cdn): ISR home + collections, move per-visitor data to client

### DIFF
--- a/src/app/[locale]/collections/page.tsx
+++ b/src/app/[locale]/collections/page.tsx
@@ -11,7 +11,10 @@ import { JsonLd } from "@/components/json-ld";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 
-export const dynamic = "force-dynamic";
+// /collections is fully public — no auth, no cookies, no per-visitor
+// data. ISR with 5 minute revalidation lets featured-collection
+// rotations show up quickly without waking a function on every visit.
+export const revalidate = 300;
 
 const SITE_URL = "https://petdex.crafter.run";
 

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,9 +1,7 @@
 import Link from "next/link";
 
-import { auth } from "@clerk/nextjs/server";
 import { getTranslations } from "next-intl/server";
 
-import { getCaughtSlugSet } from "@/lib/catch-status";
 import {
   getFeaturedCollections,
   type PetCollectionWithPets,
@@ -16,7 +14,6 @@ import {
   getFeaturedPetsWithMetrics,
   type PetWithMetrics,
 } from "@/lib/pets";
-import { readShuffleSeed } from "@/lib/shuffle-seed";
 
 import { CollectionCover } from "@/components/collection-cover";
 import { CommandLine } from "@/components/command-line";
@@ -29,37 +26,36 @@ import { SiteHeader } from "@/components/site-header";
 import { SubmitCTA } from "@/components/submit-cta";
 import { SurprisePetCard } from "@/components/surprise-pet-card";
 
-export const dynamic = "force-dynamic";
+// ISR. The home page used to be force-dynamic because it pulled the
+// visitor's shuffle seed cookie and caught-slug set. Both moved to
+// the client: PetGallery re-fetches /api/pets/search after hydration
+// (which picks up the cookie) and /api/me/caught-slugs feeds the
+// "caught" highlight. The server now renders an alpha-ordered, anon
+// shell that the edge can cache for 60s — enough to keep new pets
+// surfacing without waking a function on every visit.
+export const revalidate = 60;
 export const metadata = {
   alternates: buildLocaleAlternates("/"),
 };
 const SITE_URL = "https://petdex.crafter.run";
 
 export default async function Home() {
-  const { userId } = await auth();
   const t = await getTranslations("home");
-
-  // Read the visitor's shuffle seed (minted by the middleware on the
-  // very first request, so every subsequent SSR + /api/pets/search call
-  // shares the same ordering). On the first visit the cookie isn't on
-  // *this* request yet — searchPets falls back to alpha for that single
-  // SSR, then the next navigation picks up the freshly-minted seed.
-  // See lib/shuffle-seed.ts + proxy.ts for context.
-  const shuffleSeed = (await readShuffleSeed()) ?? undefined;
 
   const [
     heroPets,
     totalPets,
     initialSearch,
     dexEntries,
-    caughtSlugs,
     allFeaturedCollections,
   ] = await Promise.all([
     getFeaturedPetsWithMetrics(6),
     getApprovedPetCount(),
-    searchPets({ sort: "curated", shuffleSeed }),
+    // No shuffleSeed → searchPets falls back to alpha order, which is
+    // the same for every visitor and therefore safe to cache. The
+    // client re-fetches with the visitor's seed on hydration.
+    searchPets({ sort: "curated" }),
     getDexNumberMap(),
-    getCaughtSlugSet(userId),
     getFeaturedCollections(20),
   ]);
 
@@ -78,7 +74,6 @@ export default async function Home() {
   // Plain-object so the server -> client serializer doesn't choke on a
   // Map. Same source of truth either way.
   const dexMap = Object.fromEntries(dexEntries.entries());
-  const caughtSlugList = Array.from(caughtSlugs);
 
   const jsonLd = [
     {
@@ -181,7 +176,6 @@ export default async function Home() {
             initial={initialSearch}
             totalPets={totalPets}
             dexMap={dexMap}
-            caughtSlugs={caughtSlugList}
           />
         ) : null}
       </section>

--- a/src/app/api/me/caught-slugs/route.ts
+++ b/src/app/api/me/caught-slugs/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+
+import { auth } from "@clerk/nextjs/server";
+
+import { getCaughtSlugSet } from "@/lib/catch-status";
+
+export const runtime = "nodejs";
+
+// Per-visitor list of pet slugs the signed-in user has caught (liked).
+// Pulled out of the home page SSR so the gallery can stay statically
+// rendered. The client fetches this after hydration and applies the
+// "caught" highlight to PetCard. Anonymous viewers get an empty array.
+export async function GET(): Promise<Response> {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json(
+      { caught: [] },
+      { headers: { "Cache-Control": "private, no-store" } },
+    );
+  }
+  const set = await getCaughtSlugSet(userId);
+  return NextResponse.json(
+    { caught: Array.from(set) },
+    { headers: { "Cache-Control": "private, no-store" } },
+  );
+}

--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -99,7 +99,30 @@ export function PetGallery({
   const [activeColors, setActiveColors] = useState<Set<ColorFamily>>(new Set());
   const [activeBatches, setActiveBatches] = useState<Set<string>>(new Set());
   const [sort, setSort] = useState<SortKey>("curated");
-  const caughtSet = new Set(caughtSlugs ?? []);
+  // The home page no longer ships caughtSlugs server-side — that would
+  // make every SSR render per-visitor and kill ISR. When the prop is
+  // missing we fetch /api/me/caught-slugs after hydration so the
+  // "caught" highlight on PetCard still works for signed-in users
+  // without holding up the static shell.
+  const [hydratedCaught, setHydratedCaught] = useState<string[] | null>(null);
+  useEffect(() => {
+    if (caughtSlugs !== undefined) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch("/api/me/caught-slugs");
+        if (!res.ok) return;
+        const data = (await res.json()) as { caught: string[] };
+        if (!cancelled) setHydratedCaught(data.caught);
+      } catch {
+        /* anonymous viewers + offline fall through */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [caughtSlugs]);
+  const caughtSet = new Set(caughtSlugs ?? hydratedCaught ?? []);
 
   const [pets, setPets] = useState<PetWithMetrics[]>(initial.pets);
   const [total, setTotal] = useState<number>(initial.total);


### PR DESCRIPTION
## What

Follow-up to #109 (already merged). Picks up the deferred ISR work for the two highest-traffic pages.

## Changes

### Home (`/[locale]/page.tsx`)
Was `force-dynamic`. Now `revalidate = 60`. The two things that made it dynamic moved to the client:

- **shuffleSeed**: `PetGallery` already re-fetches `/api/pets/search` after hydration, which picks up the visitor's seed cookie there. The initial render uses alpha order so it's identical for every visitor (and therefore safe to cache). The reorder happens on first client paint.
- **caughtSlugs**: new endpoint `/api/me/caught-slugs` returns the slug set for the signed-in viewer. `PetGallery` fetches it after mount and applies the "caught" highlight to PetCards. Anonymous viewers short-circuit to `[]`.

The endpoint sets `Cache-Control: private, no-store` so per-user data never lands in the edge cache.

### Collections index (`/[locale]/collections/page.tsx`)
Was `force-dynamic` for no reason — no auth, no cookies, no per-visitor data. Now `revalidate = 300`.

### New endpoint
`/api/me/caught-slugs` — auth-gated, returns `{ caught: string[] }` for the signed-in viewer. Anon → `{ caught: [] }`.

## Why it works

| What | Before | After |
|---|---|---|
| Home request from anon viewer | function invocation, full SSR | edge cache hit, no function |
| Home request from signed-in viewer | function invocation, full SSR | edge cache hit + 1 client fetch to `/api/me/caught-slugs` |
| Collections index | function invocation | edge cache hit |

The shuffle reorder happens on first client paint. Most visitors won't notice — initial alpha order shows up, then ~150ms later the personalized order replaces it. Same UX as today's loading state for sort changes.

## Out of scope

`/u/<handle>` still uses `auth()` to surface owner submissions, collection editor, catch progress, and the pinned reorder grid in a single SSR pass. Refactoring it to a public shell + client-side owner overlay needs a new endpoint plus restructuring `ProfileTabs`, and the page is per-user low-traffic so the ROI is much lower than the home. Leaving for a follow-up if the bill stays high after this lands.

## Verification

- `bun --bun tsc --noEmit` clean
- `bun test` 46/46 pass
- `biome check` clean on touched files
- Smoke tested locally via `bun run dev:mock`: \`/\`, \`/collections\`, \`/api/me/caught-slugs\` all 200
- Gallery renders correctly with caught highlight after sign-in
- PetGallery re-fetch picks up shuffle seed cookie on hydration

## Test plan

- [ ] Verify home returns ISR cache headers (\`x-vercel-cache: HIT\` after first hit) on prod
- [ ] Verify \`/api/me/caught-slugs\` returns 200 with empty array for anon viewer
- [ ] Confirm signed-in viewer's caught pets still render with the heart highlight on \`/\`
- [ ] Watch Vercel dashboard daily burn rate for 48h after merge — expect another drop of ~30% on top of #109