### PR TITLE
revert: roll back Cache Components stack (#129, #136, #138)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "petdex",

--- a/next.config.ts
+++ b/next.config.ts
@@ -85,7 +85,6 @@ const securityHeaders = [
 const mockRoot = path.resolve(__dirname, "src/lib/mock");
 
 const nextConfig: NextConfig = {
-  cacheComponents: true,
   // Hide the framework banner on every response.
   poweredByHeader: false,
   images: {

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -12,6 +12,8 @@ import { SiteHeader } from "@/components/site-header";
 
 const SITE_URL = "https://petdex.crafter.run";
 
+export const revalidate = 3600;
+
 export async function generateMetadata({
   params,
 }: {

--- a/src/app/[locale]/admin/collection-requests/page.tsx
+++ b/src/app/[locale]/admin/collection-requests/page.tsx
@@ -12,6 +12,8 @@ export const metadata = {
   robots: { index: false, follow: false },
 };
 
+export const dynamic = "force-dynamic";
+
 export default async function AdminCollectionRequestsPage() {
   // Pending first (newest first), then anything decided in the last
   // ~30 days for a quick audit trail. Older history can stay paged

--- a/src/app/[locale]/admin/edits/page.tsx
+++ b/src/app/[locale]/admin/edits/page.tsx
@@ -11,6 +11,8 @@ export const metadata = {
   robots: { index: false, follow: false },
 };
 
+export const dynamic = "force-dynamic";
+
 function DiffField({
   label,
   before,

--- a/src/app/[locale]/admin/feedback/[id]/page.tsx
+++ b/src/app/[locale]/admin/feedback/[id]/page.tsx
@@ -9,6 +9,8 @@ import { db, schema } from "@/lib/db/client";
 
 import { FeedbackThread } from "@/components/feedback-thread";
 
+export const dynamic = "force-dynamic";
+
 export const metadata = {
   title: "Feedback thread — Admin",
   robots: { index: false, follow: false },

--- a/src/app/[locale]/admin/feedback/page.tsx
+++ b/src/app/[locale]/admin/feedback/page.tsx
@@ -22,6 +22,8 @@ export const metadata = {
   robots: { index: false, follow: false },
 };
 
+export const dynamic = "force-dynamic";
+
 const KIND_META: Record<
   string,
   { label: string; tone: string; icon: React.ReactNode }

--- a/src/app/[locale]/admin/insights/page.tsx
+++ b/src/app/[locale]/admin/insights/page.tsx
@@ -14,6 +14,8 @@ import {
 import { AdminFeatureToggle } from "@/components/admin-feature-toggle";
 import { AdminVelocityChart } from "@/components/admin-velocity-chart";
 
+export const dynamic = "force-dynamic";
+
 export const metadata = {
   title: "Insights — Petdex admin",
   robots: { index: false, follow: false },

--- a/src/app/[locale]/admin/layout.tsx
+++ b/src/app/[locale]/admin/layout.tsx
@@ -1,5 +1,4 @@
 import { notFound } from "next/navigation";
-import { Suspense } from "react";
 
 import { auth } from "@clerk/nextjs/server";
 
@@ -12,20 +11,15 @@ export const metadata = {
   robots: { index: false, follow: false },
 };
 
-export default function AdminLayout({
+export default async function AdminLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <Suspense fallback={null}>
-      <AdminGate>{children}</AdminGate>
-    </Suspense>
-  );
-}
-
-async function AdminGate({ children }: { children: React.ReactNode }) {
   const { userId } = await auth();
+  // Single gate at the layout level — every nested page (/admin,
+  // /admin/requests, /admin/feedback) inherits this protection so
+  // no individual page has to re-check.
   if (!isAdmin(userId)) notFound();
 
   return (

--- a/src/app/[locale]/admin/manifest/page.tsx
+++ b/src/app/[locale]/admin/manifest/page.tsx
@@ -7,6 +7,8 @@ export const metadata = {
   robots: { index: false, follow: false },
 };
 
+export const dynamic = "force-dynamic";
+
 export default async function AdminManifestPage() {
   // Last 7 days, basic shape: total fetches, by-day, by-country, by-UA,
   // and the loudest IPs. Anything older than 7d gets pruned periodically

--- a/src/app/[locale]/admin/page.tsx
+++ b/src/app/[locale]/admin/page.tsx
@@ -24,6 +24,8 @@ export async function generateMetadata({
   };
 }
 
+export const dynamic = "force-dynamic";
+
 type SP = { status?: string };
 
 type Filter =

--- a/src/app/[locale]/admin/requests/page.tsx
+++ b/src/app/[locale]/admin/requests/page.tsx
@@ -13,6 +13,8 @@ export const metadata = {
   robots: { index: false, follow: false },
 };
 
+export const dynamic = "force-dynamic";
+
 type ClerkInfo = {
   imageUrl: string | null;
   displayName: string | null;

--- a/src/app/[locale]/collections/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/collections/[slug]/opengraph-image.tsx
@@ -13,12 +13,14 @@ import { isAllowedAssetUrl } from "@/lib/url-allowlist";
 
 import { defaultLocale, hasLocale } from "@/i18n/config";
 
+export const runtime = "nodejs";
 export const contentType = "image/png";
 export const size = { width: 1200, height: 630 };
 export const alt = "Petdex collection preview";
 // 24h ISR for the same reason the per-pet OG caches: every Discord /
 // Slack / X unfurl was re-running sharp + 6 sprite fetches before
 // this. See per-pet opengraph-image.tsx.
+export const revalidate = 86400;
 
 const FRAME_W = 192;
 const FRAME_H = 208;

--- a/src/app/[locale]/collections/[slug]/page.tsx
+++ b/src/app/[locale]/collections/[slug]/page.tsx
@@ -6,7 +6,7 @@ import { ExternalLink, Heart, TerminalSquare } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 
 import { getCaughtSlugSet } from "@/lib/catch-status";
-import { getAllCollections, getCollection } from "@/lib/collections";
+import { getCollection } from "@/lib/collections";
 import { getDexNumberMap } from "@/lib/dex";
 import { buildLocaleAlternates } from "@/lib/locale-routing";
 import { resolveOwnerCredits } from "@/lib/owner-credit";
@@ -17,14 +17,11 @@ import { PetSprite } from "@/components/pet-sprite";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 
+export const dynamic = "force-dynamic";
+
 const SITE_URL = "https://petdex.crafter.run";
 
 type PageProps = { params: Promise<{ slug: string; locale: string }> };
-
-export async function generateStaticParams() {
-  const collections = await getAllCollections();
-  return collections.map((collection) => ({ slug: collection.slug }));
-}
 
 export async function generateMetadata({ params }: PageProps) {
   const { slug } = await params;

--- a/src/app/[locale]/collections/opengraph-image.tsx
+++ b/src/app/[locale]/collections/opengraph-image.tsx
@@ -11,6 +11,7 @@ import { isAllowedAssetUrl } from "@/lib/url-allowlist";
 
 import { defaultLocale, hasLocale } from "@/i18n/config";
 
+export const runtime = "nodejs";
 export const contentType = "image/png";
 export const size = { width: 1200, height: 630 };
 export const alt = "Petdex featured collections";
@@ -19,6 +20,7 @@ export const alt = "Petdex featured collections";
 // thing on the Vercel bill, and the rendered PNG is identical for
 // hours at a time. See per-pet opengraph-image.tsx for the same
 // reasoning.
+export const revalidate = 86400;
 
 const FRAME_W = 192;
 const FRAME_H = 208;

--- a/src/app/[locale]/collections/page.tsx
+++ b/src/app/[locale]/collections/page.tsx
@@ -14,6 +14,7 @@ import { SiteHeader } from "@/components/site-header";
 // /collections is fully public — no auth, no cookies, no per-visitor
 // data. ISR with 5 minute revalidation lets featured-collection
 // rotations show up quickly without waking a function on every visit.
+export const revalidate = 300;
 
 const SITE_URL = "https://petdex.crafter.run";
 

--- a/src/app/[locale]/community/page.tsx
+++ b/src/app/[locale]/community/page.tsx
@@ -15,6 +15,7 @@ import { JsonLd } from "@/components/json-ld";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 
+export const dynamic = "force-static";
 const SITE_URL = "https://petdex.crafter.run";
 
 export async function generateMetadata() {

--- a/src/app/[locale]/create/page.tsx
+++ b/src/app/[locale]/create/page.tsx
@@ -84,7 +84,9 @@ export default async function CreatePage() {
               </code>
               {t("steps.hatch.afterCommand")}
             </p>
-            <p className="text-xs text-muted-3">{t("steps.hatch.tip")}</p>
+            <p className="text-xs text-muted-3">
+              {t("steps.hatch.tip")}
+            </p>
           </Step>
 
           <Step

--- a/src/app/[locale]/install/[slug]/route.ts
+++ b/src/app/[locale]/install/[slug]/route.ts
@@ -8,16 +8,15 @@ import {
 } from "@/lib/install-script";
 import { installCounterRatelimit } from "@/lib/ratelimit";
 
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
 type Params = { locale: string; slug: string };
 
 function detectPlatformFromRequest(req: Request): "posix" | "ps1" {
   const url = new URL(req.url);
   const explicit = url.searchParams.get("platform")?.toLowerCase();
-  if (
-    explicit === "ps1" ||
-    explicit === "windows" ||
-    explicit === "powershell"
-  ) {
+  if (explicit === "ps1" || explicit === "windows" || explicit === "powershell") {
     return "ps1";
   }
   if (explicit === "posix" || explicit === "sh" || explicit === "unix") {

--- a/src/app/[locale]/kind/[kind]/page.tsx
+++ b/src/app/[locale]/kind/[kind]/page.tsx
@@ -12,6 +12,8 @@ const SITE_URL = "https://petdex.crafter.run";
 
 type Props = { params: Promise<{ kind: string; locale: string }> };
 
+export const revalidate = 600;
+
 export function generateStaticParams() {
   return PET_KINDS.map((kind) => ({ kind }));
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,11 +1,14 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { notFound } from "next/navigation";
-import { Suspense } from "react";
 
 import { Analytics } from "@vercel/analytics/next";
 import { NextIntlClientProvider } from "next-intl";
-import { getTranslations, setRequestLocale } from "next-intl/server";
+import {
+  getMessages,
+  getTranslations,
+  setRequestLocale,
+} from "next-intl/server";
 
 import { AnnouncementQueue } from "@/components/announcement-queue";
 import { FeedbackWidget } from "@/components/feedback-widget";
@@ -14,9 +17,6 @@ import { ProfileAnnouncementModal } from "@/components/profile-announcement-moda
 import { AppProviders } from "@/components/theme-providers";
 
 import { hasLocale, locales } from "@/i18n/config";
-import enMessages from "@/i18n/messages/en.json";
-import esMessages from "@/i18n/messages/es.json";
-import zhMessages from "@/i18n/messages/zh.json";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -34,11 +34,6 @@ type Props = {
 };
 
 const SITE_URL = "https://petdex.crafter.run";
-const messagesByLocale = {
-  en: enMessages,
-  es: esMessages,
-  zh: zhMessages,
-};
 
 export function generateStaticParams() {
   return locales.map((locale) => ({ locale }));
@@ -95,7 +90,7 @@ export default async function LocaleLayout({ children, params }: Props) {
   }
 
   setRequestLocale(locale);
-  const messages = messagesByLocale[locale];
+  const messages = await getMessages();
 
   return (
     <html
@@ -104,26 +99,16 @@ export default async function LocaleLayout({ children, params }: Props) {
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col bg-background text-foreground">
-        <NextIntlClientProvider
-          formats={{}}
-          locale={locale}
-          messages={messages}
-          now={new Date(0)}
-          timeZone="UTC"
-        >
-          <Suspense fallback={null}>
-            <AppProviders>
-              <HeaderStateProvider>
-                {children}
-                <Suspense fallback={null}>
-                  <FeedbackWidget />
-                  <AnnouncementQueue />
-                  <ProfileAnnouncementModal />
-                </Suspense>
-                <Analytics />
-              </HeaderStateProvider>
-            </AppProviders>
-          </Suspense>
+        <NextIntlClientProvider messages={messages}>
+          <AppProviders>
+            <HeaderStateProvider>
+              {children}
+              <FeedbackWidget />
+              <AnnouncementQueue />
+              <ProfileAnnouncementModal />
+              <Analytics />
+            </HeaderStateProvider>
+          </AppProviders>
         </NextIntlClientProvider>
       </body>
     </html>

--- a/src/app/[locale]/leaderboard/page.tsx
+++ b/src/app/[locale]/leaderboard/page.tsx
@@ -13,6 +13,8 @@ import { LeaderboardView } from "@/components/leaderboard-view";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 
+export const dynamic = "force-dynamic";
+
 export async function generateMetadata({
   params,
 }: {

--- a/src/app/[locale]/my-feedback/[id]/page.tsx
+++ b/src/app/[locale]/my-feedback/[id]/page.tsx
@@ -11,6 +11,8 @@ import { FeedbackThread } from "@/components/feedback-thread";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 
+export const dynamic = "force-dynamic";
+
 type Params = { id: string; locale: string };
 
 export async function generateMetadata({

--- a/src/app/[locale]/my-feedback/page.tsx
+++ b/src/app/[locale]/my-feedback/page.tsx
@@ -12,6 +12,8 @@ import { MyFeedbackFilters } from "@/components/my-feedback-filters";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 
+export const dynamic = "force-dynamic";
+
 export async function generateMetadata({
   params,
 }: {
@@ -187,7 +189,9 @@ export default async function MyFeedbackPage({
           <h1 className="text-4xl font-medium tracking-tight md:text-5xl">
             {t("title")}
           </h1>
-          <p className="text-sm text-muted-2">{t("subtitle")}</p>
+          <p className="text-sm text-muted-2">
+            {t("subtitle")}
+          </p>
           {decorated.length > 0 ? (
             <MyFeedbackFilters counts={counts} defaultFilter={defaultFilter} />
           ) : null}

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -10,6 +10,8 @@ import { PetSprite } from "@/components/pet-sprite";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 
+export const dynamic = "force-dynamic";
+
 export async function generateMetadata({
   params,
 }: {
@@ -32,7 +34,9 @@ export default async function NotFound() {
     getApprovedPetCount(),
   ]);
 
-  const lost = featured[0] ?? null;
+  // Pick a random featured pet for the "lost" sprite. Falls back gracefully
+  // if the curated set is empty (early days / fresh DB).
+  const lost = featured[Math.floor(Math.random() * featured.length)] ?? null;
 
   return (
     <main className="min-h-dvh bg-background text-foreground">

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -34,6 +34,7 @@ import { SurprisePetCard } from "@/components/surprise-pet-card";
 // "caught" highlight. The server now renders an alpha-ordered, anon
 // shell that the edge can cache for 60s — enough to keep new pets
 // surfacing without waking a function on every visit.
+export const revalidate = 60;
 export const metadata = {
   alternates: buildLocaleAlternates("/"),
 };

--- a/src/app/[locale]/pets/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/pets/[slug]/opengraph-image.tsx
@@ -13,6 +13,7 @@ import { isAllowedAssetUrl } from "@/lib/url-allowlist";
 
 import { defaultLocale, hasLocale } from "@/i18n/config";
 
+export const runtime = "nodejs";
 export const contentType = "image/png";
 export const size = { width: 1200, height: 630 };
 export const alt = "Petdex pet preview";
@@ -22,6 +23,7 @@ export const alt = "Petdex pet preview";
 // / Slack / X unfurl re-runs sharp + the spritesheet fetch, which is
 // the single biggest line on the Vercel bill (Fluid CPU + Origin
 // Transfer combined). 24h ISR + immutable headers neutralize it.
+export const revalidate = 86400;
 
 // Petdex spritesheets are an 8-column × 9-row grid (max frames per state ×
 // state count). Per-frame size is 192×208 — most states use fewer than 8

--- a/src/app/[locale]/pets/[slug]/page.tsx
+++ b/src/app/[locale]/pets/[slug]/page.tsx
@@ -48,6 +48,9 @@ type PageProps = {
   }>;
 };
 
+export const dynamicParams = true;
+export const revalidate = 60;
+
 type DexNavPet = {
   slug: string;
   displayName: string;

--- a/src/app/[locale]/pets/[slug]/page.tsx
+++ b/src/app/[locale]/pets/[slug]/page.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { Suspense } from "react";
 
 import { auth } from "@clerk/nextjs/server";
 import { and, eq, inArray } from "drizzle-orm";
@@ -158,14 +157,16 @@ export default async function PetPage({ params }: PageProps) {
         }
       : null;
 
-  const [allPets, ownerRow, variants, memberOfCollections] = await Promise.all([
-    getApprovedPetsWithMetrics(),
-    db.query.submittedPets.findFirst({
-      where: eq(schema.submittedPets.slug, slug),
-    }),
-    getVariantsFor(slug),
-    getCollectionsContainingPet(slug),
-  ]);
+  const [{ userId }, allPets, ownerRow, variants, memberOfCollections] =
+    await Promise.all([
+      auth(),
+      getApprovedPetsWithMetrics(),
+      db.query.submittedPets.findFirst({
+        where: eq(schema.submittedPets.slug, slug),
+      }),
+      getVariantsFor(slug),
+      getCollectionsContainingPet(slug),
+    ]);
   const petWithMetrics = allPets.find((candidate) => candidate.slug === slug);
   const metrics = petWithMetrics?.metrics ?? {
     installCount: 0,
@@ -182,6 +183,16 @@ export default async function PetPage({ params }: PageProps) {
       metrics: candidate.metrics,
     })),
   );
+  const initialLiked = userId
+    ? Boolean(
+        await db.query.petLikes.findFirst({
+          where: and(
+            eq(schema.petLikes.userId, userId),
+            eq(schema.petLikes.petSlug, slug),
+          ),
+        }),
+      )
+    : false;
 
   // Resolve the "submitted by" credit live from Clerk so name/url/avatar
   // reflect the user's *current* profile (not the snapshot taken at
@@ -207,6 +218,45 @@ export default async function PetPage({ params }: PageProps) {
         ownerIsProxy: ownerRow.source === "discover",
       })
     : null;
+
+  let ownerEditState: {
+    isOwner: boolean;
+    petId: string;
+    currentTags: string[];
+    pending: {
+      displayName: string | null;
+      description: string | null;
+      tags: string[] | null;
+      submittedAt: string | null;
+    } | null;
+    lastRejection: string | null;
+  } | null = null;
+  if (userId && ownerRow && ownerRow.ownerId === userId) {
+    const hasPending = Boolean(ownerRow.pendingSubmittedAt);
+    ownerEditState = {
+      isOwner: true,
+      petId: ownerRow.id,
+      currentTags: (ownerRow.tags as string[]) ?? [],
+      pending: hasPending
+        ? {
+            displayName: ownerRow.pendingDisplayName,
+            description: ownerRow.pendingDescription,
+            tags: (ownerRow.pendingTags as string[] | null) ?? null,
+            submittedAt: ownerRow.pendingSubmittedAt
+              ? ownerRow.pendingSubmittedAt.toISOString()
+              : null,
+          }
+        : null,
+      lastRejection: ownerRow.pendingRejectionReason,
+    };
+  }
+
+  // Owner-only: candidate featured collections + already-submitted
+  // pending requests for the suggest button.
+  const collectionSuggest =
+    userId && ownerRow && ownerRow.ownerId === userId
+      ? await getCollectionCandidatesForPet(slug, userId)
+      : null;
 
   const url = `${SITE_URL}/pets/${pet.slug}`;
   const jsonLd = [
@@ -340,30 +390,29 @@ export default async function PetPage({ params }: PageProps) {
               <h1 className="text-balance text-[44px] leading-[1] font-semibold tracking-tight text-foreground md:text-[64px]">
                 {pet.displayName}
               </h1>
-              <Suspense fallback={null}>
-                <OwnerEditPanelLeaf ownerRow={ownerRow} pet={pet} />
-              </Suspense>
+              {ownerEditState ? (
+                <OwnerEditPanel
+                  petId={ownerEditState.petId}
+                  slug={pet.slug}
+                  currentDisplayName={pet.displayName}
+                  currentDescription={pet.description}
+                  currentTags={ownerEditState.currentTags}
+                  initialPending={ownerEditState.pending}
+                  initialRejection={ownerEditState.lastRejection}
+                />
+              ) : null}
             </div>
             <p className="max-w-3xl text-balance text-base leading-7 text-muted-1 md:text-lg">
               {pet.description}
             </p>
 
             <div className="flex flex-wrap items-center gap-3">
-              <Suspense
-                fallback={
-                  <LikeButton
-                    slug={pet.slug}
-                    initialCount={metrics.likeCount}
-                    initialLiked={false}
-                    signedIn={false}
-                  />
-                }
-              >
-                <LikeButtonLeaf
-                  slug={pet.slug}
-                  initialCount={metrics.likeCount}
-                />
-              </Suspense>
+              <LikeButton
+                slug={pet.slug}
+                initialCount={metrics.likeCount}
+                initialLiked={initialLiked}
+                signedIn={Boolean(userId)}
+              />
               {pet.soundUrl ? (
                 <PetSoundButton
                   soundUrl={pet.soundUrl}
@@ -417,13 +466,14 @@ export default async function PetPage({ params }: PageProps) {
               </div>
             ) : null}
 
-            <Suspense fallback={null}>
-              <SuggestCollectionButtonLeaf
-                slug={slug}
+            {collectionSuggest && collectionSuggest.candidates.length > 0 ? (
+              <SuggestCollectionButton
+                petSlug={slug}
                 petDisplayName={pet.displayName}
-                ownerRow={ownerRow}
+                candidateCollections={collectionSuggest.candidates}
+                alreadyRequested={collectionSuggest.alreadyRequested}
               />
-            </Suspense>
+            ) : null}
 
             {/* Keyboard hint strip — minimal, mono-spaced, only on
                 pointer-fine media so we don't spam mobile users with
@@ -464,17 +514,15 @@ export default async function PetPage({ params }: PageProps) {
           {ownerCredit ? (
             <div className="space-y-3">
               <SubmittedBy credit={ownerCredit} />
-              {ownerRow?.source === "discover" ? (
-                <Suspense fallback={null}>
-                  <ClaimCTALeaf
-                    petName={pet.displayName}
-                    authorLabel={ownerCredit.name}
-                    githubUrl={
-                      ownerCredit.externals.find((e) => e.provider === "github")
-                        ?.url ?? null
-                    }
-                  />
-                </Suspense>
+              {ownerRow?.source === "discover" && !userId ? (
+                <ClaimCTA
+                  petName={pet.displayName}
+                  authorLabel={ownerCredit.name}
+                  githubUrl={
+                    ownerCredit.externals.find((e) => e.provider === "github")
+                      ?.url ?? null
+                  }
+                />
               ) : null}
             </div>
           ) : null}
@@ -593,111 +641,5 @@ function InfoCard({
         {children}
       </div>
     </div>
-  );
-}
-
-async function LikeButtonLeaf({
-  slug,
-  initialCount,
-}: {
-  slug: string;
-  initialCount: number;
-}) {
-  const { userId } = await auth();
-  const initialLiked = userId
-    ? Boolean(
-        await db.query.petLikes.findFirst({
-          where: and(
-            eq(schema.petLikes.userId, userId),
-            eq(schema.petLikes.petSlug, slug),
-          ),
-        }),
-      )
-    : false;
-  return (
-    <LikeButton
-      slug={slug}
-      initialCount={initialCount}
-      initialLiked={initialLiked}
-      signedIn={Boolean(userId)}
-    />
-  );
-}
-
-async function OwnerEditPanelLeaf({
-  ownerRow,
-  pet,
-}: {
-  ownerRow: typeof schema.submittedPets.$inferSelect | undefined;
-  pet: { slug: string; displayName: string; description: string };
-}) {
-  const { userId } = await auth();
-  if (!userId || !ownerRow || ownerRow.ownerId !== userId) return null;
-  const hasPending = Boolean(ownerRow.pendingSubmittedAt);
-  return (
-    <OwnerEditPanel
-      petId={ownerRow.id}
-      slug={pet.slug}
-      currentDisplayName={pet.displayName}
-      currentDescription={pet.description}
-      currentTags={(ownerRow.tags as string[]) ?? []}
-      initialPending={
-        hasPending
-          ? {
-              displayName: ownerRow.pendingDisplayName,
-              description: ownerRow.pendingDescription,
-              tags: (ownerRow.pendingTags as string[] | null) ?? null,
-              submittedAt: ownerRow.pendingSubmittedAt
-                ? ownerRow.pendingSubmittedAt.toISOString()
-                : null,
-            }
-          : null
-      }
-      initialRejection={ownerRow.pendingRejectionReason}
-    />
-  );
-}
-
-async function SuggestCollectionButtonLeaf({
-  slug,
-  petDisplayName,
-  ownerRow,
-}: {
-  slug: string;
-  petDisplayName: string;
-  ownerRow: typeof schema.submittedPets.$inferSelect | undefined;
-}) {
-  const { userId } = await auth();
-  if (!userId || !ownerRow || ownerRow.ownerId !== userId) return null;
-  const collectionSuggest = await getCollectionCandidatesForPet(slug, userId);
-  if (!collectionSuggest || collectionSuggest.candidates.length === 0)
-    return null;
-  return (
-    <SuggestCollectionButton
-      petSlug={slug}
-      petDisplayName={petDisplayName}
-      candidateCollections={collectionSuggest.candidates}
-      alreadyRequested={collectionSuggest.alreadyRequested}
-    />
-  );
-}
-
-async function ClaimCTALeaf({
-  petName,
-  authorLabel,
-  githubUrl,
-}: {
-  petName: string;
-  authorLabel: string;
-  githubUrl: string | null;
-}) {
-  const { userId } = await auth();
-  if (userId) return null;
-  return (
-    <ClaimCTA
-      petName={petName}
-      authorLabel={authorLabel}
-      githubUrl={githubUrl}
-    />
   );
 }

--- a/src/app/[locale]/requests/page.tsx
+++ b/src/app/[locale]/requests/page.tsx
@@ -11,6 +11,8 @@ import { type RequestRow, RequestsView } from "@/components/requests-view";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 
+export const dynamic = "force-dynamic";
+
 export async function generateMetadata({
   params,
 }: {

--- a/src/app/[locale]/submit/page.tsx
+++ b/src/app/[locale]/submit/page.tsx
@@ -37,7 +37,9 @@ export default async function SubmitPage() {
           <h1 className="mt-4 text-5xl leading-tight font-medium tracking-normal text-foreground md:text-7xl">
             {t("title")}
           </h1>
-          <p className="mt-6 text-lg leading-8 text-muted-2">{t("body")}</p>
+          <p className="mt-6 text-lg leading-8 text-muted-2">
+            {t("body")}
+          </p>
           <Link
             href="/create"
             className="mt-5 inline-flex items-center gap-2 rounded-full border border-border-base bg-surface/70 px-4 py-2 text-sm font-medium text-muted-2 backdrop-blur transition hover:bg-white hover:text-foreground dark:hover:bg-stone-800"

--- a/src/app/[locale]/u/[handle]/opengraph-image.tsx
+++ b/src/app/[locale]/u/[handle]/opengraph-image.tsx
@@ -17,12 +17,14 @@ import { db, schema } from "@/lib/db/client";
 import { userIdForHandle } from "@/lib/handles";
 import { isAllowedAssetUrl, isAllowedAvatarUrl } from "@/lib/url-allowlist";
 
+export const runtime = "nodejs";
 export const contentType = "image/png";
 export const size = { width: 1200, height: 630 };
 export const alt = "Petdex profile preview";
 // 24h ISR — same reasoning as the per-pet OG. Profile bios change
 // rarely and the unfurl bots that hit this path are noisy. Cached
 // PNG saves Fluid CPU + Origin Transfer on every Discord/X share.
+export const revalidate = 86400;
 
 const FRAME_W = 192;
 const FRAME_H = 208;

--- a/src/app/[locale]/u/[handle]/page.tsx
+++ b/src/app/[locale]/u/[handle]/page.tsx
@@ -37,30 +37,52 @@ const SITE_URL = "https://petdex.crafter.run";
 
 type PageProps = { params: Promise<{ handle: string; locale: string }> };
 
-type PublicProfile = {
-  ownerId: string;
-  publicHandle: string;
-  displayName: string | null;
-  avatarUrl: string | null;
-  externalUrls: { url: string; label: string }[];
-  memberSince: number | null;
-  bio: string | null;
-  featuredSlugs: string[];
-  approvedPets: PetWithMetrics[];
-  collection: Awaited<ReturnType<typeof getOwnerCollection>>;
-  totalLikes: number;
-  totalInstalls: number;
-  isOwnerAdmin: boolean;
-  rank: { rank: number; total: number } | null;
-};
+export async function generateMetadata({ params }: PageProps) {
+  const { handle } = await params;
+  const userId = await userIdForHandle(handle);
+  if (!userId) return { title: "Profile not found", robots: { index: false } };
+  let displayName = `@${handle}`;
+  const profile = await db.query.userProfiles.findFirst({
+    where: eq(schema.userProfiles.userId, userId),
+  });
+  try {
+    const client = await clerkClient();
+    const u = await client.users.getUser(userId);
+    const name = [u.firstName, u.lastName].filter(Boolean).join(" ").trim();
+    const fallbackName = name || (u.username ? `@${u.username}` : `@${handle}`);
+    displayName = profile?.displayName ?? fallbackName;
+  } catch {
+    if (profile?.displayName) displayName = profile.displayName;
+    /* fall back */
+  }
+  const publicHandle = profile?.handle ?? handle.toLowerCase();
+  return {
+    title: `${displayName} on Petdex`,
+    description: `Pets created by ${displayName} for Codex.`,
+    alternates: buildLocaleAlternates(`/u/${publicHandle}`),
+    openGraph: {
+      title: `${displayName} on Petdex`,
+      description: `Animated Codex pets created by ${displayName}.`,
+      url: `${SITE_URL}/u/${publicHandle}`,
+    },
+  };
+}
 
-async function loadPublicProfile(
-  handle: string,
-): Promise<PublicProfile | null> {
+export default function UserProfilePage({ params }: PageProps) {
+  return (
+    <Suspense fallback={null}>
+      <UserProfileContent params={params} />
+    </Suspense>
+  );
+}
+
+async function UserProfileContent({ params }: PageProps) {
+  const { handle } = await params;
   const requestedHandle = handle.toLowerCase();
   const ownerId = await userIdForHandle(handle);
-  if (!ownerId) return null;
+  if (!ownerId) notFound();
 
+  // Pull Clerk profile.
   let displayName: string | null = null;
   let username: string | null = null;
   let avatarUrl: string | null = null;
@@ -96,6 +118,7 @@ async function loadPublicProfile(
     /* will render with handle only */
   }
 
+  // Profile customization (bio, featured slug).
   const profile = await db.query.userProfiles.findFirst({
     where: eq(schema.userProfiles.userId, ownerId),
   });
@@ -109,6 +132,13 @@ async function loadPublicProfile(
   const featuredSlugs =
     (profile?.featuredPetSlugs as string[] | undefined) ?? [];
 
+  // Viewer detection runs ahead of the pets query so the owner sees
+  // their pending + rejected rows alongside the approved gallery.
+  const { userId: viewerId } = await auth();
+  const isOwner = viewerId === ownerId;
+
+  // Pets owned by this user. Visitors only see approved rows; the owner
+  // sees everything so the profile doubles as their dashboard.
   const allOwnerRows = await db
     .select()
     .from(schema.submittedPets)
@@ -116,6 +146,7 @@ async function loadPublicProfile(
     .orderBy(desc(schema.submittedPets.approvedAt));
 
   const approvedRows = allOwnerRows.filter((r) => r.status === "approved");
+
   const slugs = approvedRows.map((r) => r.slug);
   const metrics = slugs.length
     ? await getMetricsBySlugs(slugs)
@@ -124,7 +155,7 @@ async function loadPublicProfile(
         { likeCount: number; installCount: number; zipDownloadCount: number }
       >();
 
-  const approvedPets: PetWithMetrics[] = approvedRows.map((row) => ({
+  const pets: PetWithMetrics[] = approvedRows.map((row) => ({
     ...rowToPet(row),
     metrics: metrics.get(row.slug) ?? {
       installCount: 0,
@@ -133,79 +164,73 @@ async function loadPublicProfile(
     },
   }));
 
+  // Owner-only: shape pending + rejected rows as Submission for the
+  // tabs panel. Sorted by createdAt desc so the most recent submit
+  // shows first.
+  const ownerSubmissions: Submission[] = isOwner
+    ? allOwnerRows
+        .filter((r) => r.status === "pending" || r.status === "rejected")
+        .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+        .map((row) => ({
+          id: row.id,
+          slug: row.slug,
+          displayName: row.displayName,
+          description: row.description,
+          spritesheetUrl: row.spritesheetUrl,
+          zipUrl: row.zipUrl,
+          kind: row.kind,
+          vibes: (row.vibes as string[]) ?? [],
+          tags: (row.tags as string[]) ?? [],
+          featured: row.featured,
+          status: row.status,
+          createdAt: row.createdAt.toISOString(),
+          approvedAt: row.approvedAt?.toISOString() ?? null,
+          rejectedAt: row.rejectedAt?.toISOString() ?? null,
+          rejectionReason: row.rejectionReason,
+          pending: row.pendingSubmittedAt
+            ? {
+                displayName: row.pendingDisplayName,
+                description: row.pendingDescription,
+                tags: (row.pendingTags as string[] | null) ?? null,
+                submittedAt: row.pendingSubmittedAt.toISOString(),
+              }
+            : null,
+          pendingRejectionReason: row.pendingRejectionReason,
+          metrics: { installCount: 0, zipDownloadCount: 0, likeCount: 0 },
+        }))
+    : [];
   const collection = await getOwnerCollection(ownerId);
-  const totalLikes = approvedPets.reduce(
-    (acc, p) => acc + p.metrics.likeCount,
-    0,
-  );
-  const totalInstalls = approvedPets.reduce(
+  const likedPets = await getLikedPetsForUser(ownerId);
+
+  // Resolve pinned slugs to full pet objects, preserving owner-chosen
+  // order. Drop any that are no longer approved (would otherwise break
+  // the layout with empty cards).
+  const featuredSet = new Set(featuredSlugs);
+  const featuredPets = featuredSlugs
+    .map((slug) => pets.find((p) => p.slug === slug))
+    .filter((p): p is PetWithMetrics => Boolean(p));
+  const restPets = pets.filter((p) => !featuredSet.has(p.slug));
+
+  // Aggregate stats.
+  const totalLikes = pets.reduce((acc, p) => acc + p.metrics.likeCount, 0);
+  const totalInstalls = pets.reduce(
     (acc, p) => acc + p.metrics.installCount,
     0,
   );
+
+  // Admins get a "Creator of Petdex" badge instead of a numeric rank,
+  // since they're filtered out of the leaderboard. For everyone else
+  // we look up their rank by approved-pet count and only render the
+  // badge when they're inside the top 50.
   const isOwnerAdmin = isAdmin(ownerId);
   const rank = isOwnerAdmin ? null : await getOwnerRank(ownerId, "pets");
 
-  return {
-    ownerId,
-    publicHandle,
-    displayName,
-    avatarUrl,
-    externalUrls,
-    memberSince,
-    bio,
-    featuredSlugs,
-    approvedPets,
-    collection,
-    totalLikes,
-    totalInstalls,
-    isOwnerAdmin,
-    rank,
-  };
-}
+  const catchProgress = isOwner ? await getCatchProgress(viewerId) : null;
+  const canManageOwnCollection = isOwner
+    ? await canManageCreatorCollections(viewerId)
+    : false;
 
-export async function generateMetadata({ params }: PageProps) {
-  const { handle } = await params;
-  const userId = await userIdForHandle(handle);
-  if (!userId) return { title: "Profile not found", robots: { index: false } };
-  let displayName = `@${handle}`;
-  const profile = await db.query.userProfiles.findFirst({
-    where: eq(schema.userProfiles.userId, userId),
-  });
-  try {
-    const client = await clerkClient();
-    const u = await client.users.getUser(userId);
-    const name = [u.firstName, u.lastName].filter(Boolean).join(" ").trim();
-    const fallbackName = name || (u.username ? `@${u.username}` : `@${handle}`);
-    displayName = profile?.displayName ?? fallbackName;
-  } catch {
-    if (profile?.displayName) displayName = profile.displayName;
-    /* fall back */
-  }
-  const publicHandle = profile?.handle ?? handle.toLowerCase();
-  return {
-    title: `${displayName} on Petdex`,
-    description: `Pets created by ${displayName} for Codex.`,
-    alternates: buildLocaleAlternates(`/u/${publicHandle}`),
-    openGraph: {
-      title: `${displayName} on Petdex`,
-      description: `Animated Codex pets created by ${displayName}.`,
-      url: `${SITE_URL}/u/${publicHandle}`,
-    },
-  };
-}
-
-export default async function UserProfilePage({ params }: PageProps) {
-  const { handle } = await params;
-  const data = await loadPublicProfile(handle);
-  if (!data) notFound();
-
-  const featuredSet = new Set(data.featuredSlugs);
-  const featuredPets = data.featuredSlugs
-    .map((slug) => data.approvedPets.find((p) => p.slug === slug))
-    .filter((p): p is PetWithMetrics => Boolean(p));
-  const restPets = data.approvedPets.filter((p) => !featuredSet.has(p.slug));
-
-  const fallbackInitial = (data.displayName ?? data.publicHandle)
+  const fallbackInitial = (displayName ?? publicHandle)
     .slice(0, 1)
     .toUpperCase();
 
@@ -214,11 +239,11 @@ export default async function UserProfilePage({ params }: PageProps) {
     "@type": "ProfilePage",
     mainEntity: {
       "@type": "Person",
-      name: data.displayName ?? `@${data.publicHandle}`,
-      url: `${SITE_URL}/u/${data.publicHandle}`,
-      ...(data.avatarUrl ? { image: data.avatarUrl } : {}),
-      ...(data.externalUrls.length > 0
-        ? { sameAs: data.externalUrls.map((e) => e.url) }
+      name: displayName ?? `@${publicHandle}`,
+      url: `${SITE_URL}/u/${publicHandle}`,
+      ...(avatarUrl ? { image: avatarUrl } : {}),
+      ...(externalUrls.length > 0
+        ? { sameAs: externalUrls.map((e) => e.url) }
         : {}),
     },
   };
@@ -226,18 +251,25 @@ export default async function UserProfilePage({ params }: PageProps) {
   return (
     <main className="min-h-dvh bg-background text-foreground">
       <JsonLd data={jsonLd} />
+      <ProfileAnalytics
+        handle={publicHandle}
+        petCount={pets.length}
+        pinnedCount={featuredPets.length}
+        viewerIsOwner={isOwner}
+      />
 
       <section className="petdex-cloud relative overflow-hidden">
         <div className="relative mx-auto flex w-full max-w-7xl flex-col px-5 pt-5 pb-10 md:px-8">
           <SiteHeader />
 
           <header className="mt-10 grid gap-8 md:mt-14 lg:grid-cols-[auto_1fr_auto] lg:items-start">
+            {/* Avatar */}
             <div className="flex justify-center lg:block">
-              {data.avatarUrl ? (
+              {avatarUrl ? (
                 // biome-ignore lint/performance/noImgElement: Clerk-hosted avatar
                 <img
-                  src={data.avatarUrl}
-                  alt={data.displayName ?? `@${data.publicHandle}`}
+                  src={avatarUrl}
+                  alt={displayName ?? `@${publicHandle}`}
                   className="size-28 rounded-3xl object-cover ring-1 ring-black/10 md:size-32"
                 />
               ) : (
@@ -247,15 +279,19 @@ export default async function UserProfilePage({ params }: PageProps) {
               )}
             </div>
 
+            {/* Identity */}
             <div className="text-center lg:text-left">
               <div className="flex flex-wrap items-center justify-center gap-2 lg:justify-start">
                 <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
                   Petdex creator
                 </p>
-                <Suspense fallback={null}>
-                  <ViewerCatchProgress ownerId={data.ownerId} />
-                </Suspense>
-                {data.isOwnerAdmin ? (
+                {catchProgress ? (
+                  <p className="font-mono text-xs tracking-[0.22em] text-muted-3 uppercase">
+                    YOUR ALBUM: {catchProgress.caught}/{catchProgress.total} (
+                    {catchProgress.pct}%)
+                  </p>
+                ) : null}
+                {isOwnerAdmin ? (
                   <span
                     className="inline-flex items-center gap-1 rounded-full bg-brand px-2 py-0.5 font-mono text-[10px] tracking-[0.15em] text-white uppercase"
                     title="One of the people who built Petdex"
@@ -263,51 +299,51 @@ export default async function UserProfilePage({ params }: PageProps) {
                     <Trophy className="size-3" />
                     Creator of Petdex
                   </span>
-                ) : data.rank ? (
+                ) : rank ? (
                   <Link
                     href="/leaderboard"
                     className="inline-flex items-center gap-1 rounded-full bg-chip-warning-bg px-2 py-0.5 font-mono text-[10px] tracking-[0.15em] text-chip-warning-fg uppercase transition hover:opacity-80"
-                    title={`Ranked #${data.rank.rank} of ${data.rank.total} by approved pets — see the full leaderboard`}
+                    title={`Ranked #${rank.rank} of ${rank.total} by approved pets — see the full leaderboard`}
                   >
-                    <Trophy className="size-3" />#{data.rank.rank} most pets
+                    <Trophy className="size-3" />#{rank.rank} most pets
                   </Link>
                 ) : null}
               </div>
               <h1 className="mt-3 text-balance text-[40px] leading-[1] font-semibold tracking-tight md:text-[56px]">
-                {data.displayName ?? `@${data.publicHandle}`}
+                {displayName ?? `@${publicHandle}`}
               </h1>
-              {data.displayName ? (
+              {displayName ? (
                 <p className="mt-2 font-mono text-sm tracking-[0.08em] text-muted-3">
-                  @{data.publicHandle}
+                  @{publicHandle}
                 </p>
               ) : null}
-              {data.bio ? (
+              {bio ? (
                 <p className="mt-4 max-w-xl text-balance text-base leading-7 text-muted-1 md:text-lg">
-                  {data.bio}
+                  {bio}
                 </p>
               ) : null}
 
+              {/* Stats row */}
               <div className="mt-5 flex flex-wrap items-center justify-center gap-x-5 gap-y-2 font-mono text-[11px] tracking-[0.18em] text-muted-3 uppercase lg:justify-start">
                 <span>
-                  {data.approvedPets.length}{" "}
-                  {data.approvedPets.length === 1 ? "pet" : "pets"}
+                  {pets.length} {pets.length === 1 ? "pet" : "pets"}
                 </span>
-                {data.totalLikes > 0 ? (
+                {totalLikes > 0 ? (
                   <span className="inline-flex items-center gap-1.5">
                     <Heart className="size-3" />
-                    {data.totalLikes}
+                    {totalLikes}
                   </span>
                 ) : null}
-                {data.totalInstalls > 0 ? (
+                {totalInstalls > 0 ? (
                   <span className="inline-flex items-center gap-1.5">
                     <TerminalSquare className="size-3" />
-                    {data.totalInstalls} installs
+                    {totalInstalls} installs
                   </span>
                 ) : null}
-                {data.memberSince ? (
+                {memberSince ? (
                   <span>
                     joined{" "}
-                    {new Date(data.memberSince).toLocaleDateString(undefined, {
+                    {new Date(memberSince).toLocaleDateString(undefined, {
                       month: "short",
                       year: "numeric",
                     })}
@@ -315,12 +351,13 @@ export default async function UserProfilePage({ params }: PageProps) {
                 ) : null}
               </div>
 
-              {data.externalUrls.length > 0 ? (
+              {/* External links */}
+              {externalUrls.length > 0 ? (
                 <div className="mt-4 flex flex-wrap items-center justify-center gap-2 lg:justify-start">
-                  {data.externalUrls.map((e) => (
+                  {externalUrls.map((e) => (
                     <ProfileExternalLink
                       key={e.url}
-                      handle={data.publicHandle}
+                      handle={publicHandle}
                       url={e.url}
                       label={e.label}
                     />
@@ -329,344 +366,108 @@ export default async function UserProfilePage({ params }: PageProps) {
               ) : null}
             </div>
 
+            {/* Owner + visitor actions. Share is on for everyone so a
+                fan can spread a profile they liked, the same growth
+                motion as the creator promoting their own page. */}
             <div className="flex flex-wrap items-center justify-center gap-2 lg:justify-end">
               <ProfileShareButton
-                handle={data.publicHandle}
-                displayName={data.displayName}
+                handle={publicHandle}
+                displayName={displayName}
               />
-              <Suspense fallback={null}>
-                <OwnerEditButton
-                  ownerId={data.ownerId}
-                  publicHandle={data.publicHandle}
-                  displayName={data.displayName}
-                  bio={data.bio}
-                  featuredSlugs={data.featuredSlugs}
-                  approvedPets={data.approvedPets.map((p) => ({
+              {isOwner ? (
+                <ProfileInlineEditor
+                  handle={publicHandle}
+                  initialDisplayName={displayName}
+                  initialBio={bio}
+                  initialFeaturedSlugs={featuredSlugs}
+                  approvedPets={pets.map((p) => ({
                     slug: p.slug,
                     displayName: p.displayName,
                   }))}
                 />
-              </Suspense>
+              ) : null}
             </div>
           </header>
         </div>
       </section>
 
       <section className="mx-auto flex w-full max-w-[1440px] flex-col gap-8 px-5 py-12 md:px-8 md:py-16">
-        <Suspense
-          fallback={
-            <PinnedSection
-              featuredPets={featuredPets}
-              isOwner={false}
+        {featuredPets.length > 0 ? (
+          isOwner && featuredPets.length >= 2 ? (
+            <PinnedReorderGrid
+              pets={featuredPets}
               petStateCount={petStates.length}
             />
-          }
-        >
-          <PinnedSectionWithViewer
-            ownerId={data.ownerId}
-            featuredPets={featuredPets}
-          />
-        </Suspense>
+          ) : (
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <p className="font-mono text-[11px] tracking-[0.22em] text-brand uppercase">
+                  ★ Pinned
+                </p>
+                <p className="font-mono text-[10px] tracking-[0.18em] text-muted-4 uppercase">
+                  {featuredPets.length} of {MAX_PINNED_PETS}
+                </p>
+              </div>
+              {featuredPets.length === 1 ? (
+                <div className="relative">
+                  {isOwner ? (
+                    <div className="absolute top-4 right-4">
+                      <ProfilePinButton
+                        slug={featuredPets[0].slug}
+                        isPinned
+                        pinnedCount={featuredPets.length}
+                        maxPins={MAX_PINNED_PETS}
+                      />
+                    </div>
+                  ) : null}
+                  <FeaturedPin pet={featuredPets[0]} />
+                </div>
+              ) : (
+                <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-6">
+                  {featuredPets.map((pet, index) => (
+                    <div key={pet.slug} className="relative h-full">
+                      <PetCard
+                        pet={pet}
+                        index={index}
+                        stateCount={petStates.length}
+                      />
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )
+        ) : null}
 
-        <Suspense
-          fallback={
-            <PublicProfileTabs
-              publicHandle={data.publicHandle}
-              approvedPets={restPets}
-              collection={data.collection}
-              approvedAll={data.approvedPets}
-            />
+        <ProfileTabs
+          isOwner={isOwner}
+          publicHandle={publicHandle}
+          approvedPets={restPets}
+          ownerSubmissions={ownerSubmissions}
+          likedPets={likedPets}
+          collection={
+            collection
+              ? {
+                  slug: collection.slug,
+                  title: collection.title,
+                  description: collection.description,
+                  externalUrl: collection.externalUrl,
+                  coverPetSlug: collection.coverPetSlug,
+                  petSlugs: collection.pets.map((pet) => pet.slug),
+                }
+              : null
           }
-        >
-          <ProfileTabsWithViewer
-            ownerId={data.ownerId}
-            publicHandle={data.publicHandle}
-            approvedPets={restPets}
-            approvedAll={data.approvedPets}
-            collection={data.collection}
-          />
-        </Suspense>
-      </section>
-
-      <Suspense fallback={null}>
-        <ViewerAnalytics
-          ownerId={data.ownerId}
-          publicHandle={data.publicHandle}
-          petCount={data.approvedPets.length}
-          pinnedCount={featuredPets.length}
+          canManageCollections={canManageOwnCollection}
+          collectionApprovedPets={pets.map((p) => ({
+            slug: p.slug,
+            displayName: p.displayName,
+            spritesheetUrl: p.spritesheetPath,
+          }))}
         />
-      </Suspense>
+      </section>
 
       <SiteFooter />
     </main>
-  );
-}
-
-async function ViewerAnalytics({
-  ownerId,
-  publicHandle,
-  petCount,
-  pinnedCount,
-}: {
-  ownerId: string;
-  publicHandle: string;
-  petCount: number;
-  pinnedCount: number;
-}) {
-  const { userId: viewerId } = await auth();
-  return (
-    <ProfileAnalytics
-      handle={publicHandle}
-      petCount={petCount}
-      pinnedCount={pinnedCount}
-      viewerIsOwner={viewerId === ownerId}
-    />
-  );
-}
-
-async function ViewerCatchProgress({ ownerId }: { ownerId: string }) {
-  const { userId: viewerId } = await auth();
-  if (viewerId !== ownerId) return null;
-  const catchProgress = await getCatchProgress(viewerId);
-  if (!catchProgress) return null;
-  return (
-    <p className="font-mono text-xs tracking-[0.22em] text-muted-3 uppercase">
-      YOUR ALBUM: {catchProgress.caught}/{catchProgress.total} (
-      {catchProgress.pct}%)
-    </p>
-  );
-}
-
-async function OwnerEditButton({
-  ownerId,
-  publicHandle,
-  displayName,
-  bio,
-  featuredSlugs,
-  approvedPets,
-}: {
-  ownerId: string;
-  publicHandle: string;
-  displayName: string | null;
-  bio: string | null;
-  featuredSlugs: string[];
-  approvedPets: { slug: string; displayName: string }[];
-}) {
-  const { userId: viewerId } = await auth();
-  if (viewerId !== ownerId) return null;
-  return (
-    <ProfileInlineEditor
-      handle={publicHandle}
-      initialDisplayName={displayName}
-      initialBio={bio}
-      initialFeaturedSlugs={featuredSlugs}
-      approvedPets={approvedPets}
-    />
-  );
-}
-
-function PinnedSection({
-  featuredPets,
-  isOwner,
-  petStateCount,
-}: {
-  featuredPets: PetWithMetrics[];
-  isOwner: boolean;
-  petStateCount: number;
-}) {
-  if (featuredPets.length === 0) return null;
-  if (isOwner && featuredPets.length >= 2) {
-    return (
-      <PinnedReorderGrid pets={featuredPets} petStateCount={petStateCount} />
-    );
-  }
-  return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <p className="font-mono text-[11px] tracking-[0.22em] text-brand uppercase">
-          ★ Pinned
-        </p>
-        <p className="font-mono text-[10px] tracking-[0.18em] text-muted-4 uppercase">
-          {featuredPets.length} of {MAX_PINNED_PETS}
-        </p>
-      </div>
-      {featuredPets.length === 1 ? (
-        <div className="relative">
-          {isOwner ? (
-            <div className="absolute top-4 right-4">
-              <ProfilePinButton
-                slug={featuredPets[0].slug}
-                isPinned
-                pinnedCount={featuredPets.length}
-                maxPins={MAX_PINNED_PETS}
-              />
-            </div>
-          ) : null}
-          <FeaturedPin pet={featuredPets[0]} />
-        </div>
-      ) : (
-        <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-6">
-          {featuredPets.map((pet, index) => (
-            <div key={pet.slug} className="relative h-full">
-              <PetCard pet={pet} index={index} stateCount={petStateCount} />
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-async function PinnedSectionWithViewer({
-  ownerId,
-  featuredPets,
-}: {
-  ownerId: string;
-  featuredPets: PetWithMetrics[];
-}) {
-  const { userId: viewerId } = await auth();
-  return (
-    <PinnedSection
-      featuredPets={featuredPets}
-      isOwner={viewerId === ownerId}
-      petStateCount={petStates.length}
-    />
-  );
-}
-
-function PublicProfileTabs({
-  publicHandle,
-  approvedPets,
-  collection,
-  approvedAll,
-}: {
-  publicHandle: string;
-  approvedPets: PetWithMetrics[];
-  collection: Awaited<ReturnType<typeof getOwnerCollection>>;
-  approvedAll: PetWithMetrics[];
-}) {
-  return (
-    <ProfileTabs
-      isOwner={false}
-      publicHandle={publicHandle}
-      approvedPets={approvedPets}
-      ownerSubmissions={[]}
-      likedPets={[]}
-      collection={
-        collection
-          ? {
-              slug: collection.slug,
-              title: collection.title,
-              description: collection.description,
-              externalUrl: collection.externalUrl,
-              coverPetSlug: collection.coverPetSlug,
-              petSlugs: collection.pets.map((pet) => pet.slug),
-            }
-          : null
-      }
-      canManageCollections={false}
-      collectionApprovedPets={approvedAll.map((p) => ({
-        slug: p.slug,
-        displayName: p.displayName,
-        spritesheetUrl: p.spritesheetPath,
-      }))}
-    />
-  );
-}
-
-async function ProfileTabsWithViewer({
-  ownerId,
-  publicHandle,
-  approvedPets,
-  approvedAll,
-  collection,
-}: {
-  ownerId: string;
-  publicHandle: string;
-  approvedPets: PetWithMetrics[];
-  approvedAll: PetWithMetrics[];
-  collection: Awaited<ReturnType<typeof getOwnerCollection>>;
-}) {
-  const { userId: viewerId } = await auth();
-  const isOwner = viewerId === ownerId;
-
-  if (!isOwner) {
-    return (
-      <PublicProfileTabs
-        publicHandle={publicHandle}
-        approvedPets={approvedPets}
-        collection={collection}
-        approvedAll={approvedAll}
-      />
-    );
-  }
-
-  const allOwnerRows = await db
-    .select()
-    .from(schema.submittedPets)
-    .where(eq(schema.submittedPets.ownerId, ownerId))
-    .orderBy(desc(schema.submittedPets.approvedAt));
-
-  const ownerSubmissions: Submission[] = allOwnerRows
-    .filter((r) => r.status === "pending" || r.status === "rejected")
-    .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
-    .map((row) => ({
-      id: row.id,
-      slug: row.slug,
-      displayName: row.displayName,
-      description: row.description,
-      spritesheetUrl: row.spritesheetUrl,
-      zipUrl: row.zipUrl,
-      kind: row.kind,
-      vibes: (row.vibes as string[]) ?? [],
-      tags: (row.tags as string[]) ?? [],
-      featured: row.featured,
-      status: row.status,
-      createdAt: row.createdAt.toISOString(),
-      approvedAt: row.approvedAt?.toISOString() ?? null,
-      rejectedAt: row.rejectedAt?.toISOString() ?? null,
-      rejectionReason: row.rejectionReason,
-      pending: row.pendingSubmittedAt
-        ? {
-            displayName: row.pendingDisplayName,
-            description: row.pendingDescription,
-            tags: (row.pendingTags as string[] | null) ?? null,
-            submittedAt: row.pendingSubmittedAt.toISOString(),
-          }
-        : null,
-      pendingRejectionReason: row.pendingRejectionReason,
-      metrics: { installCount: 0, zipDownloadCount: 0, likeCount: 0 },
-    }));
-
-  const likedPets = await getLikedPetsForUser(ownerId);
-  const canManageOwnCollection = await canManageCreatorCollections(viewerId);
-
-  return (
-    <ProfileTabs
-      isOwner
-      publicHandle={publicHandle}
-      approvedPets={approvedPets}
-      ownerSubmissions={ownerSubmissions}
-      likedPets={likedPets}
-      collection={
-        collection
-          ? {
-              slug: collection.slug,
-              title: collection.title,
-              description: collection.description,
-              externalUrl: collection.externalUrl,
-              coverPetSlug: collection.coverPetSlug,
-              petSlugs: collection.pets.map((pet) => pet.slug),
-            }
-          : null
-      }
-      canManageCollections={canManageOwnCollection}
-      collectionApprovedPets={approvedAll.map((p) => ({
-        slug: p.slug,
-        displayName: p.displayName,
-        spritesheetUrl: p.spritesheetPath,
-      }))}
-    />
   );
 }
 

--- a/src/app/[locale]/u/[handle]/page.tsx
+++ b/src/app/[locale]/u/[handle]/page.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
-import { Suspense } from "react";
 
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import { desc, eq } from "drizzle-orm";
@@ -32,6 +31,8 @@ import { ProfileShareButton } from "@/components/profile-share-button";
 import { ProfileTabs } from "@/components/profile-tabs";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
+
+export const dynamic = "force-dynamic";
 
 const SITE_URL = "https://petdex.crafter.run";
 
@@ -68,15 +69,7 @@ export async function generateMetadata({ params }: PageProps) {
   };
 }
 
-export default function UserProfilePage({ params }: PageProps) {
-  return (
-    <Suspense fallback={null}>
-      <UserProfileContent params={params} />
-    </Suspense>
-  );
-}
-
-async function UserProfileContent({ params }: PageProps) {
+export default async function UserProfilePage({ params }: PageProps) {
   const { handle } = await params;
   const requestedHandle = handle.toLowerCase();
   const ownerId = await userIdForHandle(handle);

--- a/src/app/[locale]/vibe/[vibe]/page.tsx
+++ b/src/app/[locale]/vibe/[vibe]/page.tsx
@@ -21,6 +21,8 @@ const SITE_URL = "https://petdex.crafter.run";
 
 type Props = { params: Promise<{ locale: string; vibe: string }> };
 
+export const revalidate = 600;
+
 export function generateStaticParams() {
   return PET_VIBES.map((vibe) => ({ vibe }));
 }

--- a/src/app/api/admin/[id]/feature/route.ts
+++ b/src/app/api/admin/[id]/feature/route.ts
@@ -7,6 +7,8 @@ import { isAdmin } from "@/lib/admin";
 import { db, schema } from "@/lib/db/client";
 import { requireSameOrigin } from "@/lib/same-origin";
 
+export const runtime = "nodejs";
+
 // Toggle the `featured` flag on an approved pet. Featured pets land
 // at the top of the gallery, get pinned tier in the curated sort, and
 // pre-fill the home page's hero strip when their slug matches the

--- a/src/app/api/admin/[id]/route.ts
+++ b/src/app/api/admin/[id]/route.ts
@@ -1,4 +1,3 @@
-import { updateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { auth } from "@clerk/nextjs/server";
@@ -9,6 +8,8 @@ import { db, schema } from "@/lib/db/client";
 import { requireSameOrigin } from "@/lib/same-origin";
 import { applySubmissionAction } from "@/lib/submission-decisions";
 import { takedownPet } from "@/lib/takedown";
+
+export const runtime = "nodejs";
 
 type Params = { id: string };
 
@@ -107,10 +108,6 @@ export async function DELETE(
     source: "admin",
     actorId: userId ?? "unknown",
   });
-
-  updateTag("gallery");
-  updateTag(`pet:${pet.slug}`);
-  updateTag(`profile:${pet.ownerId}`);
 
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/admin/[id]/route.ts
+++ b/src/app/api/admin/[id]/route.ts
@@ -1,4 +1,4 @@
-import { revalidateTag } from "next/cache";
+import { updateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { auth } from "@clerk/nextjs/server";
@@ -108,9 +108,9 @@ export async function DELETE(
     actorId: userId ?? "unknown",
   });
 
-  revalidateTag("gallery", "max");
-  revalidateTag(`pet:${pet.slug}`, "max");
-  revalidateTag(`profile:${pet.ownerId}`, "max");
+  updateTag("gallery");
+  updateTag(`pet:${pet.slug}`);
+  updateTag(`profile:${pet.ownerId}`);
 
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/admin/collection-requests/[id]/route.ts
+++ b/src/app/api/admin/collection-requests/[id]/route.ts
@@ -12,6 +12,8 @@ import { isAdmin } from "@/lib/admin";
 import { db, schema } from "@/lib/db/client";
 import { requireSameOrigin } from "@/lib/same-origin";
 
+export const runtime = "nodejs";
+
 type Params = { id: string };
 type PatchBody = {
   action: "approve" | "reject";

--- a/src/app/api/admin/edits/[id]/route.ts
+++ b/src/app/api/admin/edits/[id]/route.ts
@@ -13,6 +13,8 @@ import { requireSameOrigin } from "@/lib/same-origin";
 import { refreshSimilarityFor } from "@/lib/similarity";
 import { getPreferredLocaleForUser } from "@/lib/user-locale";
 
+export const runtime = "nodejs";
+
 type Params = { id: string };
 
 type PatchBody = {
@@ -52,7 +54,10 @@ export async function PATCH(
     return NextResponse.json({ error: "not_found" }, { status: 404 });
   }
   if (!row.pendingSubmittedAt) {
-    return NextResponse.json({ error: "no_pending_edit" }, { status: 400 });
+    return NextResponse.json(
+      { error: "no_pending_edit" },
+      { status: 400 },
+    );
   }
 
   if (body.action === "approve") {

--- a/src/app/api/admin/feedback/[id]/route.ts
+++ b/src/app/api/admin/feedback/[id]/route.ts
@@ -7,6 +7,8 @@ import { isAdmin } from "@/lib/admin";
 import { db, schema } from "@/lib/db/client";
 import { requireSameOrigin } from "@/lib/same-origin";
 
+export const runtime = "nodejs";
+
 type Params = { id: string };
 
 type PatchBody = {

--- a/src/app/api/admin/requests/[id]/route.ts
+++ b/src/app/api/admin/requests/[id]/route.ts
@@ -8,6 +8,8 @@ import { db, schema } from "@/lib/db/client";
 import { createNotification } from "@/lib/notifications";
 import { requireSameOrigin } from "@/lib/same-origin";
 
+export const runtime = "nodejs";
+
 type Params = { id: string };
 
 type PatchBody = {

--- a/src/app/api/ads/checkout/route.ts
+++ b/src/app/api/ads/checkout/route.ts
@@ -10,6 +10,7 @@ import { adCheckoutRatelimit } from "@/lib/ratelimit";
 import { requireSameOrigin } from "@/lib/same-origin";
 import { getSiteUrl, getStripe } from "@/lib/stripe";
 
+export const runtime = "nodejs";
 
 type Body = {
   campaignId?: string;

--- a/src/app/api/ads/event/route.ts
+++ b/src/app/api/ads/event/route.ts
@@ -7,6 +7,7 @@ import { validateAdEventInput } from "@/lib/ads/validation";
 import { adEventRatelimit } from "@/lib/ratelimit";
 import { requireSameOrigin } from "@/lib/same-origin";
 
+export const runtime = "nodejs";
 
 export async function POST(req: Request): Promise<Response> {
   const csrf = requireSameOrigin(req);

--- a/src/app/api/ads/image/presign/route.ts
+++ b/src/app/api/ads/image/presign/route.ts
@@ -6,6 +6,7 @@ import { presignPut } from "@/lib/r2";
 import { presignRatelimit } from "@/lib/ratelimit";
 import { requireSameOrigin } from "@/lib/same-origin";
 
+export const runtime = "nodejs";
 
 const ALLOWED_CT = new Set(["image/png", "image/webp", "image/jpeg"]);
 const MAX_BYTES = 10 * 1024 * 1024;

--- a/src/app/api/ads/impression/route.ts
+++ b/src/app/api/ads/impression/route.ts
@@ -9,6 +9,7 @@ import { validateImpressionInput } from "@/lib/ads/validation";
 import { adImpressionRatelimit } from "@/lib/ratelimit";
 import { requireSameOrigin } from "@/lib/same-origin";
 
+export const runtime = "nodejs";
 
 export async function POST(req: Request): Promise<Response> {
   const csrf = requireSameOrigin(req);

--- a/src/app/api/ads/route.ts
+++ b/src/app/api/ads/route.ts
@@ -7,6 +7,7 @@ import { validateAdCampaignInput } from "@/lib/ads/validation";
 import { adCampaignRatelimit } from "@/lib/ratelimit";
 import { requireSameOrigin } from "@/lib/same-origin";
 
+export const runtime = "nodejs";
 
 export async function POST(req: Request): Promise<Response> {
   const csrf = requireSameOrigin(req);

--- a/src/app/api/cli/auth-config/route.ts
+++ b/src/app/api/cli/auth-config/route.ts
@@ -5,6 +5,8 @@
 
 import { NextResponse } from "next/server";
 
+export const runtime = "nodejs";
+
 const DEFAULT_ISSUER = "https://clerk.petdex.crafter.run";
 const DEFAULT_CLIENT_ID = "LcThwEayl6KAA1Qm";
 const DEFAULT_SCOPES = ["profile", "email", "openid", "offline_access"];

--- a/src/app/api/cli/submit/check/route.ts
+++ b/src/app/api/cli/submit/check/route.ts
@@ -15,6 +15,8 @@ import { db, schema } from "@/lib/db/client";
 import { cliVerifyRatelimit } from "@/lib/ratelimit";
 import { slugify } from "@/lib/submissions";
 
+export const runtime = "nodejs";
+
 const MAX_CANDIDATES = 100;
 
 type Candidate = { petId?: string; slugHint?: string };

--- a/src/app/api/cli/submit/register/route.ts
+++ b/src/app/api/cli/submit/register/route.ts
@@ -15,6 +15,8 @@ import {
   validateSubmission,
 } from "@/lib/submissions";
 
+export const runtime = "nodejs";
+
 function clientIp(req: Request): string {
   const xff = req.headers.get("x-forwarded-for") ?? "";
   return xff.split(",")[0]?.trim() || "anon";

--- a/src/app/api/cli/submit/route.ts
+++ b/src/app/api/cli/submit/route.ts
@@ -11,6 +11,8 @@ import { verifyCliBearer } from "@/lib/cli-auth";
 import { presignPut } from "@/lib/r2";
 import { cliVerifyRatelimit, submitRatelimit } from "@/lib/ratelimit";
 
+export const runtime = "nodejs";
+
 const MAX_KEY_LEN = 80;
 const MAX_BYTES = 8 * 1024 * 1024;
 
@@ -65,7 +67,8 @@ export async function POST(req: Request): Promise<Response> {
   if (!slugHint) {
     return NextResponse.json({ error: "invalid_slug_hint" }, { status: 400 });
   }
-  const ext: "webp" | "png" = body.spritesheetExt === "png" ? "png" : "webp";
+  const ext: "webp" | "png" =
+    body.spritesheetExt === "png" ? "png" : "webp";
   const spriteCT = ext === "png" ? "image/png" : "image/webp";
 
   const uploadId = crypto.randomUUID().replace(/-/g, "").slice(0, 12);

--- a/src/app/api/collections/[slug]/request/route.ts
+++ b/src/app/api/collections/[slug]/request/route.ts
@@ -15,6 +15,8 @@ import { db, schema } from "@/lib/db/client";
 import { submitRatelimit } from "@/lib/ratelimit";
 import { requireSameOrigin } from "@/lib/same-origin";
 
+export const runtime = "nodejs";
+
 type Body = { petSlug?: string; note?: string };
 
 export async function POST(

--- a/src/app/api/feedback/[id]/replies/route.ts
+++ b/src/app/api/feedback/[id]/replies/route.ts
@@ -12,6 +12,8 @@ import { createNotification } from "@/lib/notifications";
 import { requireSameOrigin } from "@/lib/same-origin";
 import { getPreferredLocaleForUser } from "@/lib/user-locale";
 
+export const runtime = "nodejs";
+
 type Params = { id: string };
 
 type PostBody = {

--- a/src/app/api/feedback/[id]/route.ts
+++ b/src/app/api/feedback/[id]/route.ts
@@ -6,6 +6,8 @@ import { eq } from "drizzle-orm";
 import { db, schema } from "@/lib/db/client";
 import { requireSameOrigin } from "@/lib/same-origin";
 
+export const runtime = "nodejs";
+
 type Params = { id: string };
 
 type PatchBody = {

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -7,6 +7,8 @@ import { Redis } from "@upstash/redis";
 import { db, schema } from "@/lib/db/client";
 import { requireSameOrigin } from "@/lib/same-origin";
 
+export const runtime = "nodejs";
+
 const VALID_KINDS = new Set(["suggestion", "bug", "praise", "other"]);
 const MAX_LEN = 4000;
 
@@ -64,7 +66,10 @@ export async function POST(req: Request): Promise<Response> {
   const userAgent = req.headers.get("user-agent")?.slice(0, 500) ?? null;
 
   if (message.length < 4) {
-    return NextResponse.json({ error: "message_too_short" }, { status: 400 });
+    return NextResponse.json(
+      { error: "message_too_short" },
+      { status: 400 },
+    );
   }
   if (message.length > MAX_LEN) {
     return NextResponse.json(

--- a/src/app/api/feedback/unread/route.ts
+++ b/src/app/api/feedback/unread/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from "next/server";
 
 import { auth } from "@clerk/nextjs/server";
-import { and, sql as dsql, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, sql as dsql } from "drizzle-orm";
 
 import { isAdmin } from "@/lib/admin";
 import { db, schema } from "@/lib/db/client";
+
+export const runtime = "nodejs";
 
 // GET /api/feedback/unread -> { count, role }
 //

--- a/src/app/api/internal/submissions/[id]/review/route.ts
+++ b/src/app/api/internal/submissions/[id]/review/route.ts
@@ -6,6 +6,8 @@ import { isAdmin } from "@/lib/admin";
 import { requireSameOrigin } from "@/lib/same-origin";
 import { reviewSubmission } from "@/lib/submission-review";
 
+export const runtime = "nodejs";
+
 type Params = { id: string };
 
 export async function POST(

--- a/src/app/api/manifest/full/route.ts
+++ b/src/app/api/manifest/full/route.ts
@@ -7,6 +7,9 @@ import { logManifestFetch } from "@/lib/manifest-telemetry";
 import { getAllApprovedPets } from "@/lib/pets";
 import { manifestFullRatelimit } from "@/lib/ratelimit";
 
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
 // Authenticated, full-fat manifest. Only returns when the caller is
 // signed in. Surfaces description, tags, vibes, install commands,
 // page URLs and counts — anything richer than the slim public path.

--- a/src/app/api/manifest/route.ts
+++ b/src/app/api/manifest/route.ts
@@ -3,12 +3,14 @@ import { NextResponse } from "next/server";
 import { logManifestFetch } from "@/lib/manifest-telemetry";
 import { getAllApprovedPets } from "@/lib/pets";
 
+export const runtime = "nodejs";
 // Cache the slim manifest at the edge for 5 minutes with a 1h
 // stale-while-revalidate window. Pet listings turn over slowly and the
 // CLI hits this endpoint on every `petdex list` / `petdex install`
 // invocation. Without edge cache every CLI install woke a function and
 // burned an invocation; the s-maxage hint below was previously
 // neutralized by force-dynamic.
+export const revalidate = 300;
 
 // Slim public manifest. Returns only the fields the CLI strictly
 // needs: slug, displayName, kind, submittedBy display name, and the

--- a/src/app/api/me/caught-slugs/route.ts
+++ b/src/app/api/me/caught-slugs/route.ts
@@ -4,6 +4,8 @@ import { auth } from "@clerk/nextjs/server";
 
 import { getCaughtSlugSet } from "@/lib/catch-status";
 
+export const runtime = "nodejs";
+
 // Per-visitor list of pet slugs the signed-in user has caught (liked).
 // Pulled out of the home page SSR so the gallery can stay statically
 // rendered. The client fetches this after hydration and applies the

--- a/src/app/api/me/header-state/route.ts
+++ b/src/app/api/me/header-state/route.ts
@@ -7,6 +7,7 @@ import { isAdmin } from "@/lib/admin";
 import { getCaughtSlugSet } from "@/lib/catch-status";
 import { db, schema } from "@/lib/db/client";
 
+export const runtime = "nodejs";
 
 // GET /api/me/header-state -> single aggregate the SiteHeader needs on
 // every page-view. Combines what used to be three separate endpoints

--- a/src/app/api/my-pets/[id]/edit/route.ts
+++ b/src/app/api/my-pets/[id]/edit/route.ts
@@ -7,6 +7,8 @@ import { db, schema } from "@/lib/db/client";
 import { editRatelimit } from "@/lib/ratelimit";
 import { requireSameOrigin } from "@/lib/same-origin";
 
+export const runtime = "nodejs";
+
 type Params = { id: string };
 
 type PatchBody = {
@@ -139,7 +141,10 @@ export async function PATCH(
     patch.pendingDescription === null &&
     patch.pendingTags === null;
   if (noOp) {
-    return NextResponse.json({ error: "nothing_changed" }, { status: 400 });
+    return NextResponse.json(
+      { error: "nothing_changed" },
+      { status: 400 },
+    );
   }
 
   const [updated] = await db

--- a/src/app/api/my-pets/[id]/withdraw/route.ts
+++ b/src/app/api/my-pets/[id]/withdraw/route.ts
@@ -7,6 +7,8 @@ import { db, schema } from "@/lib/db/client";
 import { withdrawRatelimit } from "@/lib/ratelimit";
 import { requireSameOrigin } from "@/lib/same-origin";
 
+export const runtime = "nodejs";
+
 type Params = { id: string };
 
 export async function POST(

--- a/src/app/api/my-pets/claim/route.ts
+++ b/src/app/api/my-pets/claim/route.ts
@@ -7,6 +7,8 @@ import { db, schema } from "@/lib/db/client";
 import { claimRatelimit } from "@/lib/ratelimit";
 import { requireSameOrigin } from "@/lib/same-origin";
 
+export const runtime = "nodejs";
+
 type ClaimIdentity = {
   email: string | null;
   githubUrl: string | null;
@@ -132,7 +134,10 @@ export async function POST(req: Request): Promise<Response> {
     row.creditUrl.toLowerCase() === ident.githubUrl.toLowerCase();
 
   if (!emailMatch && !githubMatch) {
-    return NextResponse.json({ error: "identity_mismatch" }, { status: 403 });
+    return NextResponse.json(
+      { error: "identity_mismatch" },
+      { status: 403 },
+    );
   }
 
   // When claiming via GitHub match (admin rescue path), also rewrite
@@ -167,8 +172,8 @@ async function getClaimIdentity(userId: string): Promise<ClaimIdentity> {
     let githubUrl: string | null = null;
     for (const acc of user.externalAccounts ?? []) {
       if (acc.provider !== "oauth_github") continue;
-      const v = (acc as { verification?: { status?: string } }).verification
-        ?.status;
+      const v =
+        (acc as { verification?: { status?: string } }).verification?.status;
       if (v && v !== "verified") continue;
       const username = (acc as { username?: string }).username?.trim();
       if (username) {

--- a/src/app/api/notifications/read/route.ts
+++ b/src/app/api/notifications/read/route.ts
@@ -6,7 +6,11 @@ import { and, eq, inArray, isNull } from "drizzle-orm";
 import { db, schema } from "@/lib/db/client";
 import { requireSameOrigin } from "@/lib/same-origin";
 
-type Body = { all: true } | { ids: string[] };
+export const runtime = "nodejs";
+
+type Body =
+  | { all: true }
+  | { ids: string[] };
 
 // POST /api/notifications/read body { all: true } -> mark every unread
 // notification of the current user as read. body { ids: [...] } ->

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -5,6 +5,8 @@ import { and, desc, eq, isNull } from "drizzle-orm";
 
 import { db, schema } from "@/lib/db/client";
 
+export const runtime = "nodejs";
+
 // GET /api/notifications -> last 20 notifications for the current user
 // + unread count. Bell polls this every 60s.
 export async function GET() {

--- a/src/app/api/pet-requests/image/route.ts
+++ b/src/app/api/pet-requests/image/route.ts
@@ -6,6 +6,8 @@ import { presignPut } from "@/lib/r2";
 import { presignRatelimit } from "@/lib/ratelimit";
 import { requireSameOrigin } from "@/lib/same-origin";
 
+export const runtime = "nodejs";
+
 const ALLOWED_CT = new Set(["image/png", "image/webp", "image/jpeg"]);
 const MAX_BYTES = 4 * 1024 * 1024;
 

--- a/src/app/api/pet-requests/route.ts
+++ b/src/app/api/pet-requests/route.ts
@@ -14,6 +14,9 @@ import { R2_PUBLIC_BASE } from "@/lib/r2";
 import { petRequestRatelimit } from "@/lib/ratelimit";
 import { requireSameOrigin } from "@/lib/same-origin";
 
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
 const rawSql = neon(process.env.DATABASE_URL ?? "");
 
 function normalize(q: string): string {

--- a/src/app/api/pets/[slug]/can-delete/route.ts
+++ b/src/app/api/pets/[slug]/can-delete/route.ts
@@ -5,6 +5,8 @@ import { eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/db/client";
 
+export const runtime = "nodejs";
+
 // Tells the client menu whether the current viewer is allowed to hard-
 // delete this pet. The check has to happen server-side because the
 // public PetdexPet shape deliberately omits ownerId (we don't want

--- a/src/app/api/pets/[slug]/like/route.ts
+++ b/src/app/api/pets/[slug]/like/route.ts
@@ -8,6 +8,8 @@ import { setLikeCount } from "@/lib/db/metrics";
 import { likeRatelimit } from "@/lib/ratelimit";
 import { requireSameOrigin } from "@/lib/same-origin";
 
+export const runtime = "nodejs";
+
 type Params = { slug: string };
 
 export async function POST(

--- a/src/app/api/pets/[slug]/owner/route.ts
+++ b/src/app/api/pets/[slug]/owner/route.ts
@@ -8,6 +8,8 @@ import { withdrawRatelimit } from "@/lib/ratelimit";
 import { requireSameOrigin } from "@/lib/same-origin";
 import { takedownPet } from "@/lib/takedown";
 
+export const runtime = "nodejs";
+
 // Owner self-service delete. Hard-removes a pet the caller owns:
 // drops the DB row, every cross-table reference, and the R2 assets.
 // The slug becomes available for someone else to reuse.

--- a/src/app/api/pets/[slug]/thumb/route.ts
+++ b/src/app/api/pets/[slug]/thumb/route.ts
@@ -16,6 +16,8 @@ import sharp from "sharp";
 import { db, schema } from "@/lib/db/client";
 import { isAllowedAssetUrl } from "@/lib/url-allowlist";
 
+export const runtime = "nodejs";
+
 // Per-pet thumbnails are content-addressed by slug; the underlying
 // sheet only changes on resubmit. One year + immutable lets the CDN +
 // browser cache hold them indefinitely. Resubmits already mint a new

--- a/src/app/api/pets/[slug]/track-zip/route.ts
+++ b/src/app/api/pets/[slug]/track-zip/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from "next/server";
-
 import { eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/db/client";
 import { incrementZipDownloadCount } from "@/lib/db/metrics";
 import { trackZipRatelimit } from "@/lib/ratelimit";
 import { requireSameOrigin } from "@/lib/same-origin";
+
+export const runtime = "nodejs";
 
 type Params = { slug: string };
 

--- a/src/app/api/pets/[slug]/variants/route.ts
+++ b/src/app/api/pets/[slug]/variants/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 
 import { getVariantsFor } from "@/lib/variants";
 
+export const runtime = "nodejs";
+
 type Params = { slug: string };
 
 export async function GET(

--- a/src/app/api/pets/random/route.ts
+++ b/src/app/api/pets/random/route.ts
@@ -4,6 +4,9 @@ import { sql } from "drizzle-orm";
 
 import { db, schema } from "@/lib/db/client";
 
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
 // GET /api/pets/random?exclude=current-slug
 //
 // Picks a random approved pet (excluding the optional `exclude` slug).

--- a/src/app/api/pets/search/route.ts
+++ b/src/app/api/pets/search/route.ts
@@ -5,6 +5,7 @@ import { SEARCH_LIMITS, type SortKey, searchPets } from "@/lib/pet-search";
 import { readShuffleSeed } from "@/lib/shuffle-seed";
 import { PET_KINDS, PET_VIBES, type PetKind, type PetVibe } from "@/lib/types";
 
+export const runtime = "nodejs";
 // Search responses for non-curated sorts are deterministic per-query
 // and can sit in the edge cache. Curated falls back to per-visitor
 // (shuffle seed cookie) so it's tagged below as private. Letting Next

--- a/src/app/api/profile/collection/route.ts
+++ b/src/app/api/profile/collection/route.ts
@@ -1,4 +1,4 @@
-import { revalidateTag } from "next/cache";
+import { updateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { auth } from "@clerk/nextjs/server";
@@ -134,9 +134,9 @@ export async function PATCH(req: Request): Promise<Response> {
     );
   }
 
-  revalidateTag("collections", "max");
-  revalidateTag(`collection:${collection.slug}`, "max");
-  revalidateTag(`profile:${userId}`, "max");
+  updateTag("collections");
+  updateTag(`collection:${collection.slug}`);
+  updateTag(`profile:${userId}`);
 
   return NextResponse.json({
     ok: true,

--- a/src/app/api/profile/collection/route.ts
+++ b/src/app/api/profile/collection/route.ts
@@ -1,4 +1,3 @@
-import { updateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { auth } from "@clerk/nextjs/server";
@@ -8,6 +7,9 @@ import { canManageCreatorCollections } from "@/lib/collection-access";
 import { db, schema } from "@/lib/db/client";
 import { validateProfileHandle } from "@/lib/profiles";
 import { requireSameOrigin } from "@/lib/same-origin";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
 const MAX_PETS = 24;
 const MAX_TITLE = 80;
@@ -133,10 +135,6 @@ export async function PATCH(req: Request): Promise<Response> {
       })),
     );
   }
-
-  updateTag("collections");
-  updateTag(`collection:${collection.slug}`);
-  updateTag(`profile:${userId}`);
 
   return NextResponse.json({
     ok: true,

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,4 +1,3 @@
-import { updateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { auth } from "@clerk/nextjs/server";
@@ -17,6 +16,8 @@ import { profileEditRatelimit, profilePinRatelimit } from "@/lib/ratelimit";
 import { requireSameOrigin } from "@/lib/same-origin";
 
 import { defaultLocale, hasLocale, type Locale } from "@/i18n/config";
+
+export const runtime = "nodejs";
 
 type PatchBody = {
   displayName?: string | null;
@@ -221,11 +222,6 @@ export async function PATCH(req: Request): Promise<Response> {
         updatedAt: new Date(),
       },
     });
-
-  updateTag(`profile:${userId}`);
-  if (typeof patch.handle === "string") {
-    updateTag(`profile:${patch.handle}`);
-  }
 
   return NextResponse.json({
     ok: true,

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,4 +1,4 @@
-import { revalidateTag } from "next/cache";
+import { updateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { auth } from "@clerk/nextjs/server";
@@ -222,9 +222,9 @@ export async function PATCH(req: Request): Promise<Response> {
       },
     });
 
-  revalidateTag(`profile:${userId}`, "max");
+  updateTag(`profile:${userId}`);
   if (typeof patch.handle === "string") {
-    revalidateTag(`profile:${patch.handle}`, "max");
+    updateTag(`profile:${patch.handle}`);
   }
 
   return NextResponse.json({

--- a/src/app/api/r2/presign/route.ts
+++ b/src/app/api/r2/presign/route.ts
@@ -7,6 +7,8 @@ import { presignPut } from "@/lib/r2";
 import { presignRatelimit } from "@/lib/ratelimit";
 import { requireSameOrigin } from "@/lib/same-origin";
 
+export const runtime = "nodejs";
+
 const MAX_KEY_LEN = 80;
 const ALLOWED_CT = new Set([
   "application/zip",

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -5,6 +5,7 @@ import type Stripe from "stripe";
 import { activateCampaignFromCheckout } from "@/lib/ads/queries";
 import { getStripe } from "@/lib/stripe";
 
+export const runtime = "nodejs";
 
 export async function POST(req: Request): Promise<Response> {
   const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -1,4 +1,3 @@
-import { updateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { auth, currentUser } from "@clerk/nextjs/server";
@@ -12,6 +11,8 @@ import {
   type SubmissionPrincipal,
   validateSubmission,
 } from "@/lib/submissions";
+
+export const runtime = "nodejs";
 
 export async function POST(req: Request) {
   const csrf = requireSameOrigin(req);
@@ -86,11 +87,6 @@ export async function POST(req: Request) {
   if (!result.ok) {
     const { status, ...rest } = result;
     return NextResponse.json(rest, { status });
-  }
-  updateTag("gallery");
-  updateTag(`profile:${result.profileHandle}`);
-  if (result.status === "approved") {
-    updateTag(`pet:${result.slug}`);
   }
   return NextResponse.json(result, { status: 201 });
 }

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -1,4 +1,4 @@
-import { revalidateTag } from "next/cache";
+import { updateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { auth, currentUser } from "@clerk/nextjs/server";
@@ -87,10 +87,10 @@ export async function POST(req: Request) {
     const { status, ...rest } = result;
     return NextResponse.json(rest, { status });
   }
-  revalidateTag("gallery", "max");
-  revalidateTag(`profile:${result.profileHandle}`, "max");
+  updateTag("gallery");
+  updateTag(`profile:${result.profileHandle}`);
   if (result.status === "approved") {
-    revalidateTag(`pet:${result.slug}`, "max");
+    updateTag(`pet:${result.slug}`);
   }
   return NextResponse.json(result, { status: 201 });
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -8,6 +8,8 @@ import {
 import { getAllApprovedPets } from "@/lib/pets";
 import { PET_KINDS, PET_VIBES } from "@/lib/types";
 
+export const revalidate = 3600;
+
 type EntryInput = {
   pathname: string;
   lastModified: Date;

--- a/src/components/admin-edit-actions.tsx
+++ b/src/components/admin-edit-actions.tsx
@@ -1,10 +1,10 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 
 import { Check, Loader2, X } from "lucide-react";
-import { useTranslations } from "next-intl";
 
 export function AdminEditActions({ id }: { id: string }) {
   const t = useTranslations("admin.editActions");

--- a/src/components/admin-feedback-actions.tsx
+++ b/src/components/admin-feedback-actions.tsx
@@ -1,10 +1,10 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 
 import { Archive, CheckCircle2, Loader2, RotateCcw } from "lucide-react";
-import { useTranslations } from "next-intl";
 
 type Status = "pending" | "addressed" | "archived";
 

--- a/src/components/admin-feedback-filters.tsx
+++ b/src/components/admin-feedback-filters.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
-
 import { useLocale, useTranslations } from "next-intl";
+import { useSearchParams } from "next/navigation";
 
 import { localizePath } from "@/i18n/config";
 

--- a/src/components/json-ld.tsx
+++ b/src/components/json-ld.tsx
@@ -16,7 +16,9 @@ const LS = String.fromCharCode(0x2028);
 const PS = String.fromCharCode(0x2029);
 
 function escapeJsonForScriptTag(json: string): string {
-  let out = json.replace(/<\/(script)/gi, "<\\/$1").replace(/<!--/g, "<\\!--");
+  let out = json
+    .replace(/<\/(script)/gi, "<\\/$1")
+    .replace(/<!--/g, "<\\!--");
   out = out.split(LS).join("\\u2028").split(PS).join("\\u2029");
   return out;
 }

--- a/src/components/owner-edit-panel.tsx
+++ b/src/components/owner-edit-panel.tsx
@@ -198,7 +198,9 @@ export function OwnerEditPanel({
                 <h2 className="text-xl font-medium tracking-tight">
                   {t("modalTitle")}
                 </h2>
-                <p className="mt-1 text-xs text-muted-3">{t("modalBody")}</p>
+                <p className="mt-1 text-xs text-muted-3">
+                  {t("modalBody")}
+                </p>
               </div>
               <button
                 type="button"

--- a/src/components/pet-floater.tsx
+++ b/src/components/pet-floater.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-
 import { createPortal } from "react-dom";
 
 import type { PetStateId } from "@/lib/pet-states";
@@ -344,10 +343,7 @@ export function PetFloater({ src, petName }: PetFloaterProps) {
 
         samples.push({ time: ev.timeStamp, x: nextX, y: nextY });
         const sampleCutoff = ev.timeStamp - THROW_SAMPLE_WINDOW_MS;
-        while (
-          samples.length > THROW_SAMPLE_MAX ||
-          samples[1]?.time < sampleCutoff
-        ) {
+        while (samples.length > THROW_SAMPLE_MAX || samples[1]?.time < sampleCutoff) {
           samples.shift();
         }
 
@@ -376,8 +372,7 @@ export function PetFloater({ src, petName }: PetFloaterProps) {
         const recentSamples = samples.filter(
           (sample) => endTime - sample.time <= THROW_SAMPLE_WINDOW_MS,
         );
-        const velocitySamples =
-          recentSamples.length > 1 ? recentSamples : samples;
+        const velocitySamples = recentSamples.length > 1 ? recentSamples : samples;
         const firstSample = velocitySamples[0];
         const lastSample = velocitySamples[velocitySamples.length - 1];
         const dt = lastSample.time - firstSample.time;
@@ -423,8 +418,8 @@ export function PetFloater({ src, petName }: PetFloaterProps) {
           const unclampedX = currentPos.x + nextVx * dtMs;
           const unclampedY = currentPos.y + nextVy * dtMs;
 
-          const nextX = Math.min(Math.max(unclampedX, SAFE_MARGIN_PX), maxX);
-          const nextY = Math.min(Math.max(unclampedY, SAFE_MARGIN_PX), maxY);
+          let nextX = Math.min(Math.max(unclampedX, SAFE_MARGIN_PX), maxX);
+          let nextY = Math.min(Math.max(unclampedY, SAFE_MARGIN_PX), maxY);
 
           if (nextX !== unclampedX) {
             nextVx *= THROW_BOUNCE_DAMPING;

--- a/src/components/pet-keyboard-nav.tsx
+++ b/src/components/pet-keyboard-nav.tsx
@@ -39,8 +39,7 @@ export function PetKeyboardNav({
       if (!target) return false;
       const el = target as HTMLElement;
       const tag = el.tagName?.toLowerCase();
-      if (tag === "input" || tag === "textarea" || tag === "select")
-        return true;
+      if (tag === "input" || tag === "textarea" || tag === "select") return true;
       if (el.isContentEditable) return true;
       return false;
     }

--- a/src/components/pet-radar.tsx
+++ b/src/components/pet-radar.tsx
@@ -110,7 +110,11 @@ export function PetRadar(props: PetRadarProps) {
           x={axis.labelX}
           y={axis.labelY}
           textAnchor={
-            axis.pointDx === 0 ? "middle" : axis.pointDx > 0 ? "start" : "end"
+            axis.pointDx === 0
+              ? "middle"
+              : axis.pointDx > 0
+                ? "start"
+                : "end"
           }
           dominantBaseline={
             axis.pointDy === 0

--- a/src/components/profile-analytics.tsx
+++ b/src/components/profile-analytics.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useEffect } from "react";
-
 import { track } from "@vercel/analytics";
+import { useEffect } from "react";
 
 // Fires a single profile_viewed event when a /u/[handle] page is opened.
 // Self-views (where viewerIsOwner === true) are tagged so they can be

--- a/src/components/submitted-by.tsx
+++ b/src/components/submitted-by.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-
 import { useTranslations } from "next-intl";
 
 import type { OwnerCredit } from "@/lib/owner-credit";

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -29,7 +29,9 @@ export function getPublicAdminUserIds(): Set<string> {
   );
 }
 
-export function isAdminClientSafe(userId: string | null | undefined): boolean {
+export function isAdminClientSafe(
+  userId: string | null | undefined,
+): boolean {
   if (!userId) return false;
   return getPublicAdminUserIds().has(userId);
 }

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -1,5 +1,3 @@
-import { cacheLife, cacheTag } from "next/cache";
-
 import { and, asc, desc, eq, getTableColumns, inArray } from "drizzle-orm";
 
 import { db, schema } from "@/lib/db/client";
@@ -21,11 +19,6 @@ export type PetCollectionWithPets = PetCollection & {
 export async function getFeaturedCollections(
   limit = 3,
 ): Promise<PetCollectionWithPets[]> {
-  "use cache";
-  cacheLife("hours");
-  cacheTag("gallery");
-  cacheTag("collections");
-
   let rows: PetCollection[];
   try {
     rows = await db
@@ -43,10 +36,6 @@ export async function getFeaturedCollections(
 }
 
 export async function getAllCollections(): Promise<PetCollectionWithPets[]> {
-  "use cache";
-  cacheLife("hours");
-  cacheTag("collections");
-
   let rows: PetCollection[];
   try {
     rows = await db
@@ -64,11 +53,6 @@ export async function getAllCollections(): Promise<PetCollectionWithPets[]> {
 export async function getCollection(
   slug: string,
 ): Promise<PetCollectionWithPets | null> {
-  "use cache";
-  cacheLife("hours");
-  cacheTag("collections");
-  cacheTag(`collection:${slug}`);
-
   let row: PetCollection | undefined;
   try {
     row = await db.query.petCollections.findFirst({
@@ -235,11 +219,6 @@ export async function getCollectionCandidatesForPet(
 export async function getCollectionsContainingPet(
   petSlug: string,
 ): Promise<Array<Pick<PetCollection, "slug" | "title" | "ownerId">>> {
-  "use cache";
-  cacheLife("hours");
-  cacheTag("collections");
-  cacheTag(`pet:${petSlug}`);
-
   try {
     const rows = await db
       .select({

--- a/src/lib/db/metrics.ts
+++ b/src/lib/db/metrics.ts
@@ -36,7 +36,10 @@ export async function incrementZipDownloadCount(slug: string): Promise<void> {
     });
 }
 
-export async function setLikeCount(slug: string, count: number): Promise<void> {
+export async function setLikeCount(
+  slug: string,
+  count: number,
+): Promise<void> {
   await db
     .insert(schema.petMetrics)
     .values({ petSlug: slug, likeCount: count })

--- a/src/lib/dex-batch.server.ts
+++ b/src/lib/dex-batch.server.ts
@@ -5,6 +5,7 @@
 import { sql } from "drizzle-orm";
 
 import { db } from "@/lib/db/client";
+
 import { formatBatchLabel } from "@/lib/dex-batch";
 
 export async function getAvailableBatches(): Promise<

--- a/src/lib/dex.ts
+++ b/src/lib/dex.ts
@@ -13,35 +13,34 @@
 //     we ever need post-removal stable numbers (e.g. a deleted #042
 //     never returns) we can freeze with a column later.
 
-import { cacheLife, cacheTag } from "next/cache";
-
+import { cache } from "react";
 import { sql } from "drizzle-orm";
 
 import { db } from "@/lib/db/client";
 
 export type DexEntry = { slug: string; dexNumber: number };
 
-export async function getDexNumberMap(): Promise<Map<string, number>> {
-  "use cache";
-  cacheLife("hours");
-  cacheTag("gallery");
-
-  const result = (await db.execute(sql`
+// Cached for the lifetime of a single render pass — every call inside
+// one request returns the same Map without re-querying.
+export const getDexNumberMap = cache(
+  async (): Promise<Map<string, number>> => {
+    const result = (await db.execute(sql`
       SELECT slug,
              ROW_NUMBER() OVER (ORDER BY approved_at ASC, created_at ASC)::int AS dex_number
       FROM submitted_pets
       WHERE status = 'approved'
         AND source <> 'discover'
     `)) as unknown as {
-    rows: Array<{ slug: string; dex_number: number }>;
-  };
+      rows: Array<{ slug: string; dex_number: number }>;
+    };
 
-  const out = new Map<string, number>();
-  for (const row of result.rows) {
-    out.set(row.slug, row.dex_number);
-  }
-  return out;
-}
+    const out = new Map<string, number>();
+    for (const row of result.rows) {
+      out.set(row.slug, row.dex_number);
+    }
+    return out;
+  },
+);
 
 // Convenience for callers that only need one slug. Still goes through
 // the cached map so calling it N times in one render is one query.
@@ -52,14 +51,10 @@ export async function getDexNumber(slug: string): Promise<number | null> {
 
 // Total album size — the denominator in "23/312". Cached alongside the
 // map; same render pass = same number.
-export async function getDexTotal(): Promise<number> {
-  "use cache";
-  cacheLife("hours");
-  cacheTag("gallery");
-
+export const getDexTotal = cache(async (): Promise<number> => {
   const map = await getDexNumberMap();
   return map.size;
-}
+});
 
 // Format a dex number for UI: "001", "042", "9999". Pads to 3 digits
 // while we have <1000 pets, then naturally widens. Keep this as the

--- a/src/lib/email-templates/edit-approved.ts
+++ b/src/lib/email-templates/edit-approved.ts
@@ -1,11 +1,5 @@
-import {
-  normalizeLocale,
-  p,
-  petdexUrl,
-  wrapEmail,
-} from "@/lib/email-templates/shared";
-
 import type { Locale } from "@/i18n/config";
+import { normalizeLocale, p, petdexUrl, wrapEmail } from "@/lib/email-templates/shared";
 
 type Vars = {
   petName: string;

--- a/src/lib/email-templates/edit-rejected.ts
+++ b/src/lib/email-templates/edit-rejected.ts
@@ -1,11 +1,5 @@
-import {
-  normalizeLocale,
-  p,
-  petdexUrl,
-  wrapEmail,
-} from "@/lib/email-templates/shared";
-
 import type { Locale } from "@/i18n/config";
+import { normalizeLocale, p, petdexUrl, wrapEmail } from "@/lib/email-templates/shared";
 
 type Vars = {
   petName: string;
@@ -42,14 +36,8 @@ export function renderEditRejectedEmail(
           };
 
   const reasonLine = vars.reason ? `Reason: ${vars.reason}` : copy.noReason;
-  const text = [copy.intro, "", reasonLine, "", copy.cta, "", "Petdex"].join(
-    "\n",
-  );
-  const html = wrapEmail(copy.subject, [
-    p(copy.intro),
-    p(reasonLine),
-    p(copy.cta),
-  ]);
+  const text = [copy.intro, "", reasonLine, "", copy.cta, "", "Petdex"].join("\n");
+  const html = wrapEmail(copy.subject, [p(copy.intro), p(reasonLine), p(copy.cta)]);
 
   return { subject: copy.subject, html, text };
 }

--- a/src/lib/email-templates/feedback-admin-reply.ts
+++ b/src/lib/email-templates/feedback-admin-reply.ts
@@ -1,3 +1,4 @@
+import type { Locale } from "@/i18n/config";
 import {
   normalizeLocale,
   p,
@@ -5,8 +6,6 @@ import {
   quoteBlock,
   wrapEmail,
 } from "@/lib/email-templates/shared";
-
-import type { Locale } from "@/i18n/config";
 
 type Vars = {
   feedbackId: string;

--- a/src/lib/email-templates/feedback-follow-up.ts
+++ b/src/lib/email-templates/feedback-follow-up.ts
@@ -1,11 +1,5 @@
-import {
-  normalizeLocale,
-  p,
-  quoteBlock,
-  wrapEmail,
-} from "@/lib/email-templates/shared";
-
 import type { Locale } from "@/i18n/config";
+import { normalizeLocale, p, quoteBlock, wrapEmail } from "@/lib/email-templates/shared";
 
 type Vars = {
   kindLabel: string;

--- a/src/lib/email-templates/new-submission.ts
+++ b/src/lib/email-templates/new-submission.ts
@@ -1,6 +1,5 @@
-import { normalizeLocale, p, wrapEmail } from "@/lib/email-templates/shared";
-
 import type { Locale } from "@/i18n/config";
+import { normalizeLocale, p, wrapEmail } from "@/lib/email-templates/shared";
 
 type Vars = {
   displayName: string;

--- a/src/lib/email-templates/shared.ts
+++ b/src/lib/email-templates/shared.ts
@@ -1,4 +1,4 @@
-import { defaultLocale, type Locale, localizePath } from "@/i18n/config";
+import { defaultLocale, localizePath, type Locale } from "@/i18n/config";
 
 const SITE_URL = "https://petdex.crafter.run";
 

--- a/src/lib/email-templates/submission-rejected.ts
+++ b/src/lib/email-templates/submission-rejected.ts
@@ -1,11 +1,5 @@
-import {
-  normalizeLocale,
-  p,
-  petdexUrl,
-  wrapEmail,
-} from "@/lib/email-templates/shared";
-
 import type { Locale } from "@/i18n/config";
+import { normalizeLocale, p, petdexUrl, wrapEmail } from "@/lib/email-templates/shared";
 
 type Vars = {
   petName: string;
@@ -23,8 +17,7 @@ export function renderSubmissionRejectedEmail(
       ? {
           subject: `Tu envío a Petdex necesita cambios — ${vars.petName}`,
           intro: `Hola, tu mascota "${vars.petName}" no fue aprobada en esta ronda.`,
-          noReason:
-            "No se indicó una razón. Si quieres, itera y vuelve a enviarla.",
+          noReason: "No se indicó una razón. Si quieres, itera y vuelve a enviarla.",
           cta: `Puedes enviar una versión revisada aquí: ${submitUrl}`,
         }
       : current === "zh"
@@ -37,20 +30,13 @@ export function renderSubmissionRejectedEmail(
         : {
             subject: `Your Petdex submission needs changes — ${vars.petName}`,
             intro: `Hey, your pet "${vars.petName}" wasn't approved this round.`,
-            noReason:
-              "No reason was provided. Feel free to iterate and resubmit.",
+            noReason: "No reason was provided. Feel free to iterate and resubmit.",
             cta: `You can submit a revised version here: ${submitUrl}`,
           };
 
   const reasonLine = vars.reason ? `Reason: ${vars.reason}` : copy.noReason;
-  const text = [copy.intro, "", reasonLine, "", copy.cta, "", "Petdex"].join(
-    "\n",
-  );
-  const html = wrapEmail(copy.subject, [
-    p(copy.intro),
-    p(reasonLine),
-    p(copy.cta),
-  ]);
+  const text = [copy.intro, "", reasonLine, "", copy.cta, "", "Petdex"].join("\n");
+  const html = wrapEmail(copy.subject, [p(copy.intro), p(reasonLine), p(copy.cta)]);
 
   return { subject: copy.subject, html, text };
 }

--- a/src/lib/pet-stats.ts
+++ b/src/lib/pet-stats.ts
@@ -73,6 +73,8 @@ export function computeStats(
       maxInstalls,
     ),
     loved: getNormalizedLogScore(pet.metrics?.likeCount ?? 0, maxLikes),
-    freshness: Math.round(100 - clamp((daysSinceApproved / 90) * 100, 0, 100)),
+    freshness: Math.round(
+      100 - clamp((daysSinceApproved / 90) * 100, 0, 100),
+    ),
   };
 }

--- a/src/lib/pets.ts
+++ b/src/lib/pets.ts
@@ -3,8 +3,6 @@
 // JSON dump is only consulted by that backfill script; the rest of the app
 // reads from the DB.
 
-import { cacheLife, cacheTag } from "next/cache";
-
 import { and, eq, sql } from "drizzle-orm";
 
 import { db, schema } from "@/lib/db/client";
@@ -24,11 +22,6 @@ const EMPTY_METRICS: Metrics = {
 };
 
 export async function getPet(slug: string): Promise<PetdexPet | undefined> {
-  "use cache";
-  cacheLife("hours");
-  cacheTag("gallery");
-  cacheTag(`pet:${slug}`);
-
   const row = await db.query.submittedPets.findFirst({
     where: and(
       eq(schema.submittedPets.slug, slug),
@@ -51,10 +44,6 @@ export async function getPetWithMetrics(
  *  pre-render featured pets at build time; everything else is rendered
  *  on-demand and revalidated. */
 export async function getStaticPetSlugs(): Promise<string[]> {
-  "use cache";
-  cacheLife("hours");
-  cacheTag("gallery");
-
   const rows = await db
     .select({ slug: schema.submittedPets.slug })
     .from(schema.submittedPets)
@@ -64,17 +53,12 @@ export async function getStaticPetSlugs(): Promise<string[]> {
         eq(schema.submittedPets.featured, true),
       ),
     );
-  const slugs = rows.map((r) => r.slug);
-  return slugs.length > 0 ? slugs : ["boba"];
+  return rows.map((r) => r.slug);
 }
 
 export async function getFeaturedPetsWithMetrics(
   limit = 6,
 ): Promise<PetWithMetrics[]> {
-  "use cache";
-  cacheLife("hours");
-  cacheTag("gallery");
-
   const rows = await db
     .select()
     .from(schema.submittedPets)
@@ -95,10 +79,6 @@ export async function getFeaturedPetsWithMetrics(
 }
 
 export async function getAllApprovedPets(): Promise<PetdexPet[]> {
-  "use cache";
-  cacheLife("hours");
-  cacheTag("gallery");
-
   const rows = await db
     .select()
     .from(schema.submittedPets)
@@ -107,10 +87,6 @@ export async function getAllApprovedPets(): Promise<PetdexPet[]> {
 }
 
 export async function getApprovedPetsWithMetrics(): Promise<PetWithMetrics[]> {
-  "use cache";
-  cacheLife("hours");
-  cacheTag("gallery");
-
   const pets = await getAllApprovedPets();
   if (pets.length === 0) return [];
   const metrics = await getAllMetrics();
@@ -121,10 +97,6 @@ export async function getApprovedPetsWithMetrics(): Promise<PetWithMetrics[]> {
 }
 
 export async function getApprovedPetCount(): Promise<number> {
-  "use cache";
-  cacheLife("hours");
-  cacheTag("gallery");
-
   const row = await db
     .select({ n: sql<number>`count(*)::int` })
     .from(schema.submittedPets)

--- a/src/lib/same-origin.ts
+++ b/src/lib/same-origin.ts
@@ -54,10 +54,10 @@ export function isSameOrigin(req: Request): boolean {
 
 export function requireSameOrigin(req: Request): Response | null {
   if (!isSameOrigin(req)) {
-    return new Response(JSON.stringify({ error: "csrf_blocked" }), {
-      status: 403,
-      headers: { "Content-Type": "application/json" },
-    });
+    return new Response(
+      JSON.stringify({ error: "csrf_blocked" }),
+      { status: 403, headers: { "Content-Type": "application/json" } },
+    );
   }
   return null;
 }

--- a/src/lib/submission-decisions.ts
+++ b/src/lib/submission-decisions.ts
@@ -1,4 +1,4 @@
-import { revalidateTag } from "next/cache";
+import { updateTag } from "next/cache";
 
 import { eq } from "drizzle-orm";
 import { Resend } from "resend";
@@ -112,9 +112,9 @@ export async function applySubmissionAction(
   let row = updated;
   if (body.action === "approve" && !options.skipSideEffects) {
     row = await runPostApprovalEffects(row, actor, db);
-    revalidateTag("gallery", "max");
-    revalidateTag(`pet:${row.slug}`, "max");
-    revalidateTag(`profile:${row.ownerId}`, "max");
+    updateTag("gallery");
+    updateTag(`pet:${row.slug}`);
+    updateTag(`profile:${row.ownerId}`);
   }
 
   if (

--- a/src/lib/submission-decisions.ts
+++ b/src/lib/submission-decisions.ts
@@ -1,5 +1,3 @@
-import { updateTag } from "next/cache";
-
 import { eq } from "drizzle-orm";
 import { Resend } from "resend";
 
@@ -112,9 +110,6 @@ export async function applySubmissionAction(
   let row = updated;
   if (body.action === "approve" && !options.skipSideEffects) {
     row = await runPostApprovalEffects(row, actor, db);
-    updateTag("gallery");
-    updateTag(`pet:${row.slug}`);
-    updateTag(`profile:${row.ownerId}`);
   }
 
   if (

--- a/src/lib/url-allowlist.ts
+++ b/src/lib/url-allowlist.ts
@@ -98,7 +98,9 @@ const ALLOWED_CREDIT_HOSTS = new Set<string>([
   "youtube.com",
 ]);
 
-export function isWellKnownCreditUrl(raw: string | null | undefined): boolean {
+export function isWellKnownCreditUrl(
+  raw: string | null | undefined,
+): boolean {
   if (!raw) return false;
   let url: URL;
   try {

--- a/src/lib/user-locale.ts
+++ b/src/lib/user-locale.ts
@@ -1,8 +1,7 @@
 import { eq } from "drizzle-orm";
 
-import { db, schema } from "@/lib/db/client";
-
 import { defaultLocale, hasLocale, type Locale } from "@/i18n/config";
+import { db, schema } from "@/lib/db/client";
 
 export async function getPreferredLocaleForUser(
   userId: string | null | undefined,


### PR DESCRIPTION
## Why

Cache Components shipped in #129 turned into a 4-bug stack:

1. #129 used \`updateTag\` in Route Handlers → fixed in #136 (\`revalidateTag\`)
2. #138 fixed \`Couldn't find resumable slots\` in /pets/[slug] + /u/[handle]
3. OG images 500ed on undefined params (fixed locally, not pushed)
4. **/pets/<slug> returned \"Pet not found\" for every pet in prod** (root cause unidentified, only repro was prod)

Manual rollback to \`585fcae\` (pre-CC commit) confirmed pets work again. Code in main was diverging from prod and any redeploy would re-break.

Removing the whole stack so main matches what's actually shipping. CC migration was the right idea but the surface area is too big to debug under prod pressure. Will retry in an isolated branch with proper smoke testing.

## What this reverts

- #138 \`fix(cc): isolate auth() into Suspense leaves\`
- #136 \`fix(cache): use revalidateTag in Route Handlers\`
- #129 \`perf(cache): enable Cache Components + Partial Prerendering\`

## Kept

- #124 \`perf(edge): aggregate header state\` — independent perf win, not CC-related
- Everything else (ads, license, etc.)

## Build

\`bun run build\` passes. Routes back to \`Static / SSG / Dynamic\`.

## Test plan
- [x] \`bun run build\` clean
- [ ] Merge → Vercel deploys → confirm /pets/<slug> works for non-featured pets
- [ ] Watch for \"Pet not found\" errors disappear