### PR TITLE
Add admin campaign dashboard

### DIFF
--- a/src/app/[locale]/admin/campaigns/page.tsx
+++ b/src/app/[locale]/admin/campaigns/page.tsx
@@ -1,0 +1,47 @@
+import {
+  type AdminAdCampaignSearchParams,
+  parseAdminAdCampaignFilters,
+} from "@/lib/ads/admin-filters";
+import {
+  getAdminAdCampaignOverview,
+  getAdminAdCampaigns,
+} from "@/lib/ads/queries";
+
+import { AdminAdDashboard } from "@/components/ads/admin-ad-dashboard";
+
+import type { Locale } from "@/i18n/config";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Petdex — Admin · Campaigns",
+  robots: { index: false, follow: false },
+};
+
+export default async function AdminCampaignsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<AdminAdCampaignSearchParams>;
+}) {
+  const [{ locale }, resolvedSearchParams] = await Promise.all([
+    params,
+    searchParams,
+  ]);
+  const filters = parseAdminAdCampaignFilters(resolvedSearchParams);
+  const [overview, campaignList] = await Promise.all([
+    getAdminAdCampaignOverview(),
+    getAdminAdCampaigns(filters),
+  ]);
+
+  return (
+    <AdminAdDashboard
+      overview={overview}
+      campaigns={campaignList.campaigns}
+      totalCount={campaignList.totalCount}
+      filters={filters}
+      locale={locale as Locale}
+    />
+  );
+}

