### PR TITLE
refactor(admin/telemetry,manifest): migrate to shadcn Card + recharts

### DIFF
--- a/src/app/[locale]/admin/manifest/page.tsx
+++ b/src/app/[locale]/admin/manifest/page.tsx
@@ -2,6 +2,10 @@ import { desc, sql as dsql } from "drizzle-orm";
 
 import { db, schema } from "@/lib/db/client";
 
+import { AdminManifestByDayChart } from "@/components/admin-manifest-by-day-chart";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
 export const metadata = {
   title: "Petdex Admin · Manifest",
   robots: { index: false, follow: false },
@@ -99,15 +103,15 @@ export default async function AdminManifestPage() {
     .limit(15);
 
   return (
-    <section className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-5 pb-12 md:px-8 md:pb-16">
+    <section className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-5 pb-12 md:px-8 md:pb-16">
       <header>
         <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
           Telemetry
         </p>
-        <h1 className="mt-2 text-4xl font-medium tracking-tight md:text-5xl">
+        <h1 className="mt-2 text-balance text-3xl font-semibold tracking-tight text-foreground md:text-4xl">
           Manifest fetches
         </h1>
-        <p className="mt-3 text-sm text-muted-2">
+        <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-2">
           Who's pulling /api/manifest. IPs are SHA-256 hashed daily so they
           group within a day but can't be reversed.
         </p>
@@ -120,123 +124,134 @@ export default async function AdminManifestPage() {
         <Stat label="Distinct IPs (24h)" value={distinct24.toLocaleString()} />
       </div>
 
-      {/* By day */}
+      {/* By day chart */}
       {byDay.length > 0 ? (
-        <Card title="By day · last 14d">
-          <ul className="space-y-1.5">
-            {byDay.map((d) => {
-              const max = Math.max(...byDay.map((x) => x.count));
-              const pct = max > 0 ? Math.round((d.count / max) * 100) : 0;
-              return (
-                <li key={d.day} className="flex items-center gap-3">
-                  <span className="w-24 shrink-0 font-mono text-[11px] text-muted-3">
-                    {d.day}
-                  </span>
-                  <span className="flex-1">
-                    <span
-                      className="block h-1.5 rounded-full bg-brand/70"
-                      style={{ width: `${pct}%` }}
-                    />
-                  </span>
-                  <span className="w-24 text-right font-mono text-[11px] text-muted-2">
-                    {d.count.toLocaleString()}{" "}
-                    <span className="text-muted-4">
-                      ({d.slim}s/{d.full}f)
-                    </span>
-                  </span>
-                </li>
-              );
-            })}
-          </ul>
+        <Card>
+          <CardHeader>
+            <p className="font-mono text-[10px] tracking-[0.22em] text-brand uppercase">
+              By day · last 14d
+            </p>
+            <CardTitle className="text-xl md:text-2xl">
+              Daily manifest fetches
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <AdminManifestByDayChart data={byDay} />
+          </CardContent>
         </Card>
       ) : null}
 
       {/* Top IPs (loudest) — likely scrapers if count is way out of band. */}
       {topIps.length > 0 ? (
-        <Card title="Loudest IPs · last 7d">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="text-left font-mono text-[10px] tracking-[0.12em] text-muted-3 uppercase">
-                <th className="pb-2 font-normal">IP hash</th>
-                <th className="pb-2 font-normal">Country</th>
-                <th className="pb-2 font-normal">Last UA</th>
-                <th className="pb-2 pr-2 text-right font-normal">Fetches</th>
-              </tr>
-            </thead>
-            <tbody>
-              {topIps.map((row) => (
-                <tr
-                  key={row.ipHash}
-                  className="border-t border-black/[0.06] align-top dark:border-white/[0.06]"
-                >
-                  <td className="py-2 pr-3 font-mono text-[11px] text-muted-2">
-                    {row.ipHash.slice(0, 12)}…
-                  </td>
-                  <td className="py-2 pr-3 font-mono text-[11px] text-muted-2">
-                    <span className="inline-flex items-center gap-1">
-                      <span className="text-sm leading-none">
-                        {countryFlag(row.lastCountry)}
-                      </span>
-                      {row.lastCountry ?? "—"}
-                    </span>
-                  </td>
-                  <td className="max-w-[24rem] truncate py-2 pr-3 text-xs text-muted-2">
-                    {row.lastUa ?? "—"}
-                  </td>
-                  <td className="py-2 pr-2 text-right font-mono text-xs font-semibold text-stone-900 dark:text-stone-100">
-                    {row.count.toLocaleString()}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <Card>
+          <CardHeader>
+            <p className="font-mono text-[10px] tracking-[0.22em] text-brand uppercase">
+              Loudest IPs · last 7d
+            </p>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left font-mono text-[10px] tracking-[0.12em] text-muted-3 uppercase">
+                    <th className="pb-2 font-normal">IP hash</th>
+                    <th className="pb-2 font-normal">Country</th>
+                    <th className="pb-2 font-normal">Last UA</th>
+                    <th className="pb-2 pr-2 text-right font-normal">
+                      Fetches
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {topIps.map((row) => (
+                    <tr
+                      key={row.ipHash}
+                      className="border-t border-black/[0.06] align-top dark:border-white/[0.06]"
+                    >
+                      <td className="py-2 pr-3 font-mono text-[11px] text-muted-2">
+                        {row.ipHash.slice(0, 12)}…
+                      </td>
+                      <td className="py-2 pr-3 font-mono text-[11px] text-muted-2">
+                        <span className="inline-flex items-center gap-1">
+                          <span className="text-sm leading-none">
+                            {countryFlag(row.lastCountry)}
+                          </span>
+                          {row.lastCountry ?? "—"}
+                        </span>
+                      </td>
+                      <td className="max-w-[24rem] truncate py-2 pr-3 text-xs text-muted-2">
+                        {row.lastUa ?? "—"}
+                      </td>
+                      <td className="py-2 pr-2 text-right font-mono text-xs font-semibold text-foreground">
+                        {row.count.toLocaleString()}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
         </Card>
       ) : null}
 
       {/* Top UAs */}
       {topUserAgents.length > 0 ? (
-        <Card title="Top user-agents · last 7d">
-          <ul className="space-y-1.5">
-            {topUserAgents.map((u) => (
-              <li
-                key={u.userAgent ?? "none"}
-                className="flex items-baseline gap-3 border-t border-black/[0.04] pt-1.5 first:border-0 first:pt-0"
-              >
-                <span className="w-16 shrink-0 text-right font-mono text-[11px] font-semibold text-muted-2">
-                  {u.count.toLocaleString()}
-                </span>
-                <span className="truncate text-xs text-muted-2">
-                  {u.userAgent ?? <em className="text-muted-4">no UA</em>}
-                </span>
-              </li>
-            ))}
-          </ul>
+        <Card>
+          <CardHeader>
+            <p className="font-mono text-[10px] tracking-[0.22em] text-brand uppercase">
+              Top user-agents · last 7d
+            </p>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-1.5">
+              {topUserAgents.map((u) => (
+                <li
+                  key={u.userAgent ?? "none"}
+                  className="flex items-baseline gap-3 border-t border-black/[0.04] pt-1.5 first:border-0 first:pt-0 dark:border-white/[0.04]"
+                >
+                  <span className="w-16 shrink-0 text-right font-mono text-[11px] font-semibold text-muted-2">
+                    {u.count.toLocaleString()}
+                  </span>
+                  <span className="truncate text-xs text-muted-2">
+                    {u.userAgent ?? <em className="text-muted-4">no UA</em>}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
         </Card>
       ) : null}
 
       {/* By country */}
       {byCountry.length > 0 ? (
-        <Card title="By country · last 7d">
-          <ul className="grid grid-cols-2 gap-1.5 sm:grid-cols-3">
-            {byCountry.map((c) => (
-              <li
-                key={c.country ?? "none"}
-                className="flex items-center justify-between rounded-xl bg-surface-muted px-3 py-2 text-xs"
-              >
-                <span className="flex items-center gap-1.5">
-                  <span className="text-base leading-none">
-                    {countryFlag(c.country)}
+        <Card>
+          <CardHeader>
+            <p className="font-mono text-[10px] tracking-[0.22em] text-brand uppercase">
+              By country · last 7d
+            </p>
+          </CardHeader>
+          <CardContent>
+            <ul className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+              {byCountry.map((c) => (
+                <li
+                  key={c.country ?? "none"}
+                  className="flex items-center justify-between rounded-xl bg-surface-muted px-3 py-2 text-xs"
+                >
+                  <span className="flex items-center gap-1.5">
+                    <span className="text-base leading-none">
+                      {countryFlag(c.country)}
+                    </span>
+                    <span className="font-mono text-[11px] tracking-[0.1em] text-muted-2 uppercase">
+                      {c.country ?? "—"}
+                    </span>
                   </span>
-                  <span className="font-mono text-[11px] tracking-[0.1em] text-muted-2 uppercase">
-                    {c.country ?? "—"}
-                  </span>
-                </span>
-                <span className="font-mono text-[11px] font-semibold text-stone-900 dark:text-stone-100">
-                  {c.count.toLocaleString()}
-                </span>
-              </li>
-            ))}
-          </ul>
+                  <Badge variant="secondary" className="font-mono text-[10px]">
+                    {c.count.toLocaleString()}
+                  </Badge>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
         </Card>
       ) : null}
     </section>
@@ -245,31 +260,16 @@ export default async function AdminManifestPage() {
 
 function Stat({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-2xl border border-border-base bg-surface/76 p-4 backdrop-blur">
-      <p className="font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
-        {label}
-      </p>
-      <p className="mt-2 font-mono text-2xl font-semibold tracking-tight text-foreground">
-        {value}
-      </p>
-    </div>
-  );
-}
-
-function Card({
-  title,
-  children,
-}: {
-  title: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <section className="rounded-2xl border border-border-base bg-surface/76 p-5 backdrop-blur">
-      <h2 className="font-mono text-[11px] tracking-[0.22em] text-brand uppercase">
-        {title}
-      </h2>
-      <div className="mt-4">{children}</div>
-    </section>
+    <Card size="sm">
+      <CardHeader>
+        <p className="font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
+          {label}
+        </p>
+        <CardTitle className="font-mono text-2xl tracking-tight">
+          {value}
+        </CardTitle>
+      </CardHeader>
+    </Card>
   );
 }
 

--- a/src/app/[locale]/admin/telemetry/page.tsx
+++ b/src/app/[locale]/admin/telemetry/page.tsx
@@ -9,6 +9,16 @@ import { getTranslations } from "next-intl/server";
 
 import { getTelemetrySummary } from "@/lib/telemetry/queries";
 
+import { AdminAdoptionChart } from "@/components/admin-adoption-chart";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
 export const dynamic = "force-dynamic";
 
 export const metadata = {
@@ -63,105 +73,152 @@ export default async function AdminTelemetryPage({
       </div>
 
       <div className="grid gap-6 lg:grid-cols-2">
-        <ChartCard
-          title={t("sections.adoptionCurve")}
-          icon={<BarChart2 className="size-3.5" />}
-        >
-          <AdoptionChart data={summary.installsByDay} />
-        </ChartCard>
+        <Card>
+          <CardHeader>
+            <p className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.22em] text-brand uppercase">
+              <BarChart2 className="size-3" />
+              {t("sections.adoptionCurve")}
+            </p>
+            <CardTitle className="text-base md:text-lg">
+              Daily installs, last 30 days
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <AdminAdoptionChart
+              data={summary.installsByDay}
+              emptyLabel={t("noData")}
+            />
+          </CardContent>
+        </Card>
 
-        <ChartCard
-          title={t("sections.osDistribution")}
-          icon={<MonitorSmartphone className="size-3.5" />}
-        >
-          <BarList
-            items={summary.osDistribution.map((r) => ({
-              label: r.os,
-              count: r.count,
-            }))}
-            emptyLabel={t("noData")}
-          />
-        </ChartCard>
+        <Card>
+          <CardHeader>
+            <p className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.22em] text-brand uppercase">
+              <MonitorSmartphone className="size-3" />
+              {t("sections.osDistribution")}
+            </p>
+          </CardHeader>
+          <CardContent>
+            <BarList
+              items={summary.osDistribution.map((r) => ({
+                label: r.os,
+                count: r.count,
+              }))}
+              emptyLabel={t("noData")}
+            />
+          </CardContent>
+        </Card>
 
-        <ChartCard
-          title={t("sections.archDistribution")}
-          icon={<MonitorSmartphone className="size-3.5" />}
-        >
-          <BarList
-            items={summary.archDistribution.map((r) => ({
-              label: r.arch,
-              count: r.count,
-            }))}
-            emptyLabel={t("noData")}
-          />
-        </ChartCard>
+        <Card>
+          <CardHeader>
+            <p className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.22em] text-brand uppercase">
+              <MonitorSmartphone className="size-3" />
+              {t("sections.archDistribution")}
+            </p>
+          </CardHeader>
+          <CardContent>
+            <BarList
+              items={summary.archDistribution.map((r) => ({
+                label: r.arch,
+                count: r.count,
+              }))}
+              emptyLabel={t("noData")}
+            />
+          </CardContent>
+        </Card>
 
-        <ChartCard
-          title={t("sections.versionAdoption")}
-          icon={<BarChart2 className="size-3.5" />}
-        >
-          <BarList
-            items={summary.versionDistribution.map((r) => ({
-              label: r.binary_version,
-              count: r.count,
-            }))}
-            emptyLabel={t("noData")}
-          />
-        </ChartCard>
+        <Card>
+          <CardHeader>
+            <p className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.22em] text-brand uppercase">
+              <BarChart2 className="size-3" />
+              {t("sections.versionAdoption")}
+            </p>
+          </CardHeader>
+          <CardContent>
+            <BarList
+              items={summary.versionDistribution.map((r) => ({
+                label: r.binary_version,
+                count: r.count,
+              }))}
+              emptyLabel={t("noData")}
+            />
+          </CardContent>
+        </Card>
 
-        <ChartCard
-          title={t("sections.topAgents")}
-          icon={<Terminal className="size-3.5" />}
-        >
-          <BarList
-            items={summary.topAgents.map((r) => ({
-              label: r.agent,
-              count: r.count,
-            }))}
-            emptyLabel={t("noData")}
-          />
-        </ChartCard>
+        <Card>
+          <CardHeader>
+            <p className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.22em] text-brand uppercase">
+              <Terminal className="size-3" />
+              {t("sections.topAgents")}
+            </p>
+          </CardHeader>
+          <CardContent>
+            <BarList
+              items={summary.topAgents.map((r) => ({
+                label: r.agent,
+                count: r.count,
+              }))}
+              emptyLabel={t("noData")}
+            />
+          </CardContent>
+        </Card>
 
-        <ChartCard
-          title={t("sections.geoTop10")}
-          icon={<Globe className="size-3.5" />}
-        >
-          <BarList
-            items={summary.countryTop10.map((r) => ({
-              label: r.country,
-              count: r.count,
-            }))}
-            emptyLabel={t("noData")}
-          />
-        </ChartCard>
+        <Card>
+          <CardHeader>
+            <p className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.22em] text-brand uppercase">
+              <Globe className="size-3" />
+              {t("sections.geoTop10")}
+            </p>
+          </CardHeader>
+          <CardContent>
+            <BarList
+              items={summary.countryTop10.map((r) => ({
+                label: r.country,
+                count: r.count,
+              }))}
+              emptyLabel={t("noData")}
+            />
+          </CardContent>
+        </Card>
       </div>
 
-      <ChartCard
-        title={t("sections.funnel")}
-        icon={<BarChart2 className="size-3.5" />}
-      >
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <FunnelCard
-            label={t("funnel.install")}
-            count={summary.funnel.install}
-          />
-          <FunnelCard
-            label={t("funnel.hooks")}
-            count={summary.funnel.hooks}
-            pct={summary.funnel.installToHooksPct}
-          />
-          <FunnelCard
-            label={t("funnel.start")}
-            count={summary.funnel.start}
-            pct={summary.funnel.hooksToStartPct}
-          />
-          <FunnelCard
-            label={t("funnel.firstEvent")}
-            count={summary.funnel.firstEvent}
-            pct={summary.funnel.startToFirstPct}
-          />
-        </div>
-      </ChartCard>
+      <Card>
+        <CardHeader>
+          <p className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.22em] text-brand uppercase">
+            <BarChart2 className="size-3" />
+            {t("sections.funnel")}
+          </p>
+          <CardTitle className="text-base md:text-lg">
+            Install to first event
+          </CardTitle>
+          <CardDescription>
+            Conversion rate from install to first telemetry event recorded.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <FunnelCard
+              label={t("funnel.install")}
+              count={summary.funnel.install}
+            />
+            <FunnelCard
+              label={t("funnel.hooks")}
+              count={summary.funnel.hooks}
+              pct={summary.funnel.installToHooksPct}
+            />
+            <FunnelCard
+              label={t("funnel.start")}
+              count={summary.funnel.start}
+              pct={summary.funnel.hooksToStartPct}
+            />
+            <FunnelCard
+              label={t("funnel.firstEvent")}
+              count={summary.funnel.firstEvent}
+              pct={summary.funnel.startToFirstPct}
+            />
+          </div>
+        </CardContent>
+      </Card>
     </section>
   );
 }
@@ -176,72 +233,17 @@ function StatCard({
   icon: React.ReactNode;
 }) {
   return (
-    <article className="rounded-3xl border border-border-base bg-surface/80 p-4 backdrop-blur">
-      <header className="flex items-center gap-1.5 font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
-        {icon}
-        {label}
-      </header>
-      <p className="mt-2 font-mono text-3xl font-semibold tracking-tight text-foreground">
-        {value.toLocaleString()}
-      </p>
-    </article>
-  );
-}
-
-function ChartCard({
-  title,
-  icon,
-  children,
-}: {
-  title: string;
-  icon: React.ReactNode;
-  children: React.ReactNode;
-}) {
-  return (
-    <article className="rounded-3xl border border-border-base bg-surface/80 p-5 backdrop-blur">
-      <header className="mb-4 flex items-center gap-1.5 font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
-        {icon}
-        {title}
-      </header>
-      {children}
-    </article>
-  );
-}
-
-function AdoptionChart({ data }: { data: { date: string; count: number }[] }) {
-  const max = data.reduce((a, r) => Math.max(a, r.count), 0);
-  if (data.length === 0 || max === 0) {
-    return <p className="text-sm text-muted-3">No data yet.</p>;
-  }
-  return (
-    <div className="relative h-24 w-full">
-      <svg
-        role="img"
-        aria-label="Daily install counts over last 30 days"
-        viewBox={`0 0 ${data.length * 10} 40`}
-        preserveAspectRatio="none"
-        className="h-full w-full"
-      >
-        {data.map((d, i) => {
-          const h = max > 0 ? (d.count / max) * 36 : 0;
-          return (
-            <rect
-              key={d.date}
-              x={i * 10 + 1}
-              y={40 - h}
-              width={8}
-              height={h}
-              rx={1}
-              className="fill-brand/70"
-            />
-          );
-        })}
-      </svg>
-      <div className="mt-1 flex justify-between font-mono text-[9px] text-muted-3">
-        <span>{data[0]?.date?.slice(5) ?? ""}</span>
-        <span>{data[data.length - 1]?.date?.slice(5) ?? ""}</span>
-      </div>
-    </div>
+    <Card size="sm">
+      <CardHeader>
+        <p className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
+          {icon}
+          {label}
+        </p>
+        <CardTitle className="font-mono text-3xl tracking-tight">
+          {value.toLocaleString()}
+        </CardTitle>
+      </CardHeader>
+    </Card>
   );
 }
 
@@ -291,16 +293,22 @@ function FunnelCard({
   pct?: number;
 }) {
   return (
-    <div className="rounded-2xl border border-border-base bg-background/40 px-3 py-3">
-      <p className="font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
-        {label}
-      </p>
-      <p className="mt-1 font-mono text-2xl font-semibold tracking-tight text-foreground">
-        {count.toLocaleString()}
-      </p>
-      {pct !== undefined ? (
-        <p className="mt-0.5 font-mono text-xs text-brand">{pct}% from prev</p>
-      ) : null}
-    </div>
+    <Card size="sm">
+      <CardHeader>
+        <p className="font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
+          {label}
+        </p>
+        <CardTitle className="font-mono text-2xl tracking-tight">
+          {count.toLocaleString()}
+        </CardTitle>
+        {pct !== undefined ? (
+          <CardDescription>
+            <Badge variant="secondary" className="font-mono text-[10px]">
+              {pct}% from prev
+            </Badge>
+          </CardDescription>
+        ) : null}
+      </CardHeader>
+    </Card>
   );
 }

--- a/src/components/admin-adoption-chart.tsx
+++ b/src/components/admin-adoption-chart.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+
+import type { InstallsByDayRow } from "@/lib/telemetry/queries";
+
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+
+type Props = {
+  data: InstallsByDayRow[];
+  emptyLabel?: string;
+};
+
+const chartConfig = {
+  count: { label: "Installs", color: "var(--brand)" },
+} satisfies ChartConfig;
+
+export function AdminAdoptionChart({
+  data,
+  emptyLabel = "No data yet.",
+}: Props) {
+  const peak = data.reduce((acc, row) => Math.max(acc, row.count), 0);
+  if (data.length === 0 || peak === 0) {
+    return <p className="text-sm text-muted-3">{emptyLabel}</p>;
+  }
+
+  const series = data.map((row) => ({
+    ...row,
+    label: row.date.slice(5),
+  }));
+
+  return (
+    <ChartContainer config={chartConfig} className="h-40 w-full">
+      <BarChart
+        accessibilityLayer
+        data={series}
+        margin={{ left: 0, right: 0, top: 4 }}
+      >
+        <CartesianGrid vertical={false} strokeOpacity={0.2} />
+        <XAxis
+          dataKey="label"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={6}
+          interval={Math.max(0, Math.floor(series.length / 6) - 1)}
+          className="text-[10px]"
+        />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          allowDecimals={false}
+          width={24}
+          className="text-[10px]"
+        />
+        <ChartTooltip content={<ChartTooltipContent indicator="dot" />} />
+        <Bar dataKey="count" fill="var(--color-count)" radius={[2, 2, 0, 0]} />
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/src/components/admin-manifest-by-day-chart.tsx
+++ b/src/components/admin-manifest-by-day-chart.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+
+type ByDayPoint = {
+  day: string;
+  count: number;
+  slim: number;
+  full: number;
+};
+
+const chartConfig = {
+  slim: { label: "Slim", color: "var(--brand)" },
+  full: { label: "Full", color: "var(--brand-deep)" },
+} satisfies ChartConfig;
+
+export function AdminManifestByDayChart({ data }: { data: ByDayPoint[] }) {
+  if (data.length === 0) {
+    return <p className="text-sm text-muted-3">No fetches in this window.</p>;
+  }
+
+  const series = [...data].reverse().map((d) => ({
+    ...d,
+    label: d.day.slice(5),
+  }));
+
+  return (
+    <ChartContainer config={chartConfig} className="h-48 w-full">
+      <BarChart
+        accessibilityLayer
+        data={series}
+        margin={{ left: 0, right: 0, top: 4 }}
+      >
+        <CartesianGrid vertical={false} strokeOpacity={0.2} />
+        <XAxis
+          dataKey="label"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={6}
+          interval={Math.max(0, Math.floor(series.length / 7) - 1)}
+          className="text-[10px]"
+        />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          allowDecimals={false}
+          width={24}
+          className="text-[10px]"
+        />
+        <ChartTooltip content={<ChartTooltipContent indicator="dot" />} />
+        <Bar dataKey="slim" stackId="a" fill="var(--color-slim)" />
+        <Bar dataKey="full" stackId="a" fill="var(--color-full)" />
+        <ChartLegend content={<ChartLegendContent />} />
+      </BarChart>
+    </ChartContainer>
+  );
+}


### PR DESCRIPTION
## Summary
- Mirrors the insights migration (842d741) for the two remaining admin dashboards.
- `admin/telemetry`: SVG AdoptionChart → recharts `AdminAdoptionChart` (axes + tooltip). StatCard / FunnelCard / BarList wrapped in shadcn `Card`, funnel delta uses `Badge`.
- `admin/manifest`: local `Card`/`Stat` helpers replaced by shadcn `Card`. By-day list → recharts stacked bar (`slim` / `full`) via `AdminManifestByDayChart`. Country chips use `Badge variant="secondary"`.
- No data layer changes; `lib/telemetry/queries` and the manifest drizzle queries are untouched.

## Test plan
- [ ] `/admin/telemetry` renders stats, adoption curve, OS/arch/version/agent/geo BarLists, and the funnel
- [ ] `/admin/manifest` renders totals, by-day stacked chart, loudest IPs table, top UAs list, country grid
- [ ] Dark mode parity with insights dashboard