### PR TITLE
feat(api): rate-limit /api/manifest/full per user

### DIFF
--- a/src/app/api/manifest/full/route.ts
+++ b/src/app/api/manifest/full/route.ts
@@ -5,6 +5,7 @@ import { auth } from "@clerk/nextjs/server";
 import { getAllPetsPackPath } from "@/lib/downloads";
 import { logManifestFetch } from "@/lib/manifest-telemetry";
 import { getAllApprovedPets } from "@/lib/pets";
+import { manifestFullRatelimit } from "@/lib/ratelimit";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -12,10 +13,27 @@ export const dynamic = "force-dynamic";
 // Authenticated, full-fat manifest. Only returns when the caller is
 // signed in. Surfaces description, tags, vibes, install commands,
 // page URLs and counts — anything richer than the slim public path.
+//
+// Rate-limited per userId because the response is heavy (full DB scan)
+// and the endpoint cannot be edge-cached — every hit wakes a function.
 export async function GET(req: Request): Promise<Response> {
   const { userId } = await auth();
   if (!userId) {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+  const lim = await manifestFullRatelimit.limit(userId);
+  if (!lim.success) {
+    return NextResponse.json(
+      { error: "rate_limited", retryAfter: lim.reset },
+      {
+        status: 429,
+        headers: {
+          "Retry-After": String(
+            Math.max(1, Math.ceil((lim.reset - Date.now()) / 1000)),
+          ),
+        },
+      },
+    );
   }
   void logManifestFetch(req, "full");
 

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -119,3 +119,16 @@ export const profilePinRatelimit = createRatelimit({
   limiter: Ratelimit.slidingWindow(60, "24 h"),
   prefix: "petdex:profile-pin",
 });
+
+// /api/manifest/full pulls the full pet catalog with descriptions,
+// tags, install commands, page URLs, and asset paths. It's auth-gated
+// so it only fires for signed-in users, but the response is bigger
+// than slim and re-runs a full DB scan on every hit. 120 reqs/hour
+// per user covers any reasonable CLI / dashboard / scripting workflow
+// (CLI does 1 per `petdex install`, ~50/h is the realistic ceiling)
+// while shutting down a loop. Keyed by userId.
+export const manifestFullRatelimit = createRatelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(120, "1 h"),
+  prefix: "petdex:manifest-full",
+});


### PR DESCRIPTION
## What

Adds `manifestFullRatelimit` at **120 reqs/hour per userId** to `/api/manifest/full`.

## Why

The endpoint:
- Is auth-gated (only signed-in users can reach it)
- Cannot be edge-cached (per-user, with `private` cache hint)
- Returns the full pet catalog with descriptions, install commands, asset URLs, page URLs — heavier than slim
- Re-runs a full DB scan on every hit

Without a ratelimit, a signed-in user with a loop (or a leaked Clerk session token) could burn function invocations + bandwidth indefinitely. Not exploited today, but it's a latent vulnerability that costs $0 in code to close.

## Audit

Before shipping I checked the `manifest_fetches` table over the last 7 days. Top fetcher had 83 hits and was on `/api/manifest` (slim, public). Zero `/full` hits made the top 15. **No active abuse to fix** — this is preventive.

## Limits chosen

- **120 reqs/hour per userId** — sliding window. Realistic ceiling for legit use (CLI, scripts, dashboard polling) is ~50/h, so 120 leaves headroom while shutting down obvious abuse loops.
- 429 response includes `Retry-After` header so well-behaved clients back off without retry storms.

## Verification

- `bun --bun tsc --noEmit` clean
- `bun test` 46/46 pass
- `biome check` clean

## Test plan

- [ ] Verify a signed-in user can hit `/api/manifest/full` ≤ 120 times in an hour
- [ ] Verify the 121st request returns 429 with a `Retry-After` header
- [ ] Confirm the existing CLI flows are well below the limit (they make ≤ 1 call per `petdex install`)