### PR TITLE
Improve pet detail ISR

### DIFF
--- a/.agents/skills/code-review-excellence/SKILL.md
+++ b/.agents/skills/code-review-excellence/SKILL.md
@@ -1,0 +1,529 @@
+---
+name: code-review-excellence
+description: Master effective code review practices to provide constructive feedback, catch bugs early, and foster knowledge sharing while maintaining team morale. Use when reviewing pull requests, establishing review standards, or mentoring developers.
+---
+
+# Code Review Excellence
+
+Transform code reviews from gatekeeping to knowledge sharing through constructive feedback, systematic analysis, and collaborative improvement.
+
+## When to Use This Skill
+
+- Reviewing pull requests and code changes
+- Establishing code review standards for teams
+- Mentoring junior developers through reviews
+- Conducting architecture reviews
+- Creating review checklists and guidelines
+- Improving team collaboration
+- Reducing code review cycle time
+- Maintaining code quality standards
+
+## Core Principles
+
+### 1. The Review Mindset
+
+**Goals of Code Review:**
+
+- Catch bugs and edge cases
+- Ensure code maintainability
+- Share knowledge across team
+- Enforce coding standards
+- Improve design and architecture
+- Build team culture
+
+**Not the Goals:**
+
+- Show off knowledge
+- Nitpick formatting (use linters)
+- Block progress unnecessarily
+- Rewrite to your preference
+
+### 2. Effective Feedback
+
+**Good Feedback is:**
+
+- Specific and actionable
+- Educational, not judgmental
+- Focused on the code, not the person
+- Balanced (praise good work too)
+- Prioritized (critical vs nice-to-have)
+
+```markdown
+❌ Bad: "This is wrong."
+✅ Good: "This could cause a race condition when multiple users
+access simultaneously. Consider using a mutex here."
+
+❌ Bad: "Why didn't you use X pattern?"
+✅ Good: "Have you considered the Repository pattern? It would
+make this easier to test. Here's an example: [link]"
+
+❌ Bad: "Rename this variable."
+✅ Good: "[nit] Consider `userCount` instead of `uc` for
+clarity. Not blocking if you prefer to keep it."
+```
+
+### 3. Review Scope
+
+**What to Review:**
+
+- Logic correctness and edge cases
+- Security vulnerabilities
+- Performance implications
+- Test coverage and quality
+- Error handling
+- Documentation and comments
+- API design and naming
+- Architectural fit
+
+**What Not to Review Manually:**
+
+- Code formatting (use Prettier, Black, etc.)
+- Import organization
+- Linting violations
+- Simple typos
+
+## Review Process
+
+### Phase 1: Context Gathering (2-3 minutes)
+
+```markdown
+Before diving into code, understand:
+
+1. Read PR description and linked issue
+2. Check PR size (>400 lines? Ask to split)
+3. Review CI/CD status (tests passing?)
+4. Understand the business requirement
+5. Note any relevant architectural decisions
+```
+
+### Phase 2: High-Level Review (5-10 minutes)
+
+```markdown
+1. **Architecture & Design**
+   - Does the solution fit the problem?
+   - Are there simpler approaches?
+   - Is it consistent with existing patterns?
+   - Will it scale?
+
+2. **File Organization**
+   - Are new files in the right places?
+   - Is code grouped logically?
+   - Are there duplicate files?
+
+3. **Testing Strategy**
+   - Are there tests?
+   - Do tests cover edge cases?
+   - Are tests readable?
+```
+
+### Phase 3: Line-by-Line Review (10-20 minutes)
+
+```markdown
+For each file:
+
+1. **Logic & Correctness**
+   - Edge cases handled?
+   - Off-by-one errors?
+   - Null/undefined checks?
+   - Race conditions?
+
+2. **Security**
+   - Input validation?
+   - SQL injection risks?
+   - XSS vulnerabilities?
+   - Sensitive data exposure?
+
+3. **Performance**
+   - N+1 queries?
+   - Unnecessary loops?
+   - Memory leaks?
+   - Blocking operations?
+
+4. **Maintainability**
+   - Clear variable names?
+   - Functions doing one thing?
+   - Complex code commented?
+   - Magic numbers extracted?
+```
+
+### Phase 4: Summary & Decision (2-3 minutes)
+
+```markdown
+1. Summarize key concerns
+2. Highlight what you liked
+3. Make clear decision:
+   - ✅ Approve
+   - 💬 Comment (minor suggestions)
+   - 🔄 Request Changes (must address)
+4. Offer to pair if complex
+```
+
+## Review Techniques
+
+### Technique 1: The Checklist Method
+
+```markdown
+## Security Checklist
+
+- [ ] User input validated and sanitized
+- [ ] SQL queries use parameterization
+- [ ] Authentication/authorization checked
+- [ ] Secrets not hardcoded
+- [ ] Error messages don't leak info
+
+## Performance Checklist
+
+- [ ] No N+1 queries
+- [ ] Database queries indexed
+- [ ] Large lists paginated
+- [ ] Expensive operations cached
+- [ ] No blocking I/O in hot paths
+
+## Testing Checklist
+
+- [ ] Happy path tested
+- [ ] Edge cases covered
+- [ ] Error cases tested
+- [ ] Test names are descriptive
+- [ ] Tests are deterministic
+```
+
+### Technique 2: The Question Approach
+
+Instead of stating problems, ask questions to encourage thinking:
+
+```markdown
+❌ "This will fail if the list is empty."
+✅ "What happens if `items` is an empty array?"
+
+❌ "You need error handling here."
+✅ "How should this behave if the API call fails?"
+
+❌ "This is inefficient."
+✅ "I see this loops through all users. Have we considered
+the performance impact with 100k users?"
+```
+
+### Technique 3: Suggest, Don't Command
+
+````markdown
+## Use Collaborative Language
+
+❌ "You must change this to use async/await"
+✅ "Suggestion: async/await might make this more readable:
+`typescript
+    async function fetchUser(id: string) {
+        const user = await db.query('SELECT * FROM users WHERE id = ?', id);
+        return user;
+    }
+    `
+What do you think?"
+
+❌ "Extract this into a function"
+✅ "This logic appears in 3 places. Would it make sense to
+extract it into a shared utility function?"
+````
+
+### Technique 4: Differentiate Severity
+
+```markdown
+Use labels to indicate priority:
+
+🔴 [blocking] - Must fix before merge
+🟡 [important] - Should fix, discuss if disagree
+🟢 [nit] - Nice to have, not blocking
+💡 [suggestion] - Alternative approach to consider
+📚 [learning] - Educational comment, no action needed
+🎉 [praise] - Good work, keep it up!
+
+Example:
+"🔴 [blocking] This SQL query is vulnerable to injection.
+Please use parameterized queries."
+
+"🟢 [nit] Consider renaming `data` to `userData` for clarity."
+
+"🎉 [praise] Excellent test coverage! This will catch edge cases."
+```
+
+## Language-Specific Patterns
+
+### Python Code Review
+
+```python
+# Check for Python-specific issues
+
+# ❌ Mutable default arguments
+def add_item(item, items=[]):  # Bug! Shared across calls
+    items.append(item)
+    return items
+
+# ✅ Use None as default
+def add_item(item, items=None):
+    if items is None:
+        items = []
+    items.append(item)
+    return items
+
+# ❌ Catching too broad
+try:
+    result = risky_operation()
+except:  # Catches everything, even KeyboardInterrupt!
+    pass
+
+# ✅ Catch specific exceptions
+try:
+    result = risky_operation()
+except ValueError as e:
+    logger.error(f"Invalid value: {e}")
+    raise
+
+# ❌ Using mutable class attributes
+class User:
+    permissions = []  # Shared across all instances!
+
+# ✅ Initialize in __init__
+class User:
+    def __init__(self):
+        self.permissions = []
+```
+
+### TypeScript/JavaScript Code Review
+
+```typescript
+// Check for TypeScript-specific issues
+
+// ❌ Using any defeats type safety
+function processData(data: any) {  // Avoid any
+    return data.value;
+}
+
+// ✅ Use proper types
+interface DataPayload {
+    value: string;
+}
+function processData(data: DataPayload) {
+    return data.value;
+}
+
+// ❌ Not handling async errors
+async function fetchUser(id: string) {
+    const response = await fetch(`/api/users/${id}`);
+    return response.json();  // What if network fails?
+}
+
+// ✅ Handle errors properly
+async function fetchUser(id: string): Promise<User> {
+    try {
+        const response = await fetch(`/api/users/${id}`);
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+        }
+        return await response.json();
+    } catch (error) {
+        console.error('Failed to fetch user:', error);
+        throw error;
+    }
+}
+
+// ❌ Mutation of props
+function UserProfile({ user }: Props) {
+    user.lastViewed = new Date();  // Mutating prop!
+    return <div>{user.name}</div>;
+}
+
+// ✅ Don't mutate props
+function UserProfile({ user, onView }: Props) {
+    useEffect(() => {
+        onView(user.id);  // Notify parent to update
+    }, [user.id]);
+    return <div>{user.name}</div>;
+}
+```
+
+## Advanced Review Patterns
+
+### Pattern 1: Architectural Review
+
+```markdown
+When reviewing significant changes:
+
+1. **Design Document First**
+   - For large features, request design doc before code
+   - Review design with team before implementation
+   - Agree on approach to avoid rework
+
+2. **Review in Stages**
+   - First PR: Core abstractions and interfaces
+   - Second PR: Implementation
+   - Third PR: Integration and tests
+   - Easier to review, faster to iterate
+
+3. **Consider Alternatives**
+   - "Have we considered using [pattern/library]?"
+   - "What's the tradeoff vs. the simpler approach?"
+   - "How will this evolve as requirements change?"
+```
+
+### Pattern 2: Test Quality Review
+
+```typescript
+// ❌ Poor test: Implementation detail testing
+test('increments counter variable', () => {
+    const component = render(<Counter />);
+    const button = component.getByRole('button');
+    fireEvent.click(button);
+    expect(component.state.counter).toBe(1);  // Testing internal state
+});
+
+// ✅ Good test: Behavior testing
+test('displays incremented count when clicked', () => {
+    render(<Counter />);
+    const button = screen.getByRole('button', { name: /increment/i });
+    fireEvent.click(button);
+    expect(screen.getByText('Count: 1')).toBeInTheDocument();
+});
+
+// Review questions for tests:
+// - Do tests describe behavior, not implementation?
+// - Are test names clear and descriptive?
+// - Do tests cover edge cases?
+// - Are tests independent (no shared state)?
+// - Can tests run in any order?
+```
+
+### Pattern 3: Security Review
+
+```markdown
+## Security Review Checklist
+
+### Authentication & Authorization
+
+- [ ] Is authentication required where needed?
+- [ ] Are authorization checks before every action?
+- [ ] Is JWT validation proper (signature, expiry)?
+- [ ] Are API keys/secrets properly secured?
+
+### Input Validation
+
+- [ ] All user inputs validated?
+- [ ] File uploads restricted (size, type)?
+- [ ] SQL queries parameterized?
+- [ ] XSS protection (escape output)?
+
+### Data Protection
+
+- [ ] Passwords hashed (bcrypt/argon2)?
+- [ ] Sensitive data encrypted at rest?
+- [ ] HTTPS enforced for sensitive data?
+- [ ] PII handled according to regulations?
+
+### Common Vulnerabilities
+
+- [ ] No eval() or similar dynamic execution?
+- [ ] No hardcoded secrets?
+- [ ] CSRF protection for state-changing operations?
+- [ ] Rate limiting on public endpoints?
+```
+
+## Giving Difficult Feedback
+
+### Pattern: The Sandwich Method (Modified)
+
+```markdown
+Traditional: Praise + Criticism + Praise (feels fake)
+
+Better: Context + Specific Issue + Helpful Solution
+
+Example:
+"I noticed the payment processing logic is inline in the
+controller. This makes it harder to test and reuse.
+
+[Specific Issue]
+The calculateTotal() function mixes tax calculation,
+discount logic, and database queries, making it difficult
+to unit test and reason about.
+
+[Helpful Solution]
+Could we extract this into a PaymentService class? That
+would make it testable and reusable. I can pair with you
+on this if helpful."
+```
+
+### Handling Disagreements
+
+```markdown
+When author disagrees with your feedback:
+
+1. **Seek to Understand**
+   "Help me understand your approach. What led you to
+   choose this pattern?"
+
+2. **Acknowledge Valid Points**
+   "That's a good point about X. I hadn't considered that."
+
+3. **Provide Data**
+   "I'm concerned about performance. Can we add a benchmark
+   to validate the approach?"
+
+4. **Escalate if Needed**
+   "Let's get [architect/senior dev] to weigh in on this."
+
+5. **Know When to Let Go**
+   If it's working and not a critical issue, approve it.
+   Perfection is the enemy of progress.
+```
+
+## Best Practices
+
+1. **Review Promptly**: Within 24 hours, ideally same day
+2. **Limit PR Size**: 200-400 lines max for effective review
+3. **Review in Time Blocks**: 60 minutes max, take breaks
+4. **Use Review Tools**: GitHub, GitLab, or dedicated tools
+5. **Automate What You Can**: Linters, formatters, security scans
+6. **Build Rapport**: Emoji, praise, and empathy matter
+7. **Be Available**: Offer to pair on complex issues
+8. **Learn from Others**: Review others' review comments
+
+## Common Pitfalls
+
+- **Perfectionism**: Blocking PRs for minor style preferences
+- **Scope Creep**: "While you're at it, can you also..."
+- **Inconsistency**: Different standards for different people
+- **Delayed Reviews**: Letting PRs sit for days
+- **Ghosting**: Requesting changes then disappearing
+- **Rubber Stamping**: Approving without actually reviewing
+- **Bike Shedding**: Debating trivial details extensively
+
+## Templates
+
+### PR Review Comment Template
+
+```markdown
+## Summary
+
+[Brief overview of what was reviewed]
+
+## Strengths
+
+- [What was done well]
+- [Good patterns or approaches]
+
+## Required Changes
+
+🔴 [Blocking issue 1]
+🔴 [Blocking issue 2]
+
+## Suggestions
+
+💡 [Improvement 1]
+💡 [Improvement 2]
+
+## Questions
+
+❓ [Clarification needed on X]
+❓ [Alternative approach consideration]
+
+## Verdict
+
+✅ Approve after addressing required changes
+```

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -10,8 +10,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -23,10 +23,8 @@ jobs:
       - uses: anomalyco/opencode/github@latest
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: openai/gpt-5.5
-          use_github_token: true
           prompt: |
             Review this pull request following the repo-local
             code-review-excellence skill at

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -22,6 +22,7 @@ jobs:
       - run: bun install --frozen-lockfile
       - uses: anomalyco/opencode/github@latest
         env:
