### PR TITLE
perf(edge): aggregate header state into one polled endpoint

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -4,10 +4,15 @@ import { notFound } from "next/navigation";
 
 import { Analytics } from "@vercel/analytics/next";
 import { NextIntlClientProvider } from "next-intl";
-import { getMessages, getTranslations, setRequestLocale } from "next-intl/server";
+import {
+  getMessages,
+  getTranslations,
+  setRequestLocale,
+} from "next-intl/server";
 
 import { AnnouncementQueue } from "@/components/announcement-queue";
 import { FeedbackWidget } from "@/components/feedback-widget";
+import { HeaderStateProvider } from "@/components/header-state-provider";
 import { ProfileAnnouncementModal } from "@/components/profile-announcement-modal";
 import { AppProviders } from "@/components/theme-providers";
 
@@ -96,11 +101,13 @@ export default async function LocaleLayout({ children, params }: Props) {
       <body className="min-h-full flex flex-col bg-background text-foreground">
         <NextIntlClientProvider messages={messages}>
           <AppProviders>
-            {children}
-            <FeedbackWidget />
-            <AnnouncementQueue />
-            <ProfileAnnouncementModal />
-            <Analytics />
+            <HeaderStateProvider>
+              {children}
+              <FeedbackWidget />
+              <AnnouncementQueue />
+              <ProfileAnnouncementModal />
+              <Analytics />
+            </HeaderStateProvider>
           </AppProviders>
         </NextIntlClientProvider>
       </body>

--- a/src/app/api/me/header-state/route.ts
+++ b/src/app/api/me/header-state/route.ts
@@ -1,0 +1,124 @@
+import { NextResponse } from "next/server";
+
+import { auth } from "@clerk/nextjs/server";
+import { and, sql as dsql, eq, inArray, isNull } from "drizzle-orm";
+
+import { isAdmin } from "@/lib/admin";
+import { getCaughtSlugSet } from "@/lib/catch-status";
+import { db, schema } from "@/lib/db/client";
+
+export const runtime = "nodejs";
+
+// GET /api/me/header-state -> single aggregate the SiteHeader needs on
+// every page-view. Combines what used to be three separate endpoints
+// (notifications unread, feedback unread, caught slugs) so we ship
+// one Edge Request per page-view instead of three.
+//
+// Returns lightweight counts + the caught slug set. The full
+// notifications list (`items[]`) still lives at /api/notifications and
+// is only fetched when the bell dropdown opens.
+export async function GET(): Promise<Response> {
+  const { userId } = await auth();
+
+  if (!userId) {
+    // Anonymous viewers always get the same empty payload, so let the
+    // edge cache absorb most of the load. 5min CDN cache + 1h SWR keeps
+    // the header snappy for visitors without hitting the function.
+    return NextResponse.json(
+      {
+        signedIn: false,
+        notifications: { unreadCount: 0 },
+        feedback: { count: 0, adminCount: 0 },
+        caught: [] as string[],
+      },
+      {
+        headers: {
+          "Cache-Control": "public, s-maxage=300, stale-while-revalidate=3600",
+        },
+      },
+    );
+  }
+
+  const headers = { "Cache-Control": "private, no-store" };
+
+  const [unreadNotifRows, caughtSet, myFeedback] = await Promise.all([
+    db
+      .select({ id: schema.notifications.id })
+      .from(schema.notifications)
+      .where(
+        and(
+          eq(schema.notifications.userId, userId),
+          isNull(schema.notifications.readAt),
+        ),
+      ),
+    getCaughtSlugSet(userId),
+    db
+      .select({
+        id: schema.feedback.id,
+        userLastReadAt: schema.feedback.userLastReadAt,
+      })
+      .from(schema.feedback)
+      .where(eq(schema.feedback.userId, userId)),
+  ]);
+
+  let feedbackCount = 0;
+  if (myFeedback.length > 0) {
+    const ids = myFeedback.map((r) => r.id);
+    const adminReplies = await db
+      .select({
+        feedbackId: schema.feedbackReplies.feedbackId,
+        latestAdminReply: dsql<Date>`MAX(${schema.feedbackReplies.createdAt})`,
+      })
+      .from(schema.feedbackReplies)
+      .where(
+        and(
+          eq(schema.feedbackReplies.authorKind, "admin"),
+          inArray(schema.feedbackReplies.feedbackId, ids),
+        ),
+      )
+      .groupBy(schema.feedbackReplies.feedbackId);
+
+    const lastReadById = new Map(
+      myFeedback.map((r) => [r.id, r.userLastReadAt]),
+    );
+    feedbackCount = adminReplies.filter((r) => {
+      const lastRead = lastReadById.get(r.feedbackId);
+      return !lastRead || new Date(r.latestAdminReply) > new Date(lastRead);
+    }).length;
+  }
+
+  let adminCount = 0;
+  if (isAdmin(userId)) {
+    const rows = await db
+      .select({
+        feedbackId: schema.feedbackReplies.feedbackId,
+        latestUserReply: dsql<Date>`MAX(${schema.feedbackReplies.createdAt})`,
+        adminLastReadAt: schema.feedback.adminLastReadAt,
+      })
+      .from(schema.feedbackReplies)
+      .innerJoin(
+        schema.feedback,
+        eq(schema.feedback.id, schema.feedbackReplies.feedbackId),
+      )
+      .where(eq(schema.feedbackReplies.authorKind, "user"))
+      .groupBy(
+        schema.feedbackReplies.feedbackId,
+        schema.feedback.adminLastReadAt,
+      );
+    adminCount = rows.filter(
+      (r) =>
+        !r.adminLastReadAt ||
+        new Date(r.latestUserReply) > new Date(r.adminLastReadAt),
+    ).length;
+  }
+
+  return NextResponse.json(
+    {
+      signedIn: true,
+      notifications: { unreadCount: unreadNotifRows.length },
+      feedback: { count: feedbackCount, adminCount },
+      caught: Array.from(caughtSet),
+    },
+    { headers },
+  );
+}

--- a/src/components/auth-badge.tsx
+++ b/src/components/auth-badge.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
-
 import { SignInButton, UserButton, useAuth, useUser } from "@clerk/nextjs";
 import { MessageSquare, Shield, UserSquare } from "lucide-react";
 
 import { isAdminClientSafe } from "@/lib/admin";
 
+import { useHeaderState } from "@/components/header-state-provider";
 import { NotificationsBell } from "@/components/notifications-bell";
 
 export function AuthBadge({ beforeUser }: { beforeUser?: React.ReactNode }) {
@@ -94,25 +93,5 @@ function UserButtonWithAdminLink() {
 }
 
 function useUnreadFeedback(): number {
-  const [count, setCount] = useState(0);
-  useEffect(() => {
-    let stop = false;
-    async function load() {
-      try {
-        const res = await fetch("/api/feedback/unread", { cache: "no-store" });
-        if (!res.ok) return;
-        const j = (await res.json()) as { count?: number };
-        if (!stop) setCount(j.count ?? 0);
-      } catch {
-        /* silent */
-      }
-    }
-    void load();
-    const interval = setInterval(() => void load(), 60000);
-    return () => {
-      stop = true;
-      clearInterval(interval);
-    };
-  }, []);
-  return count;
+  return useHeaderState().state.feedback.count;
 }

--- a/src/components/header-state-provider.tsx
+++ b/src/components/header-state-provider.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+type HeaderState = {
+  signedIn: boolean;
+  notifications: { unreadCount: number };
+  feedback: { count: number; adminCount: number };
+  caught: string[];
+};
+
+const INITIAL: HeaderState = {
+  signedIn: false,
+  notifications: { unreadCount: 0 },
+  feedback: { count: 0, adminCount: 0 },
+  caught: [],
+};
+
+type Ctx = {
+  state: HeaderState;
+  refresh: () => Promise<void>;
+};
+
+const HeaderStateContext = createContext<Ctx | null>(null);
+
+const POLL_MS = 90_000;
+
+// Single source of truth for SiteHeader badges + caught-slug set.
+// Replaces 3 separate fetches per page-view (auth-badge feedback unread,
+// notifications-bell unread, pet-gallery caught slugs) with 1 polled
+// aggregate from /api/me/header-state. Cuts Edge Requests ~3x on busy
+// pages, which is what was driving the May 5-6 Vercel spike.
+export function HeaderStateProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [state, setState] = useState<HeaderState>(INITIAL);
+  const stopped = useRef(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch("/api/me/header-state", { cache: "no-store" });
+      if (!res.ok) return;
+      const json = (await res.json()) as HeaderState;
+      if (!stopped.current) setState(json);
+    } catch {
+      /* offline / network blip — keep last known state */
+    }
+  }, []);
+
+  useEffect(() => {
+    stopped.current = false;
+    void refresh();
+    const id = window.setInterval(() => void refresh(), POLL_MS);
+    const onFocus = () => void refresh();
+    window.addEventListener("focus", onFocus);
+    return () => {
+      stopped.current = true;
+      window.clearInterval(id);
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [refresh]);
+
+  return (
+    <HeaderStateContext.Provider value={{ state, refresh }}>
+      {children}
+    </HeaderStateContext.Provider>
+  );
+}
+
+export function useHeaderState(): Ctx {
+  const ctx = useContext(HeaderStateContext);
+  if (ctx) return ctx;
+  return { state: INITIAL, refresh: async () => {} };
+}

--- a/src/components/notifications-bell.tsx
+++ b/src/components/notifications-bell.tsx
@@ -13,6 +13,8 @@ import {
   XCircle,
 } from "lucide-react";
 
+import { useHeaderState } from "@/components/header-state-provider";
+
 type Kind =
   | "pet_approved"
   | "pet_rejected"
@@ -112,31 +114,35 @@ function relativeTime(iso: string): string {
 }
 
 export function NotificationsBell() {
+  const { state, refresh } = useHeaderState();
+  const unread = state.notifications.unreadCount;
   const [items, setItems] = useState<Notif[]>([]);
-  const [unread, setUnread] = useState(0);
+  const [itemsLoaded, setItemsLoaded] = useState(false);
   const [open, setOpen] = useState(false);
   const popoverRef = useRef<HTMLDivElement | null>(null);
 
-  const load = useCallback(async () => {
+  const setUnread = useCallback(
+    (_next: number | ((n: number) => number)) => {
+      void refresh();
+    },
+    [refresh],
+  );
+
+  const loadItems = useCallback(async () => {
     try {
       const res = await fetch("/api/notifications", { cache: "no-store" });
       if (!res.ok) return;
-      const j = (await res.json()) as {
-        items?: Notif[];
-        unreadCount?: number;
-      };
+      const j = (await res.json()) as { items?: Notif[] };
       setItems(j.items ?? []);
-      setUnread(j.unreadCount ?? 0);
+      setItemsLoaded(true);
     } catch {
       /* silent */
     }
   }, []);
 
   useEffect(() => {
-    void load();
-    const i = setInterval(() => void load(), 60000);
-    return () => clearInterval(i);
-  }, [load]);
+    if (open && !itemsLoaded) void loadItems();
+  }, [open, itemsLoaded, loadItems]);
 
   // Click outside / Escape closes the panel.
   useEffect(() => {

--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -23,6 +23,7 @@ import type { PetWithMetrics } from "@/lib/pets";
 import { PET_KINDS, PET_VIBES, type PetKind, type PetVibe } from "@/lib/types";
 import { isAllowedAvatarUrl } from "@/lib/url-allowlist";
 
+import { useHeaderState } from "@/components/header-state-provider";
 import { PetActionMenu } from "@/components/pet-action-menu";
 import { PetCardFooter } from "@/components/pet-card-footer";
 import { PetSprite } from "@/components/pet-sprite";
@@ -100,29 +101,12 @@ export function PetGallery({
   const [activeBatches, setActiveBatches] = useState<Set<string>>(new Set());
   const [sort, setSort] = useState<SortKey>("curated");
   // The home page no longer ships caughtSlugs server-side — that would
-  // make every SSR render per-visitor and kill ISR. When the prop is
-  // missing we fetch /api/me/caught-slugs after hydration so the
-  // "caught" highlight on PetCard still works for signed-in users
-  // without holding up the static shell.
-  const [hydratedCaught, setHydratedCaught] = useState<string[] | null>(null);
-  useEffect(() => {
-    if (caughtSlugs !== undefined) return;
-    let cancelled = false;
-    void (async () => {
-      try {
-        const res = await fetch("/api/me/caught-slugs");
-        if (!res.ok) return;
-        const data = (await res.json()) as { caught: string[] };
-        if (!cancelled) setHydratedCaught(data.caught);
-      } catch {
-        /* anonymous viewers + offline fall through */
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [caughtSlugs]);
-  const caughtSet = new Set(caughtSlugs ?? hydratedCaught ?? []);
+  // make every SSR render per-visitor and kill ISR. We pull the caught
+  // slug set from the shared HeaderStateProvider (one polled aggregate
+  // instead of per-component fetch) so the "caught" highlight still
+  // works for signed-in users without an extra Edge Request per page.
+  const headerCaught = useHeaderState().state.caught;
+  const caughtSet = new Set(caughtSlugs ?? headerCaught);
 
   const [pets, setPets] = useState<PetWithMetrics[]>(initial.pets);
   const [total, setTotal] = useState<number>(initial.total);


### PR DESCRIPTION
## Summary

The May 2-6 Vercel spike (Edge Requests 9.73M / Fast Origin Transfer 84GB) was driven by every page-view firing 3+ separate fetches from the SiteHeader.

This collapses them into a single polled endpoint + shared React context.

## Endpoints removed from per-page-view fanout
- \`/api/me/caught-slugs\` — pet-gallery on every gallery view
- \`/api/notifications\` — bell, polled every 60s on every page
- \`/api/feedback/unread\` — auth-badge on mount

All three now read from \`/api/me/header-state\` via \`HeaderStateProvider\`. NotificationsBell still fetches the full notifications list, but only when the dropdown opens (lazy).

## Cache strategy
- Anonymous viewers: \`s-maxage=300, stale-while-revalidate=3600\` — CDN absorbs
- Signed-in: \`private, no-store\` — function runs, but once per page-view + once per 90s

## Expected impact

| Metric | Before | After |
|---|---|---|
| Edge Requests / page-view (signed-in) | 3-5 | 1 |
| Bell polling interval | 60s | 90s |
| Anonymous header-state | function call | CDN cache hit |

Back-of-envelope: ~3x reduction on Edge Requests, proportional drop on Function Invocations and Fluid CPU.

## Test plan
- [ ] Smoke test: home loads, bell badge shows correct unread count
- [ ] Open bell dropdown → items load
- [ ] Mark notification as read → badge updates within 90s (or on focus)
- [ ] Pet gallery: caught highlight still works for signed-in users
- [ ] Sign out → no fetches to /api/me/header-state header beyond cached