### PR TITLE
fix: render surprise pet thumbnails correctly in mock mode

### DIFF
--- a/src/components/surprise-pet-card.tsx
+++ b/src/components/surprise-pet-card.tsx
@@ -23,6 +23,7 @@ type SurprisePet = {
 };
 
 const BASE_KEY = "petdex_surprise_pet_seen";
+const THUMBNAIL_SPRITE_SCALE = 0.45;
 
 export function SurprisePetCard() {
   const locale = useLocale();
@@ -88,13 +89,13 @@ export function SurprisePetCard() {
       <div className="mt-4 flex gap-4">
         <Link
           href={petHref}
-          className="grid size-24 shrink-0 place-items-center rounded-2xl border border-border-base bg-surface-muted transition hover:-translate-y-0.5"
+          className="grid size-24 shrink-0 place-items-center overflow-hidden rounded-2xl border border-border-base bg-surface-muted transition hover:-translate-y-0.5"
           aria-label={t("viewAria", { name: pet.displayName })}
         >
           <PetSprite
             src={pet.spritesheetPath}
             state="idle"
-            scale={0.58}
+            scale={THUMBNAIL_SPRITE_SCALE}
             label={t("spriteAlt", { name: pet.displayName })}
           />
         </Link>

--- a/src/lib/mock/db.ts
+++ b/src/lib/mock/db.ts
@@ -32,6 +32,15 @@ if (!globalMockDb.__petdexMockDb) {
   };
 }
 const state: MockDbState = globalMockDb.__petdexMockDb;
+const MOCK_R2_PUBLIC_BASE =
+  "https://pub-94495283df974cfea5e98d6a9e3fa462.r2.dev";
+const MOCK_CURATED_ASSET_SLUGS = new Set([
+  "nukey",
+  "boba",
+  "boxcat",
+  "scoop",
+  "byte-bunny",
+]);
 
 async function bootstrap(client: PGlite): Promise<void> {
   // Drizzle migrations are SQL files. We run them in order, tolerating
@@ -276,14 +285,17 @@ async function seed(client: PGlite): Promise<void> {
     const idea = sample[i];
     const slug = idea.id;
     const id = `pet_mock_${i.toString().padStart(3, "0")}`;
-    // Use a 1x1 transparent webp data URI as a stand-in spritesheet so
-    // <img> tags don't 404 in the gallery. Real R2 URLs would point to
-    // multi-frame sprite sheets.
-    const placeholder =
-      "data:image/svg+xml;utf8," +
-      encodeURIComponent(
-        `<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256"><rect width="256" height="256" fill="#1a1a1a"/><text x="50%" y="50%" fill="#888" text-anchor="middle" dominant-baseline="middle" font-family="monospace" font-size="20">${idea.name}</text></svg>`,
-      );
+    const assetBase = `${MOCK_R2_PUBLIC_BASE}/curated/${slug}`;
+    const fallbackSpritesheet = mockSpritesheetDataUri(idea.name, slug);
+    const spritesheetUrl = MOCK_CURATED_ASSET_SLUGS.has(slug)
+      ? `${assetBase}/spritesheet.webp`
+      : fallbackSpritesheet;
+    const petJsonUrl = MOCK_CURATED_ASSET_SLUGS.has(slug)
+      ? `${assetBase}/pet.json`
+      : fallbackSpritesheet;
+    const zipUrl = MOCK_CURATED_ASSET_SLUGS.has(slug)
+      ? `${assetBase}/${slug}.zip`
+      : fallbackSpritesheet;
     await client.query(
       `INSERT INTO submitted_pets (
         id, slug, display_name, description, spritesheet_url,
@@ -292,8 +304,8 @@ async function seed(client: PGlite): Promise<void> {
         approved_at
       ) VALUES (
         $1, $2, $3, $4, $5,
-        $5, $5, 'creature', '[]'::jsonb, $6::jsonb,
-        'approved', 'submit', $7, $8, $9,
+        $6, $7, 'creature', '[]'::jsonb, $8::jsonb,
+        'approved', 'submit', $9, $10, $11,
         now()
       )
       ON CONFLICT (slug) DO NOTHING`,
@@ -302,7 +314,9 @@ async function seed(client: PGlite): Promise<void> {
         slug,
         idea.name,
         idea.description,
-        placeholder,
+        spritesheetUrl,
+        petJsonUrl,
+        zipUrl,
         JSON.stringify(idea.tags ?? []),
         MOCK_USER.userId,
         MOCK_USER.email,
@@ -323,6 +337,57 @@ async function seed(client: PGlite): Promise<void> {
       "Mock user for local QA",
     ],
   );
+}
+
+function mockSpritesheetDataUri(name: string, slug: string): string {
+  const accent = colorFromSlug(slug);
+  const initials = name
+    .split(/\s+/)
+    .map((part) => part[0])
+    .join("")
+    .slice(0, 3)
+    .toUpperCase();
+  const safeName = escapeSvgText(name);
+  const safeInitials = escapeSvgText(initials);
+  const frames = Array.from({ length: 9 }, (_, row) =>
+    Array.from({ length: 8 }, (_, col) => {
+      const x = col * 192;
+      const y = row * 208;
+      const bob = col % 2 === 0 ? 0 : -5;
+      return `<g transform="translate(${x} ${y})">
+        <rect width="192" height="208" fill="#f8fafc"/>
+        <ellipse cx="96" cy="${157 - bob}" rx="54" ry="12" fill="#d9e2f0"/>
+        <circle cx="96" cy="${92 + bob}" r="42" fill="${accent}"/>
+        <circle cx="80" cy="${82 + bob}" r="5" fill="#111827"/>
+        <circle cx="112" cy="${82 + bob}" r="5" fill="#111827"/>
+        <path d="M82 ${104 + bob} Q96 ${118 + bob} 110 ${104 + bob}" fill="none" stroke="#111827" stroke-width="6" stroke-linecap="round"/>
+        <rect x="42" y="${138 + bob}" width="108" height="24" rx="12" fill="#111827" opacity="0.9"/>
+        <text x="96" y="${155 + bob}" fill="#ffffff" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" font-weight="700">${safeInitials}</text>
+        <text x="96" y="190" fill="#475569" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="14">${safeName}</text>
+      </g>`;
+    }).join(""),
+  ).join("");
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="1536" height="1872" viewBox="0 0 1536 1872">${frames}</svg>`;
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)
+    .replaceAll("'", "%27")
+    .replaceAll("(", "%28")
+    .replaceAll(")", "%29")}`;
+}
+
+function colorFromSlug(slug: string): string {
+  let hash = 0;
+  for (const char of slug) {
+    hash = (hash * 31 + char.charCodeAt(0)) >>> 0;
+  }
+  const hue = hash % 360;
+  return `hsl(${hue} 78% 62%)`;
+}
+
+function escapeSvgText(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
 }
 
 // Bootstrap+seed are run synchronously at module load via top-level

--- a/src/lib/mock/db.ts
+++ b/src/lib/mock/db.ts
@@ -286,16 +286,21 @@ async function seed(client: PGlite): Promise<void> {
     const slug = idea.id;
     const id = `pet_mock_${i.toString().padStart(3, "0")}`;
     const assetBase = `${MOCK_R2_PUBLIC_BASE}/curated/${slug}`;
+    const isCurated = MOCK_CURATED_ASSET_SLUGS.has(slug);
     const fallbackSpritesheet = mockSpritesheetDataUri(idea.name, slug);
-    const spritesheetUrl = MOCK_CURATED_ASSET_SLUGS.has(slug)
+    const spritesheetUrl = isCurated
       ? `${assetBase}/spritesheet.webp`
       : fallbackSpritesheet;
-    const petJsonUrl = MOCK_CURATED_ASSET_SLUGS.has(slug)
+    // Non-curated mocks have no real pet.json or zip on R2. Point at a
+    // recognizable mock:// URI so dev:mock testers see an honest 404 if
+    // they try install/download instead of receiving the SVG markup.
+    // pet_json_url and zip_url are NOT NULL in schema so we cannot null.
+    const petJsonUrl = isCurated
       ? `${assetBase}/pet.json`
-      : fallbackSpritesheet;
-    const zipUrl = MOCK_CURATED_ASSET_SLUGS.has(slug)
+      : `mock://no-asset/${slug}/pet.json`;
+    const zipUrl = isCurated
       ? `${assetBase}/${slug}.zip`
-      : fallbackSpritesheet;
+      : `mock://no-asset/${slug}/${slug}.zip`;
     await client.query(
       `INSERT INTO submitted_pets (
         id, slug, display_name, description, spritesheet_url,


### PR DESCRIPTION
## Summary
- Resize and clip the Surprise Drop pet thumbnail so oversized sprite frames stay inside the card.
- Improve `dev:mock` seeded pet assets by using real curated R2 spritesheets when available.
- Generate sprite-grid-compatible mock placeholders for pets without real assets, avoiding blank or black thumbnails during local QA.

## Validation
- `bun x biome check src/lib/mock/db.ts src/components/surprise-pet-card.tsx`
- `bun run i18n:check`
- Manual QA with `bun run dev:mock` on `localhost:3001`
- Verified Surprise Drop thumbnails render images and stay inside the card.
- Verified mock fallback sprites render for pets without real R2 spritesheets.

## Notes
- The mock placeholder change only affects `dev:mock`; production, real DB data, and real R2 assets are unchanged.
- `bun run check` currently fails on upstream Biome issues in unrelated CLI/desktop/drizzle files

## Before and after
<img width="794" height="538" alt="surprise-drop-bug" src="https://github.com/user-attachments/assets/b3b3907c-c9d1-4258-ad02-27f3a74312c7" />
<img width="854" height="532" alt="surprise-drop-fix" src="https://github.com/user-attachments/assets/f297505b-d759-457f-9c8c-bb38a88553c4" />
