### PR TITLE
Add WeChat QR dialog for zh community

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,19 @@ PETDEX_ALL_PETS_PACK_URL=
 VERCEL_URL=
 PETDEX_URL=
 
+# Community
+# Enables the Discord CTA and /community page when set.
+NEXT_PUBLIC_DISCORD_INVITE_URL=
+# Enables the zh-only WeChat CTA when set to 1. Requires the Aliyun OSS
+# server envs below because the QR is served through /api/wechat-qr.
+NEXT_PUBLIC_WECHAT_COMMUNITY_ENABLED=
+
+# Aliyun OSS credentials for /api/wechat-qr and QR rotation.
+ALIYUN_OSS_ACCESS_KEY_ID=
+ALIYUN_OSS_ACCESS_KEY_SECRET=
+ALIYUN_OSS_BUCKET=
+ALIYUN_OSS_REGION=
+
 # Stripe ads checkout
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=

--- a/next.config.ts
+++ b/next.config.ts
@@ -18,19 +18,6 @@ function r2PublicHost(): string {
   }
 }
 
-// WeChat group QR is hosted on Aliyun OSS (Henry's bucket). Pulled from
-// the env var Henry's PR shipped, so any future bucket swap doesn't
-// require a code change to the CSP. Returns null when the env var is
-// missing so we don't hand the CSP a bad host.
-function wechatQrHost(): string | null {
-  if (!process.env.NEXT_PUBLIC_WECHAT_GROUP_QR_URL) return null;
-  try {
-    return new URL(process.env.NEXT_PUBLIC_WECHAT_GROUP_QR_URL).hostname;
-  } catch {
-    return null;
-  }
-}
-
 // Content-Security-Policy. Blocks inline <script> sources we didn't ship,
 // caps img / connect / frame ancestors. The `unsafe-inline` allowance for
 // styles is required by Next/Tailwind during hydration; for scripts we
