### PR TITLE
feat(pets): owner self-service delete

### DIFF
--- a/src/app/[locale]/admin/insights/page.tsx
+++ b/src/app/[locale]/admin/insights/page.tsx
@@ -1,0 +1,297 @@
+import Link from "next/link";
+
+import { Heart, Plus, TerminalSquare, Users } from "lucide-react";
+
+import {
+  getActiveCreators,
+  getHiddenHits,
+  getOverviewStats,
+  getQueueDepth,
+  getSubmissionVelocity,
+} from "@/lib/admin-insights";
+
+import { AdminVelocityChart } from "@/components/admin-velocity-chart";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Insights — Petdex admin",
+  robots: { index: false, follow: false },
+};
+
+export default async function AdminInsightsPage() {
+  const [overview, queueDepth, velocity, hiddenHits, activeCreators] =
+    await Promise.all([
+      getOverviewStats(),
+      getQueueDepth(),
+      getSubmissionVelocity(24),
+      getHiddenHits(8),
+      getActiveCreators(7, 12),
+    ]);
+
+  return (
+    <section className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-5 pb-16 md:px-8">
+      <header>
+        <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
+          Insights
+        </p>
+        <h1 className="mt-2 text-balance text-3xl font-semibold tracking-tight text-foreground md:text-4xl">
+          Operational dashboard
+        </h1>
+        <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-2">
+          Numbers Vercel and Clerk don't surface — submission throughput, queue
+          health, hidden hits in the catalog, and active creators.
+        </p>
+      </header>
+
+      {/* Headline cards */}
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          label="Approved"
+          value={overview.totalApproved}
+          delta={`+${overview.approvedLast24h} last 24h`}
+          icon={<Plus className="size-3.5" />}
+        />
+        <StatCard
+          label="Active creators"
+          value={overview.totalCreators}
+          delta={`${activeCreators.length} shipped this week`}
+          icon={<Users className="size-3.5" />}
+        />
+        <StatCard
+          label="Total likes"
+          value={overview.totalLikes}
+          delta={`${overview.totalInstalls.toLocaleString()} total installs`}
+          icon={<Heart className="size-3.5" />}
+        />
+        <StatCard
+          label="Approved last 7d"
+          value={overview.approvedLast7d}
+          delta={`${overview.totalRejected} rejected lifetime`}
+          icon={<TerminalSquare className="size-3.5" />}
+        />
+      </div>
+
+      {/* Queue depth */}
+      <section className="rounded-3xl border border-border-base bg-surface/80 p-5 backdrop-blur md:p-6">
+        <header className="mb-4 flex flex-wrap items-end justify-between gap-2">
+          <div>
+            <p className="font-mono text-[10px] tracking-[0.22em] text-brand uppercase">
+              Queue depth
+            </p>
+            <h2 className="mt-1 text-xl font-semibold tracking-tight text-foreground md:text-2xl">
+              {overview.totalPending === 1
+                ? "1 submission waiting"
+                : `${overview.totalPending} submissions waiting`}
+            </h2>
+          </div>
+          <Link
+            href="/admin"
+            className="inline-flex h-8 items-center rounded-full border border-border-base bg-surface px-3 text-xs font-medium text-muted-2 transition hover:border-border-strong hover:text-foreground"
+          >
+            Open queue →
+          </Link>
+        </header>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <QueueRow
+            label="New submissions"
+            count={queueDepth.pending}
+            ageMinutes={queueDepth.oldestPendingAgeMinutes}
+            tone="warning"
+          />
+          <QueueRow
+            label="Pending edits"
+            count={queueDepth.pendingEdits}
+            ageMinutes={queueDepth.oldestPendingEditAgeMinutes}
+            tone="default"
+          />
+        </div>
+      </section>
+
+      {/* Submission velocity */}
+      <section className="rounded-3xl border border-border-base bg-surface/80 p-5 backdrop-blur md:p-6">
+        <header className="mb-4">
+          <p className="font-mono text-[10px] tracking-[0.22em] text-brand uppercase">
+            Submission velocity
+          </p>
+          <h2 className="mt-1 text-xl font-semibold tracking-tight text-foreground md:text-2xl">
+            Hourly submissions, last 24 hours
+          </h2>
+        </header>
+        <AdminVelocityChart data={velocity} />
+      </section>
+
+      {/* Hidden hits */}
+      <section className="rounded-3xl border border-border-base bg-surface/80 p-5 backdrop-blur md:p-6">
+        <header className="mb-4">
+          <p className="font-mono text-[10px] tracking-[0.22em] text-brand uppercase">
+            Hidden hits
+          </p>
+          <h2 className="mt-1 text-xl font-semibold tracking-tight text-foreground md:text-2xl">
+            High install-to-like ratio, not yet featured
+          </h2>
+          <p className="mt-1 text-xs text-muted-3">
+            Pets quietly converting installs without much heart pressure.
+            Promote-worthy candidates.
+          </p>
+        </header>
+        {hiddenHits.length === 0 ? (
+          <p className="text-sm text-muted-3">
+            Nothing crossed the install threshold yet.
+          </p>
+        ) : (
+          <ul className="divide-y divide-black/[0.05] dark:divide-white/[0.05]">
+            {hiddenHits.map((pet) => {
+              const ratio =
+                pet.likeCount > 0
+                  ? (pet.installCount / pet.likeCount).toFixed(2)
+                  : `${pet.installCount}.0`;
+              return (
+                <li
+                  key={pet.slug}
+                  className="flex flex-wrap items-center justify-between gap-3 py-2.5"
+                >
+                  <div className="flex flex-col">
+                    <Link
+                      href={`/pets/${pet.slug}`}
+                      className="font-medium text-foreground transition hover:text-brand"
+                    >
+                      {pet.displayName}
+                    </Link>
+                    <span className="font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
+                      {pet.slug}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-4 font-mono text-[11px] tracking-[0.16em] text-muted-2 uppercase">
+                    <span className="inline-flex items-center gap-1">
+                      <TerminalSquare className="size-3" />
+                      {pet.installCount}
+                    </span>
+                    <span className="inline-flex items-center gap-1">
+                      <Heart className="size-3" />
+                      {pet.likeCount}
+                    </span>
+                    <span className="rounded-full bg-chip-success-bg px-2 py-0.5 text-chip-success-fg">
+                      {ratio}× ratio
+                    </span>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      {/* Active creators */}
+      <section className="rounded-3xl border border-border-base bg-surface/80 p-5 backdrop-blur md:p-6">
+        <header className="mb-4">
+          <p className="font-mono text-[10px] tracking-[0.22em] text-brand uppercase">
+            Active creators
+          </p>
+          <h2 className="mt-1 text-xl font-semibold tracking-tight text-foreground md:text-2xl">
+            Shipped a submission in the last 7 days
+          </h2>
+        </header>
+        {activeCreators.length === 0 ? (
+          <p className="text-sm text-muted-3">No creator activity this week.</p>
+        ) : (
+          <ul className="grid gap-2 sm:grid-cols-2">
+            {activeCreators.map((creator) => (
+              <li
+                key={creator.ownerId}
+                className="flex items-center justify-between rounded-2xl bg-background/40 px-3 py-2 text-sm"
+              >
+                <span className="truncate text-foreground">
+                  {creator.creditName ?? `${creator.ownerId.slice(-8)}…`}
+                </span>
+                <span className="ml-3 shrink-0 font-mono text-[10px] tracking-[0.16em] text-muted-3 uppercase">
+                  {creator.approvedCount > 0
+                    ? `${creator.approvedCount} approved`
+                    : `${formatRelative(creator.lastSubmittedAt)} ago`}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </section>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  delta,
+  icon,
+}: {
+  label: string;
+  value: number;
+  delta?: string;
+  icon: React.ReactNode;
+}) {
+  return (
+    <article className="rounded-3xl border border-border-base bg-surface/80 p-4 backdrop-blur">
+      <header className="flex items-center gap-1.5 font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
+        {icon}
+        {label}
+      </header>
+      <p className="mt-2 font-mono text-3xl font-semibold tracking-tight text-foreground">
+        {value.toLocaleString()}
+      </p>
+      {delta ? <p className="mt-1 text-xs text-muted-2">{delta}</p> : null}
+    </article>
+  );
+}
+
+function QueueRow({
+  label,
+  count,
+  ageMinutes,
+  tone,
+}: {
+  label: string;
+  count: number;
+  ageMinutes: number | null;
+  tone: "warning" | "default";
+}) {
+  const tint =
+    tone === "warning" &&
+    count > 0 &&
+    ageMinutes != null &&
+    ageMinutes > 24 * 60
+      ? "border-chip-warning-fg/30 bg-chip-warning-bg text-chip-warning-fg"
+      : "border-border-base bg-background/40 text-foreground";
+  return (
+    <div className={`rounded-2xl border px-3 py-3 ${tint}`}>
+      <p className="font-mono text-[10px] tracking-[0.18em] uppercase opacity-70">
+        {label}
+      </p>
+      <p className="mt-1 font-mono text-2xl font-semibold tracking-tight">
+        {count}
+      </p>
+      <p className="mt-1 text-xs opacity-80">
+        {count === 0
+          ? "All caught up"
+          : ageMinutes == null
+            ? "Oldest unknown"
+            : `Oldest ${formatAge(ageMinutes)}`}
+      </p>
+    </div>
+  );
+}
+
+function formatAge(minutes: number): string {
+  if (minutes < 60) return `${Math.round(minutes)}m`;
+  if (minutes < 60 * 24) return `${Math.round(minutes / 60)}h`;
+  return `${Math.round(minutes / (60 * 24))}d`;
+}
+
+function formatRelative(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const min = Math.round(diff / 60000);
+  if (min < 60) return `${min}m`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h`;
+  const d = Math.round(hr / 24);
+  return `${d}d`;
+}

--- a/src/app/api/admin/[id]/route.ts
+++ b/src/app/api/admin/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { auth } from "@clerk/nextjs/server";
-import { eq, sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { Resend } from "resend";
 
 import { isAdmin } from "@/lib/admin";
@@ -10,15 +10,14 @@ import { classifyColorFamily, extractDominantColor } from "@/lib/color-extract";
 import { db, schema } from "@/lib/db/client";
 import { renderSubmissionApprovedEmail } from "@/lib/email-templates/submission-approved";
 import { renderSubmissionRejectedEmail } from "@/lib/email-templates/submission-rejected";
-import { renderSubmissionTakedownEmail } from "@/lib/email-templates/submission-takedown";
 import { createNotification } from "@/lib/notifications";
 import {
   getApprovedPetMissingSoundBySlug,
   processPetSound,
 } from "@/lib/pet-sound";
-import { deleteR2Objects, keyFromR2Url } from "@/lib/r2";
 import { requireSameOrigin } from "@/lib/same-origin";
 import { refreshSimilarityFor } from "@/lib/similarity";
+import { takedownPet } from "@/lib/takedown";
 import { getPreferredLocaleForUser } from "@/lib/user-locale";
 
 export const runtime = "nodejs";
@@ -294,105 +293,11 @@ export async function DELETE(
     return NextResponse.json({ error: "not_found" }, { status: 404 });
   }
 
-  const slug = pet.slug;
-
-  // 1. Cross-table cleanup keyed by slug. None of these have FKs to
-  //    submitted_pets so they have to go by hand.
-  await db.delete(schema.petLikes).where(eq(schema.petLikes.petSlug, slug));
-  await db.delete(schema.petMetrics).where(eq(schema.petMetrics.petSlug, slug));
-  await db
-    .delete(schema.petCollectionItems)
-    .where(eq(schema.petCollectionItems.petSlug, slug));
-  await db
-    .delete(schema.petCollectionRequests)
-    .where(eq(schema.petCollectionRequests.petSlug, slug));
-
-  // 2. Null out collections that used this pet as their cover.
-  await db
-    .update(schema.petCollections)
-    .set({ coverPetSlug: null })
-    .where(eq(schema.petCollections.coverPetSlug, slug));
-
-  // 3. Reopen any pet request this submission fulfilled so it goes back
-  //    to the queue instead of pointing at a dead slug.
-  await db
-    .update(schema.petRequests)
-    .set({ fulfilledPetSlug: null, status: "open" })
-    .where(eq(schema.petRequests.fulfilledPetSlug, slug));
-
-  // 4. Strip the slug from any user_profile featured arrays. We only
-  //    touch profiles that actually contain the slug so the jsonb
-  //    rewrite stays scoped.
-  await db.execute(sql`
-    UPDATE user_profiles
-    SET featured_pet_slugs = (
-      SELECT COALESCE(jsonb_agg(elem), '[]'::jsonb)
-      FROM jsonb_array_elements(featured_pet_slugs) AS elem
-      WHERE elem <> to_jsonb(${slug}::text)
-    )
-    WHERE featured_pet_slugs @> to_jsonb(${slug}::text)
-  `);
-
-  // 5. Drop the row itself.
-  await db.delete(schema.submittedPets).where(eq(schema.submittedPets.id, id));
-
-  // 6. Best-effort R2 cleanup. We derive keys from the URLs the
-  //    submission stored; anything off-host (legacy or external credit
-  //    image) is skipped. R2 errors are logged but don't fail the
-  //    takedown — the DB is already gone.
-  const keys = [
-    keyFromR2Url(pet.spritesheetUrl),
-    keyFromR2Url(pet.petJsonUrl),
-    keyFromR2Url(pet.zipUrl),
-    keyFromR2Url(pet.soundUrl),
-  ].filter((k): k is string => Boolean(k));
-  try {
-    await deleteR2Objects(keys);
-  } catch (err) {
-    console.warn("[takedown] r2 cleanup failed", { id, slug, err });
-  }
-
-  // 7. Notify the owner so they know they can re-submit if needed.
-  void createNotification({
-    userId: pet.ownerId,
-    kind: "pet_rejected",
-    payload: {
-      petSlug: slug,
-      petName: pet.displayName,
-      ...(reason ? { reason } : {}),
-      takedown: true,
-    },
-    href: "/",
-  }).catch(() => {});
-
-  if (pet.ownerEmail && process.env.RESEND_API_KEY) {
-    try {
-      const resend = new Resend(process.env.RESEND_API_KEY);
-      const from =
-        process.env.RESEND_FROM ?? "Petdex <petdex@updates.railly.dev>";
-      const locale = await getPreferredLocaleForUser(pet.ownerId);
-      const email = renderSubmissionTakedownEmail(locale, {
-        petName: pet.displayName,
-        reason,
-      });
-      await resend.emails.send({
-        from,
-        to: pet.ownerEmail,
-        subject: email.subject,
-        html: email.html,
-        text: email.text,
-      });
-    } catch {
-      /* silent */
-    }
-  }
-
-  console.info("[takedown] pet removed", {
-    id,
-    slug,
-    by: userId,
+  await takedownPet({
+    pet,
     reason,
-    keys,
+    source: "admin",
+    actorId: userId ?? "unknown",
   });
 
   return NextResponse.json({ ok: true });

--- a/src/app/api/pets/[slug]/can-delete/route.ts
+++ b/src/app/api/pets/[slug]/can-delete/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+
+import { auth } from "@clerk/nextjs/server";
+import { eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/db/client";
+
+export const runtime = "nodejs";
+
+// Tells the client menu whether the current viewer is allowed to hard-
+// delete this pet. The check has to happen server-side because the
+// public PetdexPet shape deliberately omits ownerId (we don't want
+// Clerk user ids in any client bundle or API payload).
+//
+// The actual delete still re-checks ownership in DELETE /api/pets/
+// [slug]/owner — this endpoint is only a UI-affordance hint, never a
+// security boundary.
+type Params = { slug: string };
+
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<Params> },
+): Promise<Response> {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json(
+      { canDelete: false },
+      { headers: { "Cache-Control": "private, no-store" } },
+    );
+  }
+
+  const { slug } = await ctx.params;
+  if (!/^[a-z0-9-]{1,60}$/.test(slug)) {
+    return NextResponse.json({ error: "invalid_slug" }, { status: 400 });
+  }
+
+  const pet = await db.query.submittedPets.findFirst({
+    where: eq(schema.submittedPets.slug, slug),
+    columns: { ownerId: true, source: true },
+  });
+  if (!pet) {
+    return NextResponse.json(
+      { canDelete: false },
+      { headers: { "Cache-Control": "private, no-store" } },
+    );
+  }
+
+  const canDelete = pet.ownerId === userId && pet.source !== "discover";
+
+  return NextResponse.json(
+    { canDelete },
+    { headers: { "Cache-Control": "private, no-store" } },
+  );
+}

--- a/src/app/api/pets/[slug]/owner/route.ts
+++ b/src/app/api/pets/[slug]/owner/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from "next/server";
+
+import { auth } from "@clerk/nextjs/server";
+import { eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/db/client";
+import { withdrawRatelimit } from "@/lib/ratelimit";
+import { requireSameOrigin } from "@/lib/same-origin";
+import { takedownPet } from "@/lib/takedown";
+
+export const runtime = "nodejs";
+
+// Owner self-service delete. Hard-removes a pet the caller owns:
+// drops the DB row, every cross-table reference, and the R2 assets.
+// The slug becomes available for someone else to reuse.
+//
+// Used by the "Remove from Petdex" entry in the per-card action menu
+// when the viewer is the pet's owner. Mirrors the admin DELETE in
+// /api/admin/[id] but is keyed by slug (the menu has the slug, not
+// the pet id) and gated on owner_id rather than admin status.
+//
+// We deliberately do NOT support this for 'discover'-source pets the
+// caller hasn't claimed — those need to go through the claim flow on
+// /u/<handle> first so we know the actor really is the original
+// author.
+type DeleteBody = {
+  reason?: string | null;
+};
+
+type Params = { slug: string };
+
+export async function DELETE(
+  req: Request,
+  ctx: { params: Promise<Params> },
+): Promise<Response> {
+  const csrf = requireSameOrigin(req);
+  if (csrf) return csrf;
+
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const lim = await withdrawRatelimit.limit(userId);
+  if (!lim.success) {
+    return NextResponse.json(
+      { error: "rate_limited", retryAfter: lim.reset },
+      { status: 429 },
+    );
+  }
+
+  const { slug } = await ctx.params;
+  if (!/^[a-z0-9-]{1,60}$/.test(slug)) {
+    return NextResponse.json({ error: "invalid_slug" }, { status: 400 });
+  }
+
+  let body: DeleteBody = {};
+  try {
+    body = (await req.json().catch(() => ({}))) as DeleteBody;
+  } catch {
+    body = {};
+  }
+  const reason = body.reason?.trim() || null;
+
+  const pet = await db.query.submittedPets.findFirst({
+    where: eq(schema.submittedPets.slug, slug),
+  });
+  if (!pet) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+  if (pet.ownerId !== userId) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+  if (pet.source === "discover") {
+    return NextResponse.json(
+      {
+        error: "claim_required",
+        message:
+          "This pet was added on your behalf. Claim it from your profile first, then delete it.",
+      },
+      { status: 409 },
+    );
+  }
+
+  await takedownPet({
+    pet,
+    reason,
+    source: "owner",
+    actorId: userId,
+    // Owner triggered it — no need to email/notify themselves.
+    silent: true,
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/components/admin-tabs.tsx
+++ b/src/components/admin-tabs.tsx
@@ -15,7 +15,8 @@ const TABS: Array<{
     | "requests"
     | "collections"
     | "feedback"
-    | "manifest";
+    | "manifest"
+    | "insights";
   match: (pathname: string) => boolean;
 }> = [
   {
@@ -47,6 +48,11 @@ const TABS: Array<{
     href: "/admin/manifest",
     key: "manifest",
     match: (p) => p.startsWith("/admin/manifest"),
+  },
+  {
+    href: "/admin/insights",
+    key: "insights",
+    match: (p) => p.startsWith("/admin/insights"),
   },
 ];
 

--- a/src/components/admin-velocity-chart.tsx
+++ b/src/components/admin-velocity-chart.tsx
@@ -1,0 +1,109 @@
+// Tiny inline SVG bar chart for submission velocity. We avoid pulling
+// a chart library into the admin bundle — this is a single 24-hour
+// view of three counts per bucket. The y-scale is fitted to the
+// max(approved + pending + rejected) across the window so the chart
+// doesn't overflow even on big spikes.
+
+import type { SubmissionVelocityPoint } from "@/lib/admin-insights";
+
+type Props = {
+  data: SubmissionVelocityPoint[];
+};
+
+const COLORS = {
+  approved: "var(--chip-success-fg)",
+  pending: "var(--chip-warning-fg)",
+  rejected: "var(--chip-danger-fg)",
+};
+
+export function AdminVelocityChart({ data }: Props) {
+  const maxStack = data.reduce(
+    (acc, point) =>
+      Math.max(acc, point.approved + point.pending + point.rejected),
+    0,
+  );
+  if (data.length === 0 || maxStack === 0) {
+    return (
+      <p className="text-sm text-muted-3">
+        No submissions in the last 24 hours.
+      </p>
+    );
+  }
+  const yScale = 1 / maxStack; // unit = bar height fraction
+  const barWidthPct = 100 / data.length;
+
+  return (
+    <div className="space-y-3">
+      <div className="relative h-32 w-full">
+        <svg
+          role="img"
+          aria-label="Submissions per hour, last 24 hours"
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+          className="size-full"
+        >
+          <title>Submissions per hour, last 24 hours</title>
+          {data.map((point, i) => {
+            const x = i * barWidthPct;
+            const approvedH = point.approved * yScale * 100;
+            const pendingH = point.pending * yScale * 100;
+            const rejectedH = point.rejected * yScale * 100;
+            const barW = barWidthPct * 0.78;
+            const xCenter = x + (barWidthPct - barW) / 2;
+            // Stack from bottom: approved → pending → rejected.
+            const yApproved = 100 - approvedH;
+            const yPending = yApproved - pendingH;
+            const yRejected = yPending - rejectedH;
+            return (
+              <g key={point.bucket}>
+                <rect
+                  x={xCenter}
+                  y={yApproved}
+                  width={barW}
+                  height={approvedH}
+                  fill={COLORS.approved}
+                  opacity={0.8}
+                />
+                <rect
+                  x={xCenter}
+                  y={yPending}
+                  width={barW}
+                  height={pendingH}
+                  fill={COLORS.pending}
+                  opacity={0.8}
+                />
+                <rect
+                  x={xCenter}
+                  y={yRejected}
+                  width={barW}
+                  height={rejectedH}
+                  fill={COLORS.rejected}
+                  opacity={0.8}
+                />
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+      <div className="flex items-center gap-4 font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
+        <Legend color={COLORS.approved} label="Approved" />
+        <Legend color={COLORS.pending} label="Pending" />
+        <Legend color={COLORS.rejected} label="Rejected" />
+        <span className="ml-auto">Last 24h • peak {maxStack}/h</span>
+      </div>
+    </div>
+  );
+}
+
+function Legend({ color, label }: { color: string; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span
+        aria-hidden
+        className="inline-block size-2.5 rounded-sm"
+        style={{ backgroundColor: color }}
+      />
+      {label}
+    </span>
+  );
+}

--- a/src/components/pet-action-menu.tsx
+++ b/src/components/pet-action-menu.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { track } from "@vercel/analytics";
@@ -10,8 +11,10 @@ import {
   Download,
   ExternalLink,
   Link2,
+  Loader2,
   MoreHorizontal,
   Terminal,
+  Trash2,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
 
@@ -33,12 +36,46 @@ type Props = {
 
 export function PetActionMenu({ pet, variant = "card" }: Props) {
   const t = useTranslations("petActions");
+  const router = useRouter();
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState<"install" | "link" | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  // canDelete is fetched lazily the first time the menu opens. The
+  // public PetdexPet shape deliberately doesn't carry ownerId, so the
+  // viewer/owner check has to round-trip. /api/pets/[slug]/can-delete
+  // is auth-cookie gated and private, no-store — anonymous viewers
+  // get false instantly.
+  const [canDelete, setCanDelete] = useState<boolean | null>(null);
   const ref = useRef<HTMLDivElement | null>(null);
 
   const installCmd = `npx petdex install ${pet.slug}`;
   const pageUrl = `${SITE_URL}/pets/${pet.slug}`;
+
+  // Lazy ownership check. Only fires the first time the menu opens —
+  // result is cached in component state. If the user signs in / out
+  // mid-session the menu won't notice until next mount, but that's
+  // fine: the actual delete still re-checks ownership server-side.
+  useEffect(() => {
+    if (!open || canDelete !== null) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(`/api/pets/${pet.slug}/can-delete`);
+        if (!res.ok) {
+          if (!cancelled) setCanDelete(false);
+          return;
+        }
+        const data = (await res.json()) as { canDelete: boolean };
+        if (!cancelled) setCanDelete(Boolean(data.canDelete));
+      } catch {
+        if (!cancelled) setCanDelete(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, canDelete, pet.slug]);
 
   // Click outside / Esc closes the menu.
   useEffect(() => {
@@ -114,6 +151,47 @@ export function PetActionMenu({ pet, variant = "card" }: Props) {
     setOpen(false);
   }, [pet.slug]);
 
+  const onDelete = useCallback(async () => {
+    if (deleting) return;
+    // Two-step confirmation: typing the slug avoids muscle-memory
+    // clicks wiping a pet you actually still want. Same pattern the
+    // admin takedown uses.
+    const typed = window.prompt(
+      `Type "${pet.slug}" to confirm. This permanently removes ${pet.displayName} from Petdex and frees the slug. The pet's files and like history are deleted.`,
+    );
+    if (typed === null) return;
+    if (typed.trim() !== pet.slug) {
+      window.alert("Slug did not match. Pet was NOT removed.");
+      return;
+    }
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      const res = await fetch(`/api/pets/${pet.slug}/owner`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reason: "owner_self_delete" }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as {
+          error?: string;
+          message?: string;
+        };
+        setDeleteError(
+          data.message ?? data.error ?? `Request failed (${res.status})`,
+        );
+        setDeleting(false);
+        return;
+      }
+      track("pet_owner_deleted", { slug: pet.slug });
+      setOpen(false);
+      router.refresh();
+    } catch {
+      setDeleteError("network_error");
+      setDeleting(false);
+    }
+  }, [deleting, pet.slug, pet.displayName, router]);
+
   // Detail variant: bigger trigger that reads as an action button next to
   // the like button. Card variant: compact circular icon in a corner.
   const triggerClassName =
@@ -132,6 +210,7 @@ export function PetActionMenu({ pet, variant = "card" }: Props) {
       : "absolute right-0 top-full mt-2";
 
   return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: stopPropagation wrapper for card-anchor + escape, not an interactive role
     <div
       ref={ref}
       // While open, lift the wrapper above sibling cards. Sibling cards
@@ -199,7 +278,9 @@ export function PetActionMenu({ pet, variant = "card" }: Props) {
                   <Terminal className="size-4" />
                 )
               }
-              label={copied === "install" ? t("copiedInstall") : t("copyInstall")}
+              label={
+                copied === "install" ? t("copiedInstall") : t("copyInstall")
+              }
               hint={installCmd}
               onClick={() => copyText(installCmd, "install")}
             />
@@ -247,7 +328,35 @@ export function PetActionMenu({ pet, variant = "card" }: Props) {
                 </a>
               </li>
             ) : null}
+            {canDelete ? (
+              <li>
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    void onDelete();
+                  }}
+                  disabled={deleting}
+                  className="flex w-full items-center gap-2.5 border-t border-black/[0.06] px-3 py-2.5 text-left text-sm text-chip-danger-fg transition hover:bg-chip-danger-bg disabled:opacity-60 dark:border-white/[0.06]"
+                >
+                  {deleting ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Trash2 className="size-4" />
+                  )}
+                  <span className="flex-1">
+                    {deleting ? t("removing") : t("removeFromPetdex")}
+                  </span>
+                </button>
+              </li>
+            ) : null}
           </ul>
+          {deleteError ? (
+            <p className="border-t border-black/[0.06] bg-chip-danger-bg px-3 py-2 text-xs text-chip-danger-fg dark:border-white/[0.06]">
+              {deleteError}
+            </p>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -771,7 +771,9 @@
     "shareToX": "Share to X",
     "shareToLinkedIn": "Share to LinkedIn",
     "more": "More…",
-    "downloadZip": "Download ZIP"
+    "downloadZip": "Download ZIP",
+    "removeFromPetdex": "Remove from Petdex",
+    "removing": "Removing…"
   },
   "petStateViewer": {
     "eyebrow": "State viewer",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -129,7 +129,8 @@
       "requests": "Requests",
       "collections": "Collections",
       "feedback": "Feedback",
-      "manifest": "Manifest"
+      "manifest": "Manifest",
+      "insights": "Insights"
     },
     "status": {
       "pending": "Pending",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -129,7 +129,8 @@
       "requests": "Pedidos",
       "collections": "Colecciones",
       "feedback": "Feedback",
-      "manifest": "Manifest"
+      "manifest": "Manifest",
+      "insights": "Métricas"
     },
     "status": {
       "pending": "Pendiente",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -771,7 +771,9 @@
     "shareToX": "Compartir en X",
     "shareToLinkedIn": "Compartir en LinkedIn",
     "more": "Más…",
-    "downloadZip": "Descargar ZIP"
+    "downloadZip": "Descargar ZIP",
+    "removeFromPetdex": "Eliminar de Petdex",
+    "removing": "Eliminando…"
   },
   "petStateViewer": {
     "eyebrow": "Visor de estados",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -163,7 +163,8 @@
       "requests": "请求",
       "collections": "合集",
       "feedback": "反馈",
-      "manifest": "Manifest"
+      "manifest": "Manifest",
+      "insights": "数据"
     },
     "status": {
       "pending": "待处理",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -924,7 +924,9 @@
     "shareToX": "分享到 X",
     "shareToLinkedIn": "分享到 LinkedIn",
     "more": "更多…",
-    "downloadZip": "下载 ZIP"
+    "downloadZip": "下载 ZIP",
+    "removeFromPetdex": "从 Petdex 删除",
+    "removing": "删除中…"
   },
   "petStateViewer": {
     "eyebrow": "状态查看器",

--- a/src/lib/admin-insights.ts
+++ b/src/lib/admin-insights.ts
@@ -1,0 +1,246 @@
+import "server-only";
+
+import { sql } from "drizzle-orm";
+
+import { db } from "@/lib/db/client";
+
+// All queries here are admin-only — no per-user gating, no row-level
+// filters beyond the obvious "approved" / "pending" splits. They run
+// against the live Postgres so numbers are real-time. Nothing is
+// cached at this layer; the page owns the revalidation policy.
+
+export type SubmissionVelocityPoint = {
+  bucket: string; // ISO timestamp at hour boundary
+  pending: number;
+  approved: number;
+  rejected: number;
+};
+
+// Submissions per hour for the last N hours, broken down by terminal
+// status. We bucket by the row's createdAt (when it landed in the
+// queue), not approvedAt — drift between submit and approve would
+// otherwise inflate "recent" buckets with old approvals.
+export async function getSubmissionVelocity(
+  hours = 24,
+): Promise<SubmissionVelocityPoint[]> {
+  const out = (await db.execute(sql`
+    WITH series AS (
+      SELECT generate_series(
+        date_trunc('hour', now() - interval '${sql.raw(`${hours} hours`)}'),
+        date_trunc('hour', now()),
+        interval '1 hour'
+      ) AS bucket
+    )
+    SELECT
+      series.bucket,
+      COALESCE(sum(CASE WHEN p.status = 'pending'  THEN 1 ELSE 0 END), 0) AS pending,
+      COALESCE(sum(CASE WHEN p.status = 'approved' THEN 1 ELSE 0 END), 0) AS approved,
+      COALESCE(sum(CASE WHEN p.status = 'rejected' THEN 1 ELSE 0 END), 0) AS rejected
+    FROM series
+    LEFT JOIN submitted_pets p
+      ON date_trunc('hour', p.created_at) = series.bucket
+    GROUP BY series.bucket
+    ORDER BY series.bucket ASC
+  `)) as unknown as {
+    rows: Array<{
+      bucket: string | Date;
+      pending: number | string;
+      approved: number | string;
+      rejected: number | string;
+    }>;
+  };
+  return (out.rows ?? []).map((row) => ({
+    bucket:
+      row.bucket instanceof Date
+        ? row.bucket.toISOString()
+        : String(row.bucket),
+    pending: Number(row.pending),
+    approved: Number(row.approved),
+    rejected: Number(row.rejected),
+  }));
+}
+
+export type QueueDepth = {
+  pending: number;
+  oldestPendingAgeMinutes: number | null;
+  pendingEdits: number;
+  oldestPendingEditAgeMinutes: number | null;
+};
+
+// Snapshot of the admin's open work: how many pets are waiting for a
+// first review, and how stale the oldest one is. Same for in-flight
+// edits to existing approved pets.
+export async function getQueueDepth(): Promise<QueueDepth> {
+  const out = (await db.execute(sql`
+    SELECT
+      (SELECT count(*) FROM submitted_pets WHERE status = 'pending' AND source <> 'discover') AS pending,
+      (SELECT extract(epoch FROM (now() - min(created_at))) / 60
+         FROM submitted_pets
+         WHERE status = 'pending' AND source <> 'discover') AS oldest_pending_age_minutes,
+      (SELECT count(*) FROM submitted_pets WHERE pending_submitted_at IS NOT NULL) AS pending_edits,
+      (SELECT extract(epoch FROM (now() - min(pending_submitted_at))) / 60
+         FROM submitted_pets
+         WHERE pending_submitted_at IS NOT NULL) AS oldest_pending_edit_age_minutes
+  `)) as unknown as {
+    rows: Array<{
+      pending: number | string;
+      oldest_pending_age_minutes: number | string | null;
+      pending_edits: number | string;
+      oldest_pending_edit_age_minutes: number | string | null;
+    }>;
+  };
+  const row = out.rows?.[0];
+  return {
+    pending: Number(row?.pending ?? 0),
+    oldestPendingAgeMinutes:
+      row?.oldest_pending_age_minutes != null
+        ? Number(row.oldest_pending_age_minutes)
+        : null,
+    pendingEdits: Number(row?.pending_edits ?? 0),
+    oldestPendingEditAgeMinutes:
+      row?.oldest_pending_edit_age_minutes != null
+        ? Number(row.oldest_pending_edit_age_minutes)
+        : null,
+  };
+}
+
+export type HiddenHit = {
+  slug: string;
+  displayName: string;
+  installCount: number;
+  zipDownloadCount: number;
+  likeCount: number;
+  approvedAt: string | null;
+};
+
+// Pets with a strong install-to-like ratio relative to the catalog
+// median. The interesting cohort is pets that aren't featured / pinned
+// but are quietly converting: they install at a higher rate per like
+// than the average pet, which means people who notice them follow
+// through. A signal for re-promote / pin to the landing strip.
+export async function getHiddenHits(limit = 10): Promise<HiddenHit[]> {
+  const out = (await db.execute(sql`
+    SELECT
+      p.slug,
+      p.display_name,
+      COALESCE(m.install_count, 0)      AS install_count,
+      COALESCE(m.zip_download_count, 0) AS zip_download_count,
+      COALESCE(m.like_count, 0)         AS like_count,
+      p.approved_at
+    FROM submitted_pets p
+    LEFT JOIN pet_metrics m ON m.pet_slug = p.slug
+    WHERE p.status = 'approved'
+      AND p.featured = false
+      AND COALESCE(m.install_count, 0) >= 3
+    ORDER BY
+      (COALESCE(m.install_count, 0)::float
+        / GREATEST(COALESCE(m.like_count, 0), 1)) DESC,
+      m.install_count DESC NULLS LAST
+    LIMIT ${limit}
+  `)) as unknown as {
+    rows: Array<{
+      slug: string;
+      display_name: string;
+      install_count: number | string;
+      zip_download_count: number | string;
+      like_count: number | string;
+      approved_at: string | Date | null;
+    }>;
+  };
+  return (out.rows ?? []).map((row) => ({
+    slug: row.slug,
+    displayName: row.display_name,
+    installCount: Number(row.install_count),
+    zipDownloadCount: Number(row.zip_download_count),
+    likeCount: Number(row.like_count),
+    approvedAt:
+      row.approved_at instanceof Date
+        ? row.approved_at.toISOString()
+        : (row.approved_at as string | null),
+  }));
+}
+
+export type ActiveCreator = {
+  ownerId: string;
+  creditName: string | null;
+  approvedCount: number;
+  lastSubmittedAt: string;
+};
+
+// Creators who shipped at least one submission in the last 7 days.
+// Sorts by recency first, then by approved count for tie-breaking.
+// Drives the "are creators churning?" health signal.
+export async function getActiveCreators(
+  days = 7,
+  limit = 20,
+): Promise<ActiveCreator[]> {
+  const out = (await db.execute(sql`
+    SELECT
+      p.owner_id,
+      max(p.credit_name) AS credit_name,
+      sum(CASE WHEN p.status = 'approved' THEN 1 ELSE 0 END) AS approved_count,
+      max(p.created_at) AS last_submitted_at
+    FROM submitted_pets p
+    WHERE p.created_at > now() - interval '${sql.raw(`${days} days`)}'
+      AND p.source <> 'discover'
+    GROUP BY p.owner_id
+    ORDER BY last_submitted_at DESC
+    LIMIT ${limit}
+  `)) as unknown as {
+    rows: Array<{
+      owner_id: string;
+      credit_name: string | null;
+      approved_count: number | string;
+      last_submitted_at: string | Date;
+    }>;
+  };
+  return (out.rows ?? []).map((row) => ({
+    ownerId: row.owner_id,
+    creditName: row.credit_name,
+    approvedCount: Number(row.approved_count),
+    lastSubmittedAt:
+      row.last_submitted_at instanceof Date
+        ? row.last_submitted_at.toISOString()
+        : String(row.last_submitted_at),
+  }));
+}
+
+export type OverviewStats = {
+  totalApproved: number;
+  totalPending: number;
+  totalRejected: number;
+  approvedLast24h: number;
+  approvedLast7d: number;
+  totalCreators: number;
+  totalLikes: number;
+  totalInstalls: number;
+};
+
+// Headline numbers for the top of the page. One round-trip via a
+// single sub-query block to keep the dashboard cheap on every reload.
+export async function getOverviewStats(): Promise<OverviewStats> {
+  const out = (await db.execute(sql`
+    SELECT
+      (SELECT count(*) FROM submitted_pets WHERE status = 'approved') AS total_approved,
+      (SELECT count(*) FROM submitted_pets WHERE status = 'pending'  AND source <> 'discover') AS total_pending,
+      (SELECT count(*) FROM submitted_pets WHERE status = 'rejected') AS total_rejected,
+      (SELECT count(*) FROM submitted_pets WHERE status = 'approved' AND approved_at > now() - interval '24 hours') AS approved_last_24h,
+      (SELECT count(*) FROM submitted_pets WHERE status = 'approved' AND approved_at > now() - interval '7 days')  AS approved_last_7d,
+      (SELECT count(distinct owner_id) FROM submitted_pets WHERE status = 'approved' AND source <> 'discover') AS total_creators,
+      (SELECT COALESCE(sum(like_count), 0)    FROM pet_metrics) AS total_likes,
+      (SELECT COALESCE(sum(install_count), 0) FROM pet_metrics) AS total_installs
+  `)) as unknown as {
+    rows: Array<Record<string, number | string>>;
+  };
+  const row = out.rows?.[0] ?? {};
+  return {
+    totalApproved: Number(row.total_approved ?? 0),
+    totalPending: Number(row.total_pending ?? 0),
+    totalRejected: Number(row.total_rejected ?? 0),
+    approvedLast24h: Number(row.approved_last_24h ?? 0),
+    approvedLast7d: Number(row.approved_last_7d ?? 0),
+    totalCreators: Number(row.total_creators ?? 0),
+    totalLikes: Number(row.total_likes ?? 0),
+    totalInstalls: Number(row.total_installs ?? 0),
+  };
+}

--- a/src/lib/takedown.ts
+++ b/src/lib/takedown.ts
@@ -1,0 +1,161 @@
+import "server-only";
+
+import { eq, sql } from "drizzle-orm";
+import { Resend } from "resend";
+
+import { db, schema } from "@/lib/db/client";
+import { renderSubmissionTakedownEmail } from "@/lib/email-templates/submission-takedown";
+import { createNotification } from "@/lib/notifications";
+import { deleteR2Objects, keyFromR2Url } from "@/lib/r2";
+import { getPreferredLocaleForUser } from "@/lib/user-locale";
+
+// Hard takedown of a pet. Removes the row, every cross-table reference
+// keyed by slug (likes, metrics, collection items, collection requests,
+// profile pins, fulfilled requests), nulls collection covers, drops
+// the R2 assets, and notifies the owner. The slug is freed.
+//
+// Caller is responsible for authz — this helper trusts whoever invoked
+// it. Used by:
+//   - DELETE /api/admin/[id]   — admin takedown via UI
+//   - DELETE /api/pets/[slug]/owner — owner self-service via card menu
+//   - scripts/takedown-pet.ts  — one-shot CLI for ops
+type TakedownPetRow = typeof schema.submittedPets.$inferSelect;
+
+export type TakedownContext = {
+  pet: TakedownPetRow;
+  /** Free-form reason captured from the actor; surfaced in email + log. */
+  reason?: string | null;
+  /**
+   * Who triggered the takedown. Goes to the structured log so the audit
+   * trail is searchable. 'admin' for /api/admin/[id], 'owner' for the
+   * self-service path, 'script' for ops CLIs.
+   */
+  source: "admin" | "owner" | "script";
+  /** Clerk user id of the actor. Logged. */
+  actorId: string;
+  /**
+   * When true, do not push the in-app notification + email. Owners
+   * doing a self-delete know what they did; no need to ping them.
+   */
+  silent?: boolean;
+};
+
+export type TakedownResult = {
+  ok: true;
+  slug: string;
+  removedR2Keys: string[];
+};
+
+export async function takedownPet(
+  ctx: TakedownContext,
+): Promise<TakedownResult> {
+  const { pet, reason, source, actorId, silent } = ctx;
+  const slug = pet.slug;
+
+  // 1. Cross-table cleanup keyed by slug. None of these have FKs to
+  //    submitted_pets so they have to go by hand.
+  await db.delete(schema.petLikes).where(eq(schema.petLikes.petSlug, slug));
+  await db.delete(schema.petMetrics).where(eq(schema.petMetrics.petSlug, slug));
+  await db
+    .delete(schema.petCollectionItems)
+    .where(eq(schema.petCollectionItems.petSlug, slug));
+  await db
+    .delete(schema.petCollectionRequests)
+    .where(eq(schema.petCollectionRequests.petSlug, slug));
+
+  // 2. Null out collections that used this pet as their cover.
+  await db
+    .update(schema.petCollections)
+    .set({ coverPetSlug: null })
+    .where(eq(schema.petCollections.coverPetSlug, slug));
+
+  // 3. Reopen any pet request this submission fulfilled so it goes back
+  //    to the queue instead of pointing at a dead slug.
+  await db
+    .update(schema.petRequests)
+    .set({ fulfilledPetSlug: null, status: "open" })
+    .where(eq(schema.petRequests.fulfilledPetSlug, slug));
+
+  // 4. Strip the slug from any user_profile featured arrays. We only
+  //    touch profiles that actually contain the slug so the jsonb
+  //    rewrite stays scoped.
+  await db.execute(sql`
+    UPDATE user_profiles
+    SET featured_pet_slugs = (
+      SELECT COALESCE(jsonb_agg(elem), '[]'::jsonb)
+      FROM jsonb_array_elements(featured_pet_slugs) AS elem
+      WHERE elem <> to_jsonb(${slug}::text)
+    )
+    WHERE featured_pet_slugs @> to_jsonb(${slug}::text)
+  `);
+
+  // 5. Drop the row itself.
+  await db
+    .delete(schema.submittedPets)
+    .where(eq(schema.submittedPets.id, pet.id));
+
+  // 6. Best-effort R2 cleanup. We derive keys from the URLs the
+  //    submission stored; anything off-host (legacy or external credit
+  //    image) is skipped. R2 errors are logged but don't fail the
+  //    takedown — the DB is already gone.
+  const keys = [
+    keyFromR2Url(pet.spritesheetUrl),
+    keyFromR2Url(pet.petJsonUrl),
+    keyFromR2Url(pet.zipUrl),
+    keyFromR2Url(pet.soundUrl),
+  ].filter((k): k is string => Boolean(k));
+  try {
+    await deleteR2Objects(keys);
+  } catch (err) {
+    console.warn("[takedown] r2 cleanup failed", { id: pet.id, slug, err });
+  }
+
+  // 7. Notify owner unless silenced. Owner self-deletes are silenced
+  //    (they're the actor — they know).
+  if (!silent) {
+    void createNotification({
+      userId: pet.ownerId,
+      kind: "pet_rejected",
+      payload: {
+        petSlug: slug,
+        petName: pet.displayName,
+        ...(reason ? { reason } : {}),
+        takedown: true,
+      },
+      href: "/",
+    }).catch(() => {});
+
+    if (pet.ownerEmail && process.env.RESEND_API_KEY) {
+      try {
+        const resend = new Resend(process.env.RESEND_API_KEY);
+        const from =
+          process.env.RESEND_FROM ?? "Petdex <petdex@updates.railly.dev>";
+        const locale = await getPreferredLocaleForUser(pet.ownerId);
+        const email = renderSubmissionTakedownEmail(locale, {
+          petName: pet.displayName,
+          reason: reason ?? null,
+        });
+        await resend.emails.send({
+          from,
+          to: pet.ownerEmail,
+          subject: email.subject,
+          html: email.html,
+          text: email.text,
+        });
+      } catch {
+        /* silent */
+      }
+    }
+  }
+
+  console.info("[takedown] pet removed", {
+    id: pet.id,
+    slug,
+    source,
+    by: actorId,
+    reason,
+    keys,
+  });
+
+  return { ok: true, slug, removedR2Keys: keys };
+}


### PR DESCRIPTION
## What

The takedown issue queue keeps filling up with rights-holder requests like #98, #110 — owners who just want to remove their own pet. This PR makes that self-service.

## How it works

When an owner opens the three-dots menu on a pet card or detail page, the client fetches \`/api/pets/[slug]/can-delete\` (auth-cookie gated). If the viewer is the pet's owner, a red **Remove from Petdex** entry appears at the bottom of the menu.

Clicking it asks for slug confirmation (typed verification, same pattern as the admin takedown UI), then hits \`DELETE /api/pets/[slug]/owner\`. The pet, every cross-table reference (likes, metrics, collection items, profile pins, fulfilled requests), and every R2 asset (sprite, pet.json, zip, sound) get hard-deleted. Slug is freed for resubmit.

## Endpoints

- \`DELETE /api/pets/[slug]/owner\` — auth required, owner check, withdrawRatelimit (20/10m), blocks \`source: discover\` pets that haven't been claimed yet.
- \`GET /api/pets/[slug]/can-delete\` — auth-gated boolean. Used by the client menu to decide whether to render the entry. The public PetdexPet shape deliberately omits \`ownerId\`, so the check has to round-trip. **This endpoint is a UI-affordance hint, never a security boundary** — the actual DELETE re-checks ownership.

## Refactor

The cross-table cleanup, R2 purge, and notify path that lived inside the admin DELETE handler now lives in \`src/lib/takedown.ts\`. Both \`/api/admin/[id]\` and \`/api/pets/[slug]/owner\` call into it. Owner self-deletes pass \`silent: true\` so the actor isn't pinged about their own action; admin takedowns still email + notify the owner.

## Edge cases handled

- **Anonymous viewer**: \`/can-delete\` short-circuits to \`{canDelete: false}\` instantly, menu hides the option.
- **Viewer != owner**: same.
- **Discover-source pet**: returns 409 with \`claim_required\` — the user has to claim from \`/u/<handle>\` first so we know they're the original author.
- **Sign-in/out mid-session**: state is cached per-mount; the actual delete still re-verifies. Worst case a user sees a stale option that fails server-side.
- **Pet not found**: 404 from both endpoints.

## i18n

\`removeFromPetdex\` + \`removing\` strings added in en, es, zh. \`bun run i18n:check\` passes.

## Verification

- \`bun --bun tsc --noEmit\` clean
- \`bun test\` 46/46 pass
- \`biome check\` clean (one pre-existing wrapper-div interaction warning suppressed inline)
- Smoke tested locally: signed-in mock user sees the red Remove option in both card and detail variants, click → prompt → confirm → DELETE returns ok → router.refresh() updates the page

## Test plan

- [ ] Sign in as a pet owner, open the three-dots menu on your pet → 'Remove from Petdex' appears in red
- [ ] Sign in as someone else's account, open menu on the same pet → option does NOT appear
- [ ] Click Remove, type the slug correctly → pet disappears, gallery updates
- [ ] Click Remove, type wrong slug → alert, no delete
- [ ] Try the endpoint manually with a different user's token → 403 forbidden
- [ ] Try on a discover-source pet → 409 claim_required