### PR TITLE
feat(requests): admin-approved claim system for fulfilling requests

### DIFF
--- a/scripts/apply-pet-request-candidates.ts
+++ b/scripts/apply-pet-request-candidates.ts
@@ -1,0 +1,75 @@
+// Idempotent migration: pet_request_candidates table.
+//
+// Run with: bun scripts/apply-pet-request-candidates.ts
+//
+// Loads .env.local automatically. Safe to re-run.
+
+import { neon } from "@neondatabase/serverless";
+
+const sql = neon(process.env.DATABASE_URL!);
+
+async function tryRun(label: string, fn: () => Promise<unknown>) {
+  try {
+    await fn();
+    console.log(`ok   ${label}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (
+      /already exists/i.test(msg) ||
+      /duplicate column/i.test(msg) ||
+      /duplicate object/i.test(msg)
+    ) {
+      console.log(`skip ${label} (already exists)`);
+    } else {
+      throw err;
+    }
+  }
+}
+
+await tryRun(
+  "create table pet_request_candidates",
+  () =>
+    sql`
+    CREATE TABLE pet_request_candidates (
+      pet_id text NOT NULL,
+      request_id text NOT NULL,
+      similarity real,
+      source text NOT NULL,
+      status text NOT NULL DEFAULT 'pending',
+      rejection_reason text,
+      suggested_at timestamptz NOT NULL DEFAULT now(),
+      resolved_at timestamptz,
+      resolved_by text,
+      PRIMARY KEY (pet_id, request_id)
+    )
+  `,
+);
+
+await tryRun(
+  "index pet_request_candidates_request_status_idx",
+  () =>
+    sql`
+    CREATE INDEX pet_request_candidates_request_status_idx
+    ON pet_request_candidates (request_id, status)
+  `,
+);
+
+await tryRun(
+  "index pet_request_candidates_status_suggested_idx",
+  () =>
+    sql`
+    CREATE INDEX pet_request_candidates_status_suggested_idx
+    ON pet_request_candidates (status, suggested_at DESC)
+  `,
+);
+
+await tryRun(
+  "index pet_request_candidates_pet_idx",
+  () =>
+    sql`
+    CREATE INDEX pet_request_candidates_pet_idx
+    ON pet_request_candidates (pet_id)
+  `,
+);
+
+console.log("\ndone.");

--- a/src/app/[locale]/admin/requests/page.tsx
+++ b/src/app/[locale]/admin/requests/page.tsx
@@ -5,7 +5,9 @@ import { desc, sql as dsql, inArray } from "drizzle-orm";
 import { ExternalLink, Sparkles } from "lucide-react";
 
 import { db, schema } from "@/lib/db/client";
+import { listPendingCandidates } from "@/lib/request-candidates";
 
+import { AdminCandidateActions } from "@/components/admin-candidate-actions";
 import { AdminRequestActions } from "@/components/admin-request-actions";
 
 export const metadata = {
@@ -138,6 +140,17 @@ export default async function AdminRequestsPage() {
   const fulfilled = rows.filter((r) => r.status === "fulfilled");
   const dismissed = rows.filter((r) => r.status === "dismissed");
 
+  const candidates = await listPendingCandidates(50);
+  const candidateOwnerIds = candidates.map((c) => c.pet.ownerId);
+  for (const id of candidateOwnerIds) userIdSet.add(id);
+  // Re-resolve clerk info if candidates introduced new owner ids that
+  // weren't in the original set. Cheap re-check; loadClerkInfo is a
+  // no-op when ids already known.
+  const candidateClerkInfo = await loadClerkInfo(
+    candidateOwnerIds.filter((id) => !clerkInfo.has(id)),
+  );
+  for (const [k, v] of candidateClerkInfo) clerkInfo.set(k, v);
+
   return (
     <section className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-5 pb-12 md:px-8 md:pb-16">
       <header>
@@ -152,6 +165,18 @@ export default async function AdminRequestsPage() {
           dismissed
         </p>
       </header>
+
+      {candidates.length > 0 ? (
+        <Section title="Candidates awaiting review" count={candidates.length}>
+          {candidates.map((c) => (
+            <CandidateRow
+              key={`${c.petId}:${c.requestId}`}
+              candidate={c}
+              owner={clerkInfo.get(c.pet.ownerId) ?? null}
+            />
+          ))}
+        </Section>
+      ) : null}
 
       {open.length > 0 ? (
         <Section title="Open" count={open.length}>
@@ -427,5 +452,90 @@ function Empty({ children }: { children: React.ReactNode }) {
     <div className="rounded-2xl border border-dashed border-border-base bg-surface/60 p-6 text-center text-sm text-muted-2">
       {children}
     </div>
+  );
+}
+
+type CandidateRowData = Awaited<
+  ReturnType<typeof listPendingCandidates>
+>[number];
+
+function CandidateRow({
+  candidate,
+  owner,
+}: {
+  candidate: CandidateRowData;
+  owner: ClerkInfo | null;
+}) {
+  const ownerLabel =
+    owner?.displayName ||
+    owner?.username ||
+    candidate.pet.creditName ||
+    "unknown";
+  const sourceLabel = candidate.source === "auto" ? "AUTO" : "MANUAL";
+  const similarityLabel =
+    candidate.similarity != null
+      ? `${Math.round(candidate.similarity * 100)}% match`
+      : null;
+
+  return (
+    <article className="grid gap-4 rounded-2xl border border-border-base bg-surface/80 p-4 md:grid-cols-[1fr_auto_1fr_auto]">
+      <Link
+        href={`/pets/${candidate.pet.slug}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center gap-3 rounded-xl p-2 transition hover:bg-surface-muted"
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={candidate.pet.spritesheetUrl}
+          alt=""
+          className="size-12 shrink-0 rounded-lg bg-surface-muted object-cover"
+        />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-foreground">
+            {candidate.pet.displayName}
+          </p>
+          <p className="truncate text-xs text-muted-3">
+            by {ownerLabel}{" "}
+            <span className="ml-1 font-mono text-[10px] tracking-[0.18em] text-muted-4">
+              {sourceLabel}
+              {similarityLabel ? ` · ${similarityLabel}` : ""}
+            </span>
+          </p>
+        </div>
+      </Link>
+
+      <div className="hidden self-center text-muted-4 md:block" aria-hidden>
+        →
+      </div>
+
+      <div className="flex items-start gap-3 p-2">
+        {candidate.request.imageUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={candidate.request.imageUrl}
+            alt=""
+            className="size-12 shrink-0 rounded-lg bg-surface-muted object-cover"
+          />
+        ) : (
+          <div className="grid size-12 shrink-0 place-items-center rounded-lg bg-surface-muted">
+            <Sparkles className="size-4 text-muted-4" />
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-foreground">
+            {candidate.request.query}
+          </p>
+          <p className="text-xs text-muted-3">
+            {candidate.request.upvoteCount} votes
+          </p>
+        </div>
+      </div>
+
+      <AdminCandidateActions
+        petId={candidate.petId}
+        requestId={candidate.requestId}
+      />
+    </article>
   );
 }

--- a/src/app/api/admin/request-candidates/route.ts
+++ b/src/app/api/admin/request-candidates/route.ts
@@ -1,0 +1,155 @@
+import { NextResponse } from "next/server";
+
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import { Resend } from "resend";
+
+import { isAdmin } from "@/lib/admin";
+import { renderRequestFulfilledCreatorEmail } from "@/lib/email-templates/request-fulfilled-creator";
+import { renderRequestFulfilledRequesterEmail } from "@/lib/email-templates/request-fulfilled-requester";
+import { createNotification } from "@/lib/notifications";
+import { approveCandidate, rejectCandidate } from "@/lib/request-candidates";
+import { requireSameOrigin } from "@/lib/same-origin";
+import { getPreferredLocaleForUser } from "@/lib/user-locale";
+
+export const runtime = "nodejs";
+
+async function emailUser(
+  userId: string,
+  rendered: { subject: string; html: string; text: string },
+): Promise<void> {
+  if (!process.env.RESEND_API_KEY) return;
+  try {
+    const client = await clerkClient();
+    const u = await client.users.getUser(userId);
+    const email = u.primaryEmailAddress?.emailAddress;
+    if (!email) return;
+    const resend = new Resend(process.env.RESEND_API_KEY);
+    const from =
+      process.env.RESEND_FROM ?? "Petdex <petdex@updates.railly.dev>";
+    await resend.emails.send({
+      from,
+      to: email,
+      subject: rendered.subject,
+      html: rendered.html,
+      text: rendered.text,
+    });
+  } catch (e) {
+    console.warn("[request-candidates] email failed:", e);
+  }
+}
+
+type Body = {
+  action: "approve" | "reject";
+  petId: string;
+  requestId: string;
+  reason?: string;
+};
+
+export async function POST(req: Request): Promise<Response> {
+  const csrf = requireSameOrigin(req);
+  if (csrf) return csrf;
+
+  const { userId } = await auth();
+  if (!isAdmin(userId)) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  let body: Body;
+  try {
+    body = (await req.json()) as Body;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  if (
+    !body.petId ||
+    !body.requestId ||
+    (body.action !== "approve" && body.action !== "reject")
+  ) {
+    return NextResponse.json({ error: "invalid_input" }, { status: 400 });
+  }
+
+  if (body.action === "reject") {
+    const result = await rejectCandidate({
+      petId: body.petId,
+      requestId: body.requestId,
+      // biome-ignore lint/style/noNonNullAssertion: isAdmin gate above
+      resolvedBy: userId!,
+      reason: body.reason,
+    });
+    if (!result.ok) {
+      return NextResponse.json(
+        { error: result.reason },
+        { status: result.reason === "not_found" ? 404 : 409 },
+      );
+    }
+    return NextResponse.json({ ok: true });
+  }
+
+  const result = await approveCandidate({
+    petId: body.petId,
+    requestId: body.requestId,
+    // biome-ignore lint/style/noNonNullAssertion: isAdmin gate above
+    resolvedBy: userId!,
+  });
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: result.reason },
+      { status: result.reason === "not_found" ? 404 : 409 },
+    );
+  }
+
+  // Fire notifications and emails: requester (their request is fulfilled)
+  // and creator (their pet earned a fulfill credit). Both use the
+  // existing request_fulfilled kind; payload distinguishes via `role`.
+  // Best-effort — failures are logged and swallowed.
+  if (result.requesterId) {
+    void createNotification({
+      userId: result.requesterId,
+      kind: "request_fulfilled",
+      payload: {
+        role: "requester",
+        requestQuery: result.requestQuery,
+        petSlug: result.petSlug,
+        petName: result.petDisplayName,
+      },
+      href: `/pets/${result.petSlug}`,
+    }).catch(() => {});
+
+    void (async () => {
+      // biome-ignore lint/style/noNonNullAssertion: requesterId checked above
+      const locale = await getPreferredLocaleForUser(result.requesterId!);
+      const rendered = renderRequestFulfilledRequesterEmail(locale, {
+        petName: result.petDisplayName,
+        petSlug: result.petSlug,
+        requestQuery: result.requestQuery,
+      });
+      // biome-ignore lint/style/noNonNullAssertion: requesterId checked above
+      await emailUser(result.requesterId!, rendered);
+    })();
+  }
+
+  void createNotification({
+    userId: result.petOwnerId,
+    kind: "request_fulfilled",
+    payload: {
+      role: "creator",
+      requestQuery: result.requestQuery,
+      petSlug: result.petSlug,
+      petName: result.petDisplayName,
+    },
+    href: `/pets/${result.petSlug}`,
+  }).catch(() => {});
+
+  void (async () => {
+    const locale = await getPreferredLocaleForUser(result.petOwnerId);
+    const rendered = renderRequestFulfilledCreatorEmail(locale, {
+      petName: result.petDisplayName,
+      petSlug: result.petSlug,
+      requestQuery: result.requestQuery,
+    });
+    await emailUser(result.petOwnerId, rendered);
+  })();
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/my-pets/approved/route.ts
+++ b/src/app/api/my-pets/approved/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+
+import { auth } from "@clerk/nextjs/server";
+import { and, desc, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/db/client";
+
+export const runtime = "nodejs";
+
+// Compact list of the signed-in user's approved pets — used by the
+// "I have a pet for this" modal on /requests to populate a selector.
+// Returns id + slug + displayName + spritesheet (and nothing else, so
+// we don't accidentally leak owner_email or pending edits).
+export async function GET(): Promise<Response> {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const rows = await db
+    .select({
+      id: schema.submittedPets.id,
+      slug: schema.submittedPets.slug,
+      displayName: schema.submittedPets.displayName,
+      spritesheetUrl: schema.submittedPets.spritesheetUrl,
+    })
+    .from(schema.submittedPets)
+    .where(
+      and(
+        eq(schema.submittedPets.ownerId, userId),
+        eq(schema.submittedPets.status, "approved"),
+      ),
+    )
+    .orderBy(desc(schema.submittedPets.approvedAt));
+
+  return NextResponse.json({ pets: rows });
+}

--- a/src/app/api/pet-requests/[id]/candidates/route.ts
+++ b/src/app/api/pet-requests/[id]/candidates/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+
+import { auth } from "@clerk/nextjs/server";
+
+import { createManualCandidate } from "@/lib/request-candidates";
+import { requireSameOrigin } from "@/lib/same-origin";
+
+export const runtime = "nodejs";
+
+type Params = { id: string };
+
+type Body = { petId: string };
+
+export async function POST(
+  req: Request,
+  ctx: { params: Promise<Params> },
+): Promise<Response> {
+  const csrf = requireSameOrigin(req);
+  if (csrf) return csrf;
+
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const { id: requestId } = await ctx.params;
+
+  let body: Body;
+  try {
+    body = (await req.json()) as Body;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  if (!body.petId || typeof body.petId !== "string") {
+    return NextResponse.json({ error: "invalid_input" }, { status: 400 });
+  }
+
+  const result = await createManualCandidate({
+    petId: body.petId,
+    requestId,
+    ownerId: userId,
+  });
+
+  if (!result.ok) {
+    const status =
+      result.reason === "pet_not_found" || result.reason === "request_not_found"
+        ? 404
+        : result.reason === "not_owner"
+          ? 403
+          : 409;
+    return NextResponse.json({ error: result.reason }, { status });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/components/admin-candidate-actions.tsx
+++ b/src/components/admin-candidate-actions.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import { Check, Loader2, X } from "lucide-react";
+
+type Action = "approve" | "reject";
+
+export function AdminCandidateActions({
+  petId,
+  requestId,
+}: {
+  petId: string;
+  requestId: string;
+}) {
+  const router = useRouter();
+  const [busy, setBusy] = useState<Action | null>(null);
+  const [, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  async function run(action: Action) {
+    setError(null);
+    setBusy(action);
+    try {
+      const res = await fetch("/api/admin/request-candidates", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ action, petId, requestId }),
+      });
+      if (!res.ok) {
+        const j = (await res.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        setError(j?.error ?? `Request failed (${res.status})`);
+        return;
+      }
+      startTransition(() => {
+        router.refresh();
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-2 self-center">
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => run("reject")}
+          disabled={busy !== null}
+          className="inline-flex h-8 items-center gap-1.5 rounded-full border border-chip-danger-fg/20 bg-chip-danger-bg px-3 text-xs font-medium text-chip-danger-fg transition hover:bg-chip-danger-bg/70 disabled:opacity-50"
+        >
+          {busy === "reject" ? (
+            <Loader2 className="size-3 animate-spin" />
+          ) : (
+            <X className="size-3" />
+          )}
+          Reject
+        </button>
+        <button
+          type="button"
+          onClick={() => run("approve")}
+          disabled={busy !== null}
+          className="inline-flex h-8 items-center gap-1.5 rounded-full bg-inverse px-3 text-xs font-medium text-on-inverse transition hover:bg-inverse-hover disabled:opacity-50"
+        >
+          {busy === "approve" ? (
+            <Loader2 className="size-3 animate-spin" />
+          ) : (
+            <Check className="size-3" />
+          )}
+          Approve
+        </button>
+      </div>
+      {error ? (
+        <p className="font-mono text-[10px] text-chip-danger-fg">{error}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/claim-request-button.tsx
+++ b/src/components/claim-request-button.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useState } from "react";
+
+import { useAuth, useClerk } from "@clerk/nextjs";
+import { Check, HandHeart, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+type ApprovedPet = {
+  id: string;
+  slug: string;
+  displayName: string;
+  spritesheetUrl: string;
+};
+
+export function ClaimRequestButton({
+  requestId,
+  requestQuery,
+}: {
+  requestId: string;
+  requestQuery: string;
+}) {
+  const { isLoaded, isSignedIn } = useAuth();
+  const { openSignIn } = useClerk();
+  const [open, setOpen] = useState(false);
+  const [pets, setPets] = useState<ApprovedPet[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  // Fetch approved pets only when the dialog opens (avoids one fetch
+  // per visible request card on /requests).
+  useEffect(() => {
+    if (!open || pets !== null) return;
+    setLoading(true);
+    setError(null);
+    void fetch("/api/my-pets/approved", { cache: "no-store" })
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error(`Failed (${res.status})`);
+        }
+        const data = (await res.json()) as { pets: ApprovedPet[] };
+        setPets(data.pets);
+      })
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [open, pets]);
+
+  function handleTriggerClick(e: React.MouseEvent) {
+    if (!isLoaded) return;
+    if (!isSignedIn) {
+      e.preventDefault();
+      openSignIn();
+    }
+  }
+
+  async function submit() {
+    if (!selected) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/pet-requests/${requestId}/candidates`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ petId: selected }),
+      });
+      if (!res.ok) {
+        const j = (await res.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        throw new Error(j?.error ?? `Failed (${res.status})`);
+      }
+      setDone(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function reset() {
+    setOpen(false);
+    setTimeout(() => {
+      setSelected(null);
+      setError(null);
+      setDone(false);
+    }, 200);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger
+        render={
+          <button
+            type="button"
+            onClick={handleTriggerClick}
+            className="inline-flex items-center gap-1.5 rounded-full border border-border-base bg-surface-muted px-2.5 py-1 font-mono text-[11px] tracking-[0.04em] text-muted-2 transition hover:border-brand/30 hover:bg-brand-tint hover:text-brand-deep dark:hover:bg-brand-tint-dark"
+          >
+            <HandHeart className="size-3" />I have a pet for this
+          </button>
+        }
+      />
+      <DialogContent className="sm:max-w-md">
+        {done ? (
+          <>
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2 text-base">
+                <Check className="size-4 text-chip-success-fg" />
+                Submitted
+              </DialogTitle>
+              <DialogDescription>
+                Your pet is now pending admin review for this request. You'll
+                get a notification if it's approved.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="petdex-cta"
+                onClick={reset}
+                className="px-4 text-sm"
+              >
+                Done
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle className="text-base">
+                Claim "{requestQuery}"
+              </DialogTitle>
+              <DialogDescription>
+                Pick one of your approved pets. Admin will review and confirm
+                the match.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="max-h-72 overflow-y-auto">
+              {loading ? (
+                <div className="flex items-center justify-center py-8">
+                  <Loader2 className="size-4 animate-spin text-muted-3" />
+                </div>
+              ) : pets && pets.length === 0 ? (
+                <div className="rounded-xl border border-dashed border-border-base p-4 text-center text-sm text-muted-2">
+                  You don't have any approved pets yet.
+                  <a
+                    href="/submit"
+                    className="ml-1 font-medium text-brand-deep underline"
+                  >
+                    Submit one →
+                  </a>
+                </div>
+              ) : (
+                <ul className="grid gap-1">
+                  {pets?.map((pet) => {
+                    const active = selected === pet.id;
+                    return (
+                      <li key={pet.id}>
+                        <button
+                          type="button"
+                          onClick={() => setSelected(pet.id)}
+                          className={`flex w-full items-center gap-3 rounded-xl border p-2 text-left transition ${
+                            active
+                              ? "border-brand bg-brand-tint dark:bg-brand-tint-dark"
+                              : "border-transparent hover:bg-surface-muted"
+                          }`}
+                        >
+                          <Image
+                            src={pet.spritesheetUrl}
+                            alt=""
+                            width={40}
+                            height={40}
+                            className="size-10 shrink-0 rounded-lg bg-surface-muted object-cover"
+                          />
+                          <span className="flex-1 truncate text-sm text-foreground">
+                            {pet.displayName}
+                          </span>
+                          {active ? (
+                            <Check className="size-4 shrink-0 text-brand" />
+                          ) : null}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+
+            {error ? (
+              <p className="rounded-lg bg-chip-danger-bg p-2 font-mono text-[10px] text-chip-danger-fg">
+                {error === "exists"
+                  ? "Already submitted as candidate."
+                  : error === "request_not_open"
+                    ? "This request is no longer open."
+                    : error === "pet_not_approved"
+                      ? "Pet must be approved first."
+                      : error}
+              </p>
+            ) : null}
+
+            <DialogFooter>
+              <DialogClose
+                render={
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="text-sm text-muted-2"
+                  >
+                    Cancel
+                  </Button>
+                }
+              />
+              <Button
+                type="button"
+                variant="petdex-cta"
+                disabled={!selected || submitting}
+                onClick={submit}
+                className="px-4 text-sm"
+              >
+                {submitting ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : null}
+                Submit candidate
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/notifications-bell.tsx
+++ b/src/components/notifications-bell.tsx
@@ -91,6 +91,16 @@ function describe(n: Notif): { title: string; sub?: string } {
         sub: p.excerpt,
       };
     case "request_fulfilled":
+      // Distinguish which side of the fulfillment received this notif.
+      // role="creator" means the recipient owns the pet that fulfilled
+      // someone else's request; role="requester" (or missing) means
+      // their own request shipped.
+      if (p.role === "creator") {
+        return {
+          title: `${p.petName ?? "Your pet"} fulfilled "${p.requestQuery ?? "a request"}"`,
+          sub: "The community asked, you delivered.",
+        };
+      }
       return {
         title: `Your request "${p.requestQuery ?? "..."}" was fulfilled`,
         sub: p.petName ? `Now live as ${p.petName}` : undefined,

--- a/src/components/requests-view.tsx
+++ b/src/components/requests-view.tsx
@@ -24,6 +24,8 @@ import {
 } from "lucide-react";
 import { useTranslations } from "next-intl";
 
+import { ClaimRequestButton } from "@/components/claim-request-button";
+
 type ClerkInfo = {
   handle: string;
   displayName: string | null;
@@ -771,6 +773,14 @@ function RequestCard({
                 {request.fulfilledPet.displayName}
                 <ExternalLink className="size-3" />
               </Link>
+            ) : null}
+
+            {/* Claim CTA — shown only on open requests */}
+            {!fulfilled ? (
+              <ClaimRequestButton
+                requestId={request.id}
+                requestQuery={parsedRequest.label}
+              />
             ) : null}
           </div>
         </div>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import type * as React from "react";
+
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { XIcon } from "@phosphor-icons/react";
+
+import { cn } from "@/lib/utils";
+
+import { Button } from "@/components/ui/button";
+
+function Dialog({ ...props }: DialogPrimitive.Root.Props) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: DialogPrimitive.Backdrop.Props) {
+  return (
+    <DialogPrimitive.Backdrop
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: DialogPrimitive.Popup.Props & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Popup
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-2xl bg-popover p-4 text-xs/relaxed text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            render={
+              <Button
+                variant="ghost"
+                className="absolute top-2 right-2"
+                size="icon-sm"
+              />
+            }
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-1 text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close render={<Button variant="outline" />}>
+          Close
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  );
+}
+
+function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-sm font-medium", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: DialogPrimitive.Description.Props) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        "text-xs/relaxed text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -7,6 +7,7 @@ import {
   pgEnum,
   pgTable,
   primaryKey,
+  real,
   text,
   timestamp,
   uniqueIndex,
@@ -621,6 +622,45 @@ export const petRequestVotes = pgTable(
     pk: primaryKey({ columns: [table.requestId, table.userId] }),
   }),
 );
+
+// Candidates linking a submitted pet to a pet request. Two sources:
+// - "auto"   created by the background match job after a pet hits
+//            status='approved'; similarity holds the cosine score
+// - "manual" created when the pet's owner clicks "I have a pet for
+//            this" on /requests; similarity is null
+// Admin resolves to either approved (request becomes fulfilled) or
+// rejected. A single (petId, requestId) pair can only appear once.
+export const petRequestCandidates = pgTable(
+  "pet_request_candidates",
+  {
+    petId: text("pet_id").notNull(),
+    requestId: text("request_id").notNull(),
+    similarity: real("similarity"),
+    source: text("source").notNull(),
+    status: text("status").notNull().default("pending"),
+    rejectionReason: text("rejection_reason"),
+    suggestedAt: timestamp("suggested_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    resolvedAt: timestamp("resolved_at", { withTimezone: true }),
+    resolvedBy: text("resolved_by"),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.petId, table.requestId] }),
+    requestStatusIdx: index("pet_request_candidates_request_status_idx").on(
+      table.requestId,
+      table.status,
+    ),
+    statusSuggestedIdx: index("pet_request_candidates_status_suggested_idx").on(
+      table.status,
+      table.suggestedAt.desc(),
+    ),
+    petIdx: index("pet_request_candidates_pet_idx").on(table.petId),
+  }),
+);
+
+export type PetRequestCandidate = typeof petRequestCandidates.$inferSelect;
+export type NewPetRequestCandidate = typeof petRequestCandidates.$inferInsert;
 
 export type SubmittedPet = typeof submittedPets.$inferSelect;
 export type NewSubmittedPet = typeof submittedPets.$inferInsert;

--- a/src/lib/email-templates/request-fulfilled-creator.ts
+++ b/src/lib/email-templates/request-fulfilled-creator.ts
@@ -1,0 +1,55 @@
+import {
+  normalizeLocale,
+  p,
+  petdexUrl,
+  wrapEmail,
+} from "@/lib/email-templates/shared";
+
+import type { Locale } from "@/i18n/config";
+
+type Vars = {
+  petName: string;
+  petSlug: string;
+  requestQuery: string;
+};
+
+export function renderRequestFulfilledCreatorEmail(
+  locale: Locale,
+  vars: Vars,
+): { subject: string; html: string; text: string } {
+  const current = normalizeLocale(locale);
+  const petUrl = petdexUrl(current, `/pets/${vars.petSlug}`);
+
+  const copy =
+    current === "es"
+      ? {
+          subject: `${vars.petName} cumplió un pedido de la comunidad`,
+          intro: `Tu mascota ${vars.petName} cumplió el pedido "${vars.requestQuery}" de la comunidad.`,
+          body: "Otros usuarios podrán encontrarla más fácil ahora. Gracias por aportar al catálogo.",
+          cta: `Ver: ${petUrl}`,
+        }
+      : current === "zh"
+        ? {
+            subject: `${vars.petName} 完成了社区请求`, // fixme:zh
+            intro: `你的宠物 ${vars.petName} 满足了社区请求 "${vars.requestQuery}"。`, // fixme:zh
+            body: "现在其他用户更容易找到它。感谢你的贡献。", // fixme:zh
+            cta: `查看：${petUrl}`, // fixme:zh
+          }
+        : {
+            subject: `${vars.petName} fulfilled a community request`,
+            intro: `Your pet ${vars.petName} fulfilled the community request "${vars.requestQuery}".`,
+            body: "It will now be easier for others to find. Thanks for contributing to the catalog.",
+            cta: `View: ${petUrl}`,
+          };
+
+  const text = [copy.intro, "", copy.body, "", copy.cta, "", "Petdex"].join(
+    "\n",
+  );
+  const html = wrapEmail(copy.subject, [
+    p(copy.intro),
+    p(copy.body),
+    p(copy.cta),
+  ]);
+
+  return { subject: copy.subject, html, text };
+}

--- a/src/lib/email-templates/request-fulfilled-requester.ts
+++ b/src/lib/email-templates/request-fulfilled-requester.ts
@@ -1,0 +1,65 @@
+import {
+  codeBlock,
+  normalizeLocale,
+  p,
+  petdexUrl,
+  wrapEmail,
+} from "@/lib/email-templates/shared";
+
+import type { Locale } from "@/i18n/config";
+
+type Vars = {
+  petName: string;
+  petSlug: string;
+  requestQuery: string;
+};
+
+export function renderRequestFulfilledRequesterEmail(
+  locale: Locale,
+  vars: Vars,
+): { subject: string; html: string; text: string } {
+  const current = normalizeLocale(locale);
+  const petUrl = petdexUrl(current, `/pets/${vars.petSlug}`);
+  const installCmd = `curl -sSf https://petdex.crafter.run/install/${vars.petSlug} | sh`;
+
+  const copy =
+    current === "es"
+      ? {
+          subject: `Tu pedido "${vars.requestQuery}" ya tiene mascota`,
+          intro: `${vars.petName} cumple tu pedido en Petdex.`,
+          install: "Comando de instalación",
+          cta: `Página: ${petUrl}`,
+        }
+      : current === "zh"
+        ? {
+            subject: `你的请求 "${vars.requestQuery}" 已被满足`, // fixme:zh
+            intro: `${vars.petName} 满足了你在 Petdex 的请求。`, // fixme:zh
+            install: "安装命令", // fixme:zh
+            cta: `页面：${petUrl}`, // fixme:zh
+          }
+        : {
+            subject: `Your request "${vars.requestQuery}" has a pet`,
+            intro: `${vars.petName} fulfills your request on Petdex.`,
+            install: "Install command",
+            cta: `Page: ${petUrl}`,
+          };
+
+  const text = [
+    copy.intro,
+    "",
+    copy.cta,
+    "",
+    `${copy.install}:`,
+    installCmd,
+    "",
+    "Petdex",
+  ].join("\n");
+  const html = wrapEmail(copy.subject, [
+    p(copy.intro),
+    p(copy.cta),
+    p(copy.install),
+    codeBlock(installCmd),
+  ]);
+
+  return { subject: copy.subject, html, text };
+}

--- a/src/lib/request-candidates.ts
+++ b/src/lib/request-candidates.ts
@@ -1,0 +1,397 @@
+import "server-only";
+
+import { and, sql as drizzleSql, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/db/client";
+import { PETDEX_EMBEDDING_MODEL } from "@/lib/embeddings";
+
+// Cosine similarity threshold for auto-suggested matches. 0.70 chosen
+// empirically — pet/request pairs above this score read as "obviously
+// related" in spot checks; below it produces too many noisy matches.
+// Tune downward if admins want a wider funnel, upward if the queue
+// gets noisy. Manual claims bypass this threshold entirely.
+export const AUTO_MATCH_THRESHOLD = 0.7;
+export const AUTO_MATCH_TOP_K = 5;
+
+export type CandidateSource = "auto" | "manual";
+export type CandidateStatus = "pending" | "approved" | "rejected";
+
+// Run after a submitted pet transitions to status='approved'. Looks
+// up open requests whose embedding lies within AUTO_MATCH_THRESHOLD of
+// the pet's own embedding, and writes them as pending candidates.
+//
+// No-ops gracefully when the pet has no embedding (older rows) or no
+// open requests cross the threshold. Idempotent: re-running won't
+// create duplicates because (pet_id, request_id) is the primary key
+// of pet_request_candidates.
+export async function autoSuggestCandidates(petId: string): Promise<{
+  inserted: number;
+  scannedRequests: number;
+}> {
+  const pet = await db.query.submittedPets.findFirst({
+    columns: { id: true, status: true },
+    where: eq(schema.submittedPets.id, petId),
+  });
+  if (!pet || pet.status !== "approved") {
+    return { inserted: 0, scannedRequests: 0 };
+  }
+
+  // Pull pet embedding via raw SQL — drizzle column type for pgvector
+  // isn't first-class; we cast to text and parse the vector literal.
+  const petRow = await db.execute<{
+    embedding: string | null;
+    embedding_model: string | null;
+  }>(drizzleSql`
+    SELECT embedding::text AS embedding, embedding_model
+    FROM submitted_pets
+    WHERE id = ${petId}
+    LIMIT 1
+  `);
+  const petEmbeddingText = petRow.rows[0]?.embedding;
+  const petEmbeddingModel = petRow.rows[0]?.embedding_model;
+  if (!petEmbeddingText || petEmbeddingModel !== PETDEX_EMBEDDING_MODEL) {
+    return { inserted: 0, scannedRequests: 0 };
+  }
+
+  // Cosine search against open requests with a matching embedding.
+  // Distance <=> returns 0 (identical) to 2 (opposite); similarity =
+  // 1 - distance. Filter at SQL level so we only fetch candidates.
+  const matches = await db.execute<{
+    request_id: string;
+    similarity: number;
+  }>(drizzleSql`
+    SELECT
+      pr.id AS request_id,
+      1 - (pr.embedding <=> ${petEmbeddingText}::vector) AS similarity
+    FROM pet_requests pr
+    WHERE pr.status = 'open'
+      AND pr.embedding IS NOT NULL
+      AND pr.embedding_model = ${PETDEX_EMBEDDING_MODEL}
+      AND 1 - (pr.embedding <=> ${petEmbeddingText}::vector) >= ${AUTO_MATCH_THRESHOLD}
+    ORDER BY pr.embedding <=> ${petEmbeddingText}::vector
+    LIMIT ${AUTO_MATCH_TOP_K}
+  `);
+
+  if (matches.rows.length === 0) {
+    return { inserted: 0, scannedRequests: 0 };
+  }
+
+  // Insert candidates, skipping any (pet, request) pair that already
+  // exists. ON CONFLICT keeps re-runs idempotent without raising.
+  const values = matches.rows.map((row) => ({
+    petId,
+    requestId: row.request_id,
+    similarity: row.similarity,
+    source: "auto" as CandidateSource,
+    status: "pending" as CandidateStatus,
+  }));
+
+  const inserted = await db
+    .insert(schema.petRequestCandidates)
+    .values(values)
+    .onConflictDoNothing({
+      target: [
+        schema.petRequestCandidates.petId,
+        schema.petRequestCandidates.requestId,
+      ],
+    })
+    .returning({ petId: schema.petRequestCandidates.petId });
+
+  return {
+    inserted: inserted.length,
+    scannedRequests: matches.rows.length,
+  };
+}
+
+// Manual claim from /requests UI. The pet must be approved and owned
+// by the caller; the request must be open. Returns "exists" if a
+// candidate is already pending for this pair (same pet, same request).
+export async function createManualCandidate(args: {
+  petId: string;
+  requestId: string;
+  ownerId: string;
+}): Promise<
+  | { ok: true }
+  | { ok: false; reason: "pet_not_found" | "not_owner" | "pet_not_approved" }
+  | { ok: false; reason: "request_not_found" | "request_not_open" }
+  | { ok: false; reason: "exists" }
+> {
+  const pet = await db.query.submittedPets.findFirst({
+    columns: { id: true, status: true, ownerId: true },
+    where: eq(schema.submittedPets.id, args.petId),
+  });
+  if (!pet) return { ok: false, reason: "pet_not_found" };
+  if (pet.ownerId !== args.ownerId) return { ok: false, reason: "not_owner" };
+  if (pet.status !== "approved")
+    return { ok: false, reason: "pet_not_approved" };
+
+  const request = await db.query.petRequests.findFirst({
+    columns: { id: true, status: true },
+    where: eq(schema.petRequests.id, args.requestId),
+  });
+  if (!request) return { ok: false, reason: "request_not_found" };
+  if (request.status !== "open")
+    return { ok: false, reason: "request_not_open" };
+
+  const existing = await db.query.petRequestCandidates.findFirst({
+    columns: { petId: true, status: true },
+    where: and(
+      eq(schema.petRequestCandidates.petId, args.petId),
+      eq(schema.petRequestCandidates.requestId, args.requestId),
+    ),
+  });
+  if (existing) return { ok: false, reason: "exists" };
+
+  await db.insert(schema.petRequestCandidates).values({
+    petId: args.petId,
+    requestId: args.requestId,
+    similarity: null,
+    source: "manual",
+    status: "pending",
+  });
+
+  return { ok: true };
+}
+
+// Lists pending candidates for the admin queue, joined with pet and
+// request snapshots so the UI can render previews without a second
+// round of queries.
+export async function listPendingCandidates(limit = 50): Promise<
+  Array<{
+    petId: string;
+    requestId: string;
+    similarity: number | null;
+    source: CandidateSource;
+    suggestedAt: Date;
+    pet: {
+      slug: string;
+      displayName: string;
+      spritesheetUrl: string;
+      ownerId: string;
+      creditName: string | null;
+    };
+    request: {
+      query: string;
+      upvoteCount: number;
+      imageUrl: string | null;
+    };
+  }>
+> {
+  const rows = await db.execute<{
+    pet_id: string;
+    request_id: string;
+    similarity: number | null;
+    source: string;
+    suggested_at: Date;
+    pet_slug: string;
+    pet_display_name: string;
+    pet_spritesheet_url: string;
+    pet_owner_id: string;
+    pet_credit_name: string | null;
+    request_query: string;
+    request_upvote_count: number;
+    request_image_url: string | null;
+    request_image_review_status: string;
+  }>(drizzleSql`
+    SELECT
+      c.pet_id, c.request_id, c.similarity, c.source, c.suggested_at,
+      p.slug AS pet_slug,
+      p.display_name AS pet_display_name,
+      p.spritesheet_url AS pet_spritesheet_url,
+      p.owner_id AS pet_owner_id,
+      p.credit_name AS pet_credit_name,
+      r.query AS request_query,
+      r.upvote_count AS request_upvote_count,
+      r.image_url AS request_image_url,
+      r.image_review_status AS request_image_review_status
+    FROM pet_request_candidates c
+    JOIN submitted_pets p ON p.id = c.pet_id
+    JOIN pet_requests r ON r.id = c.request_id
+    WHERE c.status = 'pending'
+      AND p.status = 'approved'
+      AND r.status = 'open'
+    ORDER BY c.suggested_at DESC
+    LIMIT ${limit}
+  `);
+
+  return rows.rows.map((row) => ({
+    petId: row.pet_id,
+    requestId: row.request_id,
+    similarity: row.similarity,
+    source: row.source as CandidateSource,
+    suggestedAt: row.suggested_at,
+    pet: {
+      slug: row.pet_slug,
+      displayName: row.pet_display_name,
+      spritesheetUrl: row.pet_spritesheet_url,
+      ownerId: row.pet_owner_id,
+      creditName: row.pet_credit_name,
+    },
+    request: {
+      query: row.request_query,
+      upvoteCount: row.request_upvote_count,
+      imageUrl:
+        row.request_image_review_status === "approved"
+          ? row.request_image_url
+          : null,
+    },
+  }));
+}
+
+// Approve resolves a pending candidate into the canonical "fulfilled"
+// state on the request, and auto-rejects any other pending candidates
+// for the same request (only one pet can fulfill a request).
+//
+// Returns the request id, fulfilled pet id, and the owner of that pet
+// so the caller can grant badges / dispatch notifications without a
+// second lookup.
+export async function approveCandidate(args: {
+  petId: string;
+  requestId: string;
+  resolvedBy: string;
+}): Promise<
+  | {
+      ok: true;
+      petOwnerId: string;
+      petSlug: string;
+      petDisplayName: string;
+      requestQuery: string;
+      requesterId: string | null;
+    }
+  | { ok: false; reason: "not_found" | "not_pending" }
+> {
+  const candidate = await db.query.petRequestCandidates.findFirst({
+    where: and(
+      eq(schema.petRequestCandidates.petId, args.petId),
+      eq(schema.petRequestCandidates.requestId, args.requestId),
+    ),
+  });
+  if (!candidate) return { ok: false, reason: "not_found" };
+  if (candidate.status !== "pending")
+    return { ok: false, reason: "not_pending" };
+
+  const pet = await db.query.submittedPets.findFirst({
+    columns: { id: true, slug: true, displayName: true, ownerId: true },
+    where: eq(schema.submittedPets.id, args.petId),
+  });
+  if (!pet) return { ok: false, reason: "not_found" };
+
+  const request = await db.query.petRequests.findFirst({
+    columns: { id: true, query: true, requestedBy: true },
+    where: eq(schema.petRequests.id, args.requestId),
+  });
+  if (!request) return { ok: false, reason: "not_found" };
+
+  const now = new Date();
+
+  // Resolve this candidate → approved
+  await db
+    .update(schema.petRequestCandidates)
+    .set({
+      status: "approved",
+      resolvedAt: now,
+      resolvedBy: args.resolvedBy,
+    })
+    .where(
+      and(
+        eq(schema.petRequestCandidates.petId, args.petId),
+        eq(schema.petRequestCandidates.requestId, args.requestId),
+      ),
+    );
+
+  // Auto-reject siblings: any other pending candidate for the same
+  // request loses now that we picked a winner.
+  await db
+    .update(schema.petRequestCandidates)
+    .set({
+      status: "rejected",
+      resolvedAt: now,
+      resolvedBy: args.resolvedBy,
+      rejectionReason: "another_candidate_approved",
+    })
+    .where(
+      and(
+        eq(schema.petRequestCandidates.requestId, args.requestId),
+        eq(schema.petRequestCandidates.status, "pending"),
+      ),
+    );
+
+  // Mark the request fulfilled with the chosen pet.
+  await db
+    .update(schema.petRequests)
+    .set({
+      status: "fulfilled",
+      fulfilledPetSlug: pet.slug,
+      updatedAt: now,
+    })
+    .where(eq(schema.petRequests.id, args.requestId));
+
+  return {
+    ok: true,
+    petOwnerId: pet.ownerId,
+    petSlug: pet.slug,
+    petDisplayName: pet.displayName,
+    requestQuery: request.query,
+    requesterId: request.requestedBy,
+  };
+}
+
+export async function rejectCandidate(args: {
+  petId: string;
+  requestId: string;
+  resolvedBy: string;
+  reason?: string;
+}): Promise<{ ok: true } | { ok: false; reason: "not_found" | "not_pending" }> {
+  const candidate = await db.query.petRequestCandidates.findFirst({
+    columns: { petId: true, status: true },
+    where: and(
+      eq(schema.petRequestCandidates.petId, args.petId),
+      eq(schema.petRequestCandidates.requestId, args.requestId),
+    ),
+  });
+  if (!candidate) return { ok: false, reason: "not_found" };
+  if (candidate.status !== "pending")
+    return { ok: false, reason: "not_pending" };
+
+  await db
+    .update(schema.petRequestCandidates)
+    .set({
+      status: "rejected",
+      resolvedAt: new Date(),
+      resolvedBy: args.resolvedBy,
+      rejectionReason: args.reason ?? null,
+    })
+    .where(
+      and(
+        eq(schema.petRequestCandidates.petId, args.petId),
+        eq(schema.petRequestCandidates.requestId, args.requestId),
+      ),
+    );
+
+  return { ok: true };
+}
+
+// Lists pending candidates for a single user — used by /requests UI
+// to mark pets that are already submitted as candidates so the modal
+// can grey them out.
+export async function getCandidatesForOwner(
+  ownerId: string,
+): Promise<
+  Array<{ petId: string; requestId: string; status: CandidateStatus }>
+> {
+  const rows = await db.execute<{
+    pet_id: string;
+    request_id: string;
+    status: string;
+  }>(drizzleSql`
+    SELECT c.pet_id, c.request_id, c.status
+    FROM pet_request_candidates c
+    JOIN submitted_pets p ON p.id = c.pet_id
+    WHERE p.owner_id = ${ownerId}
+  `);
+  return rows.rows.map((row) => ({
+    petId: row.pet_id,
+    requestId: row.request_id,
+    status: row.status as CandidateStatus,
+  }));
+}

--- a/src/lib/submission-decisions.ts
+++ b/src/lib/submission-decisions.ts
@@ -183,6 +183,26 @@ async function runPostApprovalEffects(
     })();
   }
 
+  // Suggest matching open requests as candidates for admin review.
+  // Background only — never blocks the approve response. Failures
+  // are logged and swallowed; the admin can still create candidates
+  // manually from /admin/requests if the auto-pass missed something.
+  void (async () => {
+    try {
+      const { autoSuggestCandidates } = await import(
+        "@/lib/request-candidates"
+      );
+      const result = await autoSuggestCandidates(row.id);
+      if (result.inserted > 0) {
+        console.log(
+          `[${actor}] suggested ${result.inserted} request candidate(s) for ${row.slug}`,
+        );
+      }
+    } catch (e) {
+      console.error("request candidate suggest failed", e);
+    }
+  })();
+
   return row;
 }
 


### PR DESCRIPTION
## Summary
Creators get rewarded when their pet fulfills a community request. Two ways to surface a candidate:

- **Auto**: when a pet hits \`status='approved'\`, a background job runs cosine search (Gemini embeddings, threshold 0.70, top 5) against open requests and inserts pending candidates.
- **Manual**: \"I have a pet for this\" button on \`/requests\` opens a shadcn dialog with the user's approved pets to pick from.

Admin reviews from a new section on \`/admin/requests\`. Approve fulfills the request, auto-rejects sibling candidates, fires in-app notifications to both creator and requester, and sends locale-aware emails via Resend.

## What ships
- Schema: \`pet_request_candidates\` table (idempotent migration script)
- API: \`POST /api/pet-requests/:id/candidates\`, \`POST /api/admin/request-candidates\`, \`GET /api/my-pets/approved\`
- Background match job in \`runPostApprovalEffects\`
- Admin UI: candidate review section + approve/reject actions
- Public UI: \`ClaimRequestButton\` on every open request card
- Bell drawer: distinguishes \`role=creator\` vs \`role=requester\` payload
- Email templates: \`request-fulfilled-creator\` + \`request-fulfilled-requester\`
- Shadcn dialog primitive (rounded-2xl Petdex style)

## What does NOT ship (next PR)
- Badges + earning logic — \`approveCandidate\` returns enough context to add badge granting later
- OG image with badges
- gpt-image-2 badge generation script

## Test plan
- [x] tsc + bun run build pass locally
- [x] Migration applied to local DB (idempotent re-run safe)
- [ ] Submit pet matching an open request → check \`pet_request_candidates\` row
- [ ] Manual claim from /requests → row appears
- [ ] Admin approve → request \`fulfilled\`, both notifs fire, both emails fire
- [ ] Admin reject → candidate marked rejected, request stays open