### PR TITLE
feat(profile): inline pin button on owner pet cards

### DIFF
--- a/src/app/[locale]/u/[handle]/page.tsx
+++ b/src/app/[locale]/u/[handle]/page.tsx
@@ -466,6 +466,11 @@ export default async function UserProfilePage({ params }: PageProps) {
             displayName: p.displayName,
             spritesheetUrl: p.spritesheetPath,
           }))}
+          pinning={
+            isOwner
+              ? { pinnedSlugs: featuredSlugs, maxPins: MAX_PINNED_PETS }
+              : null
+          }
         />
       </section>
 

--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -34,6 +34,7 @@ import { useHeaderState } from "@/components/header-state-provider";
 import { PetActionMenu } from "@/components/pet-action-menu";
 import { PetCardFooter } from "@/components/pet-card-footer";
 import { PetSprite } from "@/components/pet-sprite";
+import { ProfilePinButton } from "@/components/profile-pin-button";
 import { Button } from "@/components/ui/button";
 import {
   InputGroup,
@@ -723,6 +724,15 @@ export type PetCardStatusOverlay = {
   tone: "warning" | "danger";
 };
 
+export type PetCardPinState = {
+  /** Whether this pet is currently in the owner's featured_pet_slugs. */
+  isPinned: boolean;
+  /** Total number of pinned pets — used to enforce the cap. */
+  pinnedCount: number;
+  /** Hard cap for the owner. Same constant the editor uses. */
+  maxPins: number;
+};
+
 type PetCardProps = {
   pet: PetWithMetrics;
   index: number;
@@ -755,6 +765,13 @@ type PetCardProps = {
    * of the gallery cards. Approved pets render no overlay.
    */
   statusOverlay?: PetCardStatusOverlay;
+  /**
+   * Pin/unpin overlay shown on the owner's own profile so they can
+   * promote pets to (or remove from) the pinned strip without going
+   * through the inline editor. Only renders when supplied — visitors
+   * never see this prop populated.
+   */
+  pinState?: PetCardPinState;
 };
 
 export function PetCard({
@@ -764,6 +781,7 @@ export function PetCard({
   caught,
   ownerActions,
   statusOverlay,
+  pinState,
 }: PetCardProps) {
   const dexLabel =
     dexNumber != null
@@ -923,6 +941,21 @@ export function PetCard({
         >
           {statusOverlay.label}
         </span>
+      ) : null}
+
+      {/* Pin overlay — owner-only on their own /u/[handle]. Sits to the
+ left of the action menu so both stay clickable above the card-wide
+ Link. The button itself toggles isPinned via /api/profile and
+ router.refresh()es. */}
+      {pinState ? (
+        <div className="absolute top-3 right-14 z-20">
+          <ProfilePinButton
+            slug={pet.slug}
+            isPinned={pinState.isPinned}
+            pinnedCount={pinState.pinnedCount}
+            maxPins={pinState.maxPins}
+          />
+        </div>
       ) : null}
 
       {/* Action menu lives outside the Link so its clicks don't navigate.

--- a/src/components/profile-tabs.tsx
+++ b/src/components/profile-tabs.tsx
@@ -44,6 +44,12 @@ export type ProfileTabsProps = {
     displayName: string;
     spritesheetUrl: string;
   }[];
+  // Owner-only pin state passed through to the Approved cards so each
+  // can render its own pin/unpin overlay. Visitors get null.
+  pinning?: {
+    pinnedSlugs: string[];
+    maxPins: number;
+  } | null;
 };
 
 type TabKey = "pets" | "liked" | "collections";
@@ -58,7 +64,14 @@ export function ProfileTabs(props: ProfileTabsProps) {
     collection,
     canManageCollections,
     collectionApprovedPets,
+    pinning,
   } = props;
+
+  // Pre-build the lookup once instead of per-card. The Set isn't worth
+  // it for the typical 6-pin cap, but we guard against the rare 100+
+  // owner with .includes().
+  const pinnedSet = pinning ? new Set(pinning.pinnedSlugs) : null;
+  const pinnedCount = pinning?.pinnedSlugs.length ?? 0;
 
   const stateCount = petStates.length;
 
@@ -145,6 +158,9 @@ export function ProfileTabs(props: ProfileTabsProps) {
           pendingSubmissions={pendingSubmissions}
           rejectedSubmissions={rejectedSubmissions}
           stateCount={stateCount}
+          pinnedSet={pinnedSet}
+          pinnedCount={pinnedCount}
+          maxPins={pinning?.maxPins ?? null}
         />
       ) : null}
 
@@ -172,6 +188,9 @@ function PetsPanel({
   pendingSubmissions,
   rejectedSubmissions,
   stateCount,
+  pinnedSet,
+  pinnedCount,
+  maxPins,
 }: {
   isOwner: boolean;
   publicHandle: string;
@@ -179,6 +198,9 @@ function PetsPanel({
   pendingSubmissions: Submission[];
   rejectedSubmissions: Submission[];
   stateCount: number;
+  pinnedSet: Set<string> | null;
+  pinnedCount: number;
+  maxPins: number | null;
 }) {
   if (
     approvedPets.length === 0 &&
@@ -231,6 +253,15 @@ function PetsPanel({
                 ownerActions={
                   isOwner
                     ? { submissionId: pet.id, status: "approved" }
+                    : undefined
+                }
+                pinState={
+                  isOwner && pinnedSet && maxPins != null
+                    ? {
+                        isPinned: pinnedSet.has(pet.slug),
+                        pinnedCount,
+                        maxPins,
+                      }
                     : undefined
                 }
               />


### PR DESCRIPTION
## Summary
Closes Amir Dayyef's feedback (\"is the pinning button missing?\"). It was: every approved pet card in the Pets tab on \`/u/<handle>\` now shows a pin/unpin button overlay when the viewer is the owner. The button was already wired for pets already pinned — visitors and non-owner cards still see nothing.

## Plumbing
- New \`PetCardPinState\` type (isPinned, pinnedCount, maxPins) flows page.tsx → ProfileTabs → PetsPanel → PetCard.
- ProfilePinButton render lives next to the existing action menu (top-right, \`right-14\` to clear the \`right-4\` ⋯ button).
- pinnedSet pre-built once per render so 100+ approved pets don't pay Array.includes per card.

## Test plan
- [x] tsc + bun run build pass
- [ ] Sign in as a user with approved pets, hit /u/<own-handle>, see Pin button on each unpinned card
- [ ] Click → pet promotes to pinned strip, button flips to pinned state
- [ ] Visitor view: no button anywhere
- [ ] Cap reached (6 pinned): clicking on an unpinned card alerts \"Pin cap reached\"