### PR TITLE
feat(admin): operational insights dashboard

### DIFF
--- a/src/app/[locale]/admin/insights/page.tsx
+++ b/src/app/[locale]/admin/insights/page.tsx
@@ -1,0 +1,297 @@
+import Link from "next/link";
+
+import { Heart, Plus, TerminalSquare, Users } from "lucide-react";
+
+import {
+  getActiveCreators,
+  getHiddenHits,
+  getOverviewStats,
+  getQueueDepth,
+  getSubmissionVelocity,
+} from "@/lib/admin-insights";
+
+import { AdminVelocityChart } from "@/components/admin-velocity-chart";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Insights — Petdex admin",
+  robots: { index: false, follow: false },
+};
+
+export default async function AdminInsightsPage() {
+  const [overview, queueDepth, velocity, hiddenHits, activeCreators] =
+    await Promise.all([
+      getOverviewStats(),
+      getQueueDepth(),
+      getSubmissionVelocity(24),
+      getHiddenHits(8),
+      getActiveCreators(7, 12),
+    ]);
+
+  return (
+    <section className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-5 pb-16 md:px-8">
+      <header>
+        <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
+          Insights
+        </p>
+        <h1 className="mt-2 text-balance text-3xl font-semibold tracking-tight text-foreground md:text-4xl">
+          Operational dashboard
+        </h1>
+        <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-2">
+          Numbers Vercel and Clerk don't surface — submission throughput, queue
+          health, hidden hits in the catalog, and active creators.
+        </p>
+      </header>
+
+      {/* Headline cards */}
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          label="Approved"
+          value={overview.totalApproved}
+          delta={`+${overview.approvedLast24h} last 24h`}
+          icon={<Plus className="size-3.5" />}
+        />
+        <StatCard
+          label="Active creators"
+          value={overview.totalCreators}
+          delta={`${activeCreators.length} shipped this week`}
+          icon={<Users className="size-3.5" />}
+        />
+        <StatCard
+          label="Total likes"
+          value={overview.totalLikes}
+          delta={`${overview.totalInstalls.toLocaleString()} total installs`}
+          icon={<Heart className="size-3.5" />}
+        />
+        <StatCard
+          label="Approved last 7d"
+          value={overview.approvedLast7d}
+          delta={`${overview.totalRejected} rejected lifetime`}
+          icon={<TerminalSquare className="size-3.5" />}
+        />
+      </div>
+
+      {/* Queue depth */}
+      <section className="rounded-3xl border border-border-base bg-surface/80 p-5 backdrop-blur md:p-6">
+        <header className="mb-4 flex flex-wrap items-end justify-between gap-2">
+          <div>
+            <p className="font-mono text-[10px] tracking-[0.22em] text-brand uppercase">
+              Queue depth
+            </p>
+            <h2 className="mt-1 text-xl font-semibold tracking-tight text-foreground md:text-2xl">
+              {overview.totalPending === 1
+                ? "1 submission waiting"
+                : `${overview.totalPending} submissions waiting`}
+            </h2>
+          </div>
+          <Link
+            href="/admin"
+            className="inline-flex h-8 items-center rounded-full border border-border-base bg-surface px-3 text-xs font-medium text-muted-2 transition hover:border-border-strong hover:text-foreground"
+          >
+            Open queue →
+          </Link>
+        </header>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <QueueRow
+            label="New submissions"
+            count={queueDepth.pending}
+            ageMinutes={queueDepth.oldestPendingAgeMinutes}
+            tone="warning"
+          />
+          <QueueRow
+            label="Pending edits"
+            count={queueDepth.pendingEdits}
+            ageMinutes={queueDepth.oldestPendingEditAgeMinutes}
+            tone="default"
+          />
+        </div>
+      </section>
+
+      {/* Submission velocity */}
+      <section className="rounded-3xl border border-border-base bg-surface/80 p-5 backdrop-blur md:p-6">
+        <header className="mb-4">
+          <p className="font-mono text-[10px] tracking-[0.22em] text-brand uppercase">
+            Submission velocity
+          </p>
+          <h2 className="mt-1 text-xl font-semibold tracking-tight text-foreground md:text-2xl">
+            Hourly submissions, last 24 hours
+          </h2>
+        </header>
+        <AdminVelocityChart data={velocity} />
+      </section>
+
+      {/* Hidden hits */}
+      <section className="rounded-3xl border border-border-base bg-surface/80 p-5 backdrop-blur md:p-6">
+        <header className="mb-4">
+          <p className="font-mono text-[10px] tracking-[0.22em] text-brand uppercase">
+            Hidden hits
+          </p>
+          <h2 className="mt-1 text-xl font-semibold tracking-tight text-foreground md:text-2xl">
+            High install-to-like ratio, not yet featured
+          </h2>
+          <p className="mt-1 text-xs text-muted-3">
+            Pets quietly converting installs without much heart pressure.
+            Promote-worthy candidates.
+          </p>
+        </header>
+        {hiddenHits.length === 0 ? (
+          <p className="text-sm text-muted-3">
+            Nothing crossed the install threshold yet.
+          </p>
+        ) : (
+          <ul className="divide-y divide-black/[0.05] dark:divide-white/[0.05]">
+            {hiddenHits.map((pet) => {
+              const ratio =
+                pet.likeCount > 0
+                  ? (pet.installCount / pet.likeCount).toFixed(2)
+                  : `${pet.installCount}.0`;
+              return (
+                <li
+                  key={pet.slug}
+                  className="flex flex-wrap items-center justify-between gap-3 py-2.5"
+                >
+                  <div className="flex flex-col">
+                    <Link
+                      href={`/pets/${pet.slug}`}
+                      className="font-medium text-foreground transition hover:text-brand"
+                    >
+                      {pet.displayName}
+                    </Link>
+                    <span className="font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
+                      {pet.slug}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-4 font-mono text-[11px] tracking-[0.16em] text-muted-2 uppercase">
+                    <span className="inline-flex items-center gap-1">
+                      <TerminalSquare className="size-3" />
+                      {pet.installCount}
+                    </span>
+                    <span className="inline-flex items-center gap-1">
+                      <Heart className="size-3" />
+                      {pet.likeCount}
+                    </span>
+                    <span className="rounded-full bg-chip-success-bg px-2 py-0.5 text-chip-success-fg">
+                      {ratio}× ratio
+                    </span>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      {/* Active creators */}
+      <section className="rounded-3xl border border-border-base bg-surface/80 p-5 backdrop-blur md:p-6">
+        <header className="mb-4">
+          <p className="font-mono text-[10px] tracking-[0.22em] text-brand uppercase">
+            Active creators
+          </p>
+          <h2 className="mt-1 text-xl font-semibold tracking-tight text-foreground md:text-2xl">
+            Shipped a submission in the last 7 days
+          </h2>
+        </header>
+        {activeCreators.length === 0 ? (
+          <p className="text-sm text-muted-3">No creator activity this week.</p>
+        ) : (
+          <ul className="grid gap-2 sm:grid-cols-2">
+            {activeCreators.map((creator) => (
+              <li
+                key={creator.ownerId}
+                className="flex items-center justify-between rounded-2xl bg-background/40 px-3 py-2 text-sm"
+              >
+                <span className="truncate text-foreground">
+                  {creator.creditName ?? `${creator.ownerId.slice(-8)}…`}
+                </span>
+                <span className="ml-3 shrink-0 font-mono text-[10px] tracking-[0.16em] text-muted-3 uppercase">
+                  {creator.approvedCount > 0
+                    ? `${creator.approvedCount} approved`
+                    : `${formatRelative(creator.lastSubmittedAt)} ago`}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </section>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  delta,
+  icon,
+}: {
+  label: string;
+  value: number;
+  delta?: string;
+  icon: React.ReactNode;
+}) {
+  return (
+    <article className="rounded-3xl border border-border-base bg-surface/80 p-4 backdrop-blur">
+      <header className="flex items-center gap-1.5 font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
+        {icon}
+        {label}
+      </header>
+      <p className="mt-2 font-mono text-3xl font-semibold tracking-tight text-foreground">
+        {value.toLocaleString()}
+      </p>
+      {delta ? <p className="mt-1 text-xs text-muted-2">{delta}</p> : null}
+    </article>
+  );
+}
+
+function QueueRow({
+  label,
+  count,
+  ageMinutes,
+  tone,
+}: {
+  label: string;
+  count: number;
+  ageMinutes: number | null;
+  tone: "warning" | "default";
+}) {
+  const tint =
+    tone === "warning" &&
+    count > 0 &&
+    ageMinutes != null &&
+    ageMinutes > 24 * 60
+      ? "border-chip-warning-fg/30 bg-chip-warning-bg text-chip-warning-fg"
+      : "border-border-base bg-background/40 text-foreground";
+  return (
+    <div className={`rounded-2xl border px-3 py-3 ${tint}`}>
+      <p className="font-mono text-[10px] tracking-[0.18em] uppercase opacity-70">
+        {label}
+      </p>
+      <p className="mt-1 font-mono text-2xl font-semibold tracking-tight">
+        {count}
+      </p>
+      <p className="mt-1 text-xs opacity-80">
+        {count === 0
+          ? "All caught up"
+          : ageMinutes == null
+            ? "Oldest unknown"
+            : `Oldest ${formatAge(ageMinutes)}`}
+      </p>
+    </div>
+  );
+}
+
+function formatAge(minutes: number): string {
+  if (minutes < 60) return `${Math.round(minutes)}m`;
+  if (minutes < 60 * 24) return `${Math.round(minutes / 60)}h`;
+  return `${Math.round(minutes / (60 * 24))}d`;
+}
+
+function formatRelative(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const min = Math.round(diff / 60000);
+  if (min < 60) return `${min}m`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h`;
+  const d = Math.round(hr / 24);
+  return `${d}d`;
+}

--- a/src/components/admin-tabs.tsx
+++ b/src/components/admin-tabs.tsx
@@ -15,7 +15,8 @@ const TABS: Array<{
     | "requests"
     | "collections"
     | "feedback"
-    | "manifest";
+    | "manifest"
+    | "insights";
   match: (pathname: string) => boolean;
 }> = [
   {
@@ -47,6 +48,11 @@ const TABS: Array<{
     href: "/admin/manifest",
     key: "manifest",
     match: (p) => p.startsWith("/admin/manifest"),
+  },
+  {
+    href: "/admin/insights",
+    key: "insights",
+    match: (p) => p.startsWith("/admin/insights"),
   },
 ];
 

--- a/src/components/admin-velocity-chart.tsx
+++ b/src/components/admin-velocity-chart.tsx
@@ -1,0 +1,109 @@
+// Tiny inline SVG bar chart for submission velocity. We avoid pulling
+// a chart library into the admin bundle — this is a single 24-hour
+// view of three counts per bucket. The y-scale is fitted to the
+// max(approved + pending + rejected) across the window so the chart
+// doesn't overflow even on big spikes.
+
+import type { SubmissionVelocityPoint } from "@/lib/admin-insights";
+
+type Props = {
+  data: SubmissionVelocityPoint[];
+};
+
+const COLORS = {
+  approved: "var(--chip-success-fg)",
+  pending: "var(--chip-warning-fg)",
+  rejected: "var(--chip-danger-fg)",
+};
+
+export function AdminVelocityChart({ data }: Props) {
+  const maxStack = data.reduce(
+    (acc, point) =>
+      Math.max(acc, point.approved + point.pending + point.rejected),
+    0,
+  );
+  if (data.length === 0 || maxStack === 0) {
+    return (
+      <p className="text-sm text-muted-3">
+        No submissions in the last 24 hours.
+      </p>
+    );
+  }
+  const yScale = 1 / maxStack; // unit = bar height fraction
+  const barWidthPct = 100 / data.length;
+
+  return (
+    <div className="space-y-3">
+      <div className="relative h-32 w-full">
+        <svg
+          role="img"
+          aria-label="Submissions per hour, last 24 hours"
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+          className="size-full"
+        >
+          <title>Submissions per hour, last 24 hours</title>
+          {data.map((point, i) => {
+            const x = i * barWidthPct;
+            const approvedH = point.approved * yScale * 100;
+            const pendingH = point.pending * yScale * 100;
+            const rejectedH = point.rejected * yScale * 100;
+            const barW = barWidthPct * 0.78;
+            const xCenter = x + (barWidthPct - barW) / 2;
+            // Stack from bottom: approved → pending → rejected.
+            const yApproved = 100 - approvedH;
+            const yPending = yApproved - pendingH;
+            const yRejected = yPending - rejectedH;
+            return (
+              <g key={point.bucket}>
+                <rect
+                  x={xCenter}
+                  y={yApproved}
+                  width={barW}
+                  height={approvedH}
+                  fill={COLORS.approved}
+                  opacity={0.8}
+                />
+                <rect
+                  x={xCenter}
+                  y={yPending}
+                  width={barW}
+                  height={pendingH}
+                  fill={COLORS.pending}
+                  opacity={0.8}
+                />
+                <rect
+                  x={xCenter}
+                  y={yRejected}
+                  width={barW}
+                  height={rejectedH}
+                  fill={COLORS.rejected}
+                  opacity={0.8}
+                />
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+      <div className="flex items-center gap-4 font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
+        <Legend color={COLORS.approved} label="Approved" />
+        <Legend color={COLORS.pending} label="Pending" />
+        <Legend color={COLORS.rejected} label="Rejected" />
+        <span className="ml-auto">Last 24h • peak {maxStack}/h</span>
+      </div>
+    </div>
+  );
+}
+
+function Legend({ color, label }: { color: string; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span
+        aria-hidden
+        className="inline-block size-2.5 rounded-sm"
+        style={{ backgroundColor: color }}
+      />
+      {label}
+    </span>
+  );
+}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -129,7 +129,8 @@
       "requests": "Requests",
       "collections": "Collections",
       "feedback": "Feedback",
-      "manifest": "Manifest"
+      "manifest": "Manifest",
+      "insights": "Insights"
     },
     "status": {
       "pending": "Pending",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -129,7 +129,8 @@
       "requests": "Pedidos",
       "collections": "Colecciones",
       "feedback": "Feedback",
-      "manifest": "Manifest"
+      "manifest": "Manifest",
+      "insights": "Métricas"
     },
     "status": {
       "pending": "Pendiente",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -163,7 +163,8 @@
       "requests": "请求",
       "collections": "合集",
       "feedback": "反馈",
-      "manifest": "Manifest"
+      "manifest": "Manifest",
+      "insights": "数据"
     },
     "status": {
       "pending": "待处理",

--- a/src/lib/admin-insights.ts
+++ b/src/lib/admin-insights.ts
@@ -1,0 +1,246 @@
+import "server-only";
+
+import { sql } from "drizzle-orm";
+
+import { db } from "@/lib/db/client";
+
+// All queries here are admin-only — no per-user gating, no row-level
+// filters beyond the obvious "approved" / "pending" splits. They run
+// against the live Postgres so numbers are real-time. Nothing is
+// cached at this layer; the page owns the revalidation policy.
+
+export type SubmissionVelocityPoint = {
+  bucket: string; // ISO timestamp at hour boundary
+  pending: number;
+  approved: number;
+  rejected: number;
+};
+
+// Submissions per hour for the last N hours, broken down by terminal
+// status. We bucket by the row's createdAt (when it landed in the
+// queue), not approvedAt — drift between submit and approve would
+// otherwise inflate "recent" buckets with old approvals.
+export async function getSubmissionVelocity(
+  hours = 24,
+): Promise<SubmissionVelocityPoint[]> {
+  const out = (await db.execute(sql`
+    WITH series AS (
+      SELECT generate_series(
+        date_trunc('hour', now() - interval '${sql.raw(`${hours} hours`)}'),
+        date_trunc('hour', now()),
+        interval '1 hour'
+      ) AS bucket
+    )
+    SELECT
+      series.bucket,
+      COALESCE(sum(CASE WHEN p.status = 'pending'  THEN 1 ELSE 0 END), 0) AS pending,
+      COALESCE(sum(CASE WHEN p.status = 'approved' THEN 1 ELSE 0 END), 0) AS approved,
+      COALESCE(sum(CASE WHEN p.status = 'rejected' THEN 1 ELSE 0 END), 0) AS rejected
+    FROM series
+    LEFT JOIN submitted_pets p
+      ON date_trunc('hour', p.created_at) = series.bucket
+    GROUP BY series.bucket
+    ORDER BY series.bucket ASC
+  `)) as unknown as {
+    rows: Array<{
+      bucket: string | Date;
+      pending: number | string;
+      approved: number | string;
+      rejected: number | string;
+    }>;
+  };
+  return (out.rows ?? []).map((row) => ({
+    bucket:
+      row.bucket instanceof Date
+        ? row.bucket.toISOString()
+        : String(row.bucket),
+    pending: Number(row.pending),
+    approved: Number(row.approved),
+    rejected: Number(row.rejected),
+  }));
+}
+
+export type QueueDepth = {
+  pending: number;
+  oldestPendingAgeMinutes: number | null;
+  pendingEdits: number;
+  oldestPendingEditAgeMinutes: number | null;
+};
+
+// Snapshot of the admin's open work: how many pets are waiting for a
+// first review, and how stale the oldest one is. Same for in-flight
+// edits to existing approved pets.
+export async function getQueueDepth(): Promise<QueueDepth> {
+  const out = (await db.execute(sql`
+    SELECT
+      (SELECT count(*) FROM submitted_pets WHERE status = 'pending' AND source <> 'discover') AS pending,
+      (SELECT extract(epoch FROM (now() - min(created_at))) / 60
+         FROM submitted_pets
+         WHERE status = 'pending' AND source <> 'discover') AS oldest_pending_age_minutes,
+      (SELECT count(*) FROM submitted_pets WHERE pending_submitted_at IS NOT NULL) AS pending_edits,
+      (SELECT extract(epoch FROM (now() - min(pending_submitted_at))) / 60
+         FROM submitted_pets
+         WHERE pending_submitted_at IS NOT NULL) AS oldest_pending_edit_age_minutes
+  `)) as unknown as {
+    rows: Array<{
+      pending: number | string;
+      oldest_pending_age_minutes: number | string | null;
+      pending_edits: number | string;
+      oldest_pending_edit_age_minutes: number | string | null;
+    }>;
+  };
+  const row = out.rows?.[0];
+  return {
+    pending: Number(row?.pending ?? 0),
+    oldestPendingAgeMinutes:
+      row?.oldest_pending_age_minutes != null
+        ? Number(row.oldest_pending_age_minutes)
+        : null,
+    pendingEdits: Number(row?.pending_edits ?? 0),
+    oldestPendingEditAgeMinutes:
+      row?.oldest_pending_edit_age_minutes != null
+        ? Number(row.oldest_pending_edit_age_minutes)
+        : null,
+  };
+}
+
+export type HiddenHit = {
+  slug: string;
+  displayName: string;
+  installCount: number;
+  zipDownloadCount: number;
+  likeCount: number;
+  approvedAt: string | null;
+};
+
+// Pets with a strong install-to-like ratio relative to the catalog
+// median. The interesting cohort is pets that aren't featured / pinned
+// but are quietly converting: they install at a higher rate per like
+// than the average pet, which means people who notice them follow
+// through. A signal for re-promote / pin to the landing strip.
+export async function getHiddenHits(limit = 10): Promise<HiddenHit[]> {
+  const out = (await db.execute(sql`
+    SELECT
+      p.slug,
+      p.display_name,
+      COALESCE(m.install_count, 0)      AS install_count,
+      COALESCE(m.zip_download_count, 0) AS zip_download_count,
+      COALESCE(m.like_count, 0)         AS like_count,
+      p.approved_at
+    FROM submitted_pets p
+    LEFT JOIN pet_metrics m ON m.pet_slug = p.slug
+    WHERE p.status = 'approved'
+      AND p.featured = false
+      AND COALESCE(m.install_count, 0) >= 3
+    ORDER BY
+      (COALESCE(m.install_count, 0)::float
+        / GREATEST(COALESCE(m.like_count, 0), 1)) DESC,
+      m.install_count DESC NULLS LAST
+    LIMIT ${limit}
+  `)) as unknown as {
+    rows: Array<{
+      slug: string;
+      display_name: string;
+      install_count: number | string;
+      zip_download_count: number | string;
+      like_count: number | string;
+      approved_at: string | Date | null;
+    }>;
+  };
+  return (out.rows ?? []).map((row) => ({
+    slug: row.slug,
+    displayName: row.display_name,
+    installCount: Number(row.install_count),
+    zipDownloadCount: Number(row.zip_download_count),
+    likeCount: Number(row.like_count),
+    approvedAt:
+      row.approved_at instanceof Date
+        ? row.approved_at.toISOString()
+        : (row.approved_at as string | null),
+  }));
+}
+
+export type ActiveCreator = {
+  ownerId: string;
+  creditName: string | null;
+  approvedCount: number;
+  lastSubmittedAt: string;
+};
+
+// Creators who shipped at least one submission in the last 7 days.
+// Sorts by recency first, then by approved count for tie-breaking.
+// Drives the "are creators churning?" health signal.
+export async function getActiveCreators(
+  days = 7,
+  limit = 20,
+): Promise<ActiveCreator[]> {
+  const out = (await db.execute(sql`
+    SELECT
+      p.owner_id,
+      max(p.credit_name) AS credit_name,
+      sum(CASE WHEN p.status = 'approved' THEN 1 ELSE 0 END) AS approved_count,
+      max(p.created_at) AS last_submitted_at
+    FROM submitted_pets p
+    WHERE p.created_at > now() - interval '${sql.raw(`${days} days`)}'
+      AND p.source <> 'discover'
+    GROUP BY p.owner_id
+    ORDER BY last_submitted_at DESC
+    LIMIT ${limit}
+  `)) as unknown as {
+    rows: Array<{
+      owner_id: string;
+      credit_name: string | null;
+      approved_count: number | string;
+      last_submitted_at: string | Date;
+    }>;
+  };
+  return (out.rows ?? []).map((row) => ({
+    ownerId: row.owner_id,
+    creditName: row.credit_name,
+    approvedCount: Number(row.approved_count),
+    lastSubmittedAt:
+      row.last_submitted_at instanceof Date
+        ? row.last_submitted_at.toISOString()
+        : String(row.last_submitted_at),
+  }));
+}
+
+export type OverviewStats = {
+  totalApproved: number;
+  totalPending: number;
+  totalRejected: number;
+  approvedLast24h: number;
+  approvedLast7d: number;
+  totalCreators: number;
+  totalLikes: number;
+  totalInstalls: number;
+};
+
+// Headline numbers for the top of the page. One round-trip via a
+// single sub-query block to keep the dashboard cheap on every reload.
+export async function getOverviewStats(): Promise<OverviewStats> {
+  const out = (await db.execute(sql`
+    SELECT
+      (SELECT count(*) FROM submitted_pets WHERE status = 'approved') AS total_approved,
+      (SELECT count(*) FROM submitted_pets WHERE status = 'pending'  AND source <> 'discover') AS total_pending,
+      (SELECT count(*) FROM submitted_pets WHERE status = 'rejected') AS total_rejected,
+      (SELECT count(*) FROM submitted_pets WHERE status = 'approved' AND approved_at > now() - interval '24 hours') AS approved_last_24h,
+      (SELECT count(*) FROM submitted_pets WHERE status = 'approved' AND approved_at > now() - interval '7 days')  AS approved_last_7d,
+      (SELECT count(distinct owner_id) FROM submitted_pets WHERE status = 'approved' AND source <> 'discover') AS total_creators,
+      (SELECT COALESCE(sum(like_count), 0)    FROM pet_metrics) AS total_likes,
+      (SELECT COALESCE(sum(install_count), 0) FROM pet_metrics) AS total_installs
+  `)) as unknown as {
+    rows: Array<Record<string, number | string>>;
+  };
+  const row = out.rows?.[0] ?? {};
+  return {
+    totalApproved: Number(row.total_approved ?? 0),
+    totalPending: Number(row.total_pending ?? 0),
+    totalRejected: Number(row.total_rejected ?? 0),
+    approvedLast24h: Number(row.approved_last_24h ?? 0),
+    approvedLast7d: Number(row.approved_last_7d ?? 0),
+    totalCreators: Number(row.total_creators ?? 0),
+    totalLikes: Number(row.total_likes ?? 0),
+    totalInstalls: Number(row.total_installs ?? 0),
+  };
+}


### PR DESCRIPTION
## What

New \`/admin/insights\` tab with five product-level metrics that neither Vercel Analytics nor the Clerk dashboard surface.

## Metrics

| Card | Question it answers |
|---|---|
| **Headline stats** (4 tiles) | Total approved, active creators, total likes/installs, approved last 7d. With deltas. |
| **Queue depth** | How many pets / edits are waiting on me, and how stale is the oldest one. Tints amber when > 24h. |
| **Submission velocity** | Hourly bar chart, last 24h, stacked by status. Detect spikes (lanzamientos) or drops (form roto). |
| **Hidden hits** | Approved + non-featured pets sorted by install/like ratio. Pets quietly converting → candidates for promotion. |
| **Active creators** | Who shipped a submission in the last 7 days. Detect creator churn. |

## Files

- \`src/lib/admin-insights.ts\` — all SQL queries, server-only, idempotent
- \`src/app/[locale]/admin/insights/page.tsx\` — server component, force-dynamic
- \`src/components/admin-velocity-chart.tsx\` — inline SVG bar chart, no library
- \`src/components/admin-tabs.tsx\` — added \`Insights\` tab
- \`src/i18n/messages/{en,es,zh}.json\` — tab label

## Why force-dynamic

Numbers must be real-time. Caching is the wrong move here — admins look at this dashboard to make decisions in the moment. The queries are cheap (5 single-shot sub-query blocks, each scans approved or pending which both have indexes).

## Verification

- \`bun --bun tsc --noEmit\` clean
- \`bun test\` 46/46 pass
- \`biome check\` clean
- \`bun run i18n:check\` clean
- Smoke tested locally with mock data: dashboard renders correctly with seeded pets, all five sections show, velocity chart draws bars
- Admin gate works: \`/admin/insights\` 404s for non-admin, 200 for admin

## What's not in this PR

The auto-review precision metric (% auto-approved / auto-rejected / held) only makes sense after #108 (Anthony's automated review) lands. I'll add a sixth card for it then.

## Test plan

- [ ] Hit \`/admin/insights\` as admin → all 5 sections render
- [ ] Hit as non-admin → 404
- [ ] Compare numbers against \`/admin\` queue (pending count should match exactly)
- [ ] Click a hidden-hit pet → lands on its public page