+          GH_TOKEN: ${{ github.token }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         with:
           model: openai/gpt-5.5
@@ -30,12 +31,30 @@ jobs:
             code-review-excellence skill at
             .agents/skills/code-review-excellence/SKILL.md.
 
+            Workflow constraints:
+            - You are running in GitHub Actions on the PR head branch.
+            - Local base branches such as main may not exist, and local git
+              history may be shallow.
+            - Do not spend time trying local git diff forms such as
+              `git diff main`, `git diff origin/main`, or merge-base discovery.
+            - Use the GitHub CLI as the source of truth for the PR diff:
+              `gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }}`.
+            - Use `gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json title,body,files,commits,reviews,comments,baseRefName,headRefName`
+              for PR metadata when needed.
+            - After identifying changed files from `gh pr diff` or the provided
+              PR context, read only the relevant files and nearby dependencies.
+            - Do not make code changes during review unless explicitly asked.
+
             Prioritize actionable findings over summary. Focus on:
             - Correctness bugs and edge cases
             - Security and data exposure risks
             - Performance regressions
             - Missing or weak tests
             - Maintainability issues that affect future changes
+
+            Avoid repeating findings already made by earlier reviewers unless
+            the current diff still contains a severe unresolved issue and the
+            new comment adds concrete evidence.
 
             Use severity labels such as [blocking], [important], [nit],
             and [suggestion]. Keep feedback specific, constructive, and

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -22,10 +22,10 @@ jobs:
       - run: bun install --frozen-lockfile
       - uses: anomalyco/opencode/github@latest
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          model: anthropic/claude-sonnet-4-20250514
+          model: openai/gpt-5.5
           use_github_token: true
           prompt: |
             Review this pull request:

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -28,7 +28,17 @@ jobs:
           model: openai/gpt-5.5
           use_github_token: true
           prompt: |
-            Review this pull request:
-            - Check for code quality issues
-            - Look for potential bugs
-            - Suggest improvements
+            Review this pull request following the repo-local
+            code-review-excellence skill at
+            .agents/skills/code-review-excellence/SKILL.md.
+
+            Prioritize actionable findings over summary. Focus on:
+            - Correctness bugs and edge cases
+            - Security and data exposure risks
+            - Performance regressions
+            - Missing or weak tests
+            - Maintainability issues that affect future changes
+
+            Use severity labels such as [blocking], [important], [nit],
+            and [suggestion]. Keep feedback specific, constructive, and
+            tied to affected files or lines when possible.

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -17,8 +17,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "code-review-excellence": {
+      "source": "wshobson/agents",
+      "sourceType": "github",
+      "skillPath": "plugins/developer-essentials/skills/code-review-excellence/SKILL.md",
+      "computedHash": "0f585a4ad2f6d8353069ca9051c6f0e8865abb9d3a6a268d423784c3c3852962"
+    }
+  }
+}

