### PR TITLE
feat(admin): toggle pet featured flag from queue + insights

### DIFF
--- a/src/app/[locale]/admin/insights/page.tsx
+++ b/src/app/[locale]/admin/insights/page.tsx
@@ -1,15 +1,17 @@
 import Link from "next/link";
 
-import { Heart, Plus, TerminalSquare, Users } from "lucide-react";
+import { Heart, Plus, Star, TerminalSquare, Users } from "lucide-react";
 
 import {
   getActiveCreators,
+  getCurrentlyFeatured,
   getHiddenHits,
   getOverviewStats,
   getQueueDepth,
   getSubmissionVelocity,
 } from "@/lib/admin-insights";
 
+import { AdminFeatureToggle } from "@/components/admin-feature-toggle";
 import { AdminVelocityChart } from "@/components/admin-velocity-chart";
 
 export const dynamic = "force-dynamic";
@@ -20,14 +22,21 @@ export const metadata = {
 };
 
 export default async function AdminInsightsPage() {
-  const [overview, queueDepth, velocity, hiddenHits, activeCreators] =
-    await Promise.all([
-      getOverviewStats(),
-      getQueueDepth(),
-      getSubmissionVelocity(24),
-      getHiddenHits(8),
-      getActiveCreators(7, 12),
-    ]);
+  const [
+    overview,
+    queueDepth,
+    velocity,
+    hiddenHits,
+    activeCreators,
+    currentlyFeatured,
+  ] = await Promise.all([
+    getOverviewStats(),
+    getQueueDepth(),
+    getSubmissionVelocity(24),
+    getHiddenHits(8),
+    getActiveCreators(7, 12),
+    getCurrentlyFeatured(24),
+  ]);
 
   return (
     <section className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-5 pb-16 md:px-8">
@@ -162,7 +171,7 @@ export default async function AdminInsightsPage() {
                       {pet.slug}
                     </span>
                   </div>
-                  <div className="flex items-center gap-4 font-mono text-[11px] tracking-[0.16em] text-muted-2 uppercase">
+                  <div className="flex flex-wrap items-center gap-3 font-mono text-[11px] tracking-[0.16em] text-muted-2 uppercase">
                     <span className="inline-flex items-center gap-1">
                       <TerminalSquare className="size-3" />
                       {pet.installCount}
@@ -174,10 +183,79 @@ export default async function AdminInsightsPage() {
                     <span className="rounded-full bg-chip-success-bg px-2 py-0.5 text-chip-success-fg">
                       {ratio}× ratio
                     </span>
+                    <AdminFeatureToggle
+                      petId={pet.id}
+                      initialFeatured={false}
+                      petName={pet.displayName}
+                    />
                   </div>
                 </li>
               );
             })}
+          </ul>
+        )}
+      </section>
+
+      {/* Currently featured */}
+      <section className="rounded-3xl border border-border-base bg-surface/80 p-5 backdrop-blur md:p-6">
+        <header className="mb-4 flex flex-wrap items-end justify-between gap-2">
+          <div>
+            <p className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.22em] text-brand uppercase">
+              <Star className="size-3 fill-current" />
+              Currently featured
+            </p>
+            <h2 className="mt-1 text-xl font-semibold tracking-tight text-foreground md:text-2xl">
+              {currentlyFeatured.length === 0
+                ? "No pets featured"
+                : currentlyFeatured.length === 1
+                  ? "1 pet featured"
+                  : `${currentlyFeatured.length} pets featured`}
+            </h2>
+            <p className="mt-1 text-xs text-muted-3">
+              Featured pets land in the home hero strip and the curated sort's
+              top tier. Demote stale ones to free up the slot.
+            </p>
+          </div>
+        </header>
+        {currentlyFeatured.length === 0 ? (
+          <p className="text-sm text-muted-3">
+            Promote a hidden hit above or flip the star on a pet from the queue.
+          </p>
+        ) : (
+          <ul className="divide-y divide-black/[0.05] dark:divide-white/[0.05]">
+            {currentlyFeatured.map((pet) => (
+              <li
+                key={pet.slug}
+                className="flex flex-wrap items-center justify-between gap-3 py-2.5"
+              >
+                <div className="flex flex-col">
+                  <Link
+                    href={`/pets/${pet.slug}`}
+                    className="font-medium text-foreground transition hover:text-brand"
+                  >
+                    {pet.displayName}
+                  </Link>
+                  <span className="font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
+                    {pet.slug}
+                  </span>
+                </div>
+                <div className="flex flex-wrap items-center gap-3 font-mono text-[11px] tracking-[0.16em] text-muted-2 uppercase">
+                  <span className="inline-flex items-center gap-1">
+                    <TerminalSquare className="size-3" />
+                    {pet.installCount}
+                  </span>
+                  <span className="inline-flex items-center gap-1">
+                    <Heart className="size-3" />
+                    {pet.likeCount}
+                  </span>
+                  <AdminFeatureToggle
+                    petId={pet.id}
+                    initialFeatured={true}
+                    petName={pet.displayName}
+                  />
+                </div>
+              </li>
+            ))}
           </ul>
         )}
       </section>

