### PR TITLE
fix(submit): tighten fallback issue template + admin import source

### DIFF
--- a/scripts/admin-import-pet.ts
+++ b/scripts/admin-import-pet.ts
@@ -137,15 +137,23 @@ async function main() {
     return;
   }
 
-  const ownerId =
-    args.ownerId ??
-    process.env.PETDEX_ADMIN_USER_IDS?.split(",")[0]?.trim() ??
-    "";
+  const explicitOwnerId = args.ownerId?.trim() ?? "";
+  const adminFallbackOwnerId =
+    process.env.PETDEX_ADMIN_USER_IDS?.split(",")[0]?.trim() ?? "";
+  const ownerId = explicitOwnerId || adminFallbackOwnerId;
   if (!ownerId) {
     throw new Error(
       "no owner id — pass --owner-id or set PETDEX_ADMIN_USER_IDS",
     );
   }
+  // When --owner-id points at the actual author the pet is a normal
+  // user submission. When we fall back to the admin user, the pet is
+  // an admin-imported orphan that the real author claims later via
+  // GitHub credit_url match.
+  const importedAsRealOwner = Boolean(explicitOwnerId);
+  const source: "submit" | "discover" = importedAsRealOwner
+    ? "submit"
+    : "discover";
 
   console.log("\nUploading to R2…");
   await r2.send(
@@ -203,11 +211,11 @@ async function main() {
     vibes: [],
     tags: [],
     status: args.approve ? "approved" : "pending",
-    source: "discover",
+    source,
     ownerId,
     ownerEmail: null,
-    creditName: args.creditName ?? null,
-    creditUrl: args.creditUrl ?? null,
+    creditName: importedAsRealOwner ? null : (args.creditName ?? null),
+    creditUrl: importedAsRealOwner ? null : (args.creditUrl ?? null),
     creditImage: null,
     approvedAt: args.approve ? new Date() : null,
   });

--- a/src/components/pet-submit-form.tsx
+++ b/src/components/pet-submit-form.tsx
@@ -65,7 +65,7 @@ const PETS_DIR = "~/.codex/pets";
 
 export function PetSubmitForm() {
   const t = useTranslations("submit.form");
-  const { isSignedIn, isLoaded } = useUser();
+  const { isSignedIn, isLoaded, user } = useUser();
   const [parsed, setParsed] = useState<ParsedPet | null>(null);
   const [isReading, setIsReading] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
@@ -654,7 +654,11 @@ export function PetSubmitForm() {
                 <p className="text-xs leading-5 text-rose-800/80">
                   {t("fallback.beforeLink")}{" "}
                   <a
-                    href={buildIssueUrl(parsed, submission.message)}
+                    href={buildIssueUrl(
+                      parsed,
+                      submission.message,
+                      user?.id ?? null,
+                    )}
                     target="_blank"
                     rel="noreferrer"
                     className="font-medium underline underline-offset-4 hover:text-rose-950"
@@ -972,23 +976,40 @@ function slugify(value: string): string {
 function buildIssueUrl(
   parsed: ParsedPet | null,
   message: string | undefined,
+  userId: string | null,
 ): string {
   const title = parsed?.displayName
     ? `[Submit fail] ${parsed.displayName}`
     : "[Submit fail] Petdex upload";
+  const description = parsed?.description?.trim();
+  const sizeText = parsed?.spritesheetWidth
+    ? `${parsed.spritesheetWidth}×${parsed.spritesheetHeight}`
+    : "n/a";
   const body = [
-    "Submission failed via the web upload. Attaching pet folder/zip below.",
+    "## ⚠️ BEFORE YOU SUBMIT THIS ISSUE",
     "",
-    `**Pet name:** ${parsed?.displayName ?? "n/a"}`,
-    `**Pet id:** ${parsed?.petId ?? "n/a"}`,
-    "**Sprite size:** " +
-      (parsed?.spritesheetWidth
-        ? `${parsed.spritesheetWidth}×${parsed.spritesheetHeight}`
-        : "n/a"),
-    `**Source:** ${parsed?.source ?? "n/a"}`,
-    `**Error:** ${message ?? "Unknown"}`,
+    "Without your pet files I cannot recover the upload. Please:",
     "",
-    "<!-- drag and drop your pet folder zipped here -->",
+    "- [ ] **Attach your zipped pet folder below** (drag-and-drop the .zip into the comment box). It must contain `pet.json` + `spritesheet.webp` (or `.png`).",
+    "- [ ] If the pet has a backstory or tags I should add, paste them in a comment.",
+    "",
+    "Issues without a zip get closed after 48h because there is nothing for me to import.",
+    "",
+    "---",
+    "",
+    "## What the form captured",
+    "",
+    `- **Pet name:** ${parsed?.displayName ?? "n/a"}`,
+    `- **Pet id:** ${parsed?.petId ?? "n/a"}`,
+    `- **Sprite size:** ${sizeText}`,
+    `- **Source:** ${parsed?.source ?? "n/a"}`,
+    `- **Error:** ${message ?? "Unknown"}`,
+    userId ? `- **User id:** \`${userId}\`` : "- **User id:** (not signed in)",
+    description
+      ? `- **Description:**\n  > ${description.replace(/\n/g, "\n  > ")}`
+      : "- **Description:** (none captured)",
+    "",
+    "<!-- ⬇️ Drag-and-drop your pet folder zipped here ⬇️ -->",
   ].join("\n");
 
   const params = new URLSearchParams({


### PR DESCRIPTION
## Why

Recent batch of [Submit fail] issues showed two patterns:

1. Users clicked the auto-generated GitHub issue link but **never attached the zip** — we got metadata only, nothing to import.
2. Manually-imported pets (recovery path) were ending up with \`source: discover\` even when the real author's user id was passed, breaking the pet detail page (showed ClaimCTA on owned pets) and profile credit chip.

## What

**\`pet-submit-form.tsx\`** — issue body rewrite:
- Leads with \`⚠️ BEFORE YOU SUBMIT THIS ISSUE\` checklist (attach zip + add backstory if relevant)
- 48h close warning so it's clear what happens without a zip
- Captures \`user.id\` from Clerk session into the body (so we can resolve email + GitHub server-side without asking them to retype it)
- Includes pet \`description\` if parsed, gives us *something* even when zip is missing

**\`scripts/admin-import-pet.ts\`** — source/credit fix:
- If \`--owner-id\` is explicit → \`source: submit\`, no \`creditName/creditUrl\` (Clerk resolves credit live)
- If we fall back to \`PETDEX_ADMIN_USER_IDS\` → keep \`source: discover\` + credit so the GitHub claim path works
- Patches Johnny Joestar in DB already to reflect this

## Test plan
- [x] \`bun run build\` clean
- [ ] Trigger a submit error in the form, click the issue link, confirm the new template renders with checklist + user id
- [ ] Run \`admin-import-pet.ts --owner-id user_xxx\` dry-run, verify source='submit'
- [ ] Run \`admin-import-pet.ts --credit-name X --credit-url Y\` (no owner-id), verify source='discover'