### PR TITLE
feat(profile): share button + OG image for /u/<handle>

### DIFF
--- a/src/app/[locale]/u/[handle]/opengraph-image.tsx
+++ b/src/app/[locale]/u/[handle]/opengraph-image.tsx
@@ -1,0 +1,448 @@
+// Per-profile OG image. Mirrors the per-pet/per-collection OGs:
+// petdex-cloud gradient + brand purple, mono caption. Renders the
+// creator's avatar (when allowlisted), display name, pet count, and
+// a sprite collage of up to 4 pinned pets so the unfurl reads as
+// "this person made these pets" instead of a generic profile card.
+//
+// Driven by the user's pinned set (featuredPetSlugs). When the user
+// has no pinned pets we fall back to the most recent approved pets.
+
+import { ImageResponse } from "next/og";
+
+import { clerkClient } from "@clerk/nextjs/server";
+import { and, desc, eq, inArray } from "drizzle-orm";
+import sharp from "sharp";
+
+import { db, schema } from "@/lib/db/client";
+import { userIdForHandle } from "@/lib/handles";
+import { isAllowedAssetUrl, isAllowedAvatarUrl } from "@/lib/url-allowlist";
+
+export const runtime = "nodejs";
+export const contentType = "image/png";
+export const size = { width: 1200, height: 630 };
+export const alt = "Petdex profile preview";
+// 24h ISR — same reasoning as the per-pet OG. Profile bios change
+// rarely and the unfurl bots that hit this path are noisy. Cached
+// PNG saves Fluid CPU + Origin Transfer on every Discord/X share.
+export const revalidate = 86400;
+
+const FRAME_W = 192;
+const FRAME_H = 208;
+const SPRITE_DISPLAY = 192; // square plate per sprite
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ locale: string; handle: string }>;
+}) {
+  const { handle } = await params;
+  const ownerId = await userIdForHandle(handle);
+  if (!ownerId) return petdexFallback();
+
+  // Profile + Clerk identity. We fetch in parallel; the Clerk call can
+  // throw on transient API errors but we swallow it and fall back to
+  // the handle since the OG should never error a share.
+  const [profile, clerkUser] = await Promise.all([
+    db.query.userProfiles.findFirst({
+      where: eq(schema.userProfiles.userId, ownerId),
+    }),
+    (async () => {
+      try {
+        const c = await clerkClient();
+        return await c.users.getUser(ownerId);
+      } catch {
+        return null;
+      }
+    })(),
+  ]);
+
+  const fullName = clerkUser
+    ? [clerkUser.firstName, clerkUser.lastName].filter(Boolean).join(" ").trim()
+    : "";
+  const displayName = profile?.displayName ?? fullName ?? `@${handle}`;
+  const safeDisplayName = displayName || `@${handle}`;
+  const publicHandle = profile?.handle ?? handle.toLowerCase();
+  const bio = profile?.bio?.trim() ?? null;
+  const featuredSlugs =
+    (profile?.featuredPetSlugs as string[] | undefined) ?? [];
+
+  // Fetch sprite URLs. Pinned pets first; fall back to the 4 most
+  // recently approved pets if the user has no pinned set yet.
+  const approvedFilter = and(
+    eq(schema.submittedPets.ownerId, ownerId),
+    eq(schema.submittedPets.status, "approved"),
+  );
+  const collageRows =
+    featuredSlugs.length > 0
+      ? await db
+          .select({
+            slug: schema.submittedPets.slug,
+            spritesheetUrl: schema.submittedPets.spritesheetUrl,
+          })
+          .from(schema.submittedPets)
+          .where(
+            and(
+              approvedFilter,
+              inArray(schema.submittedPets.slug, featuredSlugs.slice(0, 4)),
+            ),
+          )
+      : await db
+          .select({
+            slug: schema.submittedPets.slug,
+            spritesheetUrl: schema.submittedPets.spritesheetUrl,
+          })
+          .from(schema.submittedPets)
+          .where(approvedFilter)
+          .orderBy(desc(schema.submittedPets.approvedAt))
+          .limit(4);
+
+  // Total pet count for the stat line. One round-trip with raw count.
+  const countRows = await db
+    .select({ slug: schema.submittedPets.slug })
+    .from(schema.submittedPets)
+    .where(approvedFilter);
+  const petCount = countRows.length;
+
+  // Decode sprites in parallel. Failures fall through to no-sprite
+  // (the slot just renders empty).
+  const spriteUrls = await Promise.all(
+    collageRows
+      .slice(0, 4)
+      .map((r) => loadFirstFrameAsDataUrl(r.spritesheetUrl)),
+  );
+
+  const avatarDataUrl = clerkUser?.imageUrl
+    ? await loadAvatarAsDataUrl(clerkUser.imageUrl)
+    : null;
+
+  const fallbackInitial = (
+    safeDisplayName[0] ??
+    handle[0] ??
+    "?"
+  ).toUpperCase();
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        background:
+          "linear-gradient(120deg, #d8e9ff 0%, #f7f8ff 47%, #c9c6ff 100%)",
+        position: "relative",
+        fontFamily:
+          "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          background:
+            "radial-gradient(circle at 50% 30%, rgba(255,255,255,0.85) 0%, rgba(255,255,255,0.45) 28%, transparent 60%)",
+          display: "flex",
+        }}
+      />
+
+      {/* Top brand row */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "44px 56px 0 56px",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 14,
+            color: "#0a0a0a",
+            fontSize: 28,
+            fontWeight: 600,
+          }}
+        >
+          <PetdexMark size={44} />
+          <span>Petdex</span>
+        </div>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            color: "#5266ea",
+            fontSize: 18,
+            letterSpacing: 4,
+            textTransform: "uppercase",
+            fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+            fontWeight: 600,
+          }}
+        >
+          Petdex creator
+        </div>
+      </div>
+
+      {/* Main row */}
+      <div
+        style={{
+          display: "flex",
+          flex: 1,
+          padding: "32px 64px 24px 64px",
+          alignItems: "center",
+          gap: 44,
+        }}
+      >
+        {/* Avatar plate */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: 220,
+            height: 220,
+            borderRadius: 40,
+            backgroundColor: "rgba(255,255,255,0.92)",
+            border: "1px solid rgba(82,102,234,0.18)",
+            flexShrink: 0,
+            overflow: "hidden",
+          }}
+        >
+          {avatarDataUrl ? (
+            // biome-ignore lint/performance/noImgElement: og runtime needs <img>
+            <img
+              src={avatarDataUrl}
+              width={220}
+              height={220}
+              alt=""
+              style={{ objectFit: "cover" }}
+            />
+          ) : (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: "100%",
+                height: "100%",
+                color: "#5b6076",
+                fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+                fontSize: 96,
+                fontWeight: 600,
+              }}
+            >
+              {fallbackInitial}
+            </div>
+          )}
+        </div>
+
+        {/* Identity column */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            flex: 1,
+            color: "#0a0a0a",
+            minWidth: 0,
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              fontSize: 22,
+              color: "#5266ea",
+              fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+              letterSpacing: 4,
+              textTransform: "uppercase",
+              marginBottom: 12,
+            }}
+          >
+            @{publicHandle}
+          </div>
+          <div
+            style={{
+              display: "flex",
+              fontSize: 80,
+              fontWeight: 700,
+              lineHeight: 1,
+              letterSpacing: -2,
+              color: "#0a0a0a",
+              marginBottom: 18,
+              maxWidth: 720,
+            }}
+          >
+            {clip(safeDisplayName, 24)}
+          </div>
+          {bio ? (
+            <div
+              style={{
+                display: "flex",
+                fontSize: 26,
+                lineHeight: 1.35,
+                color: "#202127",
+                maxWidth: 620,
+                marginBottom: 18,
+              }}
+            >
+              {clip(bio, 110)}
+            </div>
+          ) : null}
+          <div
+            style={{
+              display: "flex",
+              fontSize: 22,
+              fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+              color: "#5b6076",
+              letterSpacing: 2,
+              textTransform: "uppercase",
+            }}
+          >
+            {petCount} {petCount === 1 ? "pet" : "pets"} · petdex.crafter.run
+          </div>
+        </div>
+      </div>
+
+      {/* Sprite collage strip */}
+      {spriteUrls.some(Boolean) ? (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "flex-end",
+            justifyContent: "flex-end",
+            gap: 16,
+            padding: "0 64px 36px 64px",
+          }}
+        >
+          {spriteUrls.map((dataUrl, i) =>
+            dataUrl ? (
+              <div
+                // biome-ignore lint/suspicious/noArrayIndexKey: collage is positional
+                key={i}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  width: SPRITE_DISPLAY,
+                  height: SPRITE_DISPLAY,
+                  borderRadius: 28,
+                  backgroundColor: "rgba(255,255,255,0.82)",
+                  border: "1px solid rgba(82,102,234,0.18)",
+                }}
+              >
+                {/* biome-ignore lint/performance/noImgElement: og runtime */}
+                <img
+                  src={dataUrl}
+                  width={SPRITE_DISPLAY - 24}
+                  height={SPRITE_DISPLAY - 24}
+                  alt=""
+                />
+              </div>
+            ) : null,
+          )}
+        </div>
+      ) : (
+        <div style={{ height: 56, display: "flex" }} />
+      )}
+    </div>,
+    { ...size },
+  );
+}
+
+async function loadFirstFrameAsDataUrl(url: string): Promise<string | null> {
+  if (!isAllowedAssetUrl(url)) return null;
+  try {
+    const res = await fetch(url, { redirect: "error" });
+    if (!res.ok) return null;
+    const buf = Buffer.from(await res.arrayBuffer());
+    const png = await sharp(buf)
+      .extract({ left: 0, top: 0, width: FRAME_W, height: FRAME_H })
+      .resize(SPRITE_DISPLAY - 24, SPRITE_DISPLAY - 24, { kernel: "nearest" })
+      .png()
+      .toBuffer();
+    return `data:image/png;base64,${png.toString("base64")}`;
+  } catch {
+    return null;
+  }
+}
+
+async function loadAvatarAsDataUrl(url: string): Promise<string | null> {
+  if (!isAllowedAvatarUrl(url)) return null;
+  try {
+    const res = await fetch(url, { redirect: "error" });
+    if (!res.ok) return null;
+    const buf = Buffer.from(await res.arrayBuffer());
+    const png = await sharp(buf)
+      .resize(220, 220, { fit: "cover" })
+      .png()
+      .toBuffer();
+    return `data:image/png;base64,${png.toString("base64")}`;
+  } catch {
+    return null;
+  }
+}
+
+function PetdexMark({ size }: { size: number }) {
+  return (
+    <svg
+      aria-hidden="true"
+      width={size}
+      height={size}
+      viewBox="0 0 64 64"
+      xmlns="http://www.w3.org/2000/svg"
+      style={{ display: "flex" }}
+    >
+      <defs>
+        <linearGradient
+          id="og-petdex-profile-body"
+          x1="8"
+          y1="8"
+          x2="56"
+          y2="56"
+        >
+          <stop stopColor="#3847f5" />
+          <stop offset="1" stopColor="#1a1d2e" />
+        </linearGradient>
+      </defs>
+      <rect
+        x="6"
+        y="6"
+        width="52"
+        height="52"
+        rx="14"
+        fill="url(#og-petdex-profile-body)"
+      />
+      <circle cx="24" cy="28" r="4" fill="#fff" />
+      <circle cx="40" cy="28" r="4" fill="#fff" />
+      <rect x="22" y="40" width="20" height="4" rx="2" fill="#fff" />
+    </svg>
+  );
+}
+
+function petdexFallback() {
+  return new ImageResponse(
+    <div
+      style={{
+        display: "flex",
+        width: "100%",
+        height: "100%",
+        background:
+          "linear-gradient(120deg, #d8e9ff 0%, #f7f8ff 47%, #c9c6ff 100%)",
+        alignItems: "center",
+        justifyContent: "center",
+        color: "#0a0a0a",
+        fontSize: 80,
+        fontWeight: 700,
+        fontFamily:
+          "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+      }}
+    >
+      Petdex
+    </div>,
+    { ...size },
+  );
+}
+
+function clip(s: string, n: number): string {
+  if (s.length <= n) return s;
+  return `${s.slice(0, n - 1).trimEnd()}…`;
+}

--- a/src/app/[locale]/u/[handle]/page.tsx
+++ b/src/app/[locale]/u/[handle]/page.tsx
@@ -27,6 +27,7 @@ import { ProfileAnalytics } from "@/components/profile-analytics";
 import { ProfileExternalLink } from "@/components/profile-external-link";
 import { ProfileInlineEditor } from "@/components/profile-inline-editor";
 import { ProfilePinButton } from "@/components/profile-pin-button";
+import { ProfileShareButton } from "@/components/profile-share-button";
 import { ProfileTabs } from "@/components/profile-tabs";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
@@ -358,8 +359,14 @@ export default async function UserProfilePage({ params }: PageProps) {
               ) : null}
             </div>
 
-            {/* Owner action */}
-            <div className="flex justify-center lg:justify-end">
+            {/* Owner + visitor actions. Share is on for everyone so a
+                fan can spread a profile they liked, the same growth
+                motion as the creator promoting their own page. */}
+            <div className="flex flex-wrap items-center justify-center gap-2 lg:justify-end">
+              <ProfileShareButton
+                handle={publicHandle}
+                displayName={displayName}
+              />
               {isOwner ? (
                 <ProfileInlineEditor
                   handle={publicHandle}

--- a/src/components/profile-share-button.tsx
+++ b/src/components/profile-share-button.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+
+import { track } from "@vercel/analytics";
+import { Check, X as CloseIcon, Link2, Share2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { createPortal } from "react-dom";
+
+const SITE_URL = "https://petdex.crafter.run";
+
+type Props = {
+  /** Public handle without leading @ — used to build the URL. */
+  handle: string;
+  /** Display name surfaced in the share text. Falls back to @handle when null. */
+  displayName: string | null;
+};
+
+// Profile-level share button. Sits next to "Edit profile" in the
+// header so creators have an obvious affordance to spread their page.
+// Visible to everyone (owner + visitor) — fans sharing a profile they
+// like is the same growth motion as the creator promoting themselves.
+//
+// Surfaces: Copy link, Share to X, Share to LinkedIn, native Share
+// (when the browser supports it). The same set the per-pet action
+// menu uses, just scoped to the /u/<handle> URL. We portal the
+// dropdown to <body> so the parent stacking context can't clip it.
+export function ProfileShareButton({ handle, displayName }: Props) {
+  const t = useTranslations("profileShare");
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const [menuPos, setMenuPos] = useState<{
+    top: number;
+    left: number;
+  } | null>(null);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const profileUrl = `${SITE_URL}/u/${handle}`;
+  const shareLabel = displayName ?? `@${handle}`;
+  const shareText = t("shareText", { name: shareLabel });
+
+  const computePos = useCallback(() => {
+    const el = triggerRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const MENU_WIDTH = 256;
+    const top = rect.bottom + 8;
+    const left = Math.max(8, rect.right - MENU_WIDTH);
+    setMenuPos({ top, left });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    computePos();
+  }, [open, computePos]);
+
+  useEffect(() => {
+    if (!open) return;
+    const h = () => computePos();
+    window.addEventListener("resize", h);
+    window.addEventListener("scroll", h, true);
+    return () => {
+      window.removeEventListener("resize", h);
+      window.removeEventListener("scroll", h, true);
+    };
+  }, [open, computePos]);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      const target = e.target as Node;
+      if (wrapRef.current?.contains(target)) return;
+      if (menuRef.current?.contains(target)) return;
+      setOpen(false);
+    }
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
+
+  const onCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(profileUrl);
+      setCopied(true);
+      track("profile_share", { handle, target: "copy" });
+      window.setTimeout(() => setCopied(false), 1400);
+    } catch {
+      /* ignore clipboard failures */
+    }
+  }, [handle, profileUrl]);
+
+  const onShareX = useCallback(() => {
+    const url = `https://x.com/intent/tweet?text=${encodeURIComponent(
+      shareText,
+    )}&url=${encodeURIComponent(profileUrl)}`;
+    track("profile_share", { handle, target: "x" });
+    window.open(url, "_blank", "noopener,noreferrer,width=560,height=540");
+    setOpen(false);
+  }, [handle, profileUrl, shareText]);
+
+  const onShareLinkedIn = useCallback(() => {
+    const url = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(
+      profileUrl,
+    )}`;
+    track("profile_share", { handle, target: "linkedin" });
+    window.open(url, "_blank", "noopener,noreferrer,width=620,height=600");
+    setOpen(false);
+  }, [handle, profileUrl]);
+
+  const onShareNative = useCallback(async () => {
+    if (typeof navigator === "undefined" || !("share" in navigator)) return;
+    try {
+      await (
+        navigator as Navigator & {
+          share: (data: ShareData) => Promise<void>;
+        }
+      ).share({
+        title: `${shareLabel} — Petdex`,
+        text: shareText,
+        url: profileUrl,
+      });
+      track("profile_share", { handle, target: "native" });
+      setOpen(false);
+    } catch {
+      /* user cancelled */
+    }
+  }, [handle, profileUrl, shareLabel, shareText]);
+
+  const supportsNative =
+    typeof navigator !== "undefined" && "share" in navigator;
+
+  const menuNode =
+    open && menuPos ? (
+      <div
+        ref={menuRef}
+        role="menu"
+        style={{ position: "fixed", top: menuPos.top, left: menuPos.left }}
+        className="z-[100] w-64 overflow-hidden rounded-2xl border border-border-base bg-surface shadow-xl shadow-blue-950/15"
+      >
+        <div className="flex items-center justify-between border-b border-black/[0.06] px-3 py-2 dark:border-white/[0.06]">
+          <span className="font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
+            {t("eyebrow")}
+          </span>
+          <button
+            type="button"
+            aria-label={t("close")}
+            onClick={() => setOpen(false)}
+            className="grid size-6 place-items-center rounded-full text-muted-4 transition hover:bg-surface-muted hover:text-foreground"
+          >
+            <CloseIcon className="size-3.5" />
+          </button>
+        </div>
+        <ul className="py-1">
+          <li>
+            <button
+              type="button"
+              role="menuitem"
+              onClick={(e) => {
+                e.preventDefault();
+                void onCopy();
+              }}
+              className="flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm text-muted-2 transition hover:bg-surface-muted hover:text-foreground"
+            >
+              {copied ? (
+                <Check className="size-4 text-emerald-600" />
+              ) : (
+                <Link2 className="size-4" />
+              )}
+              <span className="flex flex-col">
+                <span>{copied ? t("copied") : t("copyLink")}</span>
+                <span className="font-mono text-[10px] tracking-tight text-muted-4">
+                  {profileUrl.replace(/^https?:\/\//, "")}
+                </span>
+              </span>
+            </button>
+          </li>
+          <li>
+            <button
+              type="button"
+              role="menuitem"
+              onClick={(e) => {
+                e.preventDefault();
+                onShareX();
+              }}
+              className="flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm text-muted-2 transition hover:bg-surface-muted hover:text-foreground"
+            >
+              <XIcon className="size-4" />
+              <span>{t("shareToX")}</span>
+            </button>
+          </li>
+          <li>
+            <button
+              type="button"
+              role="menuitem"
+              onClick={(e) => {
+                e.preventDefault();
+                onShareLinkedIn();
+              }}
+              className="flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm text-muted-2 transition hover:bg-surface-muted hover:text-foreground"
+            >
+              <LinkedInIcon className="size-4" />
+              <span>{t("shareToLinkedIn")}</span>
+            </button>
+          </li>
+          {supportsNative ? (
+            <li>
+              <button
+                type="button"
+                role="menuitem"
+                onClick={(e) => {
+                  e.preventDefault();
+                  void onShareNative();
+                }}
+                className="flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm text-muted-2 transition hover:bg-surface-muted hover:text-foreground"
+              >
+                <Share2 className="size-4" />
+                <span>{t("more")}</span>
+              </button>
+            </li>
+          ) : null}
+        </ul>
+      </div>
+    ) : null;
+
+  return (
+    <div ref={wrapRef} className="relative inline-flex">
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen((v) => !v);
+        }}
+        className="inline-flex h-10 items-center gap-2 rounded-full border border-border-base bg-surface px-4 text-sm font-medium text-muted-2 transition hover:border-border-strong hover:text-foreground"
+      >
+        <Share2 className="size-4" />
+        {t("share")}
+      </button>
+      {mounted && menuNode ? createPortal(menuNode, document.body) : null}
+    </div>
+  );
+}
+
+function XIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      className={className}
+      fill="currentColor"
+    >
+      <path d="M18.244 2H21l-6.55 7.49L22 22h-6.93l-4.83-6.31L4.6 22H1.84l7.01-8.02L1 2h7.07l4.36 5.78L18.244 2zm-2.43 18h1.91L7.27 4H5.27l10.544 16z" />
+    </svg>
+  );
+}
+
+function LinkedInIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      className={className}
+      fill="currentColor"
+    >
+      <path d="M19 3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2zM8.34 18.34V10.5H5.67v7.84zm-1.34-9a1.55 1.55 0 1 0 0-3.1 1.55 1.55 0 0 0 0 3.1zm11.34 9v-4.49c0-2.4-1.28-3.52-2.99-3.52a2.58 2.58 0 0 0-2.34 1.29h-.04V10.5h-2.55v7.84h2.66v-3.88c0-1.02.2-2.01 1.46-2.01 1.25 0 1.27 1.17 1.27 2.07v3.82z" />
+    </svg>
+  );
+}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -760,6 +760,17 @@
   "commandLine": {
     "copyAria": "Copy command"
   },
+  "profileShare": {
+    "share": "Share",
+    "eyebrow": "Share this profile",
+    "close": "Close",
+    "copyLink": "Copy link",
+    "copied": "Copied",
+    "shareToX": "Share to X",
+    "shareToLinkedIn": "Share to LinkedIn",
+    "more": "More…",
+    "shareText": "Check out {name}'s Codex pet collection on Petdex"
+  },
   "petActions": {
     "moreActions": "More actions for {name}",
     "share": "Share",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -760,6 +760,17 @@
   "commandLine": {
     "copyAria": "Copiar comando"
   },
+  "profileShare": {
+    "share": "Compartir",
+    "eyebrow": "Compartir este perfil",
+    "close": "Cerrar",
+    "copyLink": "Copiar enlace",
+    "copied": "Copiado",
+    "shareToX": "Compartir en X",
+    "shareToLinkedIn": "Compartir en LinkedIn",
+    "more": "Más…",
+    "shareText": "Mira la colección de mascotas de Codex de {name} en Petdex"
+  },
   "petActions": {
     "moreActions": "Más acciones para {name}",
     "share": "Compartir",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -911,6 +911,17 @@
   "commandLine": {
     "copyAria": "复制命令"
   },
+  "profileShare": {
+    "share": "分享",
+    "eyebrow": "分享此资料",
+    "close": "关闭",
+    "copyLink": "复制链接",
+    "copied": "已复制",
+    "shareToX": "分享到 X",
+    "shareToLinkedIn": "分享到 LinkedIn",
+    "more": "更多…",
+    "shareText": "看看 {name} 在 Petdex 上的 Codex 宠物合集"
+  },
   "petActions": {
     "moreActions": "{name} 的更多操作",
     "moreActions__fixme": true,


### PR DESCRIPTION
Closes feedback [fb_6e39375cf03945d68b](https://petdex.crafter.run/admin/feedback/fb_6e39375cf03945d68b) — "profile share links to help creators spread awareness/bring viewers in" from Chris Mafia.

## What

A Share button on every `/u/<handle>` page plus a custom OG image so the unfurl in Discord/Slack/X looks like a recommendation, not a generic link.

## ProfileShareButton

- Sits next to Edit profile in the header.
- Visible to **everyone** — fans sharing a profile they like is the same growth motion as the creator promoting their own.
- Surfaces: Copy link, Share to X, Share to LinkedIn, native Share (mobile only, when supported).
- Pre-filled tweet text uses the creator's display name: *Check out [name]'s Codex pet collection on Petdex →*. The unfurl reads as a recommendation.
- `profile_share { handle, target }` analytics event so we can see which surface jala más.
- Portals the dropdown to `<body>` to escape the parent stacking context (same pattern as the action menu fix in #117).

## OG image

`/u/<handle>/opengraph-image.tsx` mirrors the per-pet and per-collection patterns:

- 1200×630, brand gradient + purple, monospace caption.
- Avatar (allowlisted Clerk URL or a fallback initial).
- Display name + @handle + optional bio.
- Pet count.
- Sprite collage of up to 4 **pinned pets** — falls back to the 4 most recent approved pets when no pin set.
- 24h ISR so Discord/Slack/X unfurl bots cache it. Same line item as the OG fixes in #109.

## Verification

- `bun --bun tsc --noEmit` clean
- `bun test` 46/46 pass
- `biome check` clean
- `bun run i18n:check` clean
- Feedback already replied + marked addressed via in-app notification (Chris doesn't have an email on file).

## Test plan

- [ ] Visit /u/<your-handle> as visitor → Share button appears in header
- [ ] Click → dropdown opens with Copy link / Share to X / Share to LinkedIn / native Share (on mobile)
- [ ] Copy link → clipboard has petdex.crafter.run/u/<handle>
- [ ] Share to X → tweet intent opens with pre-filled text + URL
- [ ] Open https://www.opengraph.xyz/url/https%3A%2F%2Fpetdex.crafter.run%2Fu%2F<handle> after deploy → preview shows avatar + name + sprite collage
- [ ] First unfurl in #showcase Discord channel after deploy materializes the PNG; subsequent shares hit edge cache