### PR TITLE
feat(profile): unify Pets tab cards with the rest of the gallery

### DIFF
--- a/src/components/pet-action-menu.tsx
+++ b/src/components/pet-action-menu.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -13,8 +14,11 @@ import {
   Link2,
   Loader2,
   MoreHorizontal,
+  Pencil,
+  Plus,
   Terminal,
   Trash2,
+  XCircle,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
 
@@ -27,20 +31,31 @@ export type PetActionMenuPet = {
   description?: string;
 };
 
+export type PetActionMenuOwnerActions = {
+  /** Submission id for the owner-action API endpoints. */
+  submissionId: string;
+  status: "pending" | "approved" | "rejected";
+};
+
 type Variant = "card" | "detail";
 
 type Props = {
   pet: PetActionMenuPet;
   variant?: Variant;
+  /** When the viewer is the owner, surfaces status-aware actions
+   *  (Withdraw, Edit link, Submit new version) inside the dropdown. */
+  ownerActions?: PetActionMenuOwnerActions;
 };
 
-export function PetActionMenu({ pet, variant = "card" }: Props) {
+export function PetActionMenu({ pet, variant = "card", ownerActions }: Props) {
   const t = useTranslations("petActions");
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState<"install" | "link" | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [withdrawing, setWithdrawing] = useState(false);
+  const [withdrawError, setWithdrawError] = useState<string | null>(null);
   // canDelete is fetched lazily the first time the menu opens. The
   // public PetdexPet shape deliberately doesn't carry ownerId, so the
   // viewer/owner check has to round-trip. /api/pets/[slug]/can-delete
@@ -192,6 +207,42 @@ export function PetActionMenu({ pet, variant = "card" }: Props) {
     }
   }, [deleting, pet.slug, pet.displayName, router]);
 
+  const onWithdraw = useCallback(async () => {
+    if (withdrawing || !ownerActions) return;
+    if (
+      !window.confirm(
+        `Withdraw "${pet.displayName}"? Pending submissions can't be brought back — you'd have to resubmit.`,
+      )
+    ) {
+      return;
+    }
+    setWithdrawing(true);
+    setWithdrawError(null);
+    try {
+      const res = await fetch(
+        `/api/my-pets/${ownerActions.submissionId}/withdraw`,
+        { method: "POST" },
+      );
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as {
+          error?: string;
+          message?: string;
+        };
+        setWithdrawError(
+          data.message ?? data.error ?? `Request failed (${res.status})`,
+        );
+        setWithdrawing(false);
+        return;
+      }
+      track("pet_owner_withdrew", { slug: pet.slug });
+      setOpen(false);
+      router.refresh();
+    } catch {
+      setWithdrawError("network_error");
+      setWithdrawing(false);
+    }
+  }, [withdrawing, ownerActions, pet.slug, pet.displayName, router]);
+
   // Detail variant: bigger trigger that reads as an action button next to
   // the like button. Card variant: compact circular icon in a corner.
   const triggerClassName =
@@ -328,6 +379,53 @@ export function PetActionMenu({ pet, variant = "card" }: Props) {
                 </a>
               </li>
             ) : null}
