### PR TITLE
fix(ads): scale ad slot stride with inventory size

### DIFF
--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -672,10 +672,14 @@ function adForPetIndex(
   index: number,
 ): PublicFeedAd | null {
   if (ads.length === 0) return null;
+  // Density scales inversely with inventory: a single advertiser would
+  // otherwise repeat every 12 pets (8x per 100), reading as spam. With
+  // a healthier roster the slots tighten back up.
+  const stride = ads.length === 1 ? 30 : ads.length <= 3 ? 18 : 12;
   const petPosition = index + 1;
   if (petPosition < 6) return null;
-  if (petPosition !== 6 && (petPosition - 6) % 12 !== 0) return null;
-  const adIndex = Math.floor((petPosition - 6) / 12) % ads.length;
+  if (petPosition !== 6 && (petPosition - 6) % stride !== 0) return null;
+  const adIndex = Math.floor((petPosition - 6) / stride) % ads.length;
   return ads[adIndex] ?? null;
 }
 


### PR DESCRIPTION
## Summary
Previous logic placed a sponsored card every 12 pets after position 6. With a single active advertiser this rendered the same card eight times in the first 100 pets, reading as spam.

Stride now adapts to inventory:
- **1 active ad**: every 30 pets (~4× per 100)
- **2-3 active ads**: every 18 pets (rotate through)
- **4+ active ads**: every 12 pets (current density)

## Test plan
- [x] tsc + biome clean
- [ ] Visual: scroll homepage, count Kebo card appearances — should now be ~4 per 100 pets instead of ~8
- [ ] Once a 2nd advertiser ships, slots tighten to every 18 pets