### PR TITLE
feat(gallery): migrate filter bar to shadcn primitives

### DIFF
--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -14,7 +14,6 @@ import { track } from "@vercel/analytics";
 import {
   Check,
   CheckCircle2,
-  ChevronDown,
   Loader2,
   Plus,
   Search,
@@ -35,6 +34,28 @@ import { useHeaderState } from "@/components/header-state-provider";
 import { PetActionMenu } from "@/components/pet-action-menu";
 import { PetCardFooter } from "@/components/pet-card-footer";
 import { PetSprite } from "@/components/pet-sprite";
+import { Button } from "@/components/ui/button";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@/components/ui/input-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { Toggle } from "@/components/ui/toggle";
 
 type Facets = {
   kinds: Record<string, number>;
@@ -102,7 +123,6 @@ export function PetGallery({
   caughtSlugs,
   ads = [],
 }: PetGalleryProps) {
-  const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
   const [query, setQuery] = useState("");
   const trimmedQuery = query.trim();
   const [activeKinds, setActiveKinds] = useState<Set<PetKind>>(new Set());
@@ -192,14 +212,6 @@ export function PetGallery({
     }, 250);
     return () => window.clearTimeout(handle);
   }, [buildParams, trimmedQuery]);
-
-  useEffect(() => {
-    if (!mobileFiltersOpen) return;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = "";
-    };
-  }, [mobileFiltersOpen]);
 
   const loadMore = useCallback(async () => {
     if (nextCursor == null || loadingMore || loadingPage) return;
@@ -293,153 +305,88 @@ export function PetGallery({
         ) : null}
       </div>
 
-      {/* Unified control bar: search input takes full width, sort sits to the
- right, filter chips wrap below. Whole thing gets the same subtle
- shadow as the announcement modal so it reads as one cohesive
- surface and the search bar feels like a primary action. */}
-      <div className="space-y-3 rounded-3xl border border-black/[0.06] bg-surface px-3 py-3 shadow-[0_8px_24px_-12px_rgba(56,71,245,0.18)] md:px-4 md:py-4 dark:border-white/[0.06]">
+      {/* Unified control bar: search input takes full width, sort sits
+ to the right, filter chips wrap below. The whole surface gets the
+ same subtle elevation as the announcement modal so it reads as a
+ single primary action region. */}
+      <div className="rounded-3xl border border-black/[0.06] bg-surface p-3 shadow-[0_8px_24px_-12px_rgba(56,71,245,0.18)] md:p-4 dark:border-white/[0.06]">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-          <label className="relative block w-full flex-1">
-            <Search className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-4 size-4 text-muted-3" />
-            <input
+          <InputGroup className="h-11 flex-1 rounded-full bg-background/40">
+            <InputGroupAddon align="inline-start">
+              <Search className="size-4 text-muted-3" />
+            </InputGroupAddon>
+            <InputGroupInput
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               placeholder="Try 'cozy night programmer' or 'fierce dragon'"
-              className="h-11 w-full rounded-full border border-border-base bg-surface pr-10 pl-11 text-sm text-foreground outline-none transition placeholder:text-muted-3 focus:border-brand/60 focus:ring-2 focus:ring-brand/15"
+              aria-label="Search pets"
+              className="text-sm placeholder:text-muted-3"
             />
             {query.length > 0 ? (
-              <button
-                type="button"
-                onClick={() => setQuery("")}
-                aria-label="Clear search"
-                className="-translate-y-1/2 absolute top-1/2 right-3 grid size-6 place-items-center rounded-full text-muted-4 transition hover:bg-surface-muted hover:text-foreground"
-              >
-                <X className="size-3.5" />
-              </button>
+              <InputGroupAddon align="inline-end">
+                <button
+                  type="button"
+                  onClick={() => setQuery("")}
+                  aria-label="Clear search"
+                  className="grid size-6 place-items-center rounded-full text-muted-4 transition hover:bg-surface-muted hover:text-foreground"
+                >
+                  <X className="size-3.5" />
+                </button>
+              </InputGroupAddon>
             ) : null}
-          </label>
-          <div className="relative shrink-0">
-            <select
-              value={sort}
-              onChange={(e) => {
-                const next = e.target.value as SortKey;
-                track("sort_changed", { sort: next });
-                setSort(next);
-              }}
+          </InputGroup>
+
+          <Select
+            value={sort}
+            onValueChange={(next) => {
+              track("sort_changed", { sort: next });
+              setSort(next as SortKey);
+            }}
+          >
+            <SelectTrigger
               aria-label="Sort pets"
-              className="h-11 w-full cursor-pointer appearance-none rounded-full border border-border-base bg-surface pr-9 pl-4 text-sm text-foreground outline-none transition hover:border-border-strong focus:border-brand/60 focus:ring-2 focus:ring-brand/15 sm:w-auto sm:min-w-[160px]"
+              className="h-11 w-full shrink-0 rounded-full text-sm sm:w-auto sm:min-w-[160px]"
             >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent align="end">
               {(Object.entries(SORT_LABELS) as [SortKey, string][]).map(
                 ([key, label]) => (
-                  <option key={key} value={key}>
+                  <SelectItem key={key} value={key}>
                     Sort: {label}
-                  </option>
+                  </SelectItem>
                 ),
               )}
-            </select>
-            <ChevronDown className="-translate-y-1/2 pointer-events-none absolute top-1/2 right-3 size-4 text-muted-3" />
-          </div>
+            </SelectContent>
+          </Select>
         </div>
 
-        {/* Filter chips: kind + vibe in one continuous wrap row. Saves a
- whole horizontal label column and roughly half the height vs
- the previous two-row layout. */}
-        <div className="flex items-center gap-2 md:hidden">
-          <button
-            type="button"
-            onClick={() => setMobileFiltersOpen(true)}
-            className="inline-flex h-10 flex-1 items-center justify-center rounded-full border border-border-base bg-surface px-4 text-sm font-medium text-foreground transition hover:border-border-strong"
-          >
-            Filters
-            {activeFilterCount > 0 ? ` (${activeFilterCount})` : ""}
-          </button>
-          {filtersActive ? (
-            <button
-              type="button"
-              onClick={() => {
-                track("filters_cleared");
-                clearFilters();
-              }}
-              className="inline-flex h-10 items-center justify-center rounded-full border border-border-base bg-surface px-4 text-sm font-medium text-muted-2 transition hover:border-border-strong"
+        {/* Mobile: collapse all filter chips into a Sheet so the bar stays
+ short on phones. The chips themselves are reused inside the sheet
+ below to avoid divergent UIs across breakpoints. */}
+        <div className="mt-3 flex items-center gap-2 md:hidden">
+          <Sheet>
+            <SheetTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="petdex-pill"
+                  className="h-10 flex-1 px-4 text-sm font-medium text-foreground"
+                >
+                  Filters
+                  {activeFilterCount > 0 ? ` (${activeFilterCount})` : ""}
+                </Button>
+              }
+            />
+            <SheetContent
+              side="bottom"
+              className="max-h-[75dvh] overflow-y-auto"
             >
-              Clear
-            </button>
-          ) : null}
-        </div>
-
-        <div className="hidden flex-wrap gap-1.5 border-t border-black/[0.05] pt-3 md:flex dark:border-white/[0.05]">
-          <FilterChips
-            options={PET_KINDS}
-            counts={facets.kinds}
-            active={activeKinds}
-            onToggle={(v) => toggleKind(v as PetKind)}
-            tone="kind"
-          />
-          <FilterChips
-            options={PET_VIBES}
-            counts={facets.vibes}
-            active={activeVibes}
-            onToggle={(v) => toggleVibe(v as PetVibe)}
-            tone="vibe"
-          />
-        </div>
-        <div className="hidden flex-wrap gap-1.5 border-t border-black/[0.05] pt-3 md:flex dark:border-white/[0.05]">
-          <FilterChips
-            options={COLOR_FAMILIES}
-            counts={facets.colors}
-            active={activeColors}
-            onToggle={(v) => toggleColor(v as ColorFamily)}
-            tone="color"
-            dotColors={FAMILY_DOT}
-          />
-        </div>
-        <div className="hidden flex-wrap gap-1.5 border-t border-black/[0.05] pt-3 md:flex dark:border-white/[0.05]">
-          <FilterChips
-            options={facets.batches.map((batch) => batch.key)}
-            counts={Object.fromEntries(
-              facets.batches.map((batch) => [batch.key, batch.count]),
-            )}
-            labels={Object.fromEntries(
-              facets.batches.map((batch) => [batch.key, batch.label]),
-            )}
-            active={activeBatches}
-            onToggle={toggleBatch}
-            tone="batch"
-          />
-        </div>
-      </div>
-
-      {mobileFiltersOpen ? (
-        <div
-          className="fixed inset-0 z-50 md:hidden"
-          role="dialog"
-          aria-modal="true"
-          aria-label="Pet filters"
-        >
-          <button
-            type="button"
-            aria-label="Close filters"
-            onClick={() => setMobileFiltersOpen(false)}
-            className="absolute inset-0 bg-black/30 backdrop-blur-sm"
-          />
-          <div className="absolute inset-x-0 bottom-0 max-h-[75dvh] overflow-y-auto rounded-t-[28px] border border-border-base bg-background px-4 pt-4 pb-6 shadow-2xl">
-            <div className="mx-auto mb-4 h-1.5 w-14 rounded-full bg-black/10 dark:bg-white/10" />
-            <div className="flex items-center justify-between gap-3">
-              <p className="text-base font-semibold text-foreground">Filters</p>
-              <button
-                type="button"
-                onClick={() => setMobileFiltersOpen(false)}
-                className="inline-flex h-9 items-center justify-center rounded-full border border-border-base bg-surface px-4 text-sm font-medium text-muted-2"
-              >
-                Done
-              </button>
-            </div>
-            <div className="mt-4 space-y-4">
-              <div className="space-y-2">
-                <p className="font-mono text-[11px] tracking-[0.18em] text-muted-3 uppercase">
-                  Kind + vibe
-                </p>
-                <div className="flex flex-wrap gap-1.5">
+              <SheetHeader>
+                <SheetTitle>Filters</SheetTitle>
+              </SheetHeader>
+              <div className="space-y-5 px-4 pb-6">
+                <FilterGroup label="Type">
                   <FilterChips
                     options={PET_KINDS}
                     counts={facets.kinds}
@@ -447,6 +394,9 @@ export function PetGallery({
                     onToggle={(v) => toggleKind(v as PetKind)}
                     tone="kind"
                   />
+                </FilterGroup>
+                <Separator className="bg-border-base" />
+                <FilterGroup label="Vibe">
                   <FilterChips
                     options={PET_VIBES}
                     counts={facets.vibes}
@@ -454,13 +404,9 @@ export function PetGallery({
                     onToggle={(v) => toggleVibe(v as PetVibe)}
                     tone="vibe"
                   />
-                </div>
-              </div>
-              <div className="space-y-2">
-                <p className="font-mono text-[11px] tracking-[0.18em] text-muted-3 uppercase">
-                  Color
-                </p>
-                <div className="flex flex-wrap gap-1.5">
+                </FilterGroup>
+                <Separator className="bg-border-base" />
+                <FilterGroup label="Color">
                   <FilterChips
                     options={COLOR_FAMILIES}
                     counts={facets.colors}
@@ -469,52 +415,101 @@ export function PetGallery({
                     tone="color"
                     dotColors={FAMILY_DOT}
                   />
-                </div>
-              </div>
-              <div className="space-y-2">
-                <p className="font-mono text-[11px] tracking-[0.18em] text-muted-3 uppercase">
-                  Batch
-                </p>
-                <div className="flex flex-wrap gap-1.5">
-                  <FilterChips
-                    options={facets.batches.map((batch) => batch.key)}
-                    counts={Object.fromEntries(
-                      facets.batches.map((batch) => [batch.key, batch.count]),
-                    )}
-                    labels={Object.fromEntries(
-                      facets.batches.map((batch) => [batch.key, batch.label]),
-                    )}
-                    active={activeBatches}
-                    onToggle={toggleBatch}
-                    tone="batch"
-                  />
-                </div>
-              </div>
-              <div className="flex items-center gap-2 pt-2">
-                {filtersActive ? (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      track("filters_cleared");
-                      clearFilters();
-                    }}
-                    className="inline-flex h-10 flex-1 items-center justify-center rounded-full border border-border-base bg-surface px-4 text-sm font-medium text-muted-2"
-                  >
-                    Clear all
-                  </button>
+                </FilterGroup>
+                {facets.batches.length > 0 ? (
+                  <>
+                    <Separator className="bg-border-base" />
+                    <FilterGroup label="Era">
+                      <FilterChips
+                        options={facets.batches.map((batch) => batch.key)}
+                        counts={Object.fromEntries(
+                          facets.batches.map((batch) => [
+                            batch.key,
+                            batch.count,
+                          ]),
+                        )}
+                        labels={Object.fromEntries(
+                          facets.batches.map((batch) => [
+                            batch.key,
+                            batch.label,
+                          ]),
+                        )}
+                        active={activeBatches}
+                        onToggle={toggleBatch}
+                        tone="batch"
+                      />
+                    </FilterGroup>
+                  </>
                 ) : null}
-                <button
-                  type="button"
-                  onClick={() => setMobileFiltersOpen(false)}
-                  className="inline-flex h-10 flex-1 items-center justify-center rounded-full bg-inverse px-4 text-sm font-medium text-on-inverse"
-                >
-                  Show pets
-                </button>
               </div>
-            </div>
-          </div>
+            </SheetContent>
+          </Sheet>
+          {filtersActive ? (
+            <Button
+              type="button"
+              variant="petdex-pill"
+              onClick={() => {
+                track("filters_cleared");
+                clearFilters();
+              }}
+              className="h-10 px-4 text-sm font-medium text-muted-2"
+            >
+              Clear
+            </Button>
+          ) : null}
         </div>
-      ) : null}
+
+        {/* Desktop: filters grouped by category with Type · Vibe · Color
+ · Era separators. Eyebrow labels mark each cluster for scan-
+ ability without losing the wrap-row density. */}
+        <div className="mt-3 hidden flex-col gap-3 border-t border-black/[0.05] pt-3 md:flex dark:border-white/[0.05]">
+          <FilterRow label="Type">
+            <FilterChips
+              options={PET_KINDS}
+              counts={facets.kinds}
+              active={activeKinds}
+              onToggle={(v) => toggleKind(v as PetKind)}
+              tone="kind"
+            />
+            <span aria-hidden className="px-1 text-muted-4">
+              ·
+            </span>
+            <FilterChips
+              options={PET_VIBES}
+              counts={facets.vibes}
+              active={activeVibes}
+              onToggle={(v) => toggleVibe(v as PetVibe)}
+              tone="vibe"
+            />
+          </FilterRow>
+          <FilterRow label="Color">
+            <FilterChips
+              options={COLOR_FAMILIES}
+              counts={facets.colors}
+              active={activeColors}
+              onToggle={(v) => toggleColor(v as ColorFamily)}
+              tone="color"
+              dotColors={FAMILY_DOT}
+            />
+          </FilterRow>
+          {facets.batches.length > 0 ? (
+            <FilterRow label="Era">
+              <FilterChips
+                options={facets.batches.map((batch) => batch.key)}
+                counts={Object.fromEntries(
+                  facets.batches.map((batch) => [batch.key, batch.count]),
+                )}
+                labels={Object.fromEntries(
+                  facets.batches.map((batch) => [batch.key, batch.label]),
+                )}
+                active={activeBatches}
+                onToggle={toggleBatch}
+                tone="batch"
+              />
+            </FilterRow>
+          ) : null}
+        </div>
+      </div>
 
       {searchMode === "vibe" && pets.length > 0 ? (
         <div className="flex items-center gap-2 rounded-2xl border border-brand-light/35 bg-brand-tint/70 px-4 py-2.5 text-sm text-muted-1">
@@ -617,19 +612,21 @@ function FilterChips({
         const isActive = active.has(value);
         const dotClass =
           tone === "kind"
-            ? "bg-[#0a0a0a]/70"
+            ? "bg-[#0a0a0a]/70 group-aria-pressed/toggle:bg-on-inverse/70"
             : tone === "vibe"
-              ? "bg-brand"
+              ? "bg-brand group-aria-pressed/toggle:bg-on-inverse"
               : tone === "color"
                 ? ""
-                : "bg-sky-500";
+                : "bg-sky-500 group-aria-pressed/toggle:bg-on-inverse";
         const dotColor = dotColors?.[value];
         const label = labels?.[value] ?? value;
         return (
-          <button
+          <Toggle
             key={value}
-            type="button"
-            onClick={() => {
+            variant="chip"
+            size="chip"
+            pressed={isActive}
+            onPressedChange={() => {
               track("filter_toggled", {
                 tone,
                 value,
@@ -637,33 +634,56 @@ function FilterChips({
               });
               onToggle(value);
             }}
-            aria-pressed={isActive}
-            className={`inline-flex h-7 items-center gap-1.5 rounded-full border px-2.5 text-[11px] capitalize transition ${
-              isActive
-                ? "border-inverse bg-inverse text-on-inverse"
-                : "border-border-base bg-surface text-muted-2 hover:border-border-strong"
-            }`}
+            className={tone === "batch" ? "" : "capitalize"}
           >
-            {!isActive || dotColor ? (
-              <span
-                className={`size-1.5 shrink-0 rounded-full ${dotClass}`}
-                style={dotColor ? { backgroundColor: dotColor } : undefined}
-              />
-            ) : null}
-            <span className={tone === "batch" ? "" : "capitalize"}>
-              {label}
-            </span>
             <span
-              className={`font-mono text-[9px] ${
-                isActive ? "text-on-inverse/60" : "text-muted-3"
-              }`}
-            >
+              className={`size-1.5 shrink-0 rounded-full ${dotClass}`}
+              style={dotColor ? { backgroundColor: dotColor } : undefined}
+            />
+            <span>{label}</span>
+            <span className="font-mono text-[9px] text-muted-3 group-aria-pressed/toggle:text-on-inverse/60">
               {count}
             </span>
-          </button>
+          </Toggle>
         );
       })}
     </>
+  );
+}
+
+function FilterRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5 sm:flex-row sm:items-start">
+      <span className="shrink-0 pt-1.5 font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase sm:w-12">
+        {label}
+      </span>
+      <div className="flex flex-1 flex-wrap items-center gap-1.5">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function FilterGroup({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-2">
+      <p className="font-mono text-[11px] tracking-[0.18em] text-muted-3 uppercase">
+        {label}
+      </p>
+      <div className="flex flex-wrap gap-1.5">{children}</div>
+    </div>
   );
 }
 

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,52 @@
+import { mergeProps } from "@base-ui/react/merge-props";
+import { useRender } from "@base-ui/react/use-render";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Badge({
+  className,
+  variant = "default",
+  render,
+  ...props
+}: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return useRender({
+    defaultTagName: "span",
+    props: mergeProps<"span">(
+      {
+        className: cn(badgeVariants({ variant }), className),
+      },
+      props,
+    ),
+    render,
+    state: {
+      slot: "badge",
+      variant,
+    },
+  });
+}
+
+export { Badge, badgeVariants };

--- a/src/components/ui/input-group.tsx
+++ b/src/components/ui/input-group.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import type * as React from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-group"
+      role="group"
+      className={cn(
+        "group/input-group relative flex h-8 w-full min-w-0 items-center rounded-full border border-input transition-colors outline-none in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-disabled:bg-input/50 has-disabled:opacity-50 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-1 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-1 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>textarea]:h-auto dark:bg-input/30 dark:has-disabled:bg-input/80 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const inputGroupAddonVariants = cva(
+  "flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-xs font-medium text-muted-foreground select-none group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-none [&>svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      align: {
+        "inline-start":
+          "order-first pl-2 has-[>button]:ml-[-0.3rem] has-[>kbd]:ml-[-0.15rem]",
+        "inline-end":
+          "order-last pr-2 has-[>button]:mr-[-0.3rem] has-[>kbd]:mr-[-0.15rem]",
+        "block-start":
+          "order-first w-full justify-start px-2.5 pt-2 group-has-[>input]/input-group:pt-2 [.border-b]:pb-2",
+        "block-end":
+          "order-last w-full justify-start px-2.5 pb-2 group-has-[>input]/input-group:pb-2 [.border-t]:pt-2",
+      },
+    },
+    defaultVariants: {
+      align: "inline-start",
+    },
+  },
+);
+
+function InputGroupAddon({
+  className,
+  align = "inline-start",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof inputGroupAddonVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="input-group-addon"
+      data-align={align}
+      className={cn(inputGroupAddonVariants({ align }), className)}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest("button")) {
+          return;
+        }
+        e.currentTarget.parentElement?.querySelector("input")?.focus();
+      }}
+      {...props}
+    />
+  );
+}
+
+const inputGroupButtonVariants = cva(
+  "flex items-center gap-2 text-xs shadow-none",
+  {
+    variants: {
+      size: {
+        xs: "h-6 gap-1 rounded-none px-1.5 [&>svg:not([class*='size-'])]:size-3.5",
+        sm: "gap-1",
+        "icon-xs": "size-6 rounded-none p-0 has-[>svg]:p-0",
+        "icon-sm": "size-7 p-0 has-[>svg]:p-0",
+      },
+    },
+    defaultVariants: {
+      size: "xs",
+    },
+  },
+);
+
+function InputGroupButton({
+  className,
+  type = "button",
+  variant = "ghost",
+  size = "xs",
+  ...props
+}: Omit<React.ComponentProps<typeof Button>, "size" | "type"> &
+  VariantProps<typeof inputGroupButtonVariants> & {
+    type?: "button" | "submit" | "reset";
+  }) {
+  return (
+    <Button
+      type={type}
+      data-size={size}
+      variant={variant}
+      className={cn(inputGroupButtonVariants({ size }), className)}
+      {...props}
+    />
+  );
+}
+
+function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-2 text-xs text-muted-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function InputGroupInput({
+  className,
+  ...props
+}: React.ComponentProps<"input">) {
+  return (
+    <Input
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function InputGroupTextarea({
+  className,
+  ...props
+}: React.ComponentProps<"textarea">) {
+  return (
+    <Textarea
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 resize-none rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+  InputGroupText,
+  InputGroupTextarea,
+};

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import type * as React from "react";
+
+import { Input as InputPrimitive } from "@base-ui/react/input";
+
+import { cn } from "@/lib/utils";
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <InputPrimitive
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-8 w-full min-w-0 rounded-full border border-input bg-transparent px-2.5 py-1 text-xs transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-xs file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 md:text-xs dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import type * as React from "react";
+
+import { Select as SelectPrimitive } from "@base-ui/react/select";
+import { CaretDownIcon, CaretUpIcon, CheckIcon } from "@phosphor-icons/react";
+
+import { cn } from "@/lib/utils";
+
+const Select = SelectPrimitive.Root;
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("flex flex-1 text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-full border border-input bg-transparent py-2 pr-2 pl-2.5 text-xs whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-none *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={
+          <CaretDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn(
+            "relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-2xl bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className,
+          )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-2 py-2 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-xl py-2 pr-8 pl-2 text-xs outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className,
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <CaretUpIcon />
+    </SelectPrimitive.ScrollUpArrow>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <CaretDownIcon />
+    </SelectPrimitive.ScrollDownArrow>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  ...props
+}: SeparatorPrimitive.Props) {
+  return (
+    <SeparatorPrimitive
+      data-slot="separator"
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import type * as React from "react";
+
+import { Dialog as SheetPrimitive } from "@base-ui/react/dialog";
+import { XIcon } from "@phosphor-icons/react";
+
+import { cn } from "@/lib/utils";
+
+import { Button } from "@/components/ui/button";
+
+function Sheet({ ...props }: SheetPrimitive.Root.Props) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />;
+}
+
+function SheetTrigger({ ...props }: SheetPrimitive.Trigger.Props) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
+}
+
+function SheetClose({ ...props }: SheetPrimitive.Close.Props) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
+}
+
+function SheetPortal({ ...props }: SheetPrimitive.Portal.Props) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
+}
+
+function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
+  return (
+    <SheetPrimitive.Backdrop
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/10 text-xs/relaxed transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: SheetPrimitive.Popup.Props & {
+  side?: "top" | "right" | "bottom" | "left";
+  showCloseButton?: boolean;
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Popup
+        data-slot="sheet-content"
+        data-side={side}
+        className={cn(
+          "fixed z-50 flex flex-col bg-popover bg-clip-padding text-xs/relaxed text-popover-foreground shadow-lg transition duration-200 ease-in-out data-ending-style:opacity-0 data-starting-style:opacity-0 data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=bottom]:data-ending-style:translate-y-[2.5rem] data-[side=bottom]:data-starting-style:translate-y-[2.5rem] data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=left]:data-ending-style:translate-x-[-2.5rem] data-[side=left]:data-starting-style:translate-x-[-2.5rem] data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=right]:data-ending-style:translate-x-[2.5rem] data-[side=right]:data-starting-style:translate-x-[2.5rem] data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=top]:data-ending-style:translate-y-[-2.5rem] data-[side=top]:data-starting-style:translate-y-[-2.5rem] data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close
+            data-slot="sheet-close"
+            render={
+              <Button
+                variant="ghost"
+                className="absolute top-3 right-3"
+                size="icon-sm"
+              />
+            }
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Popup>
+    </SheetPortal>
+  );
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-0.5 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetTitle({ className, ...props }: SheetPrimitive.Title.Props) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-sm font-medium text-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: SheetPrimitive.Description.Props) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-xs/relaxed text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+};

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-none border border-input bg-transparent px-2.5 py-2 text-xs transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 md:text-xs dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const toggleVariants = cva(
+  "group/toggle inline-flex items-center justify-center gap-1 rounded-full text-xs font-medium whitespace-nowrap transition-all outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted data-[state=on]:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline: "border border-input bg-transparent hover:bg-muted",
+        // Petdex filter chip — outline by default, fills to inverse on
+        // active. base-ui Toggle exposes both data-[state=on] and the
+        // ARIA aria-pressed attribute, so styling either keeps screen
+        // readers and keyboard nav happy.
+        chip: "border border-border-base bg-surface text-muted-2 hover:border-border-strong hover:bg-surface hover:text-foreground aria-pressed:border-inverse aria-pressed:bg-inverse aria-pressed:text-on-inverse aria-pressed:hover:bg-inverse-hover data-[state=on]:border-inverse data-[state=on]:bg-inverse data-[state=on]:text-on-inverse data-[state=on]:hover:bg-inverse-hover",
+      },
+      size: {
+        default:
+          "h-8 min-w-8 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        sm: "h-7 min-w-7 px-2.5 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5",
+        lg: "h-9 min-w-9 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        chip: "h-7 px-2.5 text-[11px]",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function Toggle({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: TogglePrimitive.Props & VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Toggle, toggleVariants };


### PR DESCRIPTION
## Summary
Search input, sort dropdown, and filter chips on the home gallery now use shadcn primitives wired to the existing Petdex token system (\`bg-surface\`, \`bg-inverse\`, \`text-on-inverse\`, \`border-border-base\`, \`bg-brand-tint\`).

- **Search**: \`InputGroup\` + \`InputGroupAddon\` (icon prefix + clear button)
- **Sort**: \`Select\` (base-ui) replacing native \`<select>\`. Rounded-2xl animated popover.
- **Chips**: \`Toggle variant='chip'\` replaces bespoke \`<button>\` — pressed/hover/focus states come from one cva block.
- **Mobile**: \`Sheet side='bottom'\` replaces the custom fixed modal with manual click-outside and body-lock.
- **Layout**: filter rows grouped by Type · Vibe · Color · Era with monospace eyebrow labels.

Behavior preserved: state shape, analytics events (\`filter_toggled\`, \`sort_changed\`, \`gallery_searched\`, etc.), and search debounce all untouched.

## Tokens
All chips/buttons/popovers use existing Petdex tokens:
- \`bg-surface\`, \`bg-surface-muted\`, \`bg-inverse\`, \`text-on-inverse\`, \`text-muted-2/3/4\`
- \`border-border-base\`, \`border-border-strong\`
- \`bg-brand-tint\`, \`bg-brand-tint-dark\` for color-family dots
- shadcn semantic tokens (\`bg-popover\`, \`bg-muted\`, \`text-foreground\`) already aliased to OKLCH brand palette in globals.css

## Test plan
- [x] tsc + bun run build pass
- [x] Smoke test: homepage renders 200
- [ ] Visual: search clears with X, sort animates, chips fill black on press
- [ ] Mobile: filters opens bottom sheet with separators between groups