### PR TITLE
fix: quote spritesheet URL in CSS to prevent injection via unescaped path

### DIFF
--- a/src/components/pet-sprite.tsx
+++ b/src/components/pet-sprite.tsx
@@ -59,7 +59,7 @@ export function PetSprite({
         className="pet-sprite"
         style={
           {
-            "--sprite-url": `url(${src})`,
+            "--sprite-url": `url("${src.replace(/"/g, '\\"')}")`,
             "--sprite-row": animation.row,
             "--sprite-frames": animation.frames,
             "--sprite-duration": `${animation.durationMs}ms`,


### PR DESCRIPTION
## Summary

- Wraps the spritesheet `src` in quotes inside CSS `url()` and escapes embedded double-quotes
- Unquoted `url()` values terminate at `)`, whitespace, or special characters — a malformed R2 path could break sprite rendering

## Test plan

- [ ] `bun run build` passes
- [ ] Pet sprites render correctly on home page, pet detail pages, and gallery
- [ ] Sprite animation continues to work (idle, waving, running states)