--- a/src/components/admin-tabs.tsx
+++ b/src/components/admin-tabs.tsx
@@ -15,6 +15,7 @@ const TABS: Array<{
     | "requests"
     | "collections"
     | "feedback"
+    | "campaigns"
     | "manifest"
     | "insights";
   match: (pathname: string) => boolean;
@@ -43,6 +44,11 @@ const TABS: Array<{
     href: "/admin/feedback",
     key: "feedback",
     match: (p) => p.startsWith("/admin/feedback"),
+  },
+  {
+    href: "/admin/campaigns",
+    key: "campaigns",
+    match: (p) => p.startsWith("/admin/campaigns"),
   },
   {
     href: "/admin/manifest",

--- a/src/components/ads/ad-campaign-card.tsx
+++ b/src/components/ads/ad-campaign-card.tsx
@@ -1,0 +1,254 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import { ExternalLink } from "lucide-react";
+
+import { formatUsd } from "@/lib/ads/packages";
+import type { AdvertiserCampaign } from "@/lib/ads/queries";
+
+import { AdAnalyticsTabs } from "@/components/ads/ad-analytics-tabs";
+
+export type AdCampaignCardLabels = {
+  editCreative?: string;
+  progress: string;
+  destination: string;
+  removedFallback: string;
+  created: (date: string) => string;
+  activated: (date: string) => string;
+  metrics: {
+    package: string;
+    served: string;
+    remaining: string;
+    spend: string;
+    clicks: string;
+    ctr: string;
+    avgTime: string;
+  };
+  chartWindows: {
+    eightHours: string;
+    day: string;
+    week: string;
+    month: string;
+  };
+};
+
+export type AdCampaignOwnerDetails = {
+  title: string;
+  userIdLabel: string;
+  contactEmailLabel: string;
+  companyLabel: string;
+  userId: string;
+  contactEmail: string;
+  companyName: string;
+};
+
+export function AdCampaignCard({
+  campaign,
+  editHref,
+  labels,
+  ownerDetails,
+}: {
+  campaign: AdvertiserCampaign;
+  editHref?: string;
+  labels: AdCampaignCardLabels;
+  ownerDetails?: AdCampaignOwnerDetails;
+}) {
+  const served = Math.min(campaign.viewsServed, campaign.packageViews);
+  const remaining = Math.max(campaign.packageViews - served, 0);
+  const progress = Math.round((served / campaign.packageViews) * 100);
+  const ctr = served > 0 ? (campaign.clicks / served) * 100 : 0;
+  const editable =
+    Boolean(editHref) && campaign.status !== "deleted" && !campaign.deletedAt;
+
+  return (
+    <article className="rounded-[2rem] border border-border-base bg-surface/82 p-5 shadow-sm shadow-blue-950/5 backdrop-blur md:p-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
+            {campaign.companyName}
+          </p>
+          <h2 className="mt-1 text-2xl font-semibold tracking-tight text-foreground">
+            {campaign.title}
+          </h2>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <StatusBadge status={campaign.status} />
+          {editable && editHref && labels.editCreative ? (
+            <Link
+              href={editHref}
+              className="inline-flex h-9 items-center justify-center rounded-full border border-border-base bg-background px-4 text-sm font-medium text-foreground transition hover:border-brand/60 hover:text-brand"
+            >
+              {labels.editCreative}
+            </Link>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="mt-5 grid gap-5 lg:grid-cols-[180px_1fr]">
+        <div className="relative aspect-[4/3] overflow-hidden rounded-2xl border border-border-base bg-background lg:aspect-square">
+          <Image
+            src={campaign.imageUrl}
+            alt=""
+            fill
+            sizes="180px"
+            className="object-cover"
+          />
+        </div>
+        <div className="min-w-0">
+          <p className="max-w-2xl text-sm leading-6 text-muted-2">
+            {campaign.description}
+          </p>
+
+          {ownerDetails ? <OwnerDetails details={ownerDetails} /> : null}
+
+          <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <Metric
+              label={labels.metrics.package}
+              value={formatAdMetricNumber(campaign.packageViews)}
+            />
+            <Metric
+              label={labels.metrics.served}
+              value={formatAdMetricNumber(served)}
+            />
+            <Metric
+              label={labels.metrics.remaining}
+              value={formatAdMetricNumber(remaining)}
+            />
+            <Metric
+              label={labels.metrics.spend}
+              value={formatUsd(campaign.priceCents)}
+            />
+            <Metric
+              label={labels.metrics.clicks}
+              value={formatAdMetricNumber(campaign.clicks)}
+            />
+            <Metric label={labels.metrics.ctr} value={`${ctr.toFixed(2)}%`} />
+            <Metric
+              label={labels.metrics.avgTime}
+              value={formatAdDuration(campaign.avgTimeInViewMs)}
+            />
+          </div>
+
+          <div className="mt-5">
+            <div className="flex items-center justify-between gap-3 font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
+              <span>{labels.progress}</span>
+              <span>{progress}%</span>
+            </div>
+            <div className="mt-2 h-2 overflow-hidden rounded-full bg-background">
+              <div
+                className="h-full rounded-full bg-brand"
+                style={{ width: `${progress}%` }}
+              />
+            </div>
+          </div>
+
+          {campaign.status === "deleted" ? (
+            <p className="mt-4 rounded-2xl bg-chip-danger-bg p-3 text-sm text-chip-danger-fg">
+              {campaign.removalReason ?? labels.removedFallback}
+            </p>
+          ) : null}
+
+          <div className="mt-5 flex flex-wrap items-center gap-3 text-sm text-muted-2">
+            <a
+              href={campaign.destinationUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-brand underline-offset-4 hover:underline"
+            >
+              {labels.destination}
+              <ExternalLink className="size-3.5" />
+            </a>
+            <span>{labels.created(formatAdDate(campaign.createdAt))}</span>
+            {campaign.activatedAt ? (
+              <span>
+                {labels.activated(formatAdDate(campaign.activatedAt))}
+              </span>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-5 rounded-3xl border border-border-base bg-background/50 p-3">
+        <AdAnalyticsTabs
+          series={campaign.timeSeries}
+          labels={labels.chartWindows}
+        />
+      </div>
+    </article>
+  );
+}
+
+function OwnerDetails({ details }: { details: AdCampaignOwnerDetails }) {
+  return (
+    <div className="mt-5 rounded-2xl border border-border-base bg-background/60 p-3">
+      <p className="font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
+        {details.title}
+      </p>
+      <div className="mt-2 grid gap-2 text-xs text-muted-2 md:grid-cols-3">
+        <OwnerField label={details.companyLabel} value={details.companyName} />
+        <OwnerField
+          label={details.contactEmailLabel}
+          value={details.contactEmail}
+        />
+        <OwnerField label={details.userIdLabel} value={details.userId} />
+      </div>
+    </div>
+  );
+}
+
+function OwnerField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0">
+      <p className="font-mono text-[9px] tracking-[0.16em] text-muted-3 uppercase">
+        {label}
+      </p>
+      <p className="mt-0.5 truncate text-foreground" title={value}>
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const tone =
+    status === "active"
+      ? "bg-chip-success-bg text-chip-success-fg"
+      : status === "deleted" || status === "paused"
+        ? "bg-chip-danger-bg text-chip-danger-fg"
+        : "bg-chip-warning-bg text-chip-warning-fg";
+  return (
+    <span
+      className={`rounded-full px-3 py-1 font-mono text-[10px] tracking-[0.16em] uppercase ${tone}`}
+    >
+      {status.replace(/_/g, " ")}
+    </span>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl border border-border-base bg-background p-3">
+      <p className="font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
+        {label}
+      </p>
+      <p className="mt-1 text-lg font-semibold text-foreground">{value}</p>
+    </div>
+  );
+}
+
+export function formatAdMetricNumber(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+export function formatAdDuration(value: number): string {
+  if (value <= 0) return "0s";
+  return `${(value / 1000).toFixed(1)}s`;
+}
+
+export function formatAdDate(value: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(value);
+}

--- a/src/components/ads/ad-dashboard.tsx
+++ b/src/components/ads/ad-dashboard.tsx
@@ -1,14 +1,14 @@
-import Image from "next/image";
 import Link from "next/link";
 
-import { ExternalLink } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 
-import { formatUsd } from "@/lib/ads/packages";
 import type { AdvertiserCampaign } from "@/lib/ads/queries";
 import { withLocale } from "@/lib/locale-routing";
 
-import { AdAnalyticsTabs } from "@/components/ads/ad-analytics-tabs";
+import {
+  AdCampaignCard,
+  formatAdMetricNumber,
+} from "@/components/ads/ad-campaign-card";
 
 import type { Locale } from "@/i18n/config";
 
@@ -57,167 +57,64 @@ export async function AdDashboard({
     (campaign) => campaign.status === "active" && !campaign.deletedAt,
   ).length;
   const ctr = totalServed > 0 ? (totalClicks / totalServed) * 100 : 0;
+  const cardLabels = {
+    editCreative: t("editCreative"),
+    progress: t("progress"),
+    destination: t("destination"),
+    removedFallback: t("removedFallback"),
+    created: (date: string) => t("created", { date }),
+    activated: (date: string) => t("activated", { date }),
+    metrics: {
+      package: t("metrics.package"),
+      served: t("metrics.served"),
+      remaining: t("metrics.remaining"),
+      spend: t("metrics.spend"),
+      clicks: t("metrics.clicks"),
+      ctr: t("metrics.ctr"),
+      avgTime: t("metrics.avgTime"),
+    },
+    chartWindows: {
+      eightHours: t("chart.windows.eightHours"),
+      day: t("chart.windows.day"),
+      week: t("chart.windows.week"),
+      month: t("chart.windows.month"),
+    },
+  };
 
   return (
     <div className="space-y-5">
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
         <SummaryCard
           label={t("summary.total")}
-          value={formatViews(campaigns.length)}
+          value={formatAdMetricNumber(campaigns.length)}
         />
         <SummaryCard
           label={t("summary.active")}
-          value={formatViews(activeCampaigns)}
+          value={formatAdMetricNumber(activeCampaigns)}
         />
         <SummaryCard
           label={t("summary.served")}
-          value={formatViews(totalServed)}
+          value={formatAdMetricNumber(totalServed)}
         />
         <SummaryCard
           label={t("summary.clicks")}
-          value={formatViews(totalClicks)}
+          value={formatAdMetricNumber(totalClicks)}
         />
         <SummaryCard label={t("summary.ctr")} value={`${ctr.toFixed(2)}%`} />
       </div>
 
       {campaigns.map((campaign) => {
-        const served = Math.min(campaign.viewsServed, campaign.packageViews);
-        const remaining = Math.max(campaign.packageViews - served, 0);
-        const progress = Math.round((served / campaign.packageViews) * 100);
-        const ctr = served > 0 ? (campaign.clicks / served) * 100 : 0;
-        const editable = campaign.status !== "deleted" && !campaign.deletedAt;
         const editHref = withLocale(
           `/advertise/dashboard/${campaign.id}/edit`,
           locale,
         );
         return (
-          <article
+          <AdCampaignCard
             key={campaign.id}
-            className="rounded-[2rem] border border-border-base bg-surface/82 p-5 shadow-sm shadow-blue-950/5 backdrop-blur md:p-6"
-          >
-            <div className="flex flex-wrap items-start justify-between gap-3">
-              <div>
-                <p className="font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
-                  {campaign.companyName}
-                </p>
-                <h2 className="mt-1 text-2xl font-semibold tracking-tight text-foreground">
-                  {campaign.title}
-                </h2>
-              </div>
-              <div className="flex flex-wrap items-center gap-2">
-                <StatusBadge status={campaign.status} />
-                {editable ? (
-                  <Link
-                    href={editHref}
-                    className="inline-flex h-9 items-center justify-center rounded-full border border-border-base bg-background px-4 text-sm font-medium text-foreground transition hover:border-brand/60 hover:text-brand"
-                  >
-                    {t("editCreative")}
-                  </Link>
-                ) : null}
-              </div>
-            </div>
-
-            <div className="mt-5 grid gap-5 lg:grid-cols-[180px_1fr]">
-              <div className="relative aspect-[4/3] overflow-hidden rounded-2xl border border-border-base bg-background lg:aspect-square">
-                <Image
-                  src={campaign.imageUrl}
-                  alt=""
-                  fill
-                  sizes="180px"
-                  className="object-cover"
-                />
-              </div>
-              <div className="min-w-0">
-                <p className="max-w-2xl text-sm leading-6 text-muted-2">
-                  {campaign.description}
-                </p>
-
-                <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-                  <Metric
-                    label={t("metrics.package")}
-                    value={formatViews(campaign.packageViews)}
-                  />
-                  <Metric
-                    label={t("metrics.served")}
-                    value={formatViews(served)}
-                  />
-                  <Metric
-                    label={t("metrics.remaining")}
-                    value={formatViews(remaining)}
-                  />
-                  <Metric
-                    label={t("metrics.spend")}
-                    value={formatUsd(campaign.priceCents)}
-                  />
-                  <Metric
-                    label={t("metrics.clicks")}
-                    value={formatViews(campaign.clicks)}
-                  />
-                  <Metric
-                    label={t("metrics.ctr")}
-                    value={`${ctr.toFixed(2)}%`}
-                  />
-                  <Metric
-                    label={t("metrics.avgTime")}
-                    value={formatDuration(campaign.avgTimeInViewMs)}
-                  />
-                </div>
-
-                <div className="mt-5">
-                  <div className="flex items-center justify-between gap-3 font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
-                    <span>{t("progress")}</span>
-                    <span>{progress}%</span>
-                  </div>
-                  <div className="mt-2 h-2 overflow-hidden rounded-full bg-background">
-                    <div
-                      className="h-full rounded-full bg-brand"
-                      style={{ width: `${progress}%` }}
-                    />
-                  </div>
-                </div>
-
-                {campaign.status === "deleted" ? (
-                  <p className="mt-4 rounded-2xl bg-chip-danger-bg p-3 text-sm text-chip-danger-fg">
-                    {campaign.removalReason ?? t("removedFallback")}
-                  </p>
-                ) : null}
-
-                <div className="mt-5 flex flex-wrap items-center gap-3 text-sm text-muted-2">
-                  <a
-                    href={campaign.destinationUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1.5 text-brand underline-offset-4 hover:underline"
-                  >
-                    {t("destination")}
-                    <ExternalLink className="size-3.5" />
-                  </a>
-                  <span>
-                    {t("created", { date: formatDate(campaign.createdAt) })}
-                  </span>
-                  {campaign.activatedAt ? (
-                    <span>
-                      {t("activated", {
-                        date: formatDate(campaign.activatedAt),
-                      })}
-                    </span>
-                  ) : null}
-                </div>
-              </div>
-            </div>
-
-            <div className="mt-5 rounded-3xl border border-border-base bg-background/50 p-3">
-              <AdAnalyticsTabs
-                series={campaign.timeSeries}
-                labels={{
-                  eightHours: t("chart.windows.eightHours"),
-                  day: t("chart.windows.day"),
-                  week: t("chart.windows.week"),
-                  month: t("chart.windows.month"),
-                }}
-              />
-            </div>
-          </article>
+            campaign={campaign}
+            editHref={editHref}
+            labels={cardLabels}
+          />
         );
       })}
     </div>
@@ -235,48 +132,4 @@ function SummaryCard({ label, value }: { label: string; value: string }) {
       </p>
     </article>
   );
-}
-
-function StatusBadge({ status }: { status: string }) {
-  const tone =
-    status === "active"
-      ? "bg-chip-success-bg text-chip-success-fg"
-      : status === "deleted" || status === "paused"
-        ? "bg-chip-danger-bg text-chip-danger-fg"
-        : "bg-chip-warning-bg text-chip-warning-fg";
-  return (
-    <span
-      className={`rounded-full px-3 py-1 font-mono text-[10px] tracking-[0.16em] uppercase ${tone}`}
-    >
-      {status.replace(/_/g, " ")}
-    </span>
-  );
-}
-
-function Metric({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-2xl border border-border-base bg-background p-3">
-      <p className="font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
-        {label}
-      </p>
-      <p className="mt-1 text-lg font-semibold text-foreground">{value}</p>
-    </div>
-  );
-}
-
-function formatViews(value: number): string {
-  return new Intl.NumberFormat("en-US").format(value);
-}
-
-function formatDuration(value: number): string {
-  if (value <= 0) return "0s";
-  return `${(value / 1000).toFixed(1)}s`;
-}
-
-function formatDate(value: Date): string {
-  return new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  }).format(value);
 }

--- a/src/components/ads/admin-ad-dashboard.tsx
+++ b/src/components/ads/admin-ad-dashboard.tsx
@@ -1,0 +1,256 @@
+import Link from "next/link";
+
+import { getTranslations } from "next-intl/server";
+
+import {
+  ADMIN_AD_CAMPAIGN_STATUSES,
+  type AdminAdCampaignFilters,
+  type AdminAdCampaignStatusFilter,
+} from "@/lib/ads/admin-filters";
+import { formatUsd } from "@/lib/ads/packages";
+import type {
+  AdminAdCampaignOverview,
+  AdminAdvertiserCampaign,
+} from "@/lib/ads/queries";
+import { withLocale } from "@/lib/locale-routing";
+
+import {
+  AdCampaignCard,
+  formatAdDuration,
+  formatAdMetricNumber,
+} from "@/components/ads/ad-campaign-card";
+
+import type { Locale } from "@/i18n/config";
+
+const STATUS_OPTIONS: AdminAdCampaignStatusFilter[] = [
+  "all",
+  ...ADMIN_AD_CAMPAIGN_STATUSES,
+];
+
+const LIMIT_OPTIONS = [10, 25, 50, 100];
+
+export async function AdminAdDashboard({
+  overview,
+  campaigns,
+  totalCount,
+  filters,
+  locale,
+}: {
+  overview: AdminAdCampaignOverview;
+  campaigns: AdminAdvertiserCampaign[];
+  totalCount: number;
+  filters: AdminAdCampaignFilters;
+  locale: Locale;
+}) {
+  const t = await getTranslations("admin.campaigns");
+  const tAd = await getTranslations("advertise.dashboard");
+  const clearHref = withLocale("/admin/campaigns", locale);
+  const cardLabels = {
+    progress: tAd("progress"),
+    destination: tAd("destination"),
+    removedFallback: tAd("removedFallback"),
+    created: (date: string) => tAd("created", { date }),
+    activated: (date: string) => tAd("activated", { date }),
+    metrics: {
+      package: tAd("metrics.package"),
+      served: tAd("metrics.served"),
+      remaining: tAd("metrics.remaining"),
+      spend: tAd("metrics.spend"),
+      clicks: tAd("metrics.clicks"),
+      ctr: tAd("metrics.ctr"),
+      avgTime: tAd("metrics.avgTime"),
+    },
+    chartWindows: {
+      eightHours: tAd("chart.windows.eightHours"),
+      day: tAd("chart.windows.day"),
+      week: tAd("chart.windows.week"),
+      month: tAd("chart.windows.month"),
+    },
+  };
+
+  return (
+    <section className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-5 pb-16 md:px-8">
+      <header>
+        <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
+          {t("eyebrow")}
+        </p>
+        <h1 className="mt-2 text-balance text-3xl font-semibold tracking-tight text-foreground md:text-4xl">
+          {t("title")}
+        </h1>
+        <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-2">
+          {t("description")}
+        </p>
+      </header>
+
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          label={t("overview.totalCampaigns")}
+          value={formatAdMetricNumber(overview.totalCampaigns)}
+          detail={t("overview.totalSpend", {
+            value: formatUsd(overview.totalSpendCents),
+          })}
+        />
+        <StatCard
+          label={t("overview.active")}
+          value={formatAdMetricNumber(overview.activeCampaigns)}
+          detail={t("overview.statusDetail", {
+            paused: formatAdMetricNumber(overview.pausedCampaigns),
+            exhausted: formatAdMetricNumber(overview.exhaustedCampaigns),
+          })}
+        />
+        <StatCard
+          label={t("overview.pendingPayment")}
+          value={formatAdMetricNumber(overview.pendingPaymentCampaigns)}
+          detail={t("overview.deletedDetail", {
+            count: formatAdMetricNumber(overview.deletedCampaigns),
+          })}
+        />
+        <StatCard
+          label={t("overview.inventory")}
+          value={formatAdMetricNumber(overview.totalPackageViews)}
+          detail={t("overview.servedDetail", {
+            value: formatAdMetricNumber(overview.totalViewsServed),
+          })}
+        />
+        <StatCard
+          label={t("overview.impressions")}
+          value={formatAdMetricNumber(overview.totalImpressions)}
+          detail={t("overview.rawImpressionsDetail")}
+        />
+        <StatCard
+          label={t("overview.clicks")}
+          value={formatAdMetricNumber(overview.clicks)}
+          detail={t("overview.ctr", { value: `${overview.ctr.toFixed(2)}%` })}
+        />
+        <StatCard
+          label={t("overview.hovers")}
+          value={formatAdMetricNumber(overview.hovers)}
+          detail={t("overview.dismissals", {
+            value: formatAdMetricNumber(overview.dismissals),
+          })}
+        />
+        <StatCard
+          label={t("overview.avgTime")}
+          value={formatAdDuration(overview.avgTimeInViewMs)}
+          detail={t("overview.avgTimeDetail")}
+        />
+      </div>
+
+      <form
+        action={clearHref}
+        className="rounded-3xl border border-border-base bg-surface/80 p-4 backdrop-blur md:p-5"
+      >
+        <div className="grid gap-3 md:grid-cols-[180px_1fr_140px_auto_auto] md:items-end">
+          <label className="flex flex-col gap-1.5 text-sm font-medium text-foreground">
+            {t("filters.status")}
+            <select
+              name="status"
+              defaultValue={filters.status}
+              className="h-10 rounded-2xl border border-border-base bg-background px-3 text-sm text-foreground outline-none transition focus:border-brand"
+            >
+              {STATUS_OPTIONS.map((status) => (
+                <option key={status} value={status}>
+                  {t(`statuses.${status}`)}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1.5 text-sm font-medium text-foreground">
+            {t("filters.search")}
+            <input
+              name="q"
+              defaultValue={filters.q}
+              placeholder={t("filters.searchPlaceholder")}
+              className="h-10 rounded-2xl border border-border-base bg-background px-3 text-sm text-foreground outline-none transition placeholder:text-muted-3 focus:border-brand"
+            />
+          </label>
+
+          <label className="flex flex-col gap-1.5 text-sm font-medium text-foreground">
+            {t("filters.limit")}
+            <select
+              name="limit"
+              defaultValue={String(filters.limit)}
+              className="h-10 rounded-2xl border border-border-base bg-background px-3 text-sm text-foreground outline-none transition focus:border-brand"
+            >
+              {LIMIT_OPTIONS.map((limit) => (
+                <option key={limit} value={limit}>
+                  {limit}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <button
+            type="submit"
+            className="inline-flex h-10 items-center justify-center rounded-full bg-inverse px-4 text-sm font-medium text-on-inverse transition hover:bg-inverse-hover"
+          >
+            {t("filters.apply")}
+          </button>
+          <Link
+            href={clearHref}
+            className="inline-flex h-10 items-center justify-center rounded-full border border-border-base bg-background px-4 text-sm font-medium text-foreground transition hover:border-brand/60 hover:text-brand"
+          >
+            {t("filters.clear")}
+          </Link>
+        </div>
+      </form>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="font-mono text-[11px] tracking-[0.18em] text-muted-3 uppercase">
+          {t("showing", {
+            shown: formatAdMetricNumber(campaigns.length),
+            total: formatAdMetricNumber(totalCount),
+          })}
+        </p>
+      </div>
+
+      {campaigns.length === 0 ? (
+        <div className="rounded-[2rem] border border-dashed border-border-base bg-surface/60 p-10 text-center text-sm text-muted-2">
+          {t("empty")}
+        </div>
+      ) : (
+        <div className="space-y-5">
+          {campaigns.map((campaign) => (
+            <AdCampaignCard
+              key={campaign.id}
+              campaign={campaign}
+              labels={cardLabels}
+              ownerDetails={{
+                title: t("owner.title"),
+                userIdLabel: t("owner.userId"),
+                contactEmailLabel: t("owner.contactEmail"),
+                companyLabel: t("owner.company"),
+                userId: campaign.userId,
+                contactEmail: campaign.contactEmail,
+                companyName: campaign.companyName,
+              }}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  detail,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+}) {
+  return (
+    <article className="rounded-3xl border border-border-base bg-surface/80 p-4 backdrop-blur">
+      <p className="font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
+        {label}
+      </p>
+      <p className="mt-2 font-mono text-3xl font-semibold tracking-tight text-foreground">
+        {value}
+      </p>
+      <p className="mt-1 text-xs text-muted-2">{detail}</p>
+    </article>
+  );
+}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -373,6 +373,7 @@
       "requests": "Requests",
       "collections": "Collections",
       "feedback": "Feedback",
+      "campaigns": "Campaigns",
       "manifest": "Manifest",
       "insights": "Insights"
     },
@@ -484,6 +485,53 @@
       "archive": "Archive",
       "reopen": "Re-open into pending",
       "failed": "Failed: {error}"
+    },
+    "campaigns": {
+      "eyebrow": "Ad operations",
+      "title": "Ad campaigns",
+      "description": "Review every advertiser campaign across users, including owner details, delivery metrics, and charted activity.",
+      "overview": {
+        "totalCampaigns": "Total campaigns",
+        "totalSpend": "{value} booked spend",
+        "active": "Active",
+        "statusDetail": "{paused} paused, {exhausted} exhausted",
+        "pendingPayment": "Pending payment",
+        "deletedDetail": "{count} deleted",
+        "inventory": "Purchased impressions",
+        "servedDetail": "{value} served",
+        "impressions": "Raw impressions",
+        "rawImpressionsDetail": "Rows in ad_impressions",
+        "clicks": "Clicks",
+        "ctr": "{value} CTR",
+        "hovers": "Hovers",
+        "dismissals": "{value} dismissals",
+        "avgTime": "Avg. time in view",
+        "avgTimeDetail": "Across time-in-view events"
+      },
+      "filters": {
+        "status": "Status",
+        "search": "Search",
+        "searchPlaceholder": "Title, company, email, user ID, URL",
+        "limit": "Limit",
+        "apply": "Apply filters",
+        "clear": "Clear"
+      },
+      "statuses": {
+        "all": "All statuses",
+        "pending_payment": "Pending payment",
+        "active": "Active",
+        "exhausted": "Exhausted",
+        "paused": "Paused",
+        "deleted": "Deleted"
+      },
+      "owner": {
+        "title": "Owner",
+        "userId": "User ID",
+        "contactEmail": "Contact email",
+        "company": "Company"
+      },
+      "showing": "Showing {shown} of {total} matching campaigns",
+      "empty": "No ad campaigns match these filters."
     },
     "requests": {
       "eyebrow": "Community wishlist",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -373,6 +373,7 @@
       "requests": "Pedidos",
       "collections": "Colecciones",
       "feedback": "Feedback",
+      "campaigns": "Campañas",
       "manifest": "Manifest",
       "insights": "Métricas"
     },
@@ -484,6 +485,53 @@
       "archive": "Archivar",
       "reopen": "Reabrir como pendiente",
       "failed": "Falló: {error}"
+    },
+    "campaigns": {
+      "eyebrow": "Operaciones de ads",
+      "title": "Campañas de ads",
+      "description": "Revisa todas las campañas de anunciantes, con datos del dueño, métricas de entrega y actividad en gráficos.",
+      "overview": {
+        "totalCampaigns": "Campañas totales",
+        "totalSpend": "{value} de gasto reservado",
+        "active": "Activas",
+        "statusDetail": "{paused} pausadas, {exhausted} agotadas",
+        "pendingPayment": "Pago pendiente",
+        "deletedDetail": "{count} eliminadas",
+        "inventory": "Impresiones compradas",
+        "servedDetail": "{value} servidas",
+        "impressions": "Impresiones raw",
+        "rawImpressionsDetail": "Filas en ad_impressions",
+        "clicks": "Clics",
+        "ctr": "{value} CTR",
+        "hovers": "Hovers",
+        "dismissals": "{value} descartes",
+        "avgTime": "Tiempo medio visible",
+        "avgTimeDetail": "En eventos time-in-view"
+      },
+      "filters": {
+        "status": "Estado",
+        "search": "Buscar",
+        "searchPlaceholder": "Título, empresa, email, user ID, URL",
+        "limit": "Límite",
+        "apply": "Aplicar filtros",
+        "clear": "Limpiar"
+      },
+      "statuses": {
+        "all": "Todos los estados",
+        "pending_payment": "Pago pendiente",
+        "active": "Activa",
+        "exhausted": "Agotada",
+        "paused": "Pausada",
+        "deleted": "Eliminada"
+      },
+      "owner": {
+        "title": "Dueño",
+        "userId": "User ID",
+        "contactEmail": "Email de contacto",
+        "company": "Empresa"
+      },
+      "showing": "Mostrando {shown} de {total} campañas coincidentes",
+      "empty": "Ninguna campaña coincide con estos filtros."
     },
     "requests": {
       "eyebrow": "Wishlist de la comunidad",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -411,6 +411,7 @@
       "requests": "请求",
       "collections": "合集",
       "feedback": "反馈",
+      "campaigns": "广告活动",
       "manifest": "Manifest",
       "insights": "数据"
     },
@@ -522,6 +523,53 @@
       "archive": "归档",
       "reopen": "重新打开为待处理",
       "failed": "失败：{error}"
+    },
+    "campaigns": {
+      "eyebrow": "广告运营",
+      "title": "广告活动",
+      "description": "查看所有用户的广告活动，包括所有者信息、投放指标和活动图表。",
+      "overview": {
+        "totalCampaigns": "活动总数",
+        "totalSpend": "已预订花费 {value}",
+        "active": "投放中",
+        "statusDetail": "{paused} 个暂停，{exhausted} 个耗尽",
+        "pendingPayment": "待付款",
+        "deletedDetail": "{count} 个已删除",
+        "inventory": "已购买曝光",
+        "servedDetail": "已投放 {value}",
+        "impressions": "原始曝光",
+        "rawImpressionsDetail": "ad_impressions 表记录数",
+        "clicks": "点击",
+        "ctr": "点击率 {value}",
+        "hovers": "悬停",
+        "dismissals": "{value} 次隐藏",
+        "avgTime": "平均可见时间",
+        "avgTimeDetail": "基于 time-in-view 事件"
+      },
+      "filters": {
+        "status": "状态",
+        "search": "搜索",
+        "searchPlaceholder": "标题、公司、邮箱、用户 ID、URL",
+        "limit": "数量限制",
+        "apply": "应用筛选",
+        "clear": "清除"
+      },
+      "statuses": {
+        "all": "所有状态",
+        "pending_payment": "待付款",
+        "active": "投放中",
+        "exhausted": "已耗尽",
+        "paused": "已暂停",
+        "deleted": "已删除"
+      },
+      "owner": {
+        "title": "所有者",
+        "userId": "用户 ID",
+        "contactEmail": "联系邮箱",
+        "company": "公司"
+      },
+      "showing": "显示 {total} 个匹配活动中的 {shown} 个",
+      "empty": "没有广告活动匹配这些筛选条件。"
     },
     "requests": {
       "eyebrow": "社区愿望单",

--- a/src/lib/ads/admin-filters.test.ts
+++ b/src/lib/ads/admin-filters.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_ADMIN_AD_CAMPAIGN_LIMIT,
+  MAX_ADMIN_AD_CAMPAIGN_LIMIT,
+  parseAdminAdCampaignFilters,
+} from "./admin-filters";
+
+describe("parseAdminAdCampaignFilters", () => {
+  test("uses safe defaults", () => {
+    expect(parseAdminAdCampaignFilters()).toEqual({
+      status: "all",
+      q: "",
+      limit: DEFAULT_ADMIN_AD_CAMPAIGN_LIMIT,
+    });
+  });
+
+  test("accepts valid campaign statuses", () => {
+    expect(parseAdminAdCampaignFilters({ status: "active" }).status).toBe(
+      "active",
+    );
+    expect(parseAdminAdCampaignFilters({ status: "deleted" }).status).toBe(
+      "deleted",
+    );
+  });
+
+  test("normalizes invalid status to all", () => {
+    expect(parseAdminAdCampaignFilters({ status: "approved" }).status).toBe(
+      "all",
+    );
+  });
+
+  test("trims search text", () => {
+    expect(parseAdminAdCampaignFilters({ q: "  pixel treats  " }).q).toBe(
+      "pixel treats",
+    );
+  });
+
+  test("clamps invalid and out-of-range limits", () => {
+    expect(parseAdminAdCampaignFilters({ limit: "nope" }).limit).toBe(
+      DEFAULT_ADMIN_AD_CAMPAIGN_LIMIT,
+    );
+    expect(parseAdminAdCampaignFilters({ limit: "-10" }).limit).toBe(1);
+    expect(parseAdminAdCampaignFilters({ limit: "999" }).limit).toBe(
+      MAX_ADMIN_AD_CAMPAIGN_LIMIT,
+    );
+  });
+});

--- a/src/lib/ads/admin-filters.ts
+++ b/src/lib/ads/admin-filters.ts
@@ -1,0 +1,51 @@
+export const ADMIN_AD_CAMPAIGN_STATUSES = [
+  "pending_payment",
+  "active",
+  "exhausted",
+  "paused",
+  "deleted",
+] as const;
+
+export type AdminAdCampaignStatus = (typeof ADMIN_AD_CAMPAIGN_STATUSES)[number];
+
+export type AdminAdCampaignStatusFilter = AdminAdCampaignStatus | "all";
+
+export type AdminAdCampaignFilters = {
+  status: AdminAdCampaignStatusFilter;
+  q: string;
+  limit: number;
+};
+
+export type AdminAdCampaignSearchParams = Record<
+  string,
+  string | string[] | undefined
+>;
+
+export const DEFAULT_ADMIN_AD_CAMPAIGN_LIMIT = 25;
+export const MAX_ADMIN_AD_CAMPAIGN_LIMIT = 100;
+
+const STATUS_VALUES = new Set<string>(["all", ...ADMIN_AD_CAMPAIGN_STATUSES]);
+
+export function parseAdminAdCampaignFilters(
+  searchParams: AdminAdCampaignSearchParams = {},
+): AdminAdCampaignFilters {
+  const rawStatus = getFirst(searchParams.status) ?? "all";
+  const status = STATUS_VALUES.has(rawStatus)
+    ? (rawStatus as AdminAdCampaignStatusFilter)
+    : "all";
+  const q = (getFirst(searchParams.q) ?? "").trim();
+  const limit = clampLimit(getFirst(searchParams.limit));
+
+  return { status, q, limit };
+}
+
+function getFirst(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function clampLimit(value: string | undefined): number {
+  if (!value) return DEFAULT_ADMIN_AD_CAMPAIGN_LIMIT;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) return DEFAULT_ADMIN_AD_CAMPAIGN_LIMIT;
+  return Math.min(Math.max(parsed, 1), MAX_ADMIN_AD_CAMPAIGN_LIMIT);
+}

--- a/src/lib/ads/queries.ts
+++ b/src/lib/ads/queries.ts
@@ -1,5 +1,16 @@
-import { and, desc, eq, isNull, lt, sql } from "drizzle-orm";
+import {
+  and,
+  desc,
+  eq,
+  ilike,
+  isNull,
+  lt,
+  or,
+  type SQL,
+  sql,
+} from "drizzle-orm";
 
+import type { AdminAdCampaignFilters } from "@/lib/ads/admin-filters";
 import { type AdUtmFields, buildAdClickUrl } from "@/lib/ads/url";
 import { db, schema } from "@/lib/db/client";
 
@@ -37,6 +48,41 @@ export type AdvertiserCampaign = {
   clicks: number;
   dismissals: number;
   avgTimeInViewMs: number;
+};
+
+type CampaignMetrics = Pick<
+  AdvertiserCampaign,
+  "timeSeries" | "hovers" | "clicks" | "dismissals" | "avgTimeInViewMs"
+>;
+
+type AdvertiserCampaignRow = Omit<AdvertiserCampaign, keyof CampaignMetrics>;
+
+export type AdminAdvertiserCampaign = AdvertiserCampaign & {
+  userId: string;
+  contactEmail: string;
+};
+
+export type AdminAdCampaignOverview = {
+  totalCampaigns: number;
+  pendingPaymentCampaigns: number;
+  activeCampaigns: number;
+  exhaustedCampaigns: number;
+  pausedCampaigns: number;
+  deletedCampaigns: number;
+  totalPackageViews: number;
+  totalViewsServed: number;
+  totalSpendCents: number;
+  totalImpressions: number;
+  hovers: number;
+  clicks: number;
+  dismissals: number;
+  avgTimeInViewMs: number;
+  ctr: number;
+};
+
+export type AdminAdCampaignList = {
+  campaigns: AdminAdvertiserCampaign[];
+  totalCount: number;
 };
 
 export type UpdateOwnedAdCampaignCreativeParams = {
@@ -320,7 +366,7 @@ export async function getActiveFeedAds(limit = 6): Promise<PublicFeedAd[]> {
 export async function getUserAdCampaigns(
   userId: string,
 ): Promise<AdvertiserCampaign[]> {
-  const campaigns = await db
+  const campaigns: AdvertiserCampaignRow[] = await db
     .select({
       id: schema.adCampaigns.id,
       companyName: schema.adCampaigns.companyName,
@@ -347,7 +393,169 @@ export async function getUserAdCampaigns(
     .where(eq(schema.adCampaigns.userId, userId))
     .orderBy(desc(schema.adCampaigns.createdAt));
 
+  return hydrateCampaignMetrics(campaigns);
+}
+
+export async function getAdminAdCampaignOverview(): Promise<AdminAdCampaignOverview> {
+  const result = await db.execute<{
+    total_campaigns: number | string;
+    pending_payment_campaigns: number | string;
+    active_campaigns: number | string;
+    exhausted_campaigns: number | string;
+    paused_campaigns: number | string;
+    deleted_campaigns: number | string;
+    total_package_views: number | string;
+    total_views_served: number | string;
+    total_spend_cents: number | string;
+    total_impressions: number | string;
+    hovers: number | string;
+    clicks: number | string;
+    dismissals: number | string;
+    avg_time_in_view_ms: number | string | null;
+  }>(sql`
+    WITH campaign_totals AS (
+      SELECT
+        count(*)::int AS total_campaigns,
+        count(*) FILTER (WHERE status = 'pending_payment')::int AS pending_payment_campaigns,
+        count(*) FILTER (WHERE status = 'active')::int AS active_campaigns,
+        count(*) FILTER (WHERE status = 'exhausted')::int AS exhausted_campaigns,
+        count(*) FILTER (WHERE status = 'paused')::int AS paused_campaigns,
+        count(*) FILTER (WHERE status = 'deleted')::int AS deleted_campaigns,
+        coalesce(sum(package_views), 0)::int AS total_package_views,
+        coalesce(sum(views_served), 0)::int AS total_views_served,
+        coalesce(sum(price_cents), 0)::int AS total_spend_cents
+      FROM ad_campaigns
+    ), impression_totals AS (
+      SELECT count(*)::int AS total_impressions
+      FROM ad_impressions
+    ), event_totals AS (
+      SELECT
+        count(*) FILTER (WHERE kind = 'hover')::int AS hovers,
+        count(*) FILTER (WHERE kind = 'click')::int AS clicks,
+        count(*) FILTER (WHERE kind = 'dismissed')::int AS dismissals,
+        avg(duration_ms) FILTER (WHERE kind = 'time_in_view')::int AS avg_time_in_view_ms
+      FROM ad_events
+    )
+    SELECT *
+    FROM campaign_totals
+    CROSS JOIN impression_totals
+    CROSS JOIN event_totals
+  `);
+
+  const row = result.rows[0];
+  const totalViewsServed = Number(row?.total_views_served ?? 0);
+  const clicks = Number(row?.clicks ?? 0);
+
+  return {
+    totalCampaigns: Number(row?.total_campaigns ?? 0),
+    pendingPaymentCampaigns: Number(row?.pending_payment_campaigns ?? 0),
+    activeCampaigns: Number(row?.active_campaigns ?? 0),
+    exhaustedCampaigns: Number(row?.exhausted_campaigns ?? 0),
+    pausedCampaigns: Number(row?.paused_campaigns ?? 0),
+    deletedCampaigns: Number(row?.deleted_campaigns ?? 0),
+    totalPackageViews: Number(row?.total_package_views ?? 0),
+    totalViewsServed,
+    totalSpendCents: Number(row?.total_spend_cents ?? 0),
+    totalImpressions: Number(row?.total_impressions ?? 0),
+    hovers: Number(row?.hovers ?? 0),
+    clicks,
+    dismissals: Number(row?.dismissals ?? 0),
+    avgTimeInViewMs: Number(row?.avg_time_in_view_ms ?? 0),
+    ctr: totalViewsServed > 0 ? (clicks / totalViewsServed) * 100 : 0,
+  };
+}
+
+export async function getAdminAdCampaigns(
+  filters: AdminAdCampaignFilters,
+): Promise<AdminAdCampaignList> {
+  const where = buildAdminCampaignWhere(filters);
+  const [countRow] = await db
+    .select({ total: sql<number>`count(*)::int` })
+    .from(schema.adCampaigns)
+    .where(where);
+
+  const campaigns = await db
+    .select({
+      id: schema.adCampaigns.id,
+      userId: schema.adCampaigns.userId,
+      contactEmail: schema.adCampaigns.contactEmail,
+      companyName: schema.adCampaigns.companyName,
+      title: schema.adCampaigns.title,
+      description: schema.adCampaigns.description,
+      imageUrl: schema.adCampaigns.imageUrl,
+      destinationUrl: schema.adCampaigns.destinationUrl,
+      utmSource: schema.adCampaigns.utmSource,
+      utmMedium: schema.adCampaigns.utmMedium,
+      utmCampaign: schema.adCampaigns.utmCampaign,
+      utmTerm: schema.adCampaigns.utmTerm,
+      utmContent: schema.adCampaigns.utmContent,
+      packageViews: schema.adCampaigns.packageViews,
+      priceCents: schema.adCampaigns.priceCents,
+      viewsServed: schema.adCampaigns.viewsServed,
+      status: schema.adCampaigns.status,
+      createdAt: schema.adCampaigns.createdAt,
+      paidAt: schema.adCampaigns.paidAt,
+      activatedAt: schema.adCampaigns.activatedAt,
+      deletedAt: schema.adCampaigns.deletedAt,
+      removalReason: schema.adCampaigns.removalReason,
+    })
+    .from(schema.adCampaigns)
+    .where(where)
+    .orderBy(desc(schema.adCampaigns.createdAt))
+    .limit(filters.limit);
+
+  return {
+    totalCount: Number(countRow?.total ?? 0),
+    campaigns: await hydrateCampaignMetrics(campaigns),
+  };
+}
+
+function buildAdminCampaignWhere(filters: AdminAdCampaignFilters) {
+  const conditions: SQL[] = [];
+
+  if (filters.status !== "all") {
+    conditions.push(eq(schema.adCampaigns.status, filters.status));
+  }
+
+  if (filters.q) {
+    const like = `%${filters.q}%`;
+    const keywordFilter = or(
+      ilike(schema.adCampaigns.title, like),
+      ilike(schema.adCampaigns.companyName, like),
+      ilike(schema.adCampaigns.contactEmail, like),
+      ilike(schema.adCampaigns.userId, like),
+      ilike(schema.adCampaigns.destinationUrl, like),
+    );
+    if (keywordFilter) conditions.push(keywordFilter);
+  }
+
+  return conditions.length > 0 ? and(...conditions) : undefined;
+}
+
+async function hydrateCampaignMetrics<T extends AdvertiserCampaignRow>(
+  campaigns: T[],
+): Promise<Array<T & CampaignMetrics>> {
   if (campaigns.length === 0) return [];
+
+  const campaignIds = campaigns.map((campaign) => campaign.id);
+  const [seriesByCampaign, eventsByCampaign] = await Promise.all([
+    loadCampaignTimeSeries(campaignIds),
+    loadCampaignEventTotals(campaignIds),
+  ]);
+
+  return campaigns.map((campaign) => ({
+    ...campaign,
+    timeSeries: seriesByCampaign.get(campaign.id) ?? createEmptyTimeSeries(),
+    hovers: eventsByCampaign.get(campaign.id)?.hovers ?? 0,
+    clicks: eventsByCampaign.get(campaign.id)?.clicks ?? 0,
+    dismissals: eventsByCampaign.get(campaign.id)?.dismissals ?? 0,
+    avgTimeInViewMs:
+      eventsByCampaign.get(campaign.id)?.avg_time_in_view_ms ?? 0,
+  }));
+}
+
+async function loadCampaignTimeSeries(campaignIds: string[]) {
+  const campaignIdsSubquery = createCampaignIdsSubquery(campaignIds);
 
   const seriesRows = await db.execute<{
     campaign_id: string;
@@ -358,7 +566,7 @@ export async function getUserAdCampaigns(
     clicks: number;
   }>(sql`
     WITH campaign_ids AS (
-      SELECT id FROM ad_campaigns WHERE user_id = ${userId}
+      ${campaignIdsSubquery}
     ), buckets AS (
       SELECT 'eightHours'::text AS window_key, generate_series(date_trunc('hour', now()) - interval '7 hours', date_trunc('hour', now()), interval '1 hour') AS bucket
       UNION ALL
@@ -435,20 +643,29 @@ export async function getUserAdCampaigns(
       seriesByCampaign.get(row.campaign_id) ?? createEmptyTimeSeries();
     current[row.window_key].push({
       label: row.bucket,
-      impressions: row.impressions,
-      hovers: row.hovers,
-      clicks: row.clicks,
+      impressions: Number(row.impressions),
+      hovers: Number(row.hovers),
+      clicks: Number(row.clicks),
     });
     seriesByCampaign.set(row.campaign_id, current);
   }
 
+  return seriesByCampaign;
+}
+
+async function loadCampaignEventTotals(campaignIds: string[]) {
+  const campaignIdsSubquery = createCampaignIdsSubquery(campaignIds);
+
   const eventRows = await db.execute<{
     campaign_id: string;
-    hovers: number;
-    clicks: number;
-    dismissals: number;
-    avg_time_in_view_ms: number | null;
+    hovers: number | string;
+    clicks: number | string;
+    dismissals: number | string;
+    avg_time_in_view_ms: number | string | null;
   }>(sql`
+    WITH campaign_ids AS (
+      ${campaignIdsSubquery}
+    )
     SELECT
       ae.campaign_id,
       count(*) FILTER (WHERE ae.kind = 'hover')::int AS hovers,
@@ -456,24 +673,31 @@ export async function getUserAdCampaigns(
       count(*) FILTER (WHERE ae.kind = 'dismissed')::int AS dismissals,
       avg(ae.duration_ms) FILTER (WHERE ae.kind = 'time_in_view')::int AS avg_time_in_view_ms
     FROM ad_events ae
-    INNER JOIN ad_campaigns ac ON ac.id = ae.campaign_id
-    WHERE ac.user_id = ${userId}
+    INNER JOIN campaign_ids ci ON ci.id = ae.campaign_id
     GROUP BY ae.campaign_id
   `);
 
   const eventsByCampaign = new Map(
-    eventRows.rows.map((row) => [row.campaign_id, row]),
+    eventRows.rows.map((row) => [
+      row.campaign_id,
+      {
+        hovers: Number(row.hovers),
+        clicks: Number(row.clicks),
+        dismissals: Number(row.dismissals),
+        avg_time_in_view_ms: Number(row.avg_time_in_view_ms ?? 0),
+      },
+    ]),
   );
 
-  return campaigns.map((campaign) => ({
-    ...campaign,
-    timeSeries: seriesByCampaign.get(campaign.id) ?? createEmptyTimeSeries(),
-    hovers: eventsByCampaign.get(campaign.id)?.hovers ?? 0,
-    clicks: eventsByCampaign.get(campaign.id)?.clicks ?? 0,
-    dismissals: eventsByCampaign.get(campaign.id)?.dismissals ?? 0,
-    avgTimeInViewMs:
-      eventsByCampaign.get(campaign.id)?.avg_time_in_view_ms ?? 0,
-  }));
+  return eventsByCampaign;
+}
+
+function createCampaignIdsSubquery(campaignIds: string[]): SQL {
+  const values = sql.join(
+    campaignIds.map((campaignId) => sql`(${campaignId})`),
+    sql`, `,
+  );
+  return sql`SELECT id::text AS id FROM (VALUES ${values}) AS selected(id)`;
 }
 
 function createEmptyTimeSeries(): AdCampaignTimeSeries {


### PR DESCRIPTION
## Summary
- Add an admin-only campaigns dashboard with all-user overview metrics, filters, limits, and owner details.
- Reuse the advertiser campaign card/charts while keeping creator queries explicitly owner-scoped.
- Add localized admin copy and focused filter parser coverage.

## Verification
- `bun test src/lib/ads/admin-filters.test.ts`
- `bun test --env-file=.env.mock`
- `bun run i18n:check`
- `bun run check`
- `bun run build` (passes with existing Turbopack NFT trace warnings)