@@ -44,13 +31,6 @@ function wechatQrHost(): string | null {
 // - vercel-scripts / vitals for Vercel analytics
 // - R2 public bucket + UploadThing host + Clerk image hosts + social
 //   avatar hosts for sprites and avatars
-// - Aliyun OSS host (when set via NEXT_PUBLIC_WECHAT_GROUP_QR_URL) for
-//   the WeChat group QR shown on /zh/community + the collaborator panel
-const WECHAT_QR_IMG_HOST = wechatQrHost();
-const wechatQrImgSrc = WECHAT_QR_IMG_HOST
-  ? ` https://${WECHAT_QR_IMG_HOST}`
-  : "";
-
 const cspDirectives = [
   "default-src 'self'",
   "base-uri 'self'",
@@ -64,7 +44,7 @@ const cspDirectives = [
   "frame-src 'self' https://challenges.cloudflare.com https://*.clerk.com https://*.clerk.accounts.dev https://accounts.petdex.crafter.run https://clerk.petdex.crafter.run",
   "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://clerk.petdex.crafter.run https://accounts.petdex.crafter.run https://*.clerk.com https://*.clerk.accounts.dev https://challenges.cloudflare.com https://va.vercel-scripts.com https://vercel.live",
   "style-src 'self' 'unsafe-inline'",
-  `img-src 'self' data: blob: https://pub-94495283df974cfea5e98d6a9e3fa462.r2.dev https://yu2vz9gndp.ufs.sh https://img.clerk.com https://images.clerk.dev https://avatars.githubusercontent.com https://pbs.twimg.com https://storage.googleapis.com${wechatQrImgSrc}`,
+  "img-src 'self' data: blob: https://pub-94495283df974cfea5e98d6a9e3fa462.r2.dev https://yu2vz9gndp.ufs.sh https://img.clerk.com https://images.clerk.dev https://avatars.githubusercontent.com https://pbs.twimg.com https://storage.googleapis.com",
   "media-src 'self' https://pub-94495283df974cfea5e98d6a9e3fa462.r2.dev",
   "font-src 'self' data:",
   // R2 reads via pub-*.r2.dev, R2 PUT uploads via the account-specific
@@ -119,9 +99,6 @@ const nextConfig: NextConfig = {
       { protocol: "https", hostname: "avatars.githubusercontent.com" },
       { protocol: "https", hostname: "pbs.twimg.com" },
       { protocol: "https", hostname: "storage.googleapis.com" },
-      ...(WECHAT_QR_IMG_HOST
-        ? [{ protocol: "https" as const, hostname: WECHAT_QR_IMG_HOST }]
-        : []),
     ],
   },
   // Server-only modules that don't survive Turbopack/webpack bundling:

--- a/src/app/[locale]/community/page.tsx
+++ b/src/app/[locale]/community/page.tsx
@@ -14,11 +14,24 @@ import { DiscordLink } from "@/components/discord-link";
 import { JsonLd } from "@/components/json-ld";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
+import { WechatCommunityDialog } from "@/components/wechat-community-dialog";
 
 import { hasLocale } from "@/i18n/config";
 
 export const dynamic = "force-static";
 const SITE_URL = "https://petdex.crafter.run";
+const WECHAT_COMMUNITY_ENABLED =
+  process.env.NEXT_PUBLIC_WECHAT_COMMUNITY_ENABLED === "1";
+const WECHAT_QR_PROXY_CONFIGURED = Boolean(
+  process.env.ALIYUN_OSS_ACCESS_KEY_ID &&
+    process.env.ALIYUN_OSS_ACCESS_KEY_SECRET &&
+    process.env.ALIYUN_OSS_BUCKET &&
+    process.env.ALIYUN_OSS_REGION,
+);
+
+type PageProps = {
+  params: Promise<{ locale: string }>;
+};
 
 export async function generateMetadata({
   params,
@@ -70,9 +83,12 @@ const SECTIONS: Array<{
   },
 ];
 
-export default function CommunityPage() {
+export default async function CommunityPage({ params }: PageProps) {
+  const { locale } = await params;
   const inviteUrl = process.env.NEXT_PUBLIC_DISCORD_INVITE_URL;
   if (!inviteUrl) notFound();
+  const showWechatCommunity =
+    locale === "zh" && WECHAT_COMMUNITY_ENABLED && WECHAT_QR_PROXY_CONFIGURED;
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "WebPage",
@@ -108,6 +124,7 @@ export default function CommunityPage() {
                 Join the Discord
                 <ArrowRight className="size-4" />
               </DiscordLink>
+              {showWechatCommunity ? <WechatCommunityDialog /> : null}
               <a
                 href="https://github.com/crafter-station/petdex"
                 target="_blank"

--- a/src/components/wechat-community-dialog.tsx
+++ b/src/components/wechat-community-dialog.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import Image from "next/image";
+import { useState } from "react";
+
+import { track } from "@vercel/analytics";
+import { Loader2, MessageCircle } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+// Use the same server-side proxy as the collaborator QR panel. The raw
+// Aliyun object may be private, and Next's optimizer can keep serving an
+// expired QR after rotation.
+const WECHAT_QR_URL = "/api/wechat-qr";
+
+export function WechatCommunityDialog() {
+  const [imageLoaded, setImageLoaded] = useState(false);
+
+  return (
+    <Dialog
+      onOpenChange={(open) => {
+        if (open) setImageLoaded(false);
+      }}
+    >
+      <DialogTrigger
+        render={
+          <button
+            type="button"
+            className="inline-flex h-11 items-center gap-2 rounded-full bg-[#07C160] px-5 text-sm font-semibold text-white transition hover:bg-[#05a653]"
+            onClick={() => {
+              track("wechat_click", { source: "community_page_hero" });
+            }}
+          >
+            <MessageCircle className="size-4" />
+            加入微信群
+          </button>
+        }
+      />
+      <DialogContent className="gap-5 p-5 sm:max-w-md">
+        <DialogHeader className="pr-8">
+          <DialogTitle className="text-lg font-semibold tracking-tight">
+            加入 Petdex 微信群
+          </DialogTitle>
+          <DialogDescription className="text-sm leading-6">
+            微信扫码加入中文社区，交流 Codex pet 创作、提交和反馈。
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="relative rounded-2xl border border-border-base bg-white p-3">
+          {imageLoaded ? null : (
+            <div className="absolute inset-3 grid place-items-center rounded-xl bg-surface-muted text-muted-2">
+              <div className="flex items-center gap-2 text-sm">
+                <Loader2 className="size-4 animate-spin" />
+                二维码加载中…
+              </div>
+            </div>
+          )}
+          <Image
+            src={WECHAT_QR_URL}
+            alt="Petdex 微信群二维码"
+            width={320}
+            height={320}
+            unoptimized
+            className={`mx-auto aspect-square w-full max-w-72 rounded-xl object-contain transition-opacity duration-200 ${
+              imageLoaded ? "opacity-100" : "opacity-0"
+            }`}
+            onLoad={() => setImageLoaded(true)}
+          />
+        </div>
+
+        <p className="text-xs leading-5 text-muted-2">
+          二维码可能会过期。如果无法加入，请通过 GitHub 或 Discord 联系维护者。
+        </p>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary

- Add a zh-only WeChat community entry on `/zh/community`
- Show the QR code in an in-page dialog instead of navigating away
- Add QR loading feedback and analytics tracking
- Allow the configured QR image origin in CSP and Next Image

## Deployment notes

- Set `NEXT_PUBLIC_DISCORD_INVITE_URL` to enable the Community page and Discord CTA.
- To enable the WeChat entry on `/zh/community`, set `NEXT_PUBLIC_WECHAT_GROUP_QR_URL` to a small public HTTPS QR image.
- For weekly WeChat QR rotation, keep the configured URL stable and overwrite the image object in storage so no code or env change is needed.

## Validation

- `bun run i18n:check`
- `bun x biome check .env.example next.config.ts 'src/app/[locale]/community/page.tsx' src/components/wechat-community-dialog.tsx`
- `NEXT_PUBLIC_WECHAT_GROUP_QR_URL=https://henryjing96.oss-ap-southeast-1.aliyuncs.com/petdex-qr-code.jpg NEXT_PUBLIC_DISCORD_INVITE_URL=https://discord.gg/petdex-test bun --env-file=.env.mock run build`

## Note

`bun run check` currently fails on the latest upstream `main` due to existing Biome issues in mailing/drizzle files unrelated to this change.
<img width="1424" height="752" alt="screenshot-20260509-143524" src="https://github.com/user-attachments/assets/84a097cd-0d6d-4cb9-a130-b19976b2abb0" />
<img width="1172" height="1130" alt="screenshot-20260509-143423" src="https://github.com/user-attachments/assets/ed28060a-c713-4f38-9ed7-176e9e93fe9b" />