--- a/src/app/[locale]/pets/[slug]/page.tsx
+++ b/src/app/[locale]/pets/[slug]/page.tsx
@@ -199,9 +199,8 @@ export default async function PetPage({ params }: PageProps) {
           ownerRow.source === "discover" ? null : ownerRow.creditImage,
         // For 'discover' rows the ownerId is the admin who imported
         // on the author's behalf, NOT the author. Use stored credit_*
-        // exclusively so the author keeps the byline. After someone
-        // claims the row source flips to 'claimed' and we go back to
-        // resolving from the live Clerk profile.
+        // exclusively so the author keeps the byline. Claimed/submit rows
+        // use stored credit plus local userProfiles so this route stays ISR.
         ownerIsProxy: ownerRow.source === "discover",
       })
     : null;
@@ -401,13 +400,6 @@ export default async function PetPage({ params }: PageProps) {
                 ))}
               </div>
             ) : null}
-
-            <OwnerPetControls
-              slug={pet.slug}
-              currentDisplayName={pet.displayName}
-              currentDescription={pet.description}
-              render="suggestions"
-            />
 
             {/* Keyboard hint strip — minimal, mono-spaced, only on
                 pointer-fine media so we don't spam mobile users with

--- a/src/app/[locale]/pets/[slug]/page.tsx
+++ b/src/app/[locale]/pets/[slug]/page.tsx
@@ -1,43 +1,35 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
-import { auth } from "@clerk/nextjs/server";
-import { and, eq, inArray } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { Layers, Shuffle, Sparkles } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 
-import {
-  getCollectionCandidatesForPet,
-  getCollectionsContainingPet,
-} from "@/lib/collections";
+import { getCollectionsContainingPet } from "@/lib/collections";
 import { db, schema } from "@/lib/db/client";
+import { getMetricsForSlug, getMetricsSummary } from "@/lib/db/metrics";
 import { formatDexNumber, getDexNumberMap } from "@/lib/dex";
 import { buildLocaleAlternates } from "@/lib/locale-routing";
-import { resolveOwnerCreditFor } from "@/lib/owner-credit";
-import { computeStats } from "@/lib/pet-stats";
-import {
-  getApprovedPetsWithMetrics,
-  getPet,
-  getStaticPetSlugs,
-} from "@/lib/pets";
+import { resolveStoredOwnerCreditFor } from "@/lib/owner-credit";
+import { computeStatsFromSummary } from "@/lib/pet-stats";
+import { getPet, getStaticPetSlugs } from "@/lib/pets";
 import { getVariantsFor } from "@/lib/variants";
 
 import { ClaimCTA } from "@/components/claim-cta";
 import { InstallCommand } from "@/components/install-command";
 import { JsonLd } from "@/components/json-ld";
 import { LikeButton } from "@/components/like-button";
-import { OwnerEditPanel } from "@/components/owner-edit-panel";
+import { OwnerPetControls } from "@/components/owner-pet-controls";
 import { PetActionMenu } from "@/components/pet-action-menu";
 import { PetFloater } from "@/components/pet-floater";
 import { PetKeyboardNav } from "@/components/pet-keyboard-nav";
 import { PetRadar } from "@/components/pet-radar";
 import { PetSoundButton } from "@/components/pet-sound-button";
-import { PetSprite } from "@/components/pet-sprite";
 import { PetStateViewer } from "@/components/pet-state-viewer";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
+import { StaticPetSprite } from "@/components/static-pet-sprite";
 import { SubmittedBy } from "@/components/submitted-by";
-import { SuggestCollectionButton } from "@/components/suggest-collection-button";
 
 const SITE_URL = "https://petdex.crafter.run";
 
@@ -172,48 +164,28 @@ export default async function PetPage({ params }: PageProps) {
         }
       : null;
 
-  const [{ userId }, allPets, ownerRow, variants, memberOfCollections] =
+  const [metrics, metricsSummary, ownerRow, variants, memberOfCollections] =
     await Promise.all([
-      auth(),
-      getApprovedPetsWithMetrics(),
+      getMetricsForSlug(slug),
+      getMetricsSummary(),
       db.query.submittedPets.findFirst({
         where: eq(schema.submittedPets.slug, slug),
       }),
       getVariantsFor(slug),
       getCollectionsContainingPet(slug),
     ]);
-  const petWithMetrics = allPets.find((candidate) => candidate.slug === slug);
-  const metrics = petWithMetrics?.metrics ?? {
-    installCount: 0,
-    zipDownloadCount: 0,
-    likeCount: 0,
-  };
-  const stats = computeStats(
+  const stats = computeStatsFromSummary(
     {
       importedAt: pet.importedAt,
       metrics,
     },
-    allPets.map((candidate) => ({
-      importedAt: candidate.importedAt,
-      metrics: candidate.metrics,
-    })),
+    metricsSummary,
   );
-  const initialLiked = userId
-    ? Boolean(
-        await db.query.petLikes.findFirst({
-          where: and(
-            eq(schema.petLikes.userId, userId),
-            eq(schema.petLikes.petSlug, slug),
-          ),
-        }),
-      )
-    : false;
 
-  // Resolve the "submitted by" credit live from Clerk so name/url/avatar
-  // reflect the user's *current* profile (not the snapshot taken at
-  // submit time). Falls back to row.credit_* for orphan rows.
+  // Resolve public credit from local data so the ISR shell is not blocked by
+  // a per-request Clerk lookup. Profile sync keeps userProfiles fresh enough.
   const ownerCredit = ownerRow
-    ? await resolveOwnerCreditFor({
+    ? await resolveStoredOwnerCreditFor({
         ownerId: ownerRow.ownerId,
         creditName: ownerRow.creditName,
         creditUrl: ownerRow.creditUrl,
@@ -233,45 +205,6 @@ export default async function PetPage({ params }: PageProps) {
         ownerIsProxy: ownerRow.source === "discover",
       })
     : null;
-
-  let ownerEditState: {
-    isOwner: boolean;
-    petId: string;
-    currentTags: string[];
-    pending: {
-      displayName: string | null;
-      description: string | null;
-      tags: string[] | null;
-      submittedAt: string | null;
-    } | null;
-    lastRejection: string | null;
-  } | null = null;
-  if (userId && ownerRow && ownerRow.ownerId === userId) {
-    const hasPending = Boolean(ownerRow.pendingSubmittedAt);
-    ownerEditState = {
-      isOwner: true,
-      petId: ownerRow.id,
-      currentTags: (ownerRow.tags as string[]) ?? [],
-      pending: hasPending
-        ? {
-            displayName: ownerRow.pendingDisplayName,
-            description: ownerRow.pendingDescription,
-            tags: (ownerRow.pendingTags as string[] | null) ?? null,
-            submittedAt: ownerRow.pendingSubmittedAt
-              ? ownerRow.pendingSubmittedAt.toISOString()
-              : null,
-          }
-        : null,
-      lastRejection: ownerRow.pendingRejectionReason,
-    };
-  }
-
-  // Owner-only: candidate featured collections + already-submitted
-  // pending requests for the suggest button.
-  const collectionSuggest =
-    userId && ownerRow && ownerRow.ownerId === userId
-      ? await getCollectionCandidatesForPet(slug, userId)
-      : null;
 
   const url = `${SITE_URL}/pets/${pet.slug}`;
   const jsonLd = [
@@ -404,29 +337,18 @@ export default async function PetPage({ params }: PageProps) {
               <h1 className="text-balance text-[44px] leading-[1] font-semibold tracking-tight text-foreground md:text-[64px]">
                 {pet.displayName}
               </h1>
-              {ownerEditState ? (
-                <OwnerEditPanel
-                  petId={ownerEditState.petId}
-                  slug={pet.slug}
-                  currentDisplayName={pet.displayName}
-                  currentDescription={pet.description}
-                  currentTags={ownerEditState.currentTags}
-                  initialPending={ownerEditState.pending}
-                  initialRejection={ownerEditState.lastRejection}
-                />
-              ) : null}
+              <OwnerPetControls
+                slug={pet.slug}
+                currentDisplayName={pet.displayName}
+                currentDescription={pet.description}
+              />
             </div>
             <p className="max-w-3xl text-balance text-base leading-7 text-muted-1 md:text-lg">
               {pet.description}
             </p>
 
             <div className="flex flex-wrap items-center gap-3">
-              <LikeButton
-                slug={pet.slug}
-                initialCount={metrics.likeCount}
-                initialLiked={initialLiked}
-                signedIn={Boolean(userId)}
-              />
+              <LikeButton slug={pet.slug} initialCount={metrics.likeCount} />
               {pet.soundUrl ? (
                 <PetSoundButton
                   soundUrl={pet.soundUrl}
@@ -480,14 +402,12 @@ export default async function PetPage({ params }: PageProps) {
               </div>
             ) : null}
 
-            {collectionSuggest && collectionSuggest.candidates.length > 0 ? (
-              <SuggestCollectionButton
-                petSlug={slug}
-                petDisplayName={pet.displayName}
-                candidateCollections={collectionSuggest.candidates}
-                alreadyRequested={collectionSuggest.alreadyRequested}
-              />
-            ) : null}
+            <OwnerPetControls
+              slug={pet.slug}
+              currentDisplayName={pet.displayName}
+              currentDescription={pet.description}
+              render="suggestions"
+            />
 
             {/* Keyboard hint strip — minimal, mono-spaced, only on
                 pointer-fine media so we don't spam mobile users with
@@ -528,7 +448,7 @@ export default async function PetPage({ params }: PageProps) {
           {ownerCredit ? (
             <div className="space-y-3">
               <SubmittedBy credit={ownerCredit} />
-              {ownerRow?.source === "discover" && !userId ? (
+              {ownerRow?.source === "discover" ? (
                 <ClaimCTA
                   petName={pet.displayName}
                   authorLabel={ownerCredit.name}
@@ -578,10 +498,10 @@ export default async function PetPage({ params }: PageProps) {
                     className="group flex items-center gap-3 rounded-2xl border border-border-base bg-background/70 p-3 transition hover:-translate-y-0.5 hover:border-brand/35 hover:bg-background"
                   >
                     <div className="shrink-0 rounded-2xl border border-border-base bg-surface p-2">
-                      <PetSprite
+                      <StaticPetSprite
                         src={variant.spritesheetUrl}
                         scale={0.45}
-                        label={`${variant.displayName} animated`}
+                        label={variant.displayName}
                       />
                     </div>
                     <div className="min-w-0">

--- a/src/app/api/pets/[slug]/like/route.ts
+++ b/src/app/api/pets/[slug]/like/route.ts
@@ -13,6 +13,7 @@ export const runtime = "nodejs";
 const PRIVATE_HEADERS = { "Cache-Control": "private, no-store" };
 
 type Params = { slug: string };
+type PostBody = { liked?: boolean };
 
 export async function POST(
   req: Request,
@@ -50,8 +51,36 @@ export async function POST(
     ),
   });
 
+  let desiredLiked: boolean | null = null;
+  try {
+    const body = (await req.json()) as PostBody;
+    desiredLiked = typeof body.liked === "boolean" ? body.liked : null;
+  } catch {
+    desiredLiked = null;
+  }
+
   let liked: boolean;
-  if (existing) {
+  if (desiredLiked === true && !existing) {
+    await db
+      .insert(schema.petLikes)
+      .values({ userId, petSlug: slug })
+      .onConflictDoNothing({
+        target: [schema.petLikes.userId, schema.petLikes.petSlug],
+      });
+    liked = true;
+  } else if (desiredLiked === false && existing) {
+    await db
+      .delete(schema.petLikes)
+      .where(
+        and(
+          eq(schema.petLikes.userId, userId),
+          eq(schema.petLikes.petSlug, slug),
+        ),
+      );
+    liked = false;
+  } else if (desiredLiked !== null) {
+    liked = desiredLiked;
+  } else if (existing) {
     await db
       .delete(schema.petLikes)
       .where(

--- a/src/app/api/pets/[slug]/like/route.ts
+++ b/src/app/api/pets/[slug]/like/route.ts
@@ -10,6 +10,8 @@ import { requireSameOrigin } from "@/lib/same-origin";
 
 export const runtime = "nodejs";
 
+const PRIVATE_HEADERS = { "Cache-Control": "private, no-store" };
+
 type Params = { slug: string };
 
 export async function POST(
@@ -72,7 +74,10 @@ export async function POST(
   const count = Number(countRow[0]?.c ?? 0);
   await setLikeCount(slug, count);
 
-  return NextResponse.json({ ok: true, liked, count });
+  return NextResponse.json(
+    { ok: true, liked, count },
+    { headers: PRIVATE_HEADERS },
+  );
 }
 
 export async function GET(
@@ -99,5 +104,5 @@ export async function GET(
     liked = Boolean(row);
   }
 
-  return NextResponse.json({ count, liked });
+  return NextResponse.json({ count, liked }, { headers: PRIVATE_HEADERS });
 }

--- a/src/app/api/pets/[slug]/owner-state/route.ts
+++ b/src/app/api/pets/[slug]/owner-state/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+
+import { auth } from "@clerk/nextjs/server";
+import { eq } from "drizzle-orm";
+
+import { getCollectionCandidatesForPet } from "@/lib/collections";
+import { db, schema } from "@/lib/db/client";
+
+export const runtime = "nodejs";
+
+type Params = { slug: string };
+
+const PRIVATE_HEADERS = { "Cache-Control": "private, no-store" };
+
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<Params> },
+): Promise<Response> {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ isOwner: false }, { headers: PRIVATE_HEADERS });
+  }
+
+  const { slug } = await ctx.params;
+  if (!/^[a-z0-9-]{1,60}$/.test(slug)) {
+    return NextResponse.json(
+      { error: "invalid_slug" },
+      { status: 400, headers: PRIVATE_HEADERS },
+    );
+  }
+
+  const row = await db.query.submittedPets.findFirst({
+    where: eq(schema.submittedPets.slug, slug),
+  });
+
+  if (!row || row.status !== "approved" || row.ownerId !== userId) {
+    return NextResponse.json({ isOwner: false }, { headers: PRIVATE_HEADERS });
+  }
+
+  const hasPending = Boolean(row.pendingSubmittedAt);
+  const collectionSuggest = await getCollectionCandidatesForPet(slug, userId);
+
+  return NextResponse.json(
+    {
+      isOwner: true,
+      petId: row.id,
+      currentTags: (row.tags as string[]) ?? [],
+      pending: hasPending
+        ? {
+            displayName: row.pendingDisplayName,
+            description: row.pendingDescription,
+            tags: (row.pendingTags as string[] | null) ?? null,
+            submittedAt: row.pendingSubmittedAt
+              ? row.pendingSubmittedAt.toISOString()
+              : null,
+          }
+        : null,
+      lastRejection: row.pendingRejectionReason,
+      collectionSuggest,
+    },
+    { headers: PRIVATE_HEADERS },
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -453,16 +453,18 @@ input {
 }
 
 /* Static variant for list contexts (leaderboard rows, owner mini-grids).
-   Renders only the first idle frame — no infinite keyframe, no paint
+   Renders only the first frame of a chosen state row — no infinite keyframe, no paint
    thrash on scroll. Same dimensions as .pet-sprite so layouts can
    swap one for the other without touching parent CSS. */
 .pet-sprite-static {
+  --sprite-row: 0;
+  --sprite-y: calc(var(--sprite-row) * -208px);
   width: 192px;
   height: 208px;
   background-image: var(--sprite-url);
   background-repeat: no-repeat;
   background-size: 1536px 1872px;
-  background-position: 0 0;
+  background-position: 0 var(--sprite-y);
   image-rendering: pixelated;
   transform: scale(var(--pet-scale, 1));
   transform-origin: top left;

--- a/src/components/like-button.tsx
+++ b/src/components/like-button.tsx
@@ -1,31 +1,53 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 
-import { useClerk } from "@clerk/nextjs";
+import { useAuth, useClerk } from "@clerk/nextjs";
 import { track } from "@vercel/analytics";
 import { Heart } from "lucide-react";
 
 type LikeButtonProps = {
   slug: string;
   initialCount: number;
-  initialLiked: boolean;
-  signedIn: boolean;
 };
 
-export function LikeButton({
-  slug,
-  initialCount,
-  initialLiked,
-  signedIn,
-}: LikeButtonProps) {
+export function LikeButton({ slug, initialCount }: LikeButtonProps) {
   const [count, setCount] = useState(initialCount);
-  const [liked, setLiked] = useState(initialLiked);
+  const [liked, setLiked] = useState(false);
   const [pending, start] = useTransition();
+  const { isLoaded, isSignedIn } = useAuth();
   const clerk = useClerk();
 
+  useEffect(() => {
+    if (!isLoaded || !isSignedIn) {
+      setLiked(false);
+      setCount(initialCount);
+      return;
+    }
+    const controller = new AbortController();
+
+    void fetch(`/api/pets/${slug}/like`, {
+      signal: controller.signal,
+      headers: { accept: "application/json" },
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: { liked: boolean; count: number } | null) => {
+        if (!data) return;
+        setLiked(data.liked);
+        setCount(data.count);
+      })
+      .catch((error: unknown) => {
+        if ((error as Error).name !== "AbortError") {
+          setLiked(false);
+          setCount(initialCount);
+        }
+      });
+
+    return () => controller.abort();
+  }, [initialCount, isLoaded, isSignedIn, slug]);
+
   function handleClick() {
-    if (!signedIn) {
+    if (!isLoaded || !isSignedIn) {
       clerk.openSignIn({});
       return;
     }

--- a/src/components/like-button.tsx
+++ b/src/components/like-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 
 import { useAuth, useClerk } from "@clerk/nextjs";
 import { track } from "@vercel/analytics";
@@ -14,17 +14,32 @@ type LikeButtonProps = {
 export function LikeButton({ slug, initialCount }: LikeButtonProps) {
   const [count, setCount] = useState(initialCount);
   const [liked, setLiked] = useState(false);
+  const [likeStateLoading, setLikeStateLoading] = useState(false);
   const [pending, start] = useTransition();
   const { isLoaded, isSignedIn } = useAuth();
   const clerk = useClerk();
+  const loadVersionRef = useRef(0);
+  const mutationVersionRef = useRef(0);
 
   useEffect(() => {
+    const loadVersion = loadVersionRef.current + 1;
+    loadVersionRef.current = loadVersion;
+
+    if (!isLoaded) {
+      setLikeStateLoading(true);
+      return;
+    }
+
     if (!isLoaded || !isSignedIn) {
       setLiked(false);
       setCount(initialCount);
+      setLikeStateLoading(false);
       return;
     }
+
+    const mutationVersion = mutationVersionRef.current;
     const controller = new AbortController();
+    setLikeStateLoading(true);
 
     void fetch(`/api/pets/${slug}/like`, {
       signal: controller.signal,
@@ -33,13 +48,21 @@ export function LikeButton({ slug, initialCount }: LikeButtonProps) {
       .then((res) => (res.ok ? res.json() : null))
       .then((data: { liked: boolean; count: number } | null) => {
         if (!data) return;
+        if (loadVersionRef.current !== loadVersion) return;
+        if (mutationVersionRef.current !== mutationVersion) return;
         setLiked(data.liked);
         setCount(data.count);
       })
       .catch((error: unknown) => {
+        if (loadVersionRef.current !== loadVersion) return;
         if ((error as Error).name !== "AbortError") {
           setLiked(false);
           setCount(initialCount);
+        }
+      })
+      .finally(() => {
+        if (loadVersionRef.current === loadVersion) {
+          setLikeStateLoading(false);
         }
       });
 
@@ -51,37 +74,48 @@ export function LikeButton({ slug, initialCount }: LikeButtonProps) {
       clerk.openSignIn({});
       return;
     }
-    if (pending) return;
+    if (pending || likeStateLoading) return;
 
     // Optimistic update
     const nextLiked = !liked;
+    const mutationVersion = mutationVersionRef.current + 1;
+    mutationVersionRef.current = mutationVersion;
     setLiked(nextLiked);
-    setCount((c) => c + (nextLiked ? 1 : -1));
+    setCount((c) => Math.max(0, c + (nextLiked ? 1 : -1)));
 
     start(async () => {
       try {
-        const res = await fetch(`/api/pets/${slug}/like`, { method: "POST" });
+        const res = await fetch(`/api/pets/${slug}/like`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ liked: nextLiked }),
+        });
         if (!res.ok) throw new Error("like failed");
         const data = (await res.json()) as { liked: boolean; count: number };
+        if (mutationVersionRef.current !== mutationVersion) return;
         setLiked(data.liked);
         setCount(data.count);
         if (data.liked) {
           track("pet_liked", { slug });
         }
       } catch {
+        if (mutationVersionRef.current !== mutationVersion) return;
         // Revert
         setLiked(!nextLiked);
-        setCount((c) => c + (nextLiked ? -1 : 1));
+        setCount((c) => Math.max(0, c + (nextLiked ? -1 : 1)));
       }
     });
   }
+
+  const disabled = pending || !isLoaded || (isSignedIn && likeStateLoading);
 
   return (
     <button
       type="button"
       onClick={handleClick}
       aria-pressed={liked}
-      disabled={pending}
+      aria-busy={disabled || undefined}
+      disabled={disabled}
       className={`inline-flex h-10 items-center gap-2 rounded-full border px-4 text-sm font-medium transition disabled:opacity-60 ${
         liked
           ? "border-rose-300 bg-rose-50 text-rose-700 hover:bg-rose-100"

--- a/src/components/owner-pet-controls.tsx
+++ b/src/components/owner-pet-controls.tsx
@@ -30,14 +30,12 @@ type OwnerPetControlsProps = {
   slug: string;
   currentDisplayName: string;
   currentDescription: string;
-  render?: "edit" | "suggestions";
 };
 
 export function OwnerPetControls({
   slug,
   currentDisplayName,
   currentDescription,
-  render = "edit",
 }: OwnerPetControlsProps) {
   const { isLoaded, isSignedIn } = useAuth();
   const [state, setState] = useState<OwnerState | null>(null);
@@ -64,27 +62,25 @@ export function OwnerPetControls({
 
   if (!state?.isOwner || !state.petId) return null;
 
-  if (render === "suggestions") {
-    if (!state.collectionSuggest?.candidates.length) return null;
-    return (
-      <SuggestCollectionButton
-        petSlug={slug}
-        petDisplayName={currentDisplayName}
-        candidateCollections={state.collectionSuggest.candidates}
-        alreadyRequested={state.collectionSuggest.alreadyRequested}
-      />
-    );
-  }
-
   return (
-    <OwnerEditPanel
-      petId={state.petId}
-      slug={slug}
-      currentDisplayName={currentDisplayName}
-      currentDescription={currentDescription}
-      currentTags={state.currentTags}
-      initialPending={state.pending}
-      initialRejection={state.lastRejection}
-    />
+    <div className="flex flex-col items-start gap-3">
+      <OwnerEditPanel
+        petId={state.petId}
+        slug={slug}
+        currentDisplayName={currentDisplayName}
+        currentDescription={currentDescription}
+        currentTags={state.currentTags}
+        initialPending={state.pending}
+        initialRejection={state.lastRejection}
+      />
+      {state.collectionSuggest?.candidates.length ? (
+        <SuggestCollectionButton
+          petSlug={slug}
+          petDisplayName={currentDisplayName}
+          candidateCollections={state.collectionSuggest.candidates}
+          alreadyRequested={state.collectionSuggest.alreadyRequested}
+        />
+      ) : null}
+    </div>
   );
 }

--- a/src/components/owner-pet-controls.tsx
+++ b/src/components/owner-pet-controls.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { useAuth } from "@clerk/nextjs";
+
+import { OwnerEditPanel } from "@/components/owner-edit-panel";
+import { SuggestCollectionButton } from "@/components/suggest-collection-button";
+
+type Pending = {
+  displayName: string | null;
+  description: string | null;
+  tags: string[] | null;
+  submittedAt: string | null;
+};
+
+type OwnerState = {
+  isOwner: boolean;
+  petId: string | null;
+  currentTags: string[];
+  pending: Pending | null;
+  lastRejection: string | null;
+  collectionSuggest: {
+    candidates: Array<{ slug: string; title: string }>;
+    alreadyRequested: string[];
+  } | null;
+};
+
+type OwnerPetControlsProps = {
+  slug: string;
+  currentDisplayName: string;
+  currentDescription: string;
+  render?: "edit" | "suggestions";
+};
+
+export function OwnerPetControls({
+  slug,
+  currentDisplayName,
+  currentDescription,
+  render = "edit",
+}: OwnerPetControlsProps) {
+  const { isLoaded, isSignedIn } = useAuth();
+  const [state, setState] = useState<OwnerState | null>(null);
+
+  useEffect(() => {
+    if (!isLoaded || !isSignedIn) {
+      setState(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    void fetch(`/api/pets/${slug}/owner-state`, {
+      signal: controller.signal,
+      headers: { accept: "application/json" },
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: OwnerState | null) => setState(data))
+      .catch((error: unknown) => {
+        if ((error as Error).name !== "AbortError") setState(null);
+      });
+
+    return () => controller.abort();
+  }, [isLoaded, isSignedIn, slug]);
+
+  if (!state?.isOwner || !state.petId) return null;
+
+  if (render === "suggestions") {
+    if (!state.collectionSuggest?.candidates.length) return null;
+    return (
+      <SuggestCollectionButton
+        petSlug={slug}
+        petDisplayName={currentDisplayName}
+        candidateCollections={state.collectionSuggest.candidates}
+        alreadyRequested={state.collectionSuggest.alreadyRequested}
+      />
+    );
+  }
+
+  return (
+    <OwnerEditPanel
+      petId={state.petId}
+      slug={slug}
+      currentDisplayName={currentDisplayName}
+      currentDescription={currentDescription}
+      currentTags={state.currentTags}
+      initialPending={state.pending}
+      initialRejection={state.lastRejection}
+    />
+  );
+}

--- a/src/components/pet-state-viewer.tsx
+++ b/src/components/pet-state-viewer.tsx
@@ -80,7 +80,7 @@ export function PetStateViewer({ src, petName }: PetStateViewerProps) {
                 </p>
               </div>
               <div className="rounded-md border border-border-base bg-surface-muted p-2">
-                <StaticPetSprite src={src} scale={0.32} />
+                <StaticPetSprite src={src} state={state.id} scale={0.32} />
               </div>
             </div>
           </button>

--- a/src/components/pet-state-viewer.tsx
+++ b/src/components/pet-state-viewer.tsx
@@ -8,6 +8,7 @@ import { useTranslations } from "next-intl";
 import { defaultPetState, type PetStateId, petStates } from "@/lib/pet-states";
 
 import { PetSprite } from "@/components/pet-sprite";
+import { StaticPetSprite } from "@/components/static-pet-sprite";
 
 type PetStateViewerProps = {
   src: string;
@@ -79,7 +80,7 @@ export function PetStateViewer({ src, petName }: PetStateViewerProps) {
                 </p>
               </div>
               <div className="rounded-md border border-border-base bg-surface-muted p-2">
-                <PetSprite src={src} state={state.id} scale={0.32} />
+                <StaticPetSprite src={src} scale={0.32} />
               </div>
             </div>
           </button>

--- a/src/components/static-pet-sprite.tsx
+++ b/src/components/static-pet-sprite.tsx
@@ -3,14 +3,17 @@
 // owner mini-grids) would tank scroll perf if every sprite ran a CSS
 // step animation + paint.
 //
-// Renders the first idle frame (col 0, row 0) of the sheet by clamping
+// Renders the first frame of a selected state row by clamping
 // background-position. No setInterval, no infinite keyframe — just a
 // static crop that the browser paints once and is done with.
 
 import type { CSSProperties } from "react";
 
+import { defaultPetState, type PetStateId, petStates } from "@/lib/pet-states";
+
 type StaticPetSpriteProps = {
   src: string;
+  state?: PetStateId;
   scale?: number;
   label?: string;
   className?: string;
@@ -18,10 +21,14 @@ type StaticPetSpriteProps = {
 
 export function StaticPetSprite({
   src,
+  state = defaultPetState.id,
   scale = 1,
   label,
   className = "",
 }: StaticPetSpriteProps) {
+  const spriteState =
+    petStates.find((item) => item.id === state) ?? defaultPetState;
+
   return (
     <div
       className={`pet-sprite-frame ${className}`}
@@ -31,7 +38,12 @@ export function StaticPetSprite({
     >
       <div
         className="pet-sprite-static"
-        style={{ "--sprite-url": `url(${src})` } as CSSProperties}
+        style={
+          {
+            "--sprite-url": `url(${src})`,
+            "--sprite-row": spriteState.row,
+          } as CSSProperties
+        }
       />
     </div>
   );

--- a/src/components/submitted-by.tsx
+++ b/src/components/submitted-by.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 
 import { useTranslations } from "next-intl";
@@ -45,6 +46,7 @@ function XIcon({ className }: { className?: string }) {
 export function SubmittedBy({ credit }: SubmittedByProps) {
   const t = useTranslations("submittedBy");
   const showAvatar = credit.imageUrl && isAllowedAvatarUrl(credit.imageUrl);
+  const avatarUrl = showAvatar ? credit.imageUrl : null;
   const profileHref = `/u/${credit.handle}`;
 
   return (
@@ -54,11 +56,12 @@ export function SubmittedBy({ credit }: SubmittedByProps) {
       className="group block rounded-2xl border border-border-base bg-surface/76 p-4 backdrop-blur transition hover:border-border-strong hover:bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
     >
       <div className="flex items-center gap-3">
-        {showAvatar ? (
-          // biome-ignore lint/performance/noImgElement: external avatar URL
-          <img
-            src={credit.imageUrl ?? undefined}
+        {avatarUrl ? (
+          <Image
+            src={avatarUrl}
             alt=""
+            width={40}
+            height={40}
             className="size-10 shrink-0 rounded-full ring-1 ring-border-base"
           />
         ) : (

--- a/src/components/submitted-by.tsx
+++ b/src/components/submitted-by.tsx
@@ -3,9 +3,10 @@
 import Image from "next/image";
 import Link from "next/link";
 
+import { useUser } from "@clerk/nextjs";
 import { useTranslations } from "next-intl";
 
-import type { OwnerCredit } from "@/lib/owner-credit";
+import type { OwnerCredit, OwnerExternal } from "@/lib/owner-credit";
 import { isAllowedAvatarUrl } from "@/lib/url-allowlist";
 
 type SubmittedByProps = {
@@ -45,14 +46,17 @@ function XIcon({ className }: { className?: string }) {
 
 export function SubmittedBy({ credit }: SubmittedByProps) {
   const t = useTranslations("submittedBy");
-  const showAvatar = credit.imageUrl && isAllowedAvatarUrl(credit.imageUrl);
-  const avatarUrl = showAvatar ? credit.imageUrl : null;
-  const profileHref = `/u/${credit.handle}`;
+  const { user } = useUser();
+  const displayCredit = mergeCurrentUserCredit(credit, user);
+  const showAvatar =
+    displayCredit.imageUrl && isAllowedAvatarUrl(displayCredit.imageUrl);
+  const avatarUrl = showAvatar ? displayCredit.imageUrl : null;
+  const profileHref = `/u/${displayCredit.handle}`;
 
   return (
     <Link
       href={profileHref}
-      aria-label={t("viewProfile", { name: credit.name })}
+      aria-label={t("viewProfile", { name: displayCredit.name })}
       className="group block rounded-2xl border border-border-base bg-surface/76 p-4 backdrop-blur transition hover:border-border-strong hover:bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
     >
       <div className="flex items-center gap-3">
@@ -66,7 +70,7 @@ export function SubmittedBy({ credit }: SubmittedByProps) {
           />
         ) : (
           <div className="grid size-10 shrink-0 place-items-center rounded-full bg-surface-muted font-mono text-sm text-muted-2 ring-1 ring-border-base">
-            {credit.name.slice(0, 1).toUpperCase()}
+            {displayCredit.name.slice(0, 1).toUpperCase()}
           </div>
         )}
         <div className="min-w-0 flex-1">
@@ -75,20 +79,20 @@ export function SubmittedBy({ credit }: SubmittedByProps) {
           </p>
           <div className="flex flex-wrap items-baseline gap-x-2">
             <p className="truncate text-sm font-medium text-foreground">
-              {credit.name}
+              {displayCredit.name}
             </p>
-            {credit.username ? (
+            {displayCredit.username ? (
               <p className="font-mono text-[11px] text-muted-4">
-                @{credit.username}
+                @{displayCredit.username}
               </p>
             ) : null}
           </div>
         </div>
       </div>
 
-      {credit.externals.length > 0 ? (
+      {displayCredit.externals.length > 0 ? (
         <div className="mt-3 flex flex-wrap items-center gap-1.5 border-t border-border-base pt-3">
-          {credit.externals.map((ext) => (
+          {displayCredit.externals.map((ext) => (
             // Rendered as a button (not nested <a>, which would be
             // invalid HTML inside the wrapping profile <Link>). The
             // button calls window.open and stops propagation so the
@@ -115,4 +119,68 @@ export function SubmittedBy({ credit }: SubmittedByProps) {
       ) : null}
     </Link>
   );
+}
+
+function mergeCurrentUserCredit(
+  credit: OwnerCredit,
+  user:
+    | {
+        id: string;
+        imageUrl?: string;
+        username?: string | null;
+        fullName?: string | null;
+        primaryEmailAddress?: { emailAddress?: string | null } | null;
+        externalAccounts?: Array<{ provider?: string; username?: string }>;
+      }
+    | null
+    | undefined,
+): OwnerCredit {
+  if (!user || user.id !== credit.userId) return credit;
+
+  const externals = externalsFor(user.externalAccounts ?? []);
+
+  return {
+    ...credit,
+    name:
+      credit.name === "anonymous"
+        ? user.fullName ||
+          user.username ||
+          user.primaryEmailAddress?.emailAddress ||
+          credit.name
+        : credit.name,
+    username: user.username ?? credit.username,
+    externals: externals.length > 0 ? externals : credit.externals,
+    imageUrl: user.imageUrl ?? credit.imageUrl,
+  };
+}
+
+function externalsFor(
+  externalAccounts: Array<{ provider?: string; username?: string }>,
+): OwnerExternal[] {
+  let github: OwnerExternal | null = null;
+  let x: OwnerExternal | null = null;
+
+  for (const account of externalAccounts) {
+    if (!account.username) continue;
+    if (account.provider === "oauth_github" && !github) {
+      github = {
+        provider: "github",
+        username: account.username,
+        url: `https://github.com/${account.username}`,
+      };
+    }
+    if (
+      (account.provider === "oauth_x" ||
+        account.provider === "oauth_twitter") &&
+      !x
+    ) {
+      x = {
+        provider: "x",
+        username: account.username,
+        url: `https://x.com/${account.username}`,
+      };
+    }
+  }
+
+  return [github, x].filter((item): item is OwnerExternal => Boolean(item));
 }

--- a/src/lib/db/metrics.ts
+++ b/src/lib/db/metrics.ts
@@ -1,4 +1,4 @@
-import { inArray, sql } from "drizzle-orm";
+import { eq, inArray, sql } from "drizzle-orm";
 
 import { db, schema } from "./client";
 
@@ -106,7 +106,12 @@ export async function getMetricsSummary(): Promise<MetricsSummary> {
       maxInstallCount: sql<number>`coalesce(max(${schema.petMetrics.installCount}), 0)::int`,
       maxLikeCount: sql<number>`coalesce(max(${schema.petMetrics.likeCount}), 0)::int`,
     })
-    .from(schema.petMetrics);
+    .from(schema.petMetrics)
+    .innerJoin(
+      schema.submittedPets,
+      eq(schema.petMetrics.petSlug, schema.submittedPets.slug),
+    )
+    .where(eq(schema.submittedPets.status, "approved"));
 
   return {
     maxInstallCount: row?.maxInstallCount ?? 0,

--- a/src/lib/db/metrics.ts
+++ b/src/lib/db/metrics.ts
@@ -52,6 +52,11 @@ export type Metrics = {
   likeCount: number;
 };
 
+export type MetricsSummary = {
+  maxInstallCount: number;
+  maxLikeCount: number;
+};
+
 export async function getAllMetrics(): Promise<Map<string, Metrics>> {
   const rows = await db.select().from(schema.petMetrics);
   const map = new Map<string, Metrics>();
@@ -92,5 +97,19 @@ export async function getMetricsForSlug(slug: string): Promise<Metrics> {
     installCount: row?.installCount ?? 0,
     zipDownloadCount: row?.zipDownloadCount ?? 0,
     likeCount: row?.likeCount ?? 0,
+  };
+}
+
+export async function getMetricsSummary(): Promise<MetricsSummary> {
+  const [row] = await db
+    .select({
+      maxInstallCount: sql<number>`coalesce(max(${schema.petMetrics.installCount}), 0)::int`,
+      maxLikeCount: sql<number>`coalesce(max(${schema.petMetrics.likeCount}), 0)::int`,
+    })
+    .from(schema.petMetrics);
+
+  return {
+    maxInstallCount: row?.maxInstallCount ?? 0,
+    maxLikeCount: row?.maxLikeCount ?? 0,
   };
 }

--- a/src/lib/owner-credit.ts
+++ b/src/lib/owner-credit.ts
@@ -265,6 +265,9 @@ export async function resolveOwnerCreditFor(
 export async function resolveStoredOwnerCreditFor(
   row: RowCreditFallback,
 ): Promise<OwnerCredit> {
+  // ISR pet pages render from persisted public identity fields only.
+  // Keeping live Clerk avatar/external-account freshness requires a future
+  // DB sync/webhook rather than a per-render Clerk lookup.
   let profile: { displayName: string | null; handle: string | null } | null =
     null;
 

--- a/src/lib/owner-credit.ts
+++ b/src/lib/owner-credit.ts
@@ -261,3 +261,52 @@ export async function resolveOwnerCreditFor(
     }
   );
 }
+
+export async function resolveStoredOwnerCreditFor(
+  row: RowCreditFallback,
+): Promise<OwnerCredit> {
+  let profile: { displayName: string | null; handle: string | null } | null =
+    null;
+
+  if (!row.ownerIsProxy) {
+    try {
+      const [storedProfile] = await db
+        .select({
+          displayName: schema.userProfiles.displayName,
+          handle: schema.userProfiles.handle,
+        })
+        .from(schema.userProfiles)
+        .where(inArray(schema.userProfiles.userId, [row.ownerId]));
+      profile = storedProfile ?? null;
+    } catch {
+      profile = null;
+    }
+  }
+
+  const externals: OwnerExternal[] = [];
+  if (row.creditUrl) {
+    try {
+      const url = new URL(row.creditUrl);
+      const username = url.pathname.slice(1);
+      if (url.host === "github.com" && username) {
+        externals.push({ provider: "github", username, url: row.creditUrl });
+      } else if (
+        (url.host === "x.com" || url.host === "twitter.com") &&
+        username
+      ) {
+        externals.push({ provider: "x", username, url: row.creditUrl });
+      }
+    } catch {
+      /* ignore malformed stored URL */
+    }
+  }
+
+  return {
+    userId: row.ownerId,
+    name: (profile?.displayName ?? row.creditName?.trim()) || "anonymous",
+    handle: profile?.handle ?? fallbackHandle(row.ownerId),
+    username: null,
+    externals,
+    imageUrl: row.creditImage,
+  };
+}

--- a/src/lib/pet-stats.ts
+++ b/src/lib/pet-stats.ts
@@ -1,4 +1,4 @@
-import type { Metrics } from "@/lib/db/metrics";
+import type { Metrics, MetricsSummary } from "@/lib/db/metrics";
 import { petStates } from "@/lib/pet-states";
 
 type PetStatsSource = {
@@ -73,6 +73,29 @@ export function computeStats(
       maxInstalls,
     ),
     loved: getNormalizedLogScore(pet.metrics?.likeCount ?? 0, maxLikes),
+    freshness: Math.round(100 - clamp((daysSinceApproved / 90) * 100, 0, 100)),
+  };
+}
+
+export function computeStatsFromSummary(
+  pet: PetStatsSource,
+  summary: MetricsSummary,
+): PetStats {
+  const approvedAt = new Date(pet.importedAt);
+  const daysSinceApproved = Number.isNaN(approvedAt.getTime())
+    ? 90
+    : (Date.now() - approvedAt.getTime()) / (1000 * 60 * 60 * 24);
+
+  return {
+    vibrance: toPercent(getVibranceValue(pet), DEFAULT_FRAME_TOTAL),
+    popularity: getNormalizedLogScore(
+      pet.metrics?.installCount ?? 0,
+      summary.maxInstallCount,
+    ),
+    loved: getNormalizedLogScore(
+      pet.metrics?.likeCount ?? 0,
+      summary.maxLikeCount,
+    ),
     freshness: Math.round(100 - clamp((daysSinceApproved / 90) * 100, 0, 100)),
   };
 }

--- a/src/lib/pets.ts
+++ b/src/lib/pets.ts
@@ -3,6 +3,8 @@
 // JSON dump is only consulted by that backfill script; the rest of the app
 // reads from the DB.
 
+import { cache } from "react";
+
 import { and, eq, sql } from "drizzle-orm";
 
 import { db, schema } from "@/lib/db/client";
@@ -21,15 +23,17 @@ const EMPTY_METRICS: Metrics = {
   likeCount: 0,
 };
 
-export async function getPet(slug: string): Promise<PetdexPet | undefined> {
-  const row = await db.query.submittedPets.findFirst({
-    where: and(
-      eq(schema.submittedPets.slug, slug),
-      eq(schema.submittedPets.status, "approved"),
-    ),
-  });
-  return row ? rowToPet(row) : undefined;
-}
+export const getPet = cache(
+  async (slug: string): Promise<PetdexPet | undefined> => {
+    const row = await db.query.submittedPets.findFirst({
+      where: and(
+        eq(schema.submittedPets.slug, slug),
+        eq(schema.submittedPets.status, "approved"),
+      ),
+    });
+    return row ? rowToPet(row) : undefined;
+  },
+);
 
 export async function getPetWithMetrics(
   slug: string,


### PR DESCRIPTION
## Summary
- Move pet detail personalization out of the server render path so `/[locale]/pets/[slug]` builds as ISR with 1 minute revalidation.
- Add private client/API islands for like state and owner-only controls.
- Reduce server and client work with targeted metrics, cached pet lookup, static sprite thumbnails, and optimized avatar images.

## Verification
- `bun run check`
- `bun run build`