+            {ownerActions?.status === "pending" ? (
+              <li>
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    void onWithdraw();
+                  }}
+                  disabled={withdrawing}
+                  className="flex w-full items-center gap-2.5 border-t border-black/[0.06] px-3 py-2.5 text-left text-sm text-chip-danger-fg transition hover:bg-chip-danger-bg disabled:opacity-60 dark:border-white/[0.06]"
+                >
+                  {withdrawing ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <XCircle className="size-4" />
+                  )}
+                  <span className="flex-1">
+                    {withdrawing ? t("withdrawing") : t("withdrawSubmission")}
+                  </span>
+                </button>
+              </li>
+            ) : null}
+            {ownerActions?.status === "rejected" ? (
+              <li>
+                <Link
+                  href="/submit"
+                  onClick={() => setOpen(false)}
+                  className="flex items-center gap-2.5 border-t border-black/[0.06] px-3 py-2.5 text-sm text-foreground transition hover:bg-[#f4f6ff] dark:border-white/[0.06]"
+                >
+                  <Plus className="size-4" />
+                  <span className="flex-1">{t("submitNewVersion")}</span>
+                </Link>
+              </li>
+            ) : null}
+            {ownerActions?.status === "approved" ? (
+              <li>
+                <Link
+                  href={`/pets/${pet.slug}#edit`}
+                  onClick={() => setOpen(false)}
+                  className="flex items-center gap-2.5 border-t border-black/[0.06] px-3 py-2.5 text-sm text-foreground transition hover:bg-[#f4f6ff] dark:border-white/[0.06]"
+                >
+                  <Pencil className="size-4" />
+                  <span className="flex-1">{t("editDetails")}</span>
+                </Link>
+              </li>
+            ) : null}
             {canDelete ? (
               <li>
                 <button
@@ -355,6 +453,11 @@ export function PetActionMenu({ pet, variant = "card" }: Props) {
           {deleteError ? (
             <p className="border-t border-black/[0.06] bg-chip-danger-bg px-3 py-2 text-xs text-chip-danger-fg dark:border-white/[0.06]">
               {deleteError}
+            </p>
+          ) : null}
+          {withdrawError ? (
+            <p className="border-t border-black/[0.06] bg-chip-danger-bg px-3 py-2 text-xs text-chip-danger-fg dark:border-white/[0.06]">
+              {withdrawError}
             </p>
           ) : null}
         </div>

--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -668,6 +668,22 @@ function FilterChips({
   );
 }
 
+export type PetCardOwnerActions = {
+  /**
+   * Submission id (pet_xxx). Required to call the owner-action APIs
+   * for edit / withdraw. When omitted the action menu only shows
+   * the public actions (copy, share, download, owner self-delete).
+   */
+  submissionId: string;
+  status: "pending" | "approved" | "rejected";
+  rejectionReason?: string | null;
+};
+
+export type PetCardStatusOverlay = {
+  label: string;
+  tone: "warning" | "danger";
+};
+
 type PetCardProps = {
   pet: PetWithMetrics;
   index: number;
@@ -687,9 +703,29 @@ type PetCardProps = {
    * card never renders a blank slot.
    */
   dexNumber?: number | null;
+  /**
+   * Owner-only actions surfaced in the action menu. Pass on the
+   * profile page when the viewer is the pet's owner so the menu
+   * gets Withdraw (pending), Edit (approved), Submit new version
+   * (rejected) entries.
+   */
+  ownerActions?: PetCardOwnerActions;
+  /**
+   * Visual badge overlaying the card. Used on the owner profile to
+   * tag pending and rejected pets with the same shape as the rest
+   * of the gallery cards. Approved pets render no overlay.
+   */
+  statusOverlay?: PetCardStatusOverlay;
 };
 
-export function PetCard({ pet, index, dexNumber, caught }: PetCardProps) {
+export function PetCard({
+  pet,
+  index,
+  dexNumber,
+  caught,
+  ownerActions,
+  statusOverlay,
+}: PetCardProps) {
   const dexLabel =
     dexNumber != null
       ? dexNumber < 1000
@@ -828,6 +864,21 @@ export function PetCard({ pet, index, dexNumber, caught }: PetCardProps) {
         />
       </div>
 
+      {/* Status overlay (owner profile only). Positioned over the dex
+          row so it reads alongside the No. label without competing
+          with the action menu in the top-right. */}
+      {statusOverlay ? (
+        <span
+          className={`pointer-events-none absolute top-3 left-3 z-20 inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-mono text-[10px] tracking-[0.15em] uppercase ring-1 ${
+            statusOverlay.tone === "danger"
+              ? "bg-chip-danger-bg text-chip-danger-fg ring-chip-danger-fg/20"
+              : "bg-chip-warning-bg text-chip-warning-fg ring-chip-warning-fg/20"
+          }`}
+        >
+          {statusOverlay.label}
+        </span>
+      ) : null}
+
       {/* Action menu lives outside the Link so its clicks don't navigate.
  Absolute-positioned to overlap the featured badge corner. */}
       <div className="absolute top-3 right-4 z-20">
@@ -838,6 +889,7 @@ export function PetCard({ pet, index, dexNumber, caught }: PetCardProps) {
             zipUrl: pet.zipUrl,
             description: pet.description,
           }}
+          ownerActions={ownerActions}
         />
       </div>
     </article>

--- a/src/components/profile-tabs.tsx
+++ b/src/components/profile-tabs.tsx
@@ -12,11 +12,7 @@ import {
   CollectionEditor,
   type EditableCollection,
 } from "@/components/collection-editor";
-import {
-  ClaimableBanner,
-  type Submission,
-  SubmissionCard,
-} from "@/components/my-pets-view";
+import { ClaimableBanner, type Submission } from "@/components/my-pets-view";
 import { PetCard } from "@/components/pet-gallery";
 
 // Tabs surface for /u/<handle>. Owner sees Pets (all statuses with
@@ -171,7 +167,7 @@ export function ProfileTabs(props: ProfileTabsProps) {
 
 function PetsPanel({
   isOwner,
-  publicHandle,
+  publicHandle: _publicHandle,
   approvedPets,
   pendingSubmissions,
   rejectedSubmissions,
@@ -213,9 +209,41 @@ function PetsPanel({
 
   return (
     <div className="space-y-10">
+      {/* Live pets first — what visitors care about, what owners see
+          as their portfolio. */}
+      {approvedPets.length > 0 ? (
+        <section className="space-y-3">
+          {isOwner &&
+          (pendingSubmissions.length > 0 || rejectedSubmissions.length > 0) ? (
+            <header>
+              <p className="font-mono text-[11px] tracking-[0.22em] text-chip-success-fg uppercase">
+                Approved ({approvedPets.length})
+              </p>
+            </header>
+          ) : null}
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+            {approvedPets.map((pet, index) => (
+              <PetCard
+                key={pet.slug}
+                pet={pet}
+                index={index}
+                stateCount={stateCount}
+                ownerActions={
+                  isOwner
+                    ? { submissionId: pet.id, status: "approved" }
+                    : undefined
+                }
+              />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {/* Pending review — owner-only. Same card shape, status pill
+          overlays the dex row so it reads as one continuous grid. */}
       {pendingSubmissions.length > 0 ? (
         <section className="space-y-3">
-          <header className="flex items-end justify-between gap-3">
+          <header className="flex flex-wrap items-end justify-between gap-3">
             <p className="font-mono text-[11px] tracking-[0.22em] text-chip-warning-fg uppercase">
               Pending review ({pendingSubmissions.length})
             </p>
@@ -223,17 +251,30 @@ function PetsPanel({
               Visible only to you until an admin approves.
             </p>
           </header>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {pendingSubmissions.map((s) => (
-              <SubmissionCard key={s.id} submission={s} />
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+            {pendingSubmissions.map((submission, index) => (
+              <PetCard
+                key={submission.id}
+                pet={submissionToPet(submission)}
+                index={index}
+                stateCount={stateCount}
+                statusOverlay={{ label: "Pending", tone: "warning" }}
+                ownerActions={{
+                  submissionId: submission.id,
+                  status: "pending",
+                }}
+              />
             ))}
           </div>
         </section>
       ) : null}
 
+      {/* Rejected — owner-only. The rejection reason still surfaces on
+          the pet detail page; the menu offers a Submit new version
+          link as the natural next step. */}
       {rejectedSubmissions.length > 0 ? (
         <section className="space-y-3">
-          <header className="flex items-end justify-between gap-3">
+          <header className="flex flex-wrap items-end justify-between gap-3">
             <p className="font-mono text-[11px] tracking-[0.22em] text-chip-danger-fg uppercase">
               Rejected ({rejectedSubmissions.length})
             </p>
@@ -241,85 +282,56 @@ function PetsPanel({
               Visible only to you. Submit a fresh version when ready.
             </p>
           </header>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {rejectedSubmissions.map((s) => (
-              <SubmissionCard key={s.id} submission={s} />
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+            {rejectedSubmissions.map((submission, index) => (
+              <PetCard
+                key={submission.id}
+                pet={submissionToPet(submission)}
+                index={index}
+                stateCount={stateCount}
+                statusOverlay={{ label: "Rejected", tone: "danger" }}
+                ownerActions={{
+                  submissionId: submission.id,
+                  status: "rejected",
+                }}
+              />
             ))}
           </div>
-        </section>
-      ) : null}
-
-      {approvedPets.length > 0 ? (
-        <section className="space-y-3">
-          {pendingSubmissions.length > 0 || rejectedSubmissions.length > 0 ? (
-            <p className="font-mono text-[11px] tracking-[0.22em] text-muted-3 uppercase">
-              Live pets
-            </p>
-          ) : null}
-          {isOwner ? (
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {approvedPets.map((pet) => (
-                <ApprovedSubmissionEditor
-                  key={pet.slug}
-                  pet={pet}
-                  publicHandle={publicHandle}
-                />
-              ))}
-            </div>
-          ) : (
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
-              {approvedPets.map((pet, index) => (
-                <PetCard
-                  key={pet.slug}
-                  pet={pet}
-                  index={index}
-                  stateCount={stateCount}
-                />
-              ))}
-            </div>
-          )}
         </section>
       ) : null}
     </div>
   );
 }
 
-// Approved pet for the owner: same PetCard the public sees, plus the
-// existing edit/withdraw flows surfaced as a SubmissionCard. We pass
-// the approved pet as a Submission shape so SubmissionCard handles
-// edit, view, install all in one place.
-function ApprovedSubmissionEditor({
-  pet,
-  publicHandle: _publicHandle,
-}: {
-  pet: PetWithMetrics;
-  publicHandle: string;
-}) {
-  const submission: Submission = {
-    id: pet.id,
-    slug: pet.slug,
-    displayName: pet.displayName,
-    description: pet.description,
-    spritesheetUrl: pet.spritesheetPath,
-    zipUrl: pet.zipUrl ?? "",
-    kind: pet.kind,
-    vibes: pet.vibes ?? [],
-    tags: pet.tags ?? [],
-    featured: pet.featured ?? false,
-    status: "approved",
-    createdAt: pet.importedAt,
-    approvedAt: pet.approvedAt ?? null,
-    rejectedAt: null,
-    rejectionReason: null,
-    pending: null,
-    pendingRejectionReason: null,
-    metrics: {
-      installCount: pet.metrics.installCount,
-      zipDownloadCount: pet.metrics.zipDownloadCount,
-      likeCount: pet.metrics.likeCount,
-    },
+// Pending and rejected submissions never make it through rowToPet
+// because the gallery queries filter on status='approved'. Build a
+// PetWithMetrics-shaped object here so PetCard can render them with
+// the same layout as the rest of the grid.
+function submissionToPet(submission: Submission): PetWithMetrics {
+  return {
+    id: submission.id,
+    slug: submission.slug,
+    displayName: submission.displayName,
+    description: submission.description,
+    spritesheetPath: submission.spritesheetUrl,
+    petJsonPath: "",
+    zipUrl: submission.zipUrl,
+    soundUrl: null,
+    approvalState:
+      submission.status === "approved" ? "approved" : "needs-review",
+    featured: submission.featured,
+    kind: submission.kind as PetWithMetrics["kind"],
+    vibes: submission.vibes as PetWithMetrics["vibes"],
+    tags: submission.tags,
+    dominantColor: null,
+    colorFamily: null,
+    submittedBy: undefined,
+    source: "submit",
+    approvedAt: submission.approvedAt,
+    importedAt: submission.createdAt,
+    qa: {},
+    metrics: submission.metrics,
   };
-  return <SubmissionCard submission={submission} />;
 }
 
 function LikedPanel({

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -773,7 +773,11 @@
     "more": "More…",
     "downloadZip": "Download ZIP",
     "removeFromPetdex": "Remove from Petdex",
-    "removing": "Removing…"
+    "removing": "Removing…",
+    "withdrawSubmission": "Withdraw submission",
+    "withdrawing": "Withdrawing…",
+    "submitNewVersion": "Submit a new version",
+    "editDetails": "Edit name & description"
   },
   "petStateViewer": {
     "eyebrow": "State viewer",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -773,7 +773,11 @@
     "more": "Más…",
     "downloadZip": "Descargar ZIP",
     "removeFromPetdex": "Eliminar de Petdex",
-    "removing": "Eliminando…"
+    "removing": "Eliminando…",
+    "withdrawSubmission": "Retirar envío",
+    "withdrawing": "Retirando…",
+    "submitNewVersion": "Enviar una nueva versión",
+    "editDetails": "Editar nombre y descripción"
   },
   "petStateViewer": {
     "eyebrow": "Visor de estados",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -926,7 +926,11 @@
     "more": "更多…",
     "downloadZip": "下载 ZIP",
     "removeFromPetdex": "从 Petdex 删除",
-    "removing": "删除中…"
+    "removing": "删除中…",
+    "withdrawSubmission": "撤回提交",
+    "withdrawing": "撤回中…",
+    "submitNewVersion": "提交新版本",
+    "editDetails": "编辑名称和描述"
   },
   "petStateViewer": {
     "eyebrow": "状态查看器",


### PR DESCRIPTION
## What

The Pets tab on `/u/<handle>` mixed two card shapes — `SubmissionCard` for owner-only pending + rejected entries and `PetCard` everywhere else. The mismatch made the owner's own profile feel like a stitched-together dashboard. Now the whole grid uses `PetCard`, with status / owner actions surfaced through a small overlay pill and the existing three-dots menu.

## Order on the owner view

1. **Approved** (also what visitors see)
2. **Pending review** — owner-only, header chip in amber + 'Visible only to you'
3. **Rejected** — owner-only, header chip in rose

Pinned pets keep rendering above the tabs section, untouched.

## PetCard changes

- `statusOverlay?: { label, tone }` renders a small pill top-left. Approved pets pass nothing, layout stays identical to the public gallery.
- `ownerActions?: { submissionId, status }` forwards owner context to the action menu.

## PetActionMenu owner items

| Status | Menu entry |
|---|---|
| pending | Withdraw submission (calls existing `/api/my-pets/[id]/withdraw`) |
| rejected | Submit a new version (link to `/submit`) |
| approved | Edit name & description (link to `/pets/[slug]#edit`) |

The existing card-anchor `Remove from Petdex` entry stays available alongside these.

## Verification

- `bun --bun tsc --noEmit` clean
- `bun test` 46/46 pass
- `biome check` clean
- `bun run i18n:check` clean

## Test plan

- [ ] Sign in on prod, open your own `/u/<handle>` → Pets tab shows Approved / Pending / Rejected sections in that order, all using the same card design as Liked tab and the gallery
- [ ] Pending card shows amber 'Pending' pill in the top-left corner
- [ ] Rejected card shows rose 'Rejected' pill
- [ ] Open the three-dots menu on a pending card → 'Withdraw submission' appears, click confirms + withdraws
- [ ] Same on a rejected card → 'Submit a new version' appears
- [ ] Open as a different user (not owner) → no overlays, no owner-only menu items, same as before