### PR TITLE
Fix header avatar size

### DIFF
--- a/src/components/auth-badge.tsx
+++ b/src/components/auth-badge.tsx
@@ -56,7 +56,11 @@ function UserButtonWithAdminLink() {
     <div className="relative">
       <UserButton
         appearance={{
-          elements: { avatarBox: "size-11 rounded-full ring-1 ring-black/10" },
+          elements: {
+            userButtonTrigger: "size-11 rounded-full",
+            userButtonAvatarBox: "size-11 rounded-full ring-1 ring-black/10",
+            avatarBox: "size-11 rounded-full ring-1 ring-black/10",
+          },
         }}
       >
         <UserButton.MenuItems>

--- a/src/lib/mock/clerk-client.tsx
+++ b/src/lib/mock/clerk-client.tsx
@@ -72,8 +72,8 @@ export function UserButton() {
   return (
     <div
       style={{
-        width: 28,
-        height: 28,
+        width: 44,
+        height: 44,
         borderRadius: "50%",
         background: "#666",
         color: "white",


### PR DESCRIPTION

<img width="1316" height="216" alt="image" src="https://github.com/user-attachments/assets/b3fa785d-1034-4e7b-b9d8-fa5189bebc2a" />


## Summary
- Size the Clerk header UserButton trigger/avatar to match the 44px header controls
- Update the local mock Clerk UserButton to the same 44px size


Note: I couldn't verify the fix locally, having some install/build issues