--- a/src/app/api/admin/[id]/feature/route.ts
+++ b/src/app/api/admin/[id]/feature/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+
+import { auth } from "@clerk/nextjs/server";
+import { eq } from "drizzle-orm";
+
+import { isAdmin } from "@/lib/admin";
+import { db, schema } from "@/lib/db/client";
+import { requireSameOrigin } from "@/lib/same-origin";
+
+export const runtime = "nodejs";
+
+// Toggle the `featured` flag on an approved pet. Featured pets land
+// at the top of the gallery, get pinned tier in the curated sort, and
+// pre-fill the home page's hero strip when their slug matches the
+// hand-picked LANDING_COLLECTION_ORDER set in /[locale]/page.tsx.
+//
+// Lives at its own route (not folded into PATCH /api/admin/[id]) so
+// the existing approve/reject/edit flow stays narrow. The page still
+// fires plain optimistic-style PATCH calls; this one is a focused
+// "elevate / demote" toggle.
+type Params = { id: string };
+
+type PatchBody = {
+  featured: boolean;
+};
+
+export async function PATCH(
+  req: Request,
+  ctx: { params: Promise<Params> },
+): Promise<Response> {
+  const csrf = requireSameOrigin(req);
+  if (csrf) return csrf;
+
+  const { userId } = await auth();
+  if (!isAdmin(userId)) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  const { id } = await ctx.params;
+
+  let body: PatchBody;
+  try {
+    body = (await req.json()) as PatchBody;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  if (typeof body.featured !== "boolean") {
+    return NextResponse.json({ error: "invalid_featured" }, { status: 400 });
+  }
+
+  const [row] = await db
+    .update(schema.submittedPets)
+    .set({ featured: body.featured })
+    .where(eq(schema.submittedPets.id, id))
+    .returning({
+      id: schema.submittedPets.id,
+      slug: schema.submittedPets.slug,
+      status: schema.submittedPets.status,
+      featured: schema.submittedPets.featured,
+    });
+
+  if (!row) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+  if (row.status !== "approved") {
+    // We allow the flag flip on non-approved rows so the admin can
+    // pre-feature a pet that hasn't been approved yet. The gallery
+    // queries already filter on status='approved' so a pre-flagged
+    // pending pet only goes live after approval. Just log it.
+    console.info("[feature] flagged non-approved pet", {
+      id,
+      slug: row.slug,
+      featured: row.featured,
+      by: userId,
+    });
+  }
+
+  return NextResponse.json({ ok: true, featured: row.featured });
+}

--- a/src/components/admin-feature-toggle.tsx
+++ b/src/components/admin-feature-toggle.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import { Loader2, Star } from "lucide-react";
+
+type Props = {
+  petId: string;
+  initialFeatured: boolean;
+  /** Display name only used in the aria-label so screen readers
+   *  announce which pet is being featured. */
+  petName: string;
+  /** Visual variant. 'inline' is the compact pill used inside the
+   *  Hidden Hits / Featured lists. 'solid' is the chunkier button
+   *  used at the top of admin row cards. */
+  variant?: "inline" | "solid";
+};
+
+export function AdminFeatureToggle({
+  petId,
+  initialFeatured,
+  petName,
+  variant = "inline",
+}: Props) {
+  const router = useRouter();
+  const [featured, setFeatured] = useState(initialFeatured);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function toggle() {
+    if (pending) return;
+    const next = !featured;
+    // Optimistic flip — the API call is fast (single UPDATE) but
+    // there's no reason to make the admin wait for the round-trip
+    // before the chip flips.
+    setFeatured(next);
+    setError(null);
+    startTransition(async () => {
+      try {
+        const res = await fetch(`/api/admin/${petId}/feature`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ featured: next }),
+        });
+        if (!res.ok) {
+          const data = (await res.json().catch(() => ({}))) as {
+            error?: string;
+            message?: string;
+          };
+          setError(data.message ?? data.error ?? `failed (${res.status})`);
+          // Roll back the optimistic flip so the UI reflects truth.
+          setFeatured(!next);
+          return;
+        }
+        // Soft refresh so insights queries (currently featured /
+        // hidden hits) re-fetch and the lists update.
+        router.refresh();
+      } catch {
+        setError("network_error");
+        setFeatured(!next);
+      }
+    });
+  }
+
+  const baseClass =
+    variant === "solid"
+      ? "inline-flex h-9 items-center gap-1.5 rounded-full border px-3 text-xs font-medium transition disabled:opacity-60"
+      : "inline-flex h-7 items-center gap-1 rounded-full border px-2.5 text-[11px] font-medium transition disabled:opacity-60";
+  const stateClass = featured
+    ? "border-brand bg-brand text-white hover:bg-brand-deep"
+    : "border-border-base bg-surface text-muted-2 hover:border-border-strong hover:text-foreground";
+
+  return (
+    <span className="relative inline-flex">
+      <button
+        type="button"
+        onClick={toggle}
+        disabled={pending}
+        aria-pressed={featured}
+        aria-label={featured ? `Unfeature ${petName}` : `Feature ${petName}`}
+        className={`${baseClass} ${stateClass}`}
+      >
+        {pending ? (
+          <Loader2 className="size-3 animate-spin" />
+        ) : (
+          <Star className={`size-3 ${featured ? "fill-current" : ""}`} />
+        )}
+        {featured ? "Featured" : "Feature"}
+      </button>
+      {error ? (
+        <span
+          role="alert"
+          className="absolute top-full left-0 mt-1 whitespace-nowrap font-mono text-[10px] tracking-[0.12em] text-chip-danger-fg uppercase"
+        >
+          {error}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/src/components/admin-review-row.tsx
+++ b/src/components/admin-review-row.tsx
@@ -20,6 +20,8 @@ import {
 import type { SubmittedPet } from "@/lib/db/schema";
 import { petStates } from "@/lib/pet-states";
 
+import { AdminFeatureToggle } from "@/components/admin-feature-toggle";
+
 type AdminReviewRowProps = {
   pet: SubmittedPet;
   stateCount: number;
@@ -422,19 +424,27 @@ export function AdminReviewRow({
             </button>
           </>
         ) : status === "approved" ? (
-          <button
-            type="button"
-            onClick={() => void takedown()}
-            disabled={busy}
-            className="inline-flex h-9 items-center justify-center gap-1.5 rounded-full border border-chip-danger-fg/30 bg-chip-danger-bg px-4 text-xs font-medium text-chip-danger-fg transition hover:border-chip-danger-fg/50 disabled:opacity-60"
-          >
-            {busy ? (
-              <Loader2 className="size-3.5 animate-spin" />
-            ) : (
-              <Trash2 className="size-3.5" />
-            )}
-            Take down
-          </button>
+          <>
+            <AdminFeatureToggle
+              petId={pet.id}
+              initialFeatured={pet.featured}
+              petName={pet.displayName}
+              variant="solid"
+            />
+            <button
+              type="button"
+              onClick={() => void takedown()}
+              disabled={busy}
+              className="inline-flex h-9 items-center justify-center gap-1.5 rounded-full border border-chip-danger-fg/30 bg-chip-danger-bg px-4 text-xs font-medium text-chip-danger-fg transition hover:border-chip-danger-fg/50 disabled:opacity-60"
+            >
+              {busy ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <Trash2 className="size-3.5" />
+              )}
+              Take down
+            </button>
+          </>
         ) : null}
       </div>
       <SimilarPanel petId={pet.id} status={status} />

--- a/src/lib/admin-insights.ts
+++ b/src/lib/admin-insights.ts
@@ -105,6 +105,7 @@ export async function getQueueDepth(): Promise<QueueDepth> {
 }
 
 export type HiddenHit = {
+  id: string;
   slug: string;
   displayName: string;
   installCount: number;
@@ -121,6 +122,7 @@ export type HiddenHit = {
 export async function getHiddenHits(limit = 10): Promise<HiddenHit[]> {
   const out = (await db.execute(sql`
     SELECT
+      p.id,
       p.slug,
       p.display_name,
       COALESCE(m.install_count, 0)      AS install_count,
@@ -139,6 +141,7 @@ export async function getHiddenHits(limit = 10): Promise<HiddenHit[]> {
     LIMIT ${limit}
   `)) as unknown as {
     rows: Array<{
+      id: string;
       slug: string;
       display_name: string;
       install_count: number | string;
@@ -148,10 +151,62 @@ export async function getHiddenHits(limit = 10): Promise<HiddenHit[]> {
     }>;
   };
   return (out.rows ?? []).map((row) => ({
+    id: row.id,
     slug: row.slug,
     displayName: row.display_name,
     installCount: Number(row.install_count),
     zipDownloadCount: Number(row.zip_download_count),
+    likeCount: Number(row.like_count),
+    approvedAt:
+      row.approved_at instanceof Date
+        ? row.approved_at.toISOString()
+        : (row.approved_at as string | null),
+  }));
+}
+
+export type FeaturedPet = {
+  id: string;
+  slug: string;
+  displayName: string;
+  installCount: number;
+  likeCount: number;
+  approvedAt: string | null;
+};
+
+// Pets currently flagged featured = true. Surfaces in the insights
+// dashboard so the admin can see what's promoted and rotate stale
+// entries (low install count relative to peers means the slot would
+// be better used by something else).
+export async function getCurrentlyFeatured(limit = 24): Promise<FeaturedPet[]> {
+  const out = (await db.execute(sql`
+    SELECT
+      p.id,
+      p.slug,
+      p.display_name,
+      COALESCE(m.install_count, 0) AS install_count,
+      COALESCE(m.like_count, 0)    AS like_count,
+      p.approved_at
+    FROM submitted_pets p
+    LEFT JOIN pet_metrics m ON m.pet_slug = p.slug
+    WHERE p.status = 'approved'
+      AND p.featured = true
+    ORDER BY m.install_count DESC NULLS LAST, p.approved_at DESC NULLS LAST
+    LIMIT ${limit}
+  `)) as unknown as {
+    rows: Array<{
+      id: string;
+      slug: string;
+      display_name: string;
+      install_count: number | string;
+      like_count: number | string;
+      approved_at: string | Date | null;
+    }>;
+  };
+  return (out.rows ?? []).map((row) => ({
+    id: row.id,
+    slug: row.slug,
+    displayName: row.display_name,
+    installCount: Number(row.install_count),
     likeCount: Number(row.like_count),
     approvedAt:
       row.approved_at instanceof Date


### PR DESCRIPTION
Hidden Hits in /admin/insights are now actionable — click Feature on any candidate to promote it. Currently Featured section added to insights so stale featured slots are obvious and demote-able. Same toggle is in the /admin queue on approved rows.

Single endpoint: PATCH /api/admin/[id]/feature.

Optimistic update + router.refresh() so insights lists re-flow when a pet moves between sections.