### PR TITLE
fix: reuse Stripe client instance instead of creating per call

### DIFF
--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -2,10 +2,15 @@ import "server-only";
 
 import Stripe from "stripe";
 
+let stripe: Stripe | undefined;
+
 export function getStripe(): Stripe {
-  const key = process.env.STRIPE_SECRET_KEY;
-  if (!key) throw new Error("STRIPE_SECRET_KEY is not set");
-  return new Stripe(key);
+  if (!stripe) {
+    const key = process.env.STRIPE_SECRET_KEY;
+    if (!key) throw new Error("STRIPE_SECRET_KEY is not set");
+    stripe = new Stripe(key);
+  }
+  return stripe;
 }
 
 export function getSiteUrl(): string {


### PR DESCRIPTION
## Summary

- Replaces the factory function with a module-level singleton, per Stripe's recommendation
- Avoids re-creating the HTTP client and reloading certificate bundles on every request

## Test plan

- [ ] `bun run build` passes
- [ ] Stripe checkout and webhook flows continue to work (needs runtime verification)