### PR TITLE
chore(observability): add @vercel/speed-insights

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.37.0",
         "@vercel/analytics": "^2.0.1",
+        "@vercel/speed-insights": "^2.0.0",
         "ai": "^6.0.175",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -749,6 +750,8 @@
     "@vercel/analytics": ["@vercel/analytics@2.0.1", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "nuxt": ">= 3", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "nuxt", "react", "svelte", "vue", "vue-router"] }, "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g=="],
 
     "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
+
+    "@vercel/speed-insights": ["@vercel/speed-insights@2.0.0", "", { "peerDependencies": { "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "nuxt": ">= 3", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@sveltejs/kit", "next", "nuxt", "react", "svelte", "vue", "vue-router"] }, "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w=="],
 
     "@vibrant/color": ["@vibrant/color@4.0.4", "", {}, "sha512-Fq2tAszz4QOPWfHZ+KuEAchXUD8i594BM2fOJt8dI/fvYbiVoBycBF/BlNH6F4IWBubxXoPqD4JmmAHvFYbNew=="],
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.37.0",
     "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "ai": "^6.0.175",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import { notFound } from "next/navigation";
 
 import { Analytics } from "@vercel/analytics/next";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import { NextIntlClientProvider } from "next-intl";
 import {
   getMessages,
@@ -107,6 +108,7 @@ export default async function LocaleLayout({ children, params }: Props) {
               <AnnouncementQueue />
               <ProfileAnnouncementModal />
               <Analytics />
+              <SpeedInsights />
             </HeaderStateProvider>
           </AppProviders>
         </NextIntlClientProvider>


### PR DESCRIPTION
## Summary

- Mount `<SpeedInsights />` alongside the existing `<Analytics />` in `[locale]/layout.tsx`.
- Adds `@vercel/speed-insights@2.0.0` (1 dependency, ~3KB gzipped client-side).

## Why

We need real-user Core Web Vitals (LCP, CLS, INP, FCP, TTFB) collecting **before** the next perf PR (#160 — memoize PetCard tree, ~76% re-render reduction in dev) lands. Otherwise we have no baseline to compare against.

After this merges:
1. Wait 24-48h for Speed Insights to accumulate samples.
2. Merge #160.
3. Compare histograms in `vercel.com/<team>/petdex/observability/speed-insights` filtered by deploy/commit.

## Test plan

- [ ] Vercel preview deploy renders without errors.
- [ ] DevTools → Network shows `/_vercel/speed-insights/vitals` POST after page load.
- [ ] Speed Insights tab in Vercel dashboard shows the new project deploy.