### PR TITLE
fix(cache): use revalidateTag in Route Handlers, not updateTag

### DIFF
--- a/src/app/api/admin/[id]/route.ts
+++ b/src/app/api/admin/[id]/route.ts
@@ -1,4 +1,4 @@
-import { updateTag } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { auth } from "@clerk/nextjs/server";
@@ -108,9 +108,9 @@ export async function DELETE(
     actorId: userId ?? "unknown",
   });
 
-  updateTag("gallery");
-  updateTag(`pet:${pet.slug}`);
-  updateTag(`profile:${pet.ownerId}`);
+  revalidateTag("gallery", "max");
+  revalidateTag(`pet:${pet.slug}`, "max");
+  revalidateTag(`profile:${pet.ownerId}`, "max");
 
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/profile/collection/route.ts
+++ b/src/app/api/profile/collection/route.ts
@@ -1,4 +1,4 @@
-import { updateTag } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { auth } from "@clerk/nextjs/server";
@@ -134,9 +134,9 @@ export async function PATCH(req: Request): Promise<Response> {
     );
   }
 
-  updateTag("collections");
-  updateTag(`collection:${collection.slug}`);
-  updateTag(`profile:${userId}`);
+  revalidateTag("collections", "max");
+  revalidateTag(`collection:${collection.slug}`, "max");
+  revalidateTag(`profile:${userId}`, "max");
 
   return NextResponse.json({
     ok: true,

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,4 +1,4 @@
-import { updateTag } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { auth } from "@clerk/nextjs/server";
@@ -222,9 +222,9 @@ export async function PATCH(req: Request): Promise<Response> {
       },
     });
 
-  updateTag(`profile:${userId}`);
+  revalidateTag(`profile:${userId}`, "max");
   if (typeof patch.handle === "string") {
-    updateTag(`profile:${patch.handle}`);
+    revalidateTag(`profile:${patch.handle}`, "max");
   }
 
   return NextResponse.json({

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -1,4 +1,4 @@
-import { updateTag } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { auth, currentUser } from "@clerk/nextjs/server";
@@ -87,10 +87,10 @@ export async function POST(req: Request) {
     const { status, ...rest } = result;
     return NextResponse.json(rest, { status });
   }
-  updateTag("gallery");
-  updateTag(`profile:${result.profileHandle}`);
+  revalidateTag("gallery", "max");
+  revalidateTag(`profile:${result.profileHandle}`, "max");
   if (result.status === "approved") {
-    updateTag(`pet:${result.slug}`);
+    revalidateTag(`pet:${result.slug}`, "max");
   }
   return NextResponse.json(result, { status: 201 });
 }

--- a/src/lib/submission-decisions.ts
+++ b/src/lib/submission-decisions.ts
@@ -1,4 +1,4 @@
-import { updateTag } from "next/cache";
+import { revalidateTag } from "next/cache";
 
 import { eq } from "drizzle-orm";
 import { Resend } from "resend";
@@ -112,9 +112,9 @@ export async function applySubmissionAction(
   let row = updated;
   if (body.action === "approve" && !options.skipSideEffects) {
     row = await runPostApprovalEffects(row, actor, db);
-    updateTag("gallery");
-    updateTag(`pet:${row.slug}`);
-    updateTag(`profile:${row.ownerId}`);
+    revalidateTag("gallery", "max");
+    revalidateTag(`pet:${row.slug}`, "max");
+    revalidateTag(`profile:${row.ownerId}`, "max");
   }
 
   if (


### PR DESCRIPTION
## Critical: prod mutations are 500ing

PR #129 (Cache Components) used \`updateTag()\` in Route Handlers. Next 16 only allows \`updateTag\` in Server Actions, so every mutation in prod is returning 500:

\`\`\`
Error: updateTag can only be called from within a Server Action.
To invalidate cache tags in Route Handlers or other contexts, use revalidateTag instead.
\`\`\`

## Affected endpoints (all 500ing in prod)

- \`POST /api/submit\` — submit a pet
- \`PATCH /api/admin/[id]\` — admin approve/reject/edit
- \`PATCH /api/profile\` — profile edits
- \`POST /api/profile/collection\` — collection create/update

## Fix

Swap \`updateTag(tag)\` for \`revalidateTag(tag, \"max\")\` per Next 16 docs. The \`\"max\"\` profile is the recommended one for Route Handler invalidation (stale-while-revalidate semantics).

5 files, 19 lines changed. Same call sites, same tags, just the right function + the now-required second-arg profile.

Reference: https://nextjs.org/docs/app/api-reference/functions/revalidateTag

## Test plan
- [x] \`bun run build\` succeeds
- [ ] Merge -> Vercel deploys -> verify mutations return 200 (submit a pet, admin approve, edit profile)