### PR TITLE
fix: use per-locale canonical URL instead of hardcoding English

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -10,6 +10,7 @@ import {
 import { getDexNumberMap } from "@/lib/dex";
 import { buildLocaleAlternates } from "@/lib/locale-routing";
 import { searchPets } from "@/lib/pet-search";
+import { hasLocale } from "@/i18n/config";
 import {
   getApprovedPetCount,
   getFeaturedPetsWithMetrics,
@@ -35,9 +36,16 @@ import { SurprisePetCard } from "@/components/surprise-pet-card";
 // shell that the edge can cache for 60s — enough to keep new pets
 // surfacing without waking a function on every visit.
 export const revalidate = 60;
-export const metadata = {
-  alternates: buildLocaleAlternates("/"),
-};
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  return {
+    alternates: buildLocaleAlternates("/", hasLocale(locale) ? locale : undefined),
+  };
+}
 const SITE_URL = "https://petdex.crafter.run";
 
 export default async function Home() {

--- a/src/lib/locale-routing.ts
+++ b/src/lib/locale-routing.ts
@@ -33,8 +33,8 @@ export function stripLocalePrefix(pathname: string): string {
   return normalized;
 }
 
-export function buildLocaleAlternates(pathname: string) {
-  const canonical = withLocale(pathname, defaultLocale);
+export function buildLocaleAlternates(pathname: string, currentLocale?: Locale) {
+  const canonical = withLocale(pathname, currentLocale ?? defaultLocale);
 
   return {
     canonical,


### PR DESCRIPTION
## Summary

- The home page used a static `metadata` export, which evaluated `buildLocaleAlternates` once at module-load time
- Every locale variant received the same `<link rel="canonical">` pointing to `/` (English), causing search engines to treat Spanish (`/es`) and Chinese (`/zh`) home pages as duplicates of the English version
- Switched to `generateMetadata` so each locale page declares itself as canonical
- Extended `buildLocaleAlternates` to accept an optional locale override — existing callers continue to work with the same default behavior

## Test plan

- [ ] `bun run build` passes
- [ ] `/` canonical → `/`
- [ ] `/es` canonical → `/es`
- [ ] `/zh` canonical → `/zh`
- [ ] `hreflang` alternates still list all three locales correctly