### PR TITLE
fix(header): hoist SiteHeader above hero section on remaining pages

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -84,9 +84,9 @@ export default async function AboutPage() {
   return (
     <main className="min-h-dvh bg-background text-foreground">
       <JsonLd data={jsonLd} />
-      <section className="petdex-cloud relative overflow-clip">
-        <div className="relative mx-auto flex w-full max-w-[1440px] flex-col px-5 pt-5 pb-10 md:px-8">
-          <SiteHeader />
+      <SiteHeader />
+      <section className="petdex-cloud relative -mt-[84px] overflow-clip pt-[84px]">
+        <div className="relative mx-auto flex w-full max-w-[1440px] flex-col px-5 pb-10 md:px-8">
           <div className="mt-12 flex flex-col items-center text-center md:mt-16">
             <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
               {t("eyebrow")}

--- a/src/app/[locale]/advertise/page.tsx
+++ b/src/app/[locale]/advertise/page.tsx
@@ -51,10 +51,11 @@ export default async function AdvertisePage({
   };
 
   return (
-    <main className="petdex-cloud relative min-h-dvh overflow-hidden bg-background text-foreground">
+    <main className="min-h-dvh bg-background text-foreground">
       <JsonLd data={jsonLd} />
-      <section className="relative mx-auto flex w-full max-w-[1440px] flex-col px-5 pt-5 pb-12 md:px-8 md:pb-16">
-        <SiteHeader />
+      <SiteHeader />
+      <section className="petdex-cloud relative -mt-[84px] overflow-clip pt-[84px]">
+        <div className="relative mx-auto flex w-full max-w-[1440px] flex-col px-5 pb-12 md:px-8 md:pb-16">
 
         <div className="mt-12 grid gap-10 lg:grid-cols-[1fr_440px] lg:items-start">
           <div>
@@ -124,6 +125,7 @@ export default async function AdvertisePage({
           </div>
 
           <AdvertiseForm />
+        </div>
         </div>
       </section>
 

--- a/src/app/[locale]/collections/[slug]/page.tsx
+++ b/src/app/[locale]/collections/[slug]/page.tsx
@@ -116,9 +116,9 @@ export default async function CollectionPage({ params }: PageProps) {
   return (
     <main className="min-h-dvh bg-background text-foreground">
       <JsonLd data={jsonLd} />
-      <section className="petdex-cloud relative overflow-clip">
-        <div className="relative mx-auto flex w-full max-w-[1440px] flex-col px-5 pt-5 pb-12 md:px-8">
-          <SiteHeader />
+      <SiteHeader />
+      <section className="petdex-cloud relative -mt-[84px] overflow-clip pt-[84px]">
+        <div className="relative mx-auto flex w-full max-w-[1440px] flex-col px-5 pb-12 md:px-8">
           <div className="mt-6">
             <Link
               href="/collections"

--- a/src/app/[locale]/collections/page.tsx
+++ b/src/app/[locale]/collections/page.tsx
@@ -59,9 +59,9 @@ export default async function CollectionsPage() {
   return (
     <main className="min-h-dvh bg-background text-foreground">
       <JsonLd data={jsonLd} />
-      <section className="petdex-cloud relative overflow-clip">
-        <div className="relative mx-auto flex w-full max-w-6xl flex-col px-5 pt-5 pb-12 md:px-8">
-          <SiteHeader />
+      <SiteHeader />
+      <section className="petdex-cloud relative -mt-[84px] overflow-clip pt-[84px]">
+        <div className="relative mx-auto flex w-full max-w-6xl flex-col px-5 pb-12 md:px-8">
           <div className="mt-12 max-w-2xl md:mt-16">
             <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
               Featured collections

--- a/src/app/[locale]/community/page.tsx
+++ b/src/app/[locale]/community/page.tsx
@@ -73,9 +73,9 @@ export default function CommunityPage() {
   return (
     <main className="min-h-dvh bg-background text-foreground">
       <JsonLd data={jsonLd} />
-      <section className="petdex-cloud relative overflow-clip">
-        <div className="relative mx-auto flex w-full max-w-5xl flex-col px-5 pt-5 pb-12 md:px-8">
-          <SiteHeader />
+      <SiteHeader />
+      <section className="petdex-cloud relative -mt-[84px] overflow-clip pt-[84px]">
+        <div className="relative mx-auto flex w-full max-w-5xl flex-col px-5 pb-12 md:px-8">
           <div className="mt-12 max-w-2xl md:mt-16">
             <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
               Petdex Community

--- a/src/app/[locale]/leaderboard/page.tsx
+++ b/src/app/[locale]/leaderboard/page.tsx
@@ -94,9 +94,9 @@ export default async function LeaderboardPage({
 
   return (
     <main className="min-h-dvh bg-background text-foreground">
-      <section className="petdex-cloud relative overflow-clip">
-        <div className="relative mx-auto flex w-full max-w-5xl flex-col px-5 pt-5 pb-10 md:px-8">
-          <SiteHeader />
+      <SiteHeader />
+      <section className="petdex-cloud relative -mt-[84px] overflow-clip pt-[84px]">
+        <div className="relative mx-auto flex w-full max-w-5xl flex-col px-5 pb-10 md:px-8">
 
           <div className="mt-12 flex flex-col items-center text-center md:mt-16">
             <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -40,9 +40,9 @@ export default async function NotFound() {
 
   return (
     <main className="min-h-dvh bg-background text-foreground">
-      <section className="petdex-cloud relative overflow-clip">
-        <div className="relative mx-auto flex w-full max-w-[1440px] flex-col px-5 pt-5 pb-10 md:px-8">
-          <SiteHeader />
+      <SiteHeader />
+      <section className="petdex-cloud relative -mt-[84px] overflow-clip pt-[84px]">
+        <div className="relative mx-auto flex w-full max-w-[1440px] flex-col px-5 pb-10 md:px-8">
 
           <div className="mt-10 flex flex-col items-center text-center md:mt-14">
             <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">

--- a/src/app/[locale]/pets/[slug]/page.tsx
+++ b/src/app/[locale]/pets/[slug]/page.tsx
@@ -349,14 +349,14 @@ export default async function PetPage({ params }: PageProps) {
         shuffleHref={shuffleHref}
       />
 
+      <SiteHeader />
       {/* Hero banner — full-width petdex-cloud gradient like /u/[handle].
           Houses the dex nav pills, the title block, the action row, and
           (if the viewer owns the pet) the inline edit button. The
           animated sprite + install command + secondary panels live
           below in their own contained section. */}
-      <section className="petdex-cloud relative z-10 overflow-visible">
-        <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-6 px-5 pt-5 pb-10 md:px-8 md:pb-14">
-          <SiteHeader />
+      <section className="petdex-cloud relative -mt-[84px] overflow-visible pt-[84px]">
+        <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-6 px-5 pb-10 md:px-8 md:pb-14">
 
           {/* Interactive floater pet — drag, click, watch. Renders an
               absolute-positioned sprite over the banner's empty right

--- a/src/app/[locale]/u/[handle]/page.tsx
+++ b/src/app/[locale]/u/[handle]/page.tsx
@@ -261,9 +261,9 @@ export default async function UserProfilePage({ params }: PageProps) {
         viewerIsOwner={isOwner}
       />
 
-      <section className="petdex-cloud relative overflow-clip">
-        <div className="relative mx-auto flex w-full max-w-[1440px] flex-col px-5 pt-5 pb-10 md:px-8">
-          <SiteHeader />
+      <SiteHeader />
+      <section className="petdex-cloud relative -mt-[84px] overflow-clip pt-[84px]">
+        <div className="relative mx-auto flex w-full max-w-[1440px] flex-col px-5 pb-10 md:px-8">
 
           <header className="mt-10 grid gap-8 md:mt-14 lg:grid-cols-[auto_1fr_auto] lg:items-start">
             {/* Avatar */}


### PR DESCRIPTION
The sticky header only worked on the homepage because every other page still nested <SiteHeader /> inside <section className="petdex-cloud relative overflow-clip">, which creates a containing block that traps sticky to the section bounds. Header would scroll out with the hero instead of following past the gallery / grid below.

Replicates the homepage pattern across:
- /pets/[slug] (also drops z-10 that was creating its own stacking context) — section is overflow-visible here
- /u/[handle], /leaderboard, /about, /community, /collections, /collections/[slug], /not-found — standard overflow-clip hero
- /advertise — was overflow-hidden petdex-cloud on <main>; restructured into the same outside-section pattern

Each page now hoists <SiteHeader /> as the first child of <main>, extends the petdex-cloud section behind it via -mt-[84px] + pt-[84px], and drops the now-redundant pt-5 from the inner container.