### PR TITLE
fix(header,ads): hoist header on remaining pages, throttle ad density

### DIFF
--- a/src/app/[locale]/advertise/dashboard/page.tsx
+++ b/src/app/[locale]/advertise/dashboard/page.tsx
@@ -44,9 +44,10 @@ export default async function AdvertiseDashboardPage({
   const campaigns = await getUserAdCampaigns(userId);
 
   return (
-    <main className="petdex-cloud relative min-h-dvh overflow-hidden bg-background text-foreground">
-      <section className="relative mx-auto flex w-full max-w-[1440px] flex-col gap-8 px-5 pt-5 pb-12 md:px-8 md:pb-16">
-        <SiteHeader />
+    <main className="min-h-dvh bg-background text-foreground">
+      <SiteHeader />
+      <section className="petdex-cloud relative -mt-[84px] overflow-clip pt-[84px]">
+        <div className="relative mx-auto flex w-full max-w-[1440px] flex-col gap-8 px-5 pb-12 md:px-8 md:pb-16">
         <header className="mt-8 flex flex-col gap-5 md:flex-row md:items-end md:justify-between">
           <div>
             <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
@@ -67,6 +68,7 @@ export default async function AdvertiseDashboardPage({
           </Link>
         </header>
         <AdDashboard campaigns={campaigns} />
+        </div>
       </section>
       <SiteFooter />
     </main>

--- a/src/app/[locale]/create/page.tsx
+++ b/src/app/[locale]/create/page.tsx
@@ -40,10 +40,10 @@ export default async function CreatePage() {
   const t = await getTranslations("create");
 
   return (
-    <main className="petdex-cloud relative min-h-dvh overflow-hidden bg-background text-foreground">
-      <section className="relative mx-auto flex w-full max-w-5xl flex-col gap-10 px-5 py-5 pb-12 md:px-8 md:py-5 md:pb-16">
-        <SiteHeader />
-
+    <main className="min-h-dvh bg-background text-foreground">
+      <SiteHeader />
+      <section className="petdex-cloud relative -mt-[84px] overflow-clip pt-[84px]">
+        <div className="relative mx-auto flex w-full max-w-5xl flex-col gap-10 px-5 pb-12 md:px-8 md:pb-16">
         <header className="mt-6 max-w-3xl">
           <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
             {t("eyebrow")}
@@ -225,6 +225,7 @@ export default async function CreatePage() {
               </p>
             </div>
           </div>
+        </div>
         </div>
       </section>
 

--- a/src/app/[locale]/docs/page.tsx
+++ b/src/app/[locale]/docs/page.tsx
@@ -29,11 +29,8 @@ const SKILL_URL = `${REPO_URL}/blob/main/.claude/skills/petdex/SKILL.md`;
 export default function DocsPage() {
   return (
     <main className="min-h-dvh bg-background text-foreground">
-      <section className="mx-auto flex w-full max-w-[1440px] flex-col gap-8 px-5 py-5 md:px-8 md:py-5">
-        <SiteHeader />
-      </section>
-
-      <section className="mx-auto grid w-full max-w-6xl gap-12 px-5 pb-12 md:grid-cols-[220px_1fr] md:px-8 md:pb-16">
+      <SiteHeader />
+      <section className="mx-auto grid w-full max-w-6xl gap-12 px-5 pt-8 pb-12 md:grid-cols-[220px_1fr] md:px-8 md:pb-16">
         <aside className="hidden md:block">
           <nav className="sticky top-6 flex flex-col gap-1.5 text-sm">
             <NavHeader>Get started</NavHeader>

--- a/src/app/[locale]/legal/takedown/page.tsx
+++ b/src/app/[locale]/legal/takedown/page.tsx
@@ -18,10 +18,8 @@ export default function TakedownPage() {
 
   return (
     <main className="min-h-dvh bg-background text-foreground">
-      <section className="mx-auto flex w-full max-w-[1440px] flex-col gap-8 px-5 py-5 md:px-8 md:py-5">
-        <SiteHeader />
-      </section>
-      <section className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-5 pb-12 md:px-8 md:pb-16">
+      <SiteHeader />
+      <section className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-5 pt-8 pb-12 md:px-8 md:pb-16">
         <header>
           <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
             Legal · Takedown

--- a/src/app/[locale]/my-feedback/page.tsx
+++ b/src/app/[locale]/my-feedback/page.tsx
@@ -178,10 +178,8 @@ export default async function MyFeedbackPage({
 
   return (
     <main className="min-h-dvh bg-background text-foreground">
-      <section className="mx-auto flex w-full max-w-[1440px] flex-col gap-8 px-5 py-5 md:px-8 md:py-5">
-        <SiteHeader />
-      </section>
-      <section className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-5 pb-20 md:px-8">
+      <SiteHeader />
+      <section className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-5 pt-8 pb-20 md:px-8">
         <header className="space-y-3">
           <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
             {t("eyebrow")}

--- a/src/app/[locale]/requests/page.tsx
+++ b/src/app/[locale]/requests/page.tsx
@@ -149,10 +149,8 @@ export default async function RequestsPage() {
 
   return (
     <main className="min-h-dvh bg-background text-foreground">
-      <section className="mx-auto flex w-full max-w-[1440px] flex-col gap-8 px-5 py-5 md:px-8 md:py-5">
-        <SiteHeader />
-      </section>
-      <section className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-5 pb-20 md:px-8">
+      <SiteHeader />
+      <section className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-5 pt-8 pb-20 md:px-8">
         <header className="space-y-3">
           <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
             {t("eyebrow")}

--- a/src/app/[locale]/submit/page.tsx
+++ b/src/app/[locale]/submit/page.tsx
@@ -28,10 +28,10 @@ export default async function SubmitPage() {
   const t = await getTranslations("submit");
 
   return (
-    <main className="petdex-cloud relative min-h-dvh overflow-hidden bg-background">
-      <section className="relative mx-auto flex w-full max-w-6xl flex-col gap-10 px-5 py-5 pb-12 md:px-8 md:py-5 md:pb-16">
-        <SiteHeader hideSubmitCta />
-
+    <main className="min-h-dvh bg-background">
+      <SiteHeader hideSubmitCta />
+      <section className="petdex-cloud relative -mt-[84px] overflow-clip pt-[84px]">
+        <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-10 px-5 pb-12 md:px-8 md:pb-16">
         <header className="max-w-3xl">
           <p className="text-sm font-medium text-brand-light">{t("eyebrow")}</p>
           <h1 className="mt-4 text-5xl leading-tight font-medium tracking-normal text-foreground md:text-7xl">
@@ -62,6 +62,7 @@ export default async function SubmitPage() {
           </Link>
           {t("legalSuffix")}
         </p>
+        </div>
       </section>
 
       <SiteFooter />

--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -672,14 +672,17 @@ function adForPetIndex(
   index: number,
 ): PublicFeedAd | null {
   if (ads.length === 0) return null;
-  // Density scales inversely with inventory: a single advertiser would
-  // otherwise repeat every 12 pets (8x per 100), reading as spam. With
-  // a healthier roster the slots tighten back up.
-  const stride = ads.length === 1 ? 30 : ads.length <= 3 ? 18 : 12;
+  // Density scales inversely with inventory: with a single advertiser
+  // any stride feels spammy, so we space generously and cap to 3 slots
+  // total. With a healthier roster the slots tighten back up.
+  const stride = ads.length === 1 ? 40 : ads.length <= 3 ? 24 : 16;
+  const maxSlots = ads.length === 1 ? 3 : 8;
   const petPosition = index + 1;
-  if (petPosition < 6) return null;
-  if (petPosition !== 6 && (petPosition - 6) % stride !== 0) return null;
-  const adIndex = Math.floor((petPosition - 6) / stride) % ads.length;
+  if (petPosition < 8) return null;
+  if (petPosition !== 8 && (petPosition - 8) % stride !== 0) return null;
+  const slotNumber = Math.floor((petPosition - 8) / stride);
+  if (slotNumber >= maxSlots) return null;
+  const adIndex = slotNumber % ads.length;
   return ads[adIndex] ?? null;
 }
 


### PR DESCRIPTION
## Summary
Caught 7 more pages where the sticky header still didn't follow scroll, plus tightened ad pacing further.

### Header
- /create, /submit, /advertise/dashboard had \`petdex-cloud + overflow-hidden\` on \`<main>\` directly. Restructured into outside-section pattern.
- /docs, /legal/takedown, /my-feedback, /requests had header inside a wrapper section contained to header height. Hoisted above.

### Ads (still felt spammy at 1-advertiser stride 30)
- 1 active ad: every 40 pets (was 30), capped at 3 total slots
- 2-3 active ads: every 24 pets (was 18), capped at 8 total slots
- 4+ active ads: every 16 pets (was 12), no cap
- First slot moved from pos 6 → pos 8

With a single Kebo card today: 3 appearances total instead of 8+.

## Test plan
- [x] tsc + build pass locally
- [ ] /create, /submit, /docs, /requests, /legal/takedown, /my-feedback, /advertise/dashboard — header follows scroll
- [ ] Gallery: count Kebo card appearances, should be max 3