### PR TITLE
fix: guard localStorage access against SecurityError in private browsing

### DIFF
--- a/src/components/feedback-widget.tsx
+++ b/src/components/feedback-widget.tsx
@@ -14,6 +14,8 @@ import {
 } from "lucide-react";
 import { useTranslations } from "next-intl";
 
+import { safeGetItem, safeSetItem } from "@/lib/utils";
+
 type Kind = "suggestion" | "bug" | "praise" | "other";
 
 const DRAG_THRESHOLD_PX = 6;
@@ -82,7 +84,7 @@ export function FeedbackWidget() {
   );
 
   useEffect(() => {
-    const stored = window.localStorage.getItem(FEEDBACK_POSITION_KEY);
+    const stored = safeGetItem(FEEDBACK_POSITION_KEY);
     const parsed = stored === null ? NaN : Number(stored);
     setClampedBottom(Number.isFinite(parsed) ? parsed : getDefaultBottom());
   }, [getDefaultBottom, setClampedBottom]);
@@ -214,7 +216,7 @@ export function FeedbackWidget() {
           const nextBottom = clampBottom(startBottom - (ev.clientY - startY));
           setBottomOffset(nextBottom);
           suppressClickUntilRef.current = Date.now() + 350;
-          window.localStorage.setItem(
+          safeSetItem(
             FEEDBACK_POSITION_KEY,
             String(nextBottom),
           );

--- a/src/components/pet-floater.tsx
+++ b/src/components/pet-floater.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import type { PetStateId } from "@/lib/pet-states";
+import { safeGetItem, safeSetItem } from "@/lib/utils";
 
 import { PetSprite } from "@/components/pet-sprite";
 
@@ -167,7 +168,7 @@ export function PetFloater({ src, petName }: PetFloaterProps) {
   useEffect(() => {
     if (!enabled) return;
     if (typeof window === "undefined") return;
-    const seen = window.localStorage.getItem(HINT_STORAGE_KEY);
+    const seen = safeGetItem(HINT_STORAGE_KEY);
     if (seen === "1") return;
     setShowHint(true);
     const fade = window.setTimeout(() => setShowHint(false), HINT_DURATION_MS);
@@ -178,7 +179,7 @@ export function PetFloater({ src, petName }: PetFloaterProps) {
     if (!showHint) return;
     setShowHint(false);
     if (typeof window !== "undefined") {
-      window.localStorage.setItem(HINT_STORAGE_KEY, "1");
+      safeSetItem(HINT_STORAGE_KEY, "1");
     }
   }, [showHint]);
 

--- a/src/components/surprise-pet-card.tsx
+++ b/src/components/surprise-pet-card.tsx
@@ -7,6 +7,7 @@ import { Dice5, ExternalLink, PackageOpen, X } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 
 import { withLocale } from "@/lib/locale-routing";
+import { safeGetItem, safeSetItem } from "@/lib/utils";
 
 import { PetSprite } from "@/components/pet-sprite";
 
@@ -50,9 +51,9 @@ export function SurprisePetCard() {
   useEffect(() => {
     const today = new Date().toISOString().slice(0, 10);
     const key = `${BASE_KEY}_${today}`;
-    if (window.localStorage.getItem(key) === "1") return;
+    if (safeGetItem(key) === "1") return;
     const timeout = window.setTimeout(() => {
-      window.localStorage.setItem(key, "1");
+      safeSetItem(key, "1");
       void loadPet();
     }, 2200);
     return () => window.clearTimeout(timeout);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,19 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function safeGetItem(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function safeSetItem(key: string, value: string): void {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // Storage unavailable (private browsing, quota exceeded, etc.)
+  }
+}


### PR DESCRIPTION
## Summary

- Add `safeGetItem` / `safeSetItem` wrappers in `src/lib/utils` that silently return null on storage errors
- Replace raw `window.localStorage` calls in FeedbackWidget, SurprisePetCard, and PetFloater
- Prevents white-screen crashes in Safari private browsing and locked-down mobile contexts

## Test plan

- [ ] `bun run build` passes
- [ ] Feedback widget still remembers drag position on normal browsers
- [ ] Surprise pet card still shows once per day on normal browsers
- [ ] Pet floater hint glow still shows only on first visit
- [ ] Verify in Safari private browsing: widgets degrade gracefully instead of crashing