### PR TITLE
fix(action-menu): dark-mode hover + dropdown clipping behind next card

### DIFF
--- a/src/components/pet-action-menu.tsx
+++ b/src/components/pet-action-menu.tsx
@@ -372,7 +372,7 @@ export function PetActionMenu({ pet, variant = "card", ownerActions }: Props) {
                   target="_blank"
                   rel="noreferrer"
                   onClick={onZipClick}
-                  className="flex items-center gap-2.5 border-t border-black/[0.06] px-3 py-2.5 text-sm text-muted-2 transition hover:bg-[#f4f6ff] hover:text-foreground dark:border-white/[0.06]"
+                  className="flex items-center gap-2.5 border-t border-black/[0.06] px-3 py-2.5 text-sm text-muted-2 transition hover:bg-surface-muted hover:text-foreground dark:border-white/[0.06]"
                 >
                   <Download className="size-4" />
                   <span className="flex-1">{t("downloadZip")}</span>
@@ -407,7 +407,7 @@ export function PetActionMenu({ pet, variant = "card", ownerActions }: Props) {
                 <Link
                   href="/submit"
                   onClick={() => setOpen(false)}
-                  className="flex items-center gap-2.5 border-t border-black/[0.06] px-3 py-2.5 text-sm text-foreground transition hover:bg-[#f4f6ff] dark:border-white/[0.06]"
+                  className="flex items-center gap-2.5 border-t border-black/[0.06] px-3 py-2.5 text-sm text-foreground transition hover:bg-surface-muted dark:border-white/[0.06]"
                 >
                   <Plus className="size-4" />
                   <span className="flex-1">{t("submitNewVersion")}</span>
@@ -419,7 +419,7 @@ export function PetActionMenu({ pet, variant = "card", ownerActions }: Props) {
                 <Link
                   href={`/pets/${pet.slug}#edit`}
                   onClick={() => setOpen(false)}
-                  className="flex items-center gap-2.5 border-t border-black/[0.06] px-3 py-2.5 text-sm text-foreground transition hover:bg-[#f4f6ff] dark:border-white/[0.06]"
+                  className="flex items-center gap-2.5 border-t border-black/[0.06] px-3 py-2.5 text-sm text-foreground transition hover:bg-surface-muted dark:border-white/[0.06]"
                 >
                   <Pencil className="size-4" />
                   <span className="flex-1">{t("editDetails")}</span>
@@ -483,7 +483,7 @@ function MenuItem({ icon, label, hint, onClick }: MenuItemProps) {
           e.preventDefault();
           onClick();
         }}
-        className="flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm text-muted-2 transition hover:bg-[#f4f6ff] hover:text-foreground"
+        className="flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm text-muted-2 transition hover:bg-surface-muted hover:text-foreground"
       >
         {icon}
         <span className="flex flex-col">

--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -744,9 +744,16 @@ export function PetCard({
       : undefined;
 
   return (
+    // The has-[] selector lifts this card above its row siblings while
+    // the action menu is open. Without it the dropdown gets clipped by
+    // the next card down: each card has its own stacking context (from
+    // backdrop-blur + the hover translate), so a z-index inside the
+    // dropdown can never climb above a later sibling's context. The
+    // PetActionMenu trigger button toggles aria-expanded, which is the
+    // signal we hook here.
     <article
       style={accentStyle}
-      className={`group relative flex h-full flex-col rounded-3xl border bg-surface/76 backdrop-blur transition hover:-translate-y-0.5 hover:bg-white hover:shadow-xl hover:shadow-blue-950/10 ${
+      className={`group relative flex h-full flex-col rounded-3xl border bg-surface/76 backdrop-blur transition has-[[aria-expanded=true]]:z-30 hover:-translate-y-0.5 hover:bg-white hover:shadow-xl hover:shadow-blue-950/10 ${
         pet.featured
           ? "border-brand-light/45 shadow-[0_0_0_1px_rgba(100,120,246,0.18),0_18px_45px_-22px_rgba(82,102,234,0.5)]"
           : pet.dominantColor


### PR DESCRIPTION
Two adjacent bugs in the per-card three-dots menu, both visible in https://petdex.crafter.run/u/<handle> dark mode.

## 1. Dark hover state

Hover bg was the hardcoded `#f4f6ff` literal. Light mode read it as a soft tint; dark mode flashed white-on-dark and the active item looked broken. Swapped all four occurrences for `hover:bg-surface-muted` (the semantic token that already alternates by theme).

## 2. Dropdown clipped by next card

Each PetCard `<article>` creates its own stacking context — `backdrop-blur` plus the `hover:-translate-y-0.5` transform both qualify. A z-index inside the dropdown can never climb above a *later* sibling article's context, so the next card down clipped the open menu.

Used a Tailwind v4 `has-[[aria-expanded=true]]:z-30` on the `<article>` itself. When the trigger button toggles `aria-expanded` open, the whole card jumps to z-30, which puts it above its row siblings. No state plumbing, no portal — the existing `aria-expanded` attribute is the signal.

## Verification

- `bun --bun tsc --noEmit` clean
- `bun test` 46/46 pass
- `biome check` clean
- Same component, no API change, no behavior change beyond the visual fix