### PR TITLE
feat(ads): allow campaign edits

### DIFF
--- a/src/app/api/ads/[id]/route.ts
+++ b/src/app/api/ads/[id]/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+
+import { auth } from "@clerk/nextjs/server";
+
+import { updateOwnedAdCampaignCreative } from "@/lib/ads/queries";
+import { validateAdCampaignUpdateInput } from "@/lib/ads/validation";
+import { adCampaignEditRatelimit } from "@/lib/ratelimit";
+import { requireSameOrigin } from "@/lib/same-origin";
+
+export const runtime = "nodejs";
+
+type Params = { id: string };
+
+export async function PATCH(
+  req: Request,
+  ctx: { params: Promise<Params> },
+): Promise<Response> {
+  const csrf = requireSameOrigin(req);
+  if (csrf) return csrf;
+
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await ctx.params;
+  const lim = await adCampaignEditRatelimit.limit(`${userId}:${id}`);
+  if (!lim.success) {
+    return NextResponse.json(
+      { error: "rate_limited", retryAfter: lim.reset },
+      { status: 429 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const parsed = validateAdCampaignUpdateInput(body);
+  if (!parsed.ok) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+
+  const result = await updateOwnedAdCampaignCreative({
+    id,
+    userId,
+    ...parsed.value,
+  });
+
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: result.error },
+      { status: result.error === "not_found" ? 404 : 400 },
+    );
+  }
+
+  return NextResponse.json({ ok: true, campaign: result.campaign });
+}

--- a/src/components/ads/ad-campaign-edit-dialog.tsx
+++ b/src/components/ads/ad-campaign-edit-dialog.tsx
@@ -1,0 +1,452 @@
+"use client";
+
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+
+import { Loader2, Upload } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import type { AdvertiserCampaign } from "@/lib/ads/queries";
+
+type EditableCampaign = Pick<
+  AdvertiserCampaign,
+  | "id"
+  | "title"
+  | "description"
+  | "imageUrl"
+  | "destinationUrl"
+  | "utmSource"
+  | "utmMedium"
+  | "utmCampaign"
+  | "utmTerm"
+  | "utmContent"
+>;
+
+type SaveState =
+  | { kind: "idle" }
+  | { kind: "uploading" }
+  | { kind: "saving" }
+  | { kind: "error"; message: string };
+
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+
+export function AdCampaignEditDialog({
+  campaign,
+  triggerLabel,
+}: {
+  campaign: EditableCampaign;
+  triggerLabel: string;
+}) {
+  const t = useTranslations("advertise.dashboard.edit");
+  const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState(campaign.title);
+  const [description, setDescription] = useState(campaign.description);
+  const [destinationUrl, setDestinationUrl] = useState(campaign.destinationUrl);
+  const [utmSource, setUtmSource] = useState(campaign.utmSource ?? "");
+  const [utmMedium, setUtmMedium] = useState(campaign.utmMedium ?? "");
+  const [utmCampaign, setUtmCampaign] = useState(campaign.utmCampaign ?? "");
+  const [utmTerm, setUtmTerm] = useState(campaign.utmTerm ?? "");
+  const [utmContent, setUtmContent] = useState(campaign.utmContent ?? "");
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [uploadedImageUrl, setUploadedImageUrl] = useState<string | null>(null);
+  const [state, setState] = useState<SaveState>({ kind: "idle" });
+
+  const isBusy = state.kind === "uploading" || state.kind === "saving";
+
+  useEffect(() => {
+    if (!imageFile) {
+      setPreviewUrl(null);
+      return;
+    }
+    const nextPreviewUrl = URL.createObjectURL(imageFile);
+    setPreviewUrl(nextPreviewUrl);
+    return () => URL.revokeObjectURL(nextPreviewUrl);
+  }, [imageFile]);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setState({ kind: "idle" });
+
+    try {
+      let nextImageUrl = uploadedImageUrl;
+      if (imageFile && !nextImageUrl) {
+        if (imageFile.size > MAX_IMAGE_BYTES) {
+          setState({ kind: "error", message: t("errors.imageTooLarge") });
+          return;
+        }
+        setState({ kind: "uploading" });
+        nextImageUrl = await uploadImage(imageFile);
+        setUploadedImageUrl(nextImageUrl);
+      }
+
+      const patch = buildPatch({
+        campaign,
+        title,
+        description,
+        destinationUrl,
+        imageUrl: nextImageUrl ?? campaign.imageUrl,
+        utmSource,
+        utmMedium,
+        utmCampaign,
+        utmTerm,
+        utmContent,
+      });
+
+      if (Object.keys(patch).length === 0) {
+        setState({ kind: "error", message: t("errors.nothingChanged") });
+        return;
+      }
+
+      setState({ kind: "saving" });
+      const res = await fetch(`/api/ads/${campaign.id}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(patch),
+      });
+      const data = (await res.json()) as { error?: string };
+      if (!res.ok) {
+        throw new Error(mapError(data.error, t));
+      }
+
+      setOpen(false);
+      setImageFile(null);
+      setUploadedImageUrl(null);
+      setState({ kind: "idle" });
+      router.refresh();
+    } catch (error) {
+      setState({
+        kind: "error",
+        message: error instanceof Error ? error.message : t("errors.network"),
+      });
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="inline-flex h-9 items-center justify-center rounded-full border border-border-base bg-background px-4 text-sm font-medium text-foreground transition hover:border-brand/60 hover:text-brand"
+      >
+        {triggerLabel}
+      </button>
+      {open ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/20 p-4 backdrop-blur-sm">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={`edit-ad-${campaign.id}`}
+            className="max-h-[90dvh] w-full max-w-3xl overflow-y-auto rounded-[2rem] border border-border-base bg-surface p-5 shadow-2xl shadow-blue-950/15 md:p-6"
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2
+                  id={`edit-ad-${campaign.id}`}
+                  className="text-2xl font-semibold tracking-tight text-foreground"
+                >
+                  {t("title")}
+                </h2>
+                <p className="mt-2 max-w-xl text-sm leading-6 text-muted-2">
+                  {t("body")}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="rounded-full px-3 py-1.5 text-sm text-muted-2 transition hover:bg-background hover:text-foreground"
+              >
+                {t("cancel")}
+              </button>
+            </div>
+
+            <form
+              onSubmit={(event) => void handleSubmit(event)}
+              className="mt-5 grid gap-5 md:grid-cols-[1fr_220px]"
+            >
+              <div className="space-y-4">
+                <Field
+                  label={t("titleLabel")}
+                  name="title"
+                  value={title}
+                  maxLength={80}
+                  required
+                  onChange={setTitle}
+                />
+                <label>
+                  <span className="text-sm font-medium text-foreground">
+                    {t("descriptionLabel")}
+                  </span>
+                  <textarea
+                    value={description}
+                    onChange={(event) => setDescription(event.target.value)}
+                    maxLength={180}
+                    required
+                    rows={4}
+                    className="mt-2 w-full rounded-2xl border border-border-base bg-background px-4 py-3 text-sm text-foreground outline-none transition placeholder:text-muted-3 focus:border-brand/60 focus:ring-2 focus:ring-brand/15"
+                  />
+                </label>
+                <Field
+                  label={t("destinationUrlLabel")}
+                  name="destinationUrl"
+                  type="url"
+                  value={destinationUrl}
+                  required
+                  onChange={setDestinationUrl}
+                />
+
+                <details className="rounded-2xl border border-border-base bg-background p-4">
+                  <summary className="cursor-pointer text-sm font-medium text-foreground">
+                    {t("utmTitle")}
+                  </summary>
+                  <p className="mt-2 text-sm leading-6 text-muted-2">
+                    {t("utmHelp")}
+                  </p>
+                  <div className="mt-4 grid gap-4 md:grid-cols-2">
+                    <Field
+                      label="utm_source"
+                      name="utmSource"
+                      value={utmSource}
+                      onChange={setUtmSource}
+                    />
+                    <Field
+                      label="utm_medium"
+                      name="utmMedium"
+                      value={utmMedium}
+                      onChange={setUtmMedium}
+                    />
+                    <Field
+                      label="utm_campaign"
+                      name="utmCampaign"
+                      value={utmCampaign}
+                      onChange={setUtmCampaign}
+                    />
+                    <Field
+                      label="utm_term"
+                      name="utmTerm"
+                      value={utmTerm}
+                      onChange={setUtmTerm}
+                    />
+                    <Field
+                      label="utm_content"
+                      name="utmContent"
+                      value={utmContent}
+                      onChange={setUtmContent}
+                    />
+                  </div>
+                </details>
+
+                <div>
+                  <span className="text-sm font-medium text-foreground">
+                    {t("imageLabel")}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    className="mt-2 flex w-full items-center justify-center gap-2 rounded-2xl border border-dashed border-border-base bg-background px-4 py-6 text-sm text-muted-2 transition hover:border-brand/60 hover:text-foreground"
+                  >
+                    <Upload className="size-4" />
+                    {imageFile ? imageFile.name : t("imageCta")}
+                  </button>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/png,image/jpeg,image/webp"
+                    className="sr-only"
+                    onChange={(event) => {
+                      setImageFile(event.target.files?.[0] ?? null);
+                      setUploadedImageUrl(null);
+                    }}
+                  />
+                  <p className="mt-2 text-xs text-muted-3">{t("imageHelp")}</p>
+                </div>
+
+                {state.kind === "error" ? (
+                  <p className="rounded-2xl bg-chip-danger-bg p-3 text-sm text-chip-danger-fg">
+                    {state.message}
+                  </p>
+                ) : null}
+
+                <div className="flex flex-wrap gap-3">
+                  <button
+                    type="submit"
+                    disabled={isBusy}
+                    className="inline-flex h-11 items-center justify-center gap-2 rounded-full bg-inverse px-5 text-sm font-medium text-on-inverse transition hover:bg-inverse-hover disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {isBusy ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : null}
+                    {state.kind === "uploading"
+                      ? t("uploading")
+                      : state.kind === "saving"
+                        ? t("saving")
+                        : t("save")}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setOpen(false)}
+                    className="inline-flex h-11 items-center justify-center rounded-full border border-border-base bg-background px-5 text-sm font-medium text-foreground transition hover:border-border-strong"
+                  >
+                    {t("cancel")}
+                  </button>
+                </div>
+              </div>
+
+              <aside className="rounded-2xl border border-border-base bg-background p-3">
+                <p className="mb-3 font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
+                  {t("currentImage")}
+                </p>
+                <div className="relative aspect-square overflow-hidden rounded-xl border border-border-base bg-surface">
+                  <Image
+                    src={previewUrl ?? uploadedImageUrl ?? campaign.imageUrl}
+                    alt=""
+                    fill
+                    sizes="220px"
+                    className="object-cover"
+                    unoptimized={Boolean(previewUrl)}
+                  />
+                </div>
+                <div className="mt-4 rounded-xl bg-surface p-3">
+                  <p className="font-mono text-[10px] tracking-[0.16em] text-muted-3 uppercase">
+                    Sponsored preview
+                  </p>
+                  <h3 className="mt-2 text-lg font-semibold tracking-tight text-foreground">
+                    {title || campaign.title}
+                  </h3>
+                  <p className="mt-2 text-sm leading-5 text-muted-2">
+                    {description || campaign.description}
+                  </p>
+                </div>
+              </aside>
+            </form>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function Field({
+  label,
+  name,
+  type = "text",
+  value,
+  required,
+  maxLength,
+  onChange,
+}: {
+  label: string;
+  name: string;
+  type?: string;
+  value: string;
+  required?: boolean;
+  maxLength?: number;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <label>
+      <span className="text-sm font-medium text-foreground">{label}</span>
+      <input
+        name={name}
+        type={type}
+        required={required}
+        maxLength={maxLength}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="mt-2 h-11 w-full rounded-full border border-border-base bg-background px-4 text-sm text-foreground outline-none transition placeholder:text-muted-3 focus:border-brand/60 focus:ring-2 focus:ring-brand/15"
+      />
+    </label>
+  );
+}
+
+function nullableText(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function buildPatch({
+  campaign,
+  title,
+  description,
+  imageUrl,
+  destinationUrl,
+  utmSource,
+  utmMedium,
+  utmCampaign,
+  utmTerm,
+  utmContent,
+}: {
+  campaign: EditableCampaign;
+  title: string;
+  description: string;
+  imageUrl: string;
+  destinationUrl: string;
+  utmSource: string;
+  utmMedium: string;
+  utmCampaign: string;
+  utmTerm: string;
+  utmContent: string;
+}) {
+  const patch: Record<string, string | null> = {};
+  if (title !== campaign.title) patch.title = title;
+  if (description !== campaign.description) patch.description = description;
+  if (imageUrl !== campaign.imageUrl) patch.imageUrl = imageUrl;
+  if (destinationUrl !== campaign.destinationUrl) {
+    patch.destinationUrl = destinationUrl;
+  }
+  const utmValues = {
+    utmSource: nullableText(utmSource),
+    utmMedium: nullableText(utmMedium),
+    utmCampaign: nullableText(utmCampaign),
+    utmTerm: nullableText(utmTerm),
+    utmContent: nullableText(utmContent),
+  };
+  for (const [key, value] of Object.entries(utmValues)) {
+    if (value !== campaign[key as keyof EditableCampaign]) {
+      patch[key] = value;
+    }
+  }
+  return patch;
+}
+
+function mapError(
+  error: string | undefined,
+  t: ReturnType<typeof useTranslations>,
+): string {
+  if (error === "nothing_changed" || error === "no_edit_fields") {
+    return t("errors.nothingChanged");
+  }
+  if (error === "image_url_invalid") return t("errors.imageInvalid");
+  if (error === "destination_url_invalid")
+    return t("errors.destinationInvalid");
+  if (error === "title_required") return t("errors.titleRequired");
+  if (error === "description_required") return t("errors.descriptionRequired");
+  return t("errors.submitFailed");
+}
+
+async function uploadImage(file: File): Promise<string> {
+  const presignRes = await fetch("/api/ads/image/presign", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ contentType: file.type, size: file.size }),
+  });
+  const presignData = (await presignRes.json()) as {
+    uploadUrl?: string;
+    publicUrl?: string;
+    error?: string;
+  };
+  if (!presignRes.ok || !presignData.uploadUrl || !presignData.publicUrl) {
+    throw new Error(presignData.error ?? "Upload failed.");
+  }
+
+  const putRes = await fetch(presignData.uploadUrl, {
+    method: "PUT",
+    headers: { "content-type": file.type },
+    body: file,
+  });
+  if (!putRes.ok) throw new Error("Image upload failed.");
+  return presignData.publicUrl;
+}

--- a/src/components/ads/ad-dashboard.tsx
+++ b/src/components/ads/ad-dashboard.tsx
@@ -8,6 +8,7 @@ import { formatUsd } from "@/lib/ads/packages";
 import type { AdvertiserCampaign } from "@/lib/ads/queries";
 
 import { AdAnalyticsTabs } from "@/components/ads/ad-analytics-tabs";
+import { AdCampaignEditDialog } from "@/components/ads/ad-campaign-edit-dialog";
 
 export async function AdDashboard({
   campaigns,
@@ -45,6 +46,7 @@ export async function AdDashboard({
         const remaining = Math.max(campaign.packageViews - served, 0);
         const progress = Math.round((served / campaign.packageViews) * 100);
         const ctr = served > 0 ? (campaign.clicks / served) * 100 : 0;
+        const editable = campaign.status !== "deleted" && !campaign.deletedAt;
         return (
           <article
             key={campaign.id}
@@ -153,6 +155,12 @@ export async function AdDashboard({
                   <span>
                     {t("activated", { date: formatDate(campaign.activatedAt) })}
                   </span>
+                ) : null}
+                {editable ? (
+                  <AdCampaignEditDialog
+                    campaign={campaign}
+                    triggerLabel={t("editCreative")}
+                  />
                 ) : null}
               </div>
             </div>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -210,6 +210,7 @@
       "title": "Your Petdex campaigns",
       "body": "Track campaign status, prepaid impression delivery, and remaining inventory for every sponsored card you have submitted.",
       "newCampaign": "Buy another campaign",
+      "editCreative": "Edit creative",
       "progress": "Delivery",
       "destination": "Destination URL",
       "created": "Created {date}",
@@ -230,6 +231,34 @@
         "title": "Launch your first sponsored card",
         "body": "Submit a creative, choose a prepaid impression package, and start reaching developers after Stripe confirms payment.",
         "cta": "Create campaign"
+      },
+      "edit": {
+        "title": "Edit campaign",
+        "body": "Change the creative, destination, or tracking fields. Active campaign edits go live immediately and remain subject to Petdex ad policies.",
+        "titleLabel": "Ad title",
+        "descriptionLabel": "Description",
+        "destinationUrlLabel": "Destination URL",
+        "imageLabel": "Ad image",
+        "imageCta": "Upload replacement creative",
+        "imageHelp": "PNG, JPG, or WebP. Max 10 MB.",
+        "currentImage": "Preview",
+        "save": "Save changes",
+        "saving": "Saving campaign",
+        "uploading": "Uploading image",
+        "cancel": "Cancel",
+        "utmTitle": "Custom UTM settings",
+        "utmHelp": "Leave fields blank to clear them. If utm_source is blank, Petdex adds utm_source=petdex to clicks.",
+        "errors": {
+          "imageTooLarge": "Image must be 10 MB or smaller.",
+          "nothingChanged": "Change at least one field before saving.",
+          "submitFailed": "Could not update the campaign.",
+          "uploadFailed": "Image upload failed.",
+          "network": "Network error. Try again.",
+          "imageInvalid": "Upload a valid Petdex ad image.",
+          "destinationInvalid": "Enter a valid HTTPS destination URL.",
+          "titleRequired": "Add an ad title.",
+          "descriptionRequired": "Add an ad description."
+        }
       },
       "chart": {
         "label": "Impressions over time",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -210,6 +210,7 @@
       "title": "Tus campañas en Petdex",
       "body": "Sigue el estado, la entrega de impresiones prepagadas y el inventario restante de cada tarjeta patrocinada enviada.",
       "newCampaign": "Comprar otra campaña",
+      "editCreative": "Editar creatividad",
       "progress": "Entrega",
       "destination": "URL de destino",
       "created": "Creada {date}",
@@ -230,6 +231,34 @@
         "title": "Lanza tu primera tarjeta patrocinada",
         "body": "Envía una creatividad, elige un paquete de impresiones prepagadas y empieza a llegar a desarrolladores cuando Stripe confirme el pago.",
         "cta": "Crear campaña"
+      },
+      "edit": {
+        "title": "Editar campaña",
+        "body": "Cambia la creatividad, el destino o los campos de tracking. Los cambios en campañas activas se publican de inmediato y siguen sujetos a las políticas de anuncios de Petdex.",
+        "titleLabel": "Título del anuncio",
+        "descriptionLabel": "Descripción",
+        "destinationUrlLabel": "URL de destino",
+        "imageLabel": "Imagen del anuncio",
+        "imageCta": "Subir creatividad de reemplazo",
+        "imageHelp": "PNG, JPG o WebP. Máximo 10 MB.",
+        "currentImage": "Vista previa",
+        "save": "Guardar cambios",
+        "saving": "Guardando campaña",
+        "uploading": "Subiendo imagen",
+        "cancel": "Cancelar",
+        "utmTitle": "UTM personalizados",
+        "utmHelp": "Deja campos vacíos para limpiarlos. Si utm_source queda vacío, Petdex agrega utm_source=petdex a los clicks.",
+        "errors": {
+          "imageTooLarge": "La imagen debe pesar 10 MB o menos.",
+          "nothingChanged": "Cambia al menos un campo antes de guardar.",
+          "submitFailed": "No se pudo actualizar la campaña.",
+          "uploadFailed": "Falló la subida de imagen.",
+          "network": "Error de red. Inténtalo de nuevo.",
+          "imageInvalid": "Sube una imagen de anuncio válida para Petdex.",
+          "destinationInvalid": "Ingresa una URL HTTPS válida.",
+          "titleRequired": "Agrega un título para el anuncio.",
+          "descriptionRequired": "Agrega una descripción para el anuncio."
+        }
       },
       "chart": {
         "label": "Impresiones en el tiempo",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -248,6 +248,7 @@
       "title": "你的 Petdex 广告系列",
       "body": "跟踪每张赞助卡片的状态、预付曝光交付和剩余库存。",
       "newCampaign": "购买另一个广告系列",
+      "editCreative": "编辑素材",
       "progress": "交付进度",
       "destination": "目标 URL",
       "created": "创建于 {date}",
@@ -268,6 +269,34 @@
         "title": "启动你的第一张赞助卡片",
         "body": "提交素材，选择预付曝光套餐，并在 Stripe 确认付款后开始触达开发者。",
         "cta": "创建广告系列"
+      },
+      "edit": {
+        "title": "编辑广告系列",
+        "body": "更改素材、目标地址或跟踪字段。活跃广告系列的修改会立即生效，并且仍需遵守 Petdex 广告政策。",
+        "titleLabel": "广告标题",
+        "descriptionLabel": "描述",
+        "destinationUrlLabel": "目标 URL",
+        "imageLabel": "广告图片",
+        "imageCta": "上传替换素材",
+        "imageHelp": "PNG、JPG 或 WebP。最大 10 MB。",
+        "currentImage": "预览",
+        "save": "保存更改",
+        "saving": "正在保存广告系列",
+        "uploading": "正在上传图片",
+        "cancel": "取消",
+        "utmTitle": "自定义 UTM 设置",
+        "utmHelp": "留空可清除字段。如果 utm_source 为空，Petdex 会为点击添加 utm_source=petdex。",
+        "errors": {
+          "imageTooLarge": "图片必须小于或等于 10 MB。",
+          "nothingChanged": "保存前请至少更改一个字段。",
+          "submitFailed": "无法更新广告系列。",
+          "uploadFailed": "图片上传失败。",
+          "network": "网络错误。请重试。",
+          "imageInvalid": "请上传有效的 Petdex 广告图片。",
+          "destinationInvalid": "请输入有效的 HTTPS 目标 URL。",
+          "titleRequired": "请填写广告标题。",
+          "descriptionRequired": "请填写广告描述。"
+        }
       },
       "chart": {
         "label": "曝光随时间变化",

--- a/src/lib/ads/queries.ts
+++ b/src/lib/ads/queries.ts
@@ -18,6 +18,11 @@ export type AdvertiserCampaign = {
   description: string;
   imageUrl: string;
   destinationUrl: string;
+  utmSource: string | null;
+  utmMedium: string | null;
+  utmCampaign: string | null;
+  utmTerm: string | null;
+  utmContent: string | null;
   packageViews: number;
   priceCents: number;
   viewsServed: number;
@@ -33,6 +38,15 @@ export type AdvertiserCampaign = {
   dismissals: number;
   avgTimeInViewMs: number;
 };
+
+export type UpdateOwnedAdCampaignCreativeParams = {
+  id: string;
+  userId: string;
+  title?: string;
+  description?: string;
+  imageUrl?: string;
+  destinationUrl?: string;
+} & Partial<AdUtmFields>;
 
 export type AdCampaignTimeSeries = {
   eightHours: AdCampaignSeriesPoint[];
@@ -108,6 +122,100 @@ export async function getPendingOwnedCampaign(id: string, userId: string) {
     )
     .limit(1);
   return rows[0] ?? null;
+}
+
+export async function updateOwnedAdCampaignCreative(
+  params: UpdateOwnedAdCampaignCreativeParams,
+): Promise<
+  | {
+      ok: true;
+      campaign: {
+        id: string;
+        title: string;
+        description: string;
+        imageUrl: string;
+        destinationUrl: string;
+        updatedAt: Date;
+      };
+    }
+  | {
+      ok: false;
+      error: "not_found" | "campaign_not_editable" | "nothing_changed";
+    }
+> {
+  const row = await db.query.adCampaigns.findFirst({
+    where: and(
+      eq(schema.adCampaigns.id, params.id),
+      eq(schema.adCampaigns.userId, params.userId),
+    ),
+  });
+
+  if (!row) return { ok: false, error: "not_found" };
+  if (row.status === "deleted" || row.deletedAt) {
+    return { ok: false, error: "campaign_not_editable" };
+  }
+
+  const patch: Partial<typeof schema.adCampaigns.$inferInsert> = {};
+  if (params.title !== undefined && params.title !== row.title) {
+    patch.title = params.title;
+  }
+  if (
+    params.description !== undefined &&
+    params.description !== row.description
+  ) {
+    patch.description = params.description;
+  }
+  if (params.imageUrl !== undefined && params.imageUrl !== row.imageUrl) {
+    patch.imageUrl = params.imageUrl;
+  }
+  if (
+    params.destinationUrl !== undefined &&
+    params.destinationUrl !== row.destinationUrl
+  ) {
+    patch.destinationUrl = params.destinationUrl;
+  }
+  if (params.utmSource !== undefined && params.utmSource !== row.utmSource) {
+    patch.utmSource = params.utmSource;
+  }
+  if (params.utmMedium !== undefined && params.utmMedium !== row.utmMedium) {
+    patch.utmMedium = params.utmMedium;
+  }
+  if (
+    params.utmCampaign !== undefined &&
+    params.utmCampaign !== row.utmCampaign
+  ) {
+    patch.utmCampaign = params.utmCampaign;
+  }
+  if (params.utmTerm !== undefined && params.utmTerm !== row.utmTerm) {
+    patch.utmTerm = params.utmTerm;
+  }
+  if (params.utmContent !== undefined && params.utmContent !== row.utmContent) {
+    patch.utmContent = params.utmContent;
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return { ok: false, error: "nothing_changed" };
+  }
+
+  const [updated] = await db
+    .update(schema.adCampaigns)
+    .set({ ...patch, updatedAt: new Date() })
+    .where(
+      and(
+        eq(schema.adCampaigns.id, params.id),
+        eq(schema.adCampaigns.userId, params.userId),
+      ),
+    )
+    .returning({
+      id: schema.adCampaigns.id,
+      title: schema.adCampaigns.title,
+      description: schema.adCampaigns.description,
+      imageUrl: schema.adCampaigns.imageUrl,
+      destinationUrl: schema.adCampaigns.destinationUrl,
+      updatedAt: schema.adCampaigns.updatedAt,
+    });
+
+  return { ok: true, campaign: updated };
 }
 
 export async function setCampaignCheckoutSession(
@@ -189,6 +297,11 @@ export async function getUserAdCampaigns(
       description: schema.adCampaigns.description,
       imageUrl: schema.adCampaigns.imageUrl,
       destinationUrl: schema.adCampaigns.destinationUrl,
+      utmSource: schema.adCampaigns.utmSource,
+      utmMedium: schema.adCampaigns.utmMedium,
+      utmCampaign: schema.adCampaigns.utmCampaign,
+      utmTerm: schema.adCampaigns.utmTerm,
+      utmContent: schema.adCampaigns.utmContent,
       packageViews: schema.adCampaigns.packageViews,
       priceCents: schema.adCampaigns.priceCents,
       viewsServed: schema.adCampaigns.viewsServed,

--- a/src/lib/ads/validation.ts
+++ b/src/lib/ads/validation.ts
@@ -23,6 +23,13 @@ export type ValidAdCampaignInput = {
   acceptedTerms: true;
 } & AdUtmFields;
 
+export type ValidAdCampaignUpdateInput = {
+  title?: string;
+  description?: string;
+  imageUrl?: string;
+  destinationUrl?: string;
+} & Partial<AdUtmFields>;
+
 export type AdValidationResult =
   | { ok: true; value: ValidAdCampaignInput }
   | { ok: false; error: string };
@@ -78,6 +85,63 @@ export function validateAdCampaignInput(body: unknown): AdValidationResult {
       utmContent: cleanUtmValue(data.utmContent),
     },
   };
+}
+
+export function validateAdCampaignUpdateInput(
+  body: unknown,
+):
+  | { ok: true; value: ValidAdCampaignUpdateInput }
+  | { ok: false; error: string } {
+  if (!body || typeof body !== "object") {
+    return { ok: false, error: "invalid_body" };
+  }
+  const data = body as Record<string, unknown>;
+  const value: ValidAdCampaignUpdateInput = {};
+
+  if (Object.hasOwn(data, "title")) {
+    const title = cleanText(data.title, 80);
+    if (!title) return { ok: false, error: "title_required" };
+    value.title = title;
+  }
+  if (Object.hasOwn(data, "description")) {
+    const description = cleanText(data.description, 180);
+    if (!description) return { ok: false, error: "description_required" };
+    value.description = description;
+  }
+  if (Object.hasOwn(data, "imageUrl")) {
+    if (!isAllowedAdImageUrl(data.imageUrl)) {
+      return { ok: false, error: "image_url_invalid" };
+    }
+    value.imageUrl = data.imageUrl;
+  }
+  if (Object.hasOwn(data, "destinationUrl")) {
+    const destinationUrl = validateAdDestinationUrl(data.destinationUrl);
+    if (!destinationUrl) {
+      return { ok: false, error: "destination_url_invalid" };
+    }
+    value.destinationUrl = destinationUrl;
+  }
+  if (Object.hasOwn(data, "utmSource")) {
+    value.utmSource = cleanUtmValue(data.utmSource);
+  }
+  if (Object.hasOwn(data, "utmMedium")) {
+    value.utmMedium = cleanUtmValue(data.utmMedium);
+  }
+  if (Object.hasOwn(data, "utmCampaign")) {
+    value.utmCampaign = cleanUtmValue(data.utmCampaign);
+  }
+  if (Object.hasOwn(data, "utmTerm")) {
+    value.utmTerm = cleanUtmValue(data.utmTerm);
+  }
+  if (Object.hasOwn(data, "utmContent")) {
+    value.utmContent = cleanUtmValue(data.utmContent);
+  }
+
+  if (Object.keys(value).length === 0) {
+    return { ok: false, error: "no_edit_fields" };
+  }
+
+  return { ok: true, value };
 }
 
 export function validateImpressionInput(body: unknown):

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -91,6 +91,12 @@ export const adCampaignRatelimit = createRatelimit({
   prefix: "petdex:ad-campaign",
 });
 
+export const adCampaignEditRatelimit = createRatelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(10, "24 h"),
+  prefix: "petdex:ad-campaign-edit",
+});
+
 export const adCheckoutRatelimit = createRatelimit({
   redis,
   limiter: Ratelimit.slidingWindow(20, "1 h"),


### PR DESCRIPTION
## Summary
- Add an owner-scoped PATCH endpoint for editing ad campaign creative, destination URL, and UTM fields.
- Add an advertiser dashboard edit dialog with image replacement upload and live preview.
- Localize the new edit UI across en, es, and zh.

## Verification
- bun run i18n:check
- bunx biome check \"src/lib/ads/validation.ts\" \"src/lib/ads/queries.ts\" \"src/lib/ratelimit.ts\" \"src/app/api/ads/[id]/route.ts\" \"src/components/ads/ad-campaign-edit-dialog.tsx\" \"src/components/ads/ad-dashboard.tsx\" \"src/i18n/messages/en.json\" \"src/i18n/messages/es.json\" \"src/i18n/messages/zh.json\"
- bun run build

## Notes
- Full bun run check currently fails on pre-existing unrelated repo-wide lint/format issues in packages/petdex-cli, scripts, src/types/bun-test.d.ts, and drizzle metadata.