### PR TITLE
perf(db): kill full pet_metrics scans + slim manifest projection (wave 1)

### DIFF
--- a/src/app/api/manifest/route.ts
+++ b/src/app/api/manifest/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { logManifestFetch } from "@/lib/manifest-telemetry";
-import { getAllApprovedPets } from "@/lib/pets";
+import { getApprovedPetsForManifest } from "@/lib/pets";
 
 export const runtime = "nodejs";
 // Cache the slim manifest at the edge for 5 minutes with a 1h
@@ -22,15 +22,15 @@ export const revalidate = 300;
 // versions keep working — they just won't see fields they never read.
 export async function GET(req: Request): Promise<Response> {
   void logManifestFetch(req, "slim");
-  const pets = await getAllApprovedPets();
+  const pets = await getApprovedPetsForManifest();
 
   const items = pets.map((pet) => ({
     slug: pet.slug,
     displayName: pet.displayName,
     kind: pet.kind,
-    submittedBy: pet.submittedBy?.name ?? null,
-    spritesheetUrl: pet.spritesheetPath,
-    petJsonUrl: pet.petJsonPath,
+    submittedBy: pet.creditName,
+    spritesheetUrl: pet.spritesheetUrl,
+    petJsonUrl: pet.petJsonUrl,
     zipUrl: pet.zipUrl ?? null,
   }));
 

--- a/src/lib/db/metrics.ts
+++ b/src/lib/db/metrics.ts
@@ -57,6 +57,11 @@ export type MetricsSummary = {
   maxLikeCount: number;
 };
 
+/**
+ * @deprecated Reads the entire pet_metrics table — drove ~20 GB/month of
+ * Neon egress when called per-request. Prefer `getMetricsBySlugs(slugs)`,
+ * which only loads the rows you actually need.
+ */
 export async function getAllMetrics(): Promise<Map<string, Metrics>> {
   const rows = await db.select().from(schema.petMetrics);
   const map = new Map<string, Metrics>();

--- a/src/lib/pets.ts
+++ b/src/lib/pets.ts
@@ -9,7 +9,7 @@ import { and, desc, eq, sql } from "drizzle-orm";
 
 import { db, schema } from "@/lib/db/client";
 import {
-  getAllMetrics,
+  getMetricsBySlugs,
   getMetricsForSlug,
   type Metrics,
 } from "@/lib/db/metrics";
@@ -75,7 +75,7 @@ export async function getFeaturedPetsWithMetrics(
     .limit(limit);
 
   if (rows.length === 0) return [];
-  const metrics = await getAllMetrics();
+  const metrics = await getMetricsBySlugs(rows.map((row) => row.slug));
   return rows.map((row) => ({
     ...rowToPet(row),
     metrics: metrics.get(row.slug) ?? EMPTY_METRICS,
@@ -88,6 +88,44 @@ export async function getAllApprovedPets(): Promise<PetdexPet[]> {
     .from(schema.submittedPets)
     .where(eq(schema.submittedPets.status, "approved"));
   return rows.map(rowToPet);
+}
+
+export type ApprovedPetSlim = {
+  slug: string;
+  displayName: string;
+  kind: PetKind;
+  spritesheetUrl: string;
+  petJsonUrl: string;
+  zipUrl: string | null;
+  creditName: string | null;
+};
+
+// Slim projection for `/api/manifest` (and any CLI consumer that only
+// reads the install metadata). The full-fat row is ~700 bytes serialized;
+// this shape is ~200 bytes, which compounds across the CLI traffic that
+// hits the slim manifest on every `petdex list` / `petdex install`.
+export async function getApprovedPetsForManifest(): Promise<ApprovedPetSlim[]> {
+  const rows = await db
+    .select({
+      slug: schema.submittedPets.slug,
+      displayName: schema.submittedPets.displayName,
+      kind: schema.submittedPets.kind,
+      spritesheetUrl: schema.submittedPets.spritesheetUrl,
+      petJsonUrl: schema.submittedPets.petJsonUrl,
+      zipUrl: schema.submittedPets.zipUrl,
+      creditName: schema.submittedPets.creditName,
+    })
+    .from(schema.submittedPets)
+    .where(eq(schema.submittedPets.status, "approved"));
+  return rows.map((row) => ({
+    slug: row.slug,
+    displayName: row.displayName,
+    kind: row.kind as PetKind,
+    spritesheetUrl: row.spritesheetUrl,
+    petJsonUrl: row.petJsonUrl,
+    zipUrl: row.zipUrl,
+    creditName: row.creditName,
+  }));
 }
 
 export async function getLatestApprovedPets(limit = 5): Promise<PetdexPet[]> {
@@ -108,7 +146,7 @@ export async function getLatestApprovedPets(limit = 5): Promise<PetdexPet[]> {
 export async function getApprovedPetsWithMetrics(): Promise<PetWithMetrics[]> {
   const pets = await getAllApprovedPets();
   if (pets.length === 0) return [];
-  const metrics = await getAllMetrics();
+  const metrics = await getMetricsBySlugs(pets.map((p) => p.slug));
   return pets.map((p) => ({
     ...p,
     metrics: metrics.get(p.slug) ?? EMPTY_METRICS,


### PR DESCRIPTION
## Summary

Wave 1 of a multi-pass effort to cut DB round-trips on hot paths. Three focused fixes, no behavior change:

- **`getFeaturedPetsWithMetrics`** — was pulling the entire `pet_metrics` table to enrich 6 featured rows. Now uses `getMetricsBySlugs()` with the 6 slugs.
- **`getApprovedPetsWithMetrics`** — same fix, scoped to the slugs already loaded. Backs `/kind/[kind]` and `/vibe/[vibe]` (ISR, `revalidate = 600`).
- **`/api/manifest` (slim)** — replaced `getAllApprovedPets()` (selects 30+ columns) with new `getApprovedPetsForManifest()` projecting only the 7 fields the CLI reads. Cuts row payload ~3x per cache miss inside the `s-maxage=300` window.

`getAllMetrics()` is marked `@deprecated` so it can't quietly return to a hot path. `/api/manifest/full` keeps the full row shape (auth-gated product surface).

## Why now

Inspected Neon query stats and identified two recurring patterns:
1. Full-table `SELECT * FROM pet_metrics` on every page render (~1M+ calls)
2. Full-row `SELECT *` from `submitted_pets` in the CLI-facing manifest

Wave 2 (planned, separate PR) will add `unstable_cache` around search facets (kind/vibes/color/batches `GROUP BY` queries) and rework `/api/me/header-state`.

## Test plan

- [ ] `bun run build` succeeds
- [ ] `bunx biome check` clean on touched files (verified locally)
- [ ] Hit `/api/manifest` and confirm payload shape matches old CLI expectations (`slug`, `displayName`, `kind`, `submittedBy`, `spritesheetUrl`, `petJsonUrl`, `zipUrl`)
- [ ] Visit `/` and confirm featured pets render with metrics
- [ ] Visit `/kind/cat` (or any populated kind) and confirm filtered list renders with metrics
- [ ] After deploy, watch Neon query log: `SELECT * FROM pet_metrics` call rate should drop sharply