### PR TITLE
fix(cc): isolate auth() into Suspense leaves on /pets/[slug] + /u/[handle]

### DIFF
--- a/src/app/[locale]/pets/[slug]/page.tsx
+++ b/src/app/[locale]/pets/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { Suspense } from "react";
 
 import { auth } from "@clerk/nextjs/server";
 import { and, eq, inArray } from "drizzle-orm";
@@ -157,16 +158,14 @@ export default async function PetPage({ params }: PageProps) {
         }
       : null;
 
-  const [{ userId }, allPets, ownerRow, variants, memberOfCollections] =
-    await Promise.all([
-      auth(),
-      getApprovedPetsWithMetrics(),
-      db.query.submittedPets.findFirst({
-        where: eq(schema.submittedPets.slug, slug),
-      }),
-      getVariantsFor(slug),
-      getCollectionsContainingPet(slug),
-    ]);
+  const [allPets, ownerRow, variants, memberOfCollections] = await Promise.all([
+    getApprovedPetsWithMetrics(),
+    db.query.submittedPets.findFirst({
+      where: eq(schema.submittedPets.slug, slug),
+    }),
+    getVariantsFor(slug),
+    getCollectionsContainingPet(slug),
+  ]);
   const petWithMetrics = allPets.find((candidate) => candidate.slug === slug);
   const metrics = petWithMetrics?.metrics ?? {
     installCount: 0,
@@ -183,16 +182,6 @@ export default async function PetPage({ params }: PageProps) {
       metrics: candidate.metrics,
     })),
   );
-  const initialLiked = userId
-    ? Boolean(
-        await db.query.petLikes.findFirst({
-          where: and(
-            eq(schema.petLikes.userId, userId),
-            eq(schema.petLikes.petSlug, slug),
-          ),
-        }),
-      )
-    : false;
 
   // Resolve the "submitted by" credit live from Clerk so name/url/avatar
   // reflect the user's *current* profile (not the snapshot taken at
@@ -218,45 +207,6 @@ export default async function PetPage({ params }: PageProps) {
         ownerIsProxy: ownerRow.source === "discover",
       })
     : null;
-
-  let ownerEditState: {
-    isOwner: boolean;
-    petId: string;
-    currentTags: string[];
-    pending: {
-      displayName: string | null;
-      description: string | null;
-      tags: string[] | null;
-      submittedAt: string | null;
-    } | null;
-    lastRejection: string | null;
-  } | null = null;
-  if (userId && ownerRow && ownerRow.ownerId === userId) {
-    const hasPending = Boolean(ownerRow.pendingSubmittedAt);
-    ownerEditState = {
-      isOwner: true,
-      petId: ownerRow.id,
-      currentTags: (ownerRow.tags as string[]) ?? [],
-      pending: hasPending
-        ? {
-            displayName: ownerRow.pendingDisplayName,
-            description: ownerRow.pendingDescription,
-            tags: (ownerRow.pendingTags as string[] | null) ?? null,
-            submittedAt: ownerRow.pendingSubmittedAt
-              ? ownerRow.pendingSubmittedAt.toISOString()
-              : null,
-          }
-        : null,
-      lastRejection: ownerRow.pendingRejectionReason,
-    };
-  }
-
-  // Owner-only: candidate featured collections + already-submitted
-  // pending requests for the suggest button.
-  const collectionSuggest =
-    userId && ownerRow && ownerRow.ownerId === userId
-      ? await getCollectionCandidatesForPet(slug, userId)
-      : null;
 
   const url = `${SITE_URL}/pets/${pet.slug}`;
   const jsonLd = [
@@ -390,29 +340,30 @@ export default async function PetPage({ params }: PageProps) {
               <h1 className="text-balance text-[44px] leading-[1] font-semibold tracking-tight text-foreground md:text-[64px]">
                 {pet.displayName}
               </h1>
-              {ownerEditState ? (
-                <OwnerEditPanel
-                  petId={ownerEditState.petId}
-                  slug={pet.slug}
-                  currentDisplayName={pet.displayName}
-                  currentDescription={pet.description}
-                  currentTags={ownerEditState.currentTags}
-                  initialPending={ownerEditState.pending}
-                  initialRejection={ownerEditState.lastRejection}
-                />
-              ) : null}
+              <Suspense fallback={null}>
+                <OwnerEditPanelLeaf ownerRow={ownerRow} pet={pet} />
+              </Suspense>
             </div>
             <p className="max-w-3xl text-balance text-base leading-7 text-muted-1 md:text-lg">
               {pet.description}
             </p>
 
             <div className="flex flex-wrap items-center gap-3">
-              <LikeButton
-                slug={pet.slug}
-                initialCount={metrics.likeCount}
-                initialLiked={initialLiked}
-                signedIn={Boolean(userId)}
-              />
+              <Suspense
+                fallback={
+                  <LikeButton
+                    slug={pet.slug}
+                    initialCount={metrics.likeCount}
+                    initialLiked={false}
+                    signedIn={false}
+                  />
+                }
+              >
+                <LikeButtonLeaf
+                  slug={pet.slug}
+                  initialCount={metrics.likeCount}
+                />
+              </Suspense>
               {pet.soundUrl ? (
                 <PetSoundButton
                   soundUrl={pet.soundUrl}
@@ -466,14 +417,13 @@ export default async function PetPage({ params }: PageProps) {
               </div>
             ) : null}
 
-            {collectionSuggest && collectionSuggest.candidates.length > 0 ? (
-              <SuggestCollectionButton
-                petSlug={slug}
+            <Suspense fallback={null}>
+              <SuggestCollectionButtonLeaf
+                slug={slug}
                 petDisplayName={pet.displayName}
-                candidateCollections={collectionSuggest.candidates}
-                alreadyRequested={collectionSuggest.alreadyRequested}
+                ownerRow={ownerRow}
               />
-            ) : null}
+            </Suspense>
 
             {/* Keyboard hint strip — minimal, mono-spaced, only on
                 pointer-fine media so we don't spam mobile users with
@@ -514,15 +464,17 @@ export default async function PetPage({ params }: PageProps) {
           {ownerCredit ? (
             <div className="space-y-3">
               <SubmittedBy credit={ownerCredit} />
-              {ownerRow?.source === "discover" && !userId ? (
-                <ClaimCTA
-                  petName={pet.displayName}
-                  authorLabel={ownerCredit.name}
-                  githubUrl={
-                    ownerCredit.externals.find((e) => e.provider === "github")
-                      ?.url ?? null
-                  }
-                />
+              {ownerRow?.source === "discover" ? (
+                <Suspense fallback={null}>
+                  <ClaimCTALeaf
+                    petName={pet.displayName}
+                    authorLabel={ownerCredit.name}
+                    githubUrl={
+                      ownerCredit.externals.find((e) => e.provider === "github")
+                        ?.url ?? null
+                    }
+                  />
+                </Suspense>
               ) : null}
             </div>
           ) : null}
@@ -641,5 +593,111 @@ function InfoCard({
         {children}
       </div>
     </div>
+  );
+}
+
+async function LikeButtonLeaf({
+  slug,
+  initialCount,
+}: {
+  slug: string;
+  initialCount: number;
+}) {
+  const { userId } = await auth();
+  const initialLiked = userId
+    ? Boolean(
+        await db.query.petLikes.findFirst({
+          where: and(
+            eq(schema.petLikes.userId, userId),
+            eq(schema.petLikes.petSlug, slug),
+          ),
+        }),
+      )
+    : false;
+  return (
+    <LikeButton
+      slug={slug}
+      initialCount={initialCount}
+      initialLiked={initialLiked}
+      signedIn={Boolean(userId)}
+    />
+  );
+}
+
+async function OwnerEditPanelLeaf({
+  ownerRow,
+  pet,
+}: {
+  ownerRow: typeof schema.submittedPets.$inferSelect | undefined;
+  pet: { slug: string; displayName: string; description: string };
+}) {
+  const { userId } = await auth();
+  if (!userId || !ownerRow || ownerRow.ownerId !== userId) return null;
+  const hasPending = Boolean(ownerRow.pendingSubmittedAt);
+  return (
+    <OwnerEditPanel
+      petId={ownerRow.id}
+      slug={pet.slug}
+      currentDisplayName={pet.displayName}
+      currentDescription={pet.description}
+      currentTags={(ownerRow.tags as string[]) ?? []}
+      initialPending={
+        hasPending
+          ? {
+              displayName: ownerRow.pendingDisplayName,
+              description: ownerRow.pendingDescription,
+              tags: (ownerRow.pendingTags as string[] | null) ?? null,
+              submittedAt: ownerRow.pendingSubmittedAt
+                ? ownerRow.pendingSubmittedAt.toISOString()
+                : null,
+            }
+          : null
+      }
+      initialRejection={ownerRow.pendingRejectionReason}
+    />
+  );
+}
+
+async function SuggestCollectionButtonLeaf({
+  slug,
+  petDisplayName,
+  ownerRow,
+}: {
+  slug: string;
+  petDisplayName: string;
+  ownerRow: typeof schema.submittedPets.$inferSelect | undefined;
+}) {
+  const { userId } = await auth();
+  if (!userId || !ownerRow || ownerRow.ownerId !== userId) return null;
+  const collectionSuggest = await getCollectionCandidatesForPet(slug, userId);
+  if (!collectionSuggest || collectionSuggest.candidates.length === 0)
+    return null;
+  return (
+    <SuggestCollectionButton
+      petSlug={slug}
+      petDisplayName={petDisplayName}
+      candidateCollections={collectionSuggest.candidates}
+      alreadyRequested={collectionSuggest.alreadyRequested}
+    />
+  );
+}
+
+async function ClaimCTALeaf({
+  petName,
+  authorLabel,
+  githubUrl,
+}: {
+  petName: string;
+  authorLabel: string;
+  githubUrl: string | null;
+}) {
+  const { userId } = await auth();
+  if (userId) return null;
+  return (
+    <ClaimCTA
+      petName={petName}
+      authorLabel={authorLabel}
+      githubUrl={githubUrl}
+    />
   );
 }

--- a/src/app/[locale]/u/[handle]/page.tsx
+++ b/src/app/[locale]/u/[handle]/page.tsx
@@ -37,52 +37,30 @@ const SITE_URL = "https://petdex.crafter.run";
 
 type PageProps = { params: Promise<{ handle: string; locale: string }> };
 
-export async function generateMetadata({ params }: PageProps) {
-  const { handle } = await params;
-  const userId = await userIdForHandle(handle);
-  if (!userId) return { title: "Profile not found", robots: { index: false } };
-  let displayName = `@${handle}`;
-  const profile = await db.query.userProfiles.findFirst({
-    where: eq(schema.userProfiles.userId, userId),
-  });
-  try {
-    const client = await clerkClient();
-    const u = await client.users.getUser(userId);
-    const name = [u.firstName, u.lastName].filter(Boolean).join(" ").trim();
-    const fallbackName = name || (u.username ? `@${u.username}` : `@${handle}`);
-    displayName = profile?.displayName ?? fallbackName;
-  } catch {
-    if (profile?.displayName) displayName = profile.displayName;
-    /* fall back */
-  }
-  const publicHandle = profile?.handle ?? handle.toLowerCase();
-  return {
-    title: `${displayName} on Petdex`,
-    description: `Pets created by ${displayName} for Codex.`,
-    alternates: buildLocaleAlternates(`/u/${publicHandle}`),
-    openGraph: {
-      title: `${displayName} on Petdex`,
-      description: `Animated Codex pets created by ${displayName}.`,
-      url: `${SITE_URL}/u/${publicHandle}`,
-    },
-  };
-}
+type PublicProfile = {
+  ownerId: string;
+  publicHandle: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  externalUrls: { url: string; label: string }[];
+  memberSince: number | null;
+  bio: string | null;
+  featuredSlugs: string[];
+  approvedPets: PetWithMetrics[];
+  collection: Awaited<ReturnType<typeof getOwnerCollection>>;
+  totalLikes: number;
+  totalInstalls: number;
+  isOwnerAdmin: boolean;
+  rank: { rank: number; total: number } | null;
+};
 
-export default function UserProfilePage({ params }: PageProps) {
-  return (
-    <Suspense fallback={null}>
-      <UserProfileContent params={params} />
-    </Suspense>
-  );
-}
-
-async function UserProfileContent({ params }: PageProps) {
-  const { handle } = await params;
+async function loadPublicProfile(
+  handle: string,
+): Promise<PublicProfile | null> {
   const requestedHandle = handle.toLowerCase();
   const ownerId = await userIdForHandle(handle);
-  if (!ownerId) notFound();
+  if (!ownerId) return null;
 
-  // Pull Clerk profile.
   let displayName: string | null = null;
   let username: string | null = null;
   let avatarUrl: string | null = null;
@@ -118,7 +96,6 @@ async function UserProfileContent({ params }: PageProps) {
     /* will render with handle only */
   }
 
-  // Profile customization (bio, featured slug).
   const profile = await db.query.userProfiles.findFirst({
     where: eq(schema.userProfiles.userId, ownerId),
   });
@@ -132,13 +109,6 @@ async function UserProfileContent({ params }: PageProps) {
   const featuredSlugs =
     (profile?.featuredPetSlugs as string[] | undefined) ?? [];
 
-  // Viewer detection runs ahead of the pets query so the owner sees
-  // their pending + rejected rows alongside the approved gallery.
-  const { userId: viewerId } = await auth();
-  const isOwner = viewerId === ownerId;
-
-  // Pets owned by this user. Visitors only see approved rows; the owner
-  // sees everything so the profile doubles as their dashboard.
   const allOwnerRows = await db
     .select()
     .from(schema.submittedPets)
@@ -146,7 +116,6 @@ async function UserProfileContent({ params }: PageProps) {
     .orderBy(desc(schema.submittedPets.approvedAt));
 
   const approvedRows = allOwnerRows.filter((r) => r.status === "approved");
-
   const slugs = approvedRows.map((r) => r.slug);
   const metrics = slugs.length
     ? await getMetricsBySlugs(slugs)
@@ -155,7 +124,7 @@ async function UserProfileContent({ params }: PageProps) {
         { likeCount: number; installCount: number; zipDownloadCount: number }
       >();
 
-  const pets: PetWithMetrics[] = approvedRows.map((row) => ({
+  const approvedPets: PetWithMetrics[] = approvedRows.map((row) => ({
     ...rowToPet(row),
     metrics: metrics.get(row.slug) ?? {
       installCount: 0,
@@ -164,73 +133,79 @@ async function UserProfileContent({ params }: PageProps) {
     },
   }));
 
-  // Owner-only: shape pending + rejected rows as Submission for the
-  // tabs panel. Sorted by createdAt desc so the most recent submit
-  // shows first.
-  const ownerSubmissions: Submission[] = isOwner
-    ? allOwnerRows
-        .filter((r) => r.status === "pending" || r.status === "rejected")
-        .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
-        .map((row) => ({
-          id: row.id,
-          slug: row.slug,
-          displayName: row.displayName,
-          description: row.description,
-          spritesheetUrl: row.spritesheetUrl,
-          zipUrl: row.zipUrl,
-          kind: row.kind,
-          vibes: (row.vibes as string[]) ?? [],
-          tags: (row.tags as string[]) ?? [],
-          featured: row.featured,
-          status: row.status,
-          createdAt: row.createdAt.toISOString(),
-          approvedAt: row.approvedAt?.toISOString() ?? null,
-          rejectedAt: row.rejectedAt?.toISOString() ?? null,
-          rejectionReason: row.rejectionReason,
-          pending: row.pendingSubmittedAt
-            ? {
-                displayName: row.pendingDisplayName,
-                description: row.pendingDescription,
-                tags: (row.pendingTags as string[] | null) ?? null,
-                submittedAt: row.pendingSubmittedAt.toISOString(),
-              }
-            : null,
-          pendingRejectionReason: row.pendingRejectionReason,
-          metrics: { installCount: 0, zipDownloadCount: 0, likeCount: 0 },
-        }))
-    : [];
   const collection = await getOwnerCollection(ownerId);
-  const likedPets = await getLikedPetsForUser(ownerId);
-
-  // Resolve pinned slugs to full pet objects, preserving owner-chosen
-  // order. Drop any that are no longer approved (would otherwise break
-  // the layout with empty cards).
-  const featuredSet = new Set(featuredSlugs);
-  const featuredPets = featuredSlugs
-    .map((slug) => pets.find((p) => p.slug === slug))
-    .filter((p): p is PetWithMetrics => Boolean(p));
-  const restPets = pets.filter((p) => !featuredSet.has(p.slug));
-
-  // Aggregate stats.
-  const totalLikes = pets.reduce((acc, p) => acc + p.metrics.likeCount, 0);
-  const totalInstalls = pets.reduce(
+  const totalLikes = approvedPets.reduce(
+    (acc, p) => acc + p.metrics.likeCount,
+    0,
+  );
+  const totalInstalls = approvedPets.reduce(
     (acc, p) => acc + p.metrics.installCount,
     0,
   );
-
-  // Admins get a "Creator of Petdex" badge instead of a numeric rank,
-  // since they're filtered out of the leaderboard. For everyone else
-  // we look up their rank by approved-pet count and only render the
-  // badge when they're inside the top 50.
   const isOwnerAdmin = isAdmin(ownerId);
   const rank = isOwnerAdmin ? null : await getOwnerRank(ownerId, "pets");
 
-  const catchProgress = isOwner ? await getCatchProgress(viewerId) : null;
-  const canManageOwnCollection = isOwner
-    ? await canManageCreatorCollections(viewerId)
-    : false;
+  return {
+    ownerId,
+    publicHandle,
+    displayName,
+    avatarUrl,
+    externalUrls,
+    memberSince,
+    bio,
+    featuredSlugs,
+    approvedPets,
+    collection,
+    totalLikes,
+    totalInstalls,
+    isOwnerAdmin,
+    rank,
+  };
+}
 
-  const fallbackInitial = (displayName ?? publicHandle)
+export async function generateMetadata({ params }: PageProps) {
+  const { handle } = await params;
+  const userId = await userIdForHandle(handle);
+  if (!userId) return { title: "Profile not found", robots: { index: false } };
+  let displayName = `@${handle}`;
+  const profile = await db.query.userProfiles.findFirst({
+    where: eq(schema.userProfiles.userId, userId),
+  });
+  try {
+    const client = await clerkClient();
+    const u = await client.users.getUser(userId);
+    const name = [u.firstName, u.lastName].filter(Boolean).join(" ").trim();
+    const fallbackName = name || (u.username ? `@${u.username}` : `@${handle}`);
+    displayName = profile?.displayName ?? fallbackName;
+  } catch {
+    if (profile?.displayName) displayName = profile.displayName;
+    /* fall back */
+  }
+  const publicHandle = profile?.handle ?? handle.toLowerCase();
+  return {
+    title: `${displayName} on Petdex`,
+    description: `Pets created by ${displayName} for Codex.`,
+    alternates: buildLocaleAlternates(`/u/${publicHandle}`),
+    openGraph: {
+      title: `${displayName} on Petdex`,
+      description: `Animated Codex pets created by ${displayName}.`,
+      url: `${SITE_URL}/u/${publicHandle}`,
+    },
+  };
+}
+
+export default async function UserProfilePage({ params }: PageProps) {
+  const { handle } = await params;
+  const data = await loadPublicProfile(handle);
+  if (!data) notFound();
+
+  const featuredSet = new Set(data.featuredSlugs);
+  const featuredPets = data.featuredSlugs
+    .map((slug) => data.approvedPets.find((p) => p.slug === slug))
+    .filter((p): p is PetWithMetrics => Boolean(p));
+  const restPets = data.approvedPets.filter((p) => !featuredSet.has(p.slug));
+
+  const fallbackInitial = (data.displayName ?? data.publicHandle)
     .slice(0, 1)
     .toUpperCase();
 
@@ -239,11 +214,11 @@ async function UserProfileContent({ params }: PageProps) {
     "@type": "ProfilePage",
     mainEntity: {
       "@type": "Person",
-      name: displayName ?? `@${publicHandle}`,
-      url: `${SITE_URL}/u/${publicHandle}`,
-      ...(avatarUrl ? { image: avatarUrl } : {}),
-      ...(externalUrls.length > 0
-        ? { sameAs: externalUrls.map((e) => e.url) }
+      name: data.displayName ?? `@${data.publicHandle}`,
+      url: `${SITE_URL}/u/${data.publicHandle}`,
+      ...(data.avatarUrl ? { image: data.avatarUrl } : {}),
+      ...(data.externalUrls.length > 0
+        ? { sameAs: data.externalUrls.map((e) => e.url) }
         : {}),
     },
   };
@@ -251,25 +226,18 @@ async function UserProfileContent({ params }: PageProps) {
   return (
     <main className="min-h-dvh bg-background text-foreground">
       <JsonLd data={jsonLd} />
-      <ProfileAnalytics
-        handle={publicHandle}
-        petCount={pets.length}
-        pinnedCount={featuredPets.length}
-        viewerIsOwner={isOwner}
-      />
 
       <section className="petdex-cloud relative overflow-hidden">
         <div className="relative mx-auto flex w-full max-w-7xl flex-col px-5 pt-5 pb-10 md:px-8">
           <SiteHeader />
 
           <header className="mt-10 grid gap-8 md:mt-14 lg:grid-cols-[auto_1fr_auto] lg:items-start">
-            {/* Avatar */}
             <div className="flex justify-center lg:block">
-              {avatarUrl ? (
+              {data.avatarUrl ? (
                 // biome-ignore lint/performance/noImgElement: Clerk-hosted avatar
                 <img
-                  src={avatarUrl}
-                  alt={displayName ?? `@${publicHandle}`}
+                  src={data.avatarUrl}
+                  alt={data.displayName ?? `@${data.publicHandle}`}
                   className="size-28 rounded-3xl object-cover ring-1 ring-black/10 md:size-32"
                 />
               ) : (
@@ -279,19 +247,15 @@ async function UserProfileContent({ params }: PageProps) {
               )}
             </div>
 
-            {/* Identity */}
             <div className="text-center lg:text-left">
               <div className="flex flex-wrap items-center justify-center gap-2 lg:justify-start">
                 <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
                   Petdex creator
                 </p>
-                {catchProgress ? (
-                  <p className="font-mono text-xs tracking-[0.22em] text-muted-3 uppercase">
-                    YOUR ALBUM: {catchProgress.caught}/{catchProgress.total} (
-                    {catchProgress.pct}%)
-                  </p>
-                ) : null}
-                {isOwnerAdmin ? (
+                <Suspense fallback={null}>
+                  <ViewerCatchProgress ownerId={data.ownerId} />
+                </Suspense>
+                {data.isOwnerAdmin ? (
                   <span
                     className="inline-flex items-center gap-1 rounded-full bg-brand px-2 py-0.5 font-mono text-[10px] tracking-[0.15em] text-white uppercase"
                     title="One of the people who built Petdex"
@@ -299,51 +263,51 @@ async function UserProfileContent({ params }: PageProps) {
                     <Trophy className="size-3" />
                     Creator of Petdex
                   </span>
-                ) : rank ? (
+                ) : data.rank ? (
                   <Link
                     href="/leaderboard"
                     className="inline-flex items-center gap-1 rounded-full bg-chip-warning-bg px-2 py-0.5 font-mono text-[10px] tracking-[0.15em] text-chip-warning-fg uppercase transition hover:opacity-80"
-                    title={`Ranked #${rank.rank} of ${rank.total} by approved pets — see the full leaderboard`}
+                    title={`Ranked #${data.rank.rank} of ${data.rank.total} by approved pets — see the full leaderboard`}
                   >
-                    <Trophy className="size-3" />#{rank.rank} most pets
+                    <Trophy className="size-3" />#{data.rank.rank} most pets
                   </Link>
                 ) : null}
               </div>
               <h1 className="mt-3 text-balance text-[40px] leading-[1] font-semibold tracking-tight md:text-[56px]">
-                {displayName ?? `@${publicHandle}`}
+                {data.displayName ?? `@${data.publicHandle}`}
               </h1>
-              {displayName ? (
+              {data.displayName ? (
                 <p className="mt-2 font-mono text-sm tracking-[0.08em] text-muted-3">
-                  @{publicHandle}
+                  @{data.publicHandle}
                 </p>
               ) : null}
-              {bio ? (
+              {data.bio ? (
                 <p className="mt-4 max-w-xl text-balance text-base leading-7 text-muted-1 md:text-lg">
-                  {bio}
+                  {data.bio}
                 </p>
               ) : null}
 
-              {/* Stats row */}
               <div className="mt-5 flex flex-wrap items-center justify-center gap-x-5 gap-y-2 font-mono text-[11px] tracking-[0.18em] text-muted-3 uppercase lg:justify-start">
                 <span>
-                  {pets.length} {pets.length === 1 ? "pet" : "pets"}
+                  {data.approvedPets.length}{" "}
+                  {data.approvedPets.length === 1 ? "pet" : "pets"}
                 </span>
-                {totalLikes > 0 ? (
+                {data.totalLikes > 0 ? (
                   <span className="inline-flex items-center gap-1.5">
                     <Heart className="size-3" />
-                    {totalLikes}
+                    {data.totalLikes}
                   </span>
                 ) : null}
-                {totalInstalls > 0 ? (
+                {data.totalInstalls > 0 ? (
                   <span className="inline-flex items-center gap-1.5">
                     <TerminalSquare className="size-3" />
-                    {totalInstalls} installs
+                    {data.totalInstalls} installs
                   </span>
                 ) : null}
-                {memberSince ? (
+                {data.memberSince ? (
                   <span>
                     joined{" "}
-                    {new Date(memberSince).toLocaleDateString(undefined, {
+                    {new Date(data.memberSince).toLocaleDateString(undefined, {
                       month: "short",
                       year: "numeric",
                     })}
@@ -351,13 +315,12 @@ async function UserProfileContent({ params }: PageProps) {
                 ) : null}
               </div>
 
-              {/* External links */}
-              {externalUrls.length > 0 ? (
+              {data.externalUrls.length > 0 ? (
                 <div className="mt-4 flex flex-wrap items-center justify-center gap-2 lg:justify-start">
-                  {externalUrls.map((e) => (
+                  {data.externalUrls.map((e) => (
                     <ProfileExternalLink
                       key={e.url}
-                      handle={publicHandle}
+                      handle={data.publicHandle}
                       url={e.url}
                       label={e.label}
                     />
@@ -366,108 +329,344 @@ async function UserProfileContent({ params }: PageProps) {
               ) : null}
             </div>
 
-            {/* Owner + visitor actions. Share is on for everyone so a
-                fan can spread a profile they liked, the same growth
-                motion as the creator promoting their own page. */}
             <div className="flex flex-wrap items-center justify-center gap-2 lg:justify-end">
               <ProfileShareButton
-                handle={publicHandle}
-                displayName={displayName}
+                handle={data.publicHandle}
+                displayName={data.displayName}
               />
-              {isOwner ? (
-                <ProfileInlineEditor
-                  handle={publicHandle}
-                  initialDisplayName={displayName}
-                  initialBio={bio}
-                  initialFeaturedSlugs={featuredSlugs}
-                  approvedPets={pets.map((p) => ({
+              <Suspense fallback={null}>
+                <OwnerEditButton
+                  ownerId={data.ownerId}
+                  publicHandle={data.publicHandle}
+                  displayName={data.displayName}
+                  bio={data.bio}
+                  featuredSlugs={data.featuredSlugs}
+                  approvedPets={data.approvedPets.map((p) => ({
                     slug: p.slug,
                     displayName: p.displayName,
                   }))}
                 />
-              ) : null}
+              </Suspense>
             </div>
           </header>
         </div>
       </section>
 
       <section className="mx-auto flex w-full max-w-[1440px] flex-col gap-8 px-5 py-12 md:px-8 md:py-16">
-        {featuredPets.length > 0 ? (
-          isOwner && featuredPets.length >= 2 ? (
-            <PinnedReorderGrid
-              pets={featuredPets}
+        <Suspense
+          fallback={
+            <PinnedSection
+              featuredPets={featuredPets}
+              isOwner={false}
               petStateCount={petStates.length}
             />
-          ) : (
-            <div className="space-y-4">
-              <div className="flex items-center justify-between">
-                <p className="font-mono text-[11px] tracking-[0.22em] text-brand uppercase">
-                  ★ Pinned
-                </p>
-                <p className="font-mono text-[10px] tracking-[0.18em] text-muted-4 uppercase">
-                  {featuredPets.length} of {MAX_PINNED_PETS}
-                </p>
-              </div>
-              {featuredPets.length === 1 ? (
-                <div className="relative">
-                  {isOwner ? (
-                    <div className="absolute top-4 right-4">
-                      <ProfilePinButton
-                        slug={featuredPets[0].slug}
-                        isPinned
-                        pinnedCount={featuredPets.length}
-                        maxPins={MAX_PINNED_PETS}
-                      />
-                    </div>
-                  ) : null}
-                  <FeaturedPin pet={featuredPets[0]} />
-                </div>
-              ) : (
-                <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-6">
-                  {featuredPets.map((pet, index) => (
-                    <div key={pet.slug} className="relative h-full">
-                      <PetCard
-                        pet={pet}
-                        index={index}
-                        stateCount={petStates.length}
-                      />
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          )
-        ) : null}
-
-        <ProfileTabs
-          isOwner={isOwner}
-          publicHandle={publicHandle}
-          approvedPets={restPets}
-          ownerSubmissions={ownerSubmissions}
-          likedPets={likedPets}
-          collection={
-            collection
-              ? {
-                  slug: collection.slug,
-                  title: collection.title,
-                  description: collection.description,
-                  externalUrl: collection.externalUrl,
-                  coverPetSlug: collection.coverPetSlug,
-                  petSlugs: collection.pets.map((pet) => pet.slug),
-                }
-              : null
           }
-          canManageCollections={canManageOwnCollection}
-          collectionApprovedPets={pets.map((p) => ({
-            slug: p.slug,
-            displayName: p.displayName,
-            spritesheetUrl: p.spritesheetPath,
-          }))}
-        />
+        >
+          <PinnedSectionWithViewer
+            ownerId={data.ownerId}
+            featuredPets={featuredPets}
+          />
+        </Suspense>
+
+        <Suspense
+          fallback={
+            <PublicProfileTabs
+              publicHandle={data.publicHandle}
+              approvedPets={restPets}
+              collection={data.collection}
+              approvedAll={data.approvedPets}
+            />
+          }
+        >
+          <ProfileTabsWithViewer
+            ownerId={data.ownerId}
+            publicHandle={data.publicHandle}
+            approvedPets={restPets}
+            approvedAll={data.approvedPets}
+            collection={data.collection}
+          />
+        </Suspense>
       </section>
+
+      <Suspense fallback={null}>
+        <ViewerAnalytics
+          ownerId={data.ownerId}
+          publicHandle={data.publicHandle}
+          petCount={data.approvedPets.length}
+          pinnedCount={featuredPets.length}
+        />
+      </Suspense>
 
       <SiteFooter />
     </main>
+  );
+}
+
+async function ViewerAnalytics({
+  ownerId,
+  publicHandle,
+  petCount,
+  pinnedCount,
+}: {
+  ownerId: string;
+  publicHandle: string;
+  petCount: number;
+  pinnedCount: number;
+}) {
+  const { userId: viewerId } = await auth();
+  return (
+    <ProfileAnalytics
+      handle={publicHandle}
+      petCount={petCount}
+      pinnedCount={pinnedCount}
+      viewerIsOwner={viewerId === ownerId}
+    />
+  );
+}
+
+async function ViewerCatchProgress({ ownerId }: { ownerId: string }) {
+  const { userId: viewerId } = await auth();
+  if (viewerId !== ownerId) return null;
+  const catchProgress = await getCatchProgress(viewerId);
+  if (!catchProgress) return null;
+  return (
+    <p className="font-mono text-xs tracking-[0.22em] text-muted-3 uppercase">
+      YOUR ALBUM: {catchProgress.caught}/{catchProgress.total} (
+      {catchProgress.pct}%)
+    </p>
+  );
+}
+
+async function OwnerEditButton({
+  ownerId,
+  publicHandle,
+  displayName,
+  bio,
+  featuredSlugs,
+  approvedPets,
+}: {
+  ownerId: string;
+  publicHandle: string;
+  displayName: string | null;
+  bio: string | null;
+  featuredSlugs: string[];
+  approvedPets: { slug: string; displayName: string }[];
+}) {
+  const { userId: viewerId } = await auth();
+  if (viewerId !== ownerId) return null;
+  return (
+    <ProfileInlineEditor
+      handle={publicHandle}
+      initialDisplayName={displayName}
+      initialBio={bio}
+      initialFeaturedSlugs={featuredSlugs}
+      approvedPets={approvedPets}
+    />
+  );
+}
+
+function PinnedSection({
+  featuredPets,
+  isOwner,
+  petStateCount,
+}: {
+  featuredPets: PetWithMetrics[];
+  isOwner: boolean;
+  petStateCount: number;
+}) {
+  if (featuredPets.length === 0) return null;
+  if (isOwner && featuredPets.length >= 2) {
+    return (
+      <PinnedReorderGrid pets={featuredPets} petStateCount={petStateCount} />
+    );
+  }
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="font-mono text-[11px] tracking-[0.22em] text-brand uppercase">
+          ★ Pinned
+        </p>
+        <p className="font-mono text-[10px] tracking-[0.18em] text-muted-4 uppercase">
+          {featuredPets.length} of {MAX_PINNED_PETS}
+        </p>
+      </div>
+      {featuredPets.length === 1 ? (
+        <div className="relative">
+          {isOwner ? (
+            <div className="absolute top-4 right-4">
+              <ProfilePinButton
+                slug={featuredPets[0].slug}
+                isPinned
+                pinnedCount={featuredPets.length}
+                maxPins={MAX_PINNED_PETS}
+              />
+            </div>
+          ) : null}
+          <FeaturedPin pet={featuredPets[0]} />
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-6">
+          {featuredPets.map((pet, index) => (
+            <div key={pet.slug} className="relative h-full">
+              <PetCard pet={pet} index={index} stateCount={petStateCount} />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+async function PinnedSectionWithViewer({
+  ownerId,
+  featuredPets,
+}: {
+  ownerId: string;
+  featuredPets: PetWithMetrics[];
+}) {
+  const { userId: viewerId } = await auth();
+  return (
+    <PinnedSection
+      featuredPets={featuredPets}
+      isOwner={viewerId === ownerId}
+      petStateCount={petStates.length}
+    />
+  );
+}
+
+function PublicProfileTabs({
+  publicHandle,
+  approvedPets,
+  collection,
+  approvedAll,
+}: {
+  publicHandle: string;
+  approvedPets: PetWithMetrics[];
+  collection: Awaited<ReturnType<typeof getOwnerCollection>>;
+  approvedAll: PetWithMetrics[];
+}) {
+  return (
+    <ProfileTabs
+      isOwner={false}
+      publicHandle={publicHandle}
+      approvedPets={approvedPets}
+      ownerSubmissions={[]}
+      likedPets={[]}
+      collection={
+        collection
+          ? {
+              slug: collection.slug,
+              title: collection.title,
+              description: collection.description,
+              externalUrl: collection.externalUrl,
+              coverPetSlug: collection.coverPetSlug,
+              petSlugs: collection.pets.map((pet) => pet.slug),
+            }
+          : null
+      }
+      canManageCollections={false}
+      collectionApprovedPets={approvedAll.map((p) => ({
+        slug: p.slug,
+        displayName: p.displayName,
+        spritesheetUrl: p.spritesheetPath,
+      }))}
+    />
+  );
+}
+
+async function ProfileTabsWithViewer({
+  ownerId,
+  publicHandle,
+  approvedPets,
+  approvedAll,
+  collection,
+}: {
+  ownerId: string;
+  publicHandle: string;
+  approvedPets: PetWithMetrics[];
+  approvedAll: PetWithMetrics[];
+  collection: Awaited<ReturnType<typeof getOwnerCollection>>;
+}) {
+  const { userId: viewerId } = await auth();
+  const isOwner = viewerId === ownerId;
+
+  if (!isOwner) {
+    return (
+      <PublicProfileTabs
+        publicHandle={publicHandle}
+        approvedPets={approvedPets}
+        collection={collection}
+        approvedAll={approvedAll}
+      />
+    );
+  }
+
+  const allOwnerRows = await db
+    .select()
+    .from(schema.submittedPets)
+    .where(eq(schema.submittedPets.ownerId, ownerId))
+    .orderBy(desc(schema.submittedPets.approvedAt));
+
+  const ownerSubmissions: Submission[] = allOwnerRows
+    .filter((r) => r.status === "pending" || r.status === "rejected")
+    .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+    .map((row) => ({
+      id: row.id,
+      slug: row.slug,
+      displayName: row.displayName,
+      description: row.description,
+      spritesheetUrl: row.spritesheetUrl,
+      zipUrl: row.zipUrl,
+      kind: row.kind,
+      vibes: (row.vibes as string[]) ?? [],
+      tags: (row.tags as string[]) ?? [],
+      featured: row.featured,
+      status: row.status,
+      createdAt: row.createdAt.toISOString(),
+      approvedAt: row.approvedAt?.toISOString() ?? null,
+      rejectedAt: row.rejectedAt?.toISOString() ?? null,
+      rejectionReason: row.rejectionReason,
+      pending: row.pendingSubmittedAt
+        ? {
+            displayName: row.pendingDisplayName,
+            description: row.pendingDescription,
+            tags: (row.pendingTags as string[] | null) ?? null,
+            submittedAt: row.pendingSubmittedAt.toISOString(),
+          }
+        : null,
+      pendingRejectionReason: row.pendingRejectionReason,
+      metrics: { installCount: 0, zipDownloadCount: 0, likeCount: 0 },
+    }));
+
+  const likedPets = await getLikedPetsForUser(ownerId);
+  const canManageOwnCollection = await canManageCreatorCollections(viewerId);
+
+  return (
+    <ProfileTabs
+      isOwner
+      publicHandle={publicHandle}
+      approvedPets={approvedPets}
+      ownerSubmissions={ownerSubmissions}
+      likedPets={likedPets}
+      collection={
+        collection
+          ? {
+              slug: collection.slug,
+              title: collection.title,
+              description: collection.description,
+              externalUrl: collection.externalUrl,
+              coverPetSlug: collection.coverPetSlug,
+              petSlugs: collection.pets.map((pet) => pet.slug),
+            }
+          : null
+      }
+      canManageCollections={canManageOwnCollection}
+      collectionApprovedPets={approvedAll.map((p) => ({
+        slug: p.slug,
+        displayName: p.displayName,
+        spritesheetUrl: p.spritesheetPath,
+      }))}
+    />
   );
 }
 


### PR DESCRIPTION
## Bug

Prod logs full of:

\`\`\`
Couldn't find all resumable slots by key/index during replaying.
The tree doesn't match so React will fallback to client rendering.
\`\`\`

200s but every hit ran a function (zero static-shell win) and shipped extra HTML to fallback render client-side.

## Root cause

PR #129 added \`'use cache'\` to data helpers but left \`auth()\` calls inside the main page tree. \`/pets/[slug]\` and \`/u/[handle]\` both branched their JSX on \`userId\` (owner panels, like state, owner-only tabs, pin overlays, claim CTA). Cache Components prerendered one shape (anonymous) and runtime returned another (signed-in / owner), React couldn't resume the slots, fallback fired.

## Fix

Isolate every \`auth()\`-dependent UI fragment into its own \`<Suspense>\` leaf. The pages now render a stable static shell for everyone; the small auth-aware bits stream in.

### \`/pets/[slug]\`
- \`LikeButton\` -> \`LikeButtonLeaf\` (with anonymous fallback so the button renders unauthenticated immediately)
- \`OwnerEditPanel\` -> \`OwnerEditPanelLeaf\`
- \`SuggestCollectionButton\` -> \`SuggestCollectionButtonLeaf\`
- \`ClaimCTA\` -> \`ClaimCTALeaf\`

### \`/u/[handle]\`
- \`ViewerCatchProgress\`, \`OwnerEditButton\`, \`ViewerAnalytics\` leaves
- \`PinnedSectionWithViewer\` swaps to \`PinnedReorderGrid\` when viewer === owner
- \`ProfileTabsWithViewer\` resolves owner submissions / liked pets / collection-manage permission only when needed

## Build

Both routes still PPR with 1h fresh / 1d SWR:

\`\`\`
├ ◐ /[locale]/pets/[slug]    1h    1d
├ ◐ /[locale]/u/[handle]     -     -
\`\`\`

\`bun run build\` passes. Local mock smoke shows 200 on both.

## Test plan
- [ ] Open a pet detail signed-in vs anonymous, verify like button + owner edit panel render correctly
- [ ] Open someone else's profile, verify pinned grid is static and tabs show only approved pets
- [ ] Open your own profile, verify owner editor button + reorder grid + pending/rejected tabs appear
- [ ] Watch Vercel logs for \"resumable slots\" error to disappear