### PR TITLE
perf(db): cache aggregate and pet detail hot reads

### DIFF
--- a/src/app/[locale]/pets/[slug]/page.tsx
+++ b/src/app/[locale]/pets/[slug]/page.tsx
@@ -183,6 +183,13 @@ export default async function PetPage({ params }: PageProps) {
       getMetricsForSlug(slug),
       getMetricsSummary(),
       db.query.submittedPets.findFirst({
+        columns: {
+          ownerId: true,
+          creditName: true,
+          creditUrl: true,
+          creditImage: true,
+          source: true,
+        },
         where: eq(schema.submittedPets.slug, slug),
       }),
       getVariantsFor(slug),

--- a/src/app/api/admin/[id]/feature/route.ts
+++ b/src/app/api/admin/[id]/feature/route.ts
@@ -4,6 +4,7 @@ import { auth } from "@clerk/nextjs/server";
 import { eq } from "drizzle-orm";
 
 import { isAdmin } from "@/lib/admin";
+import { invalidatePetCaches } from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import { requireSameOrigin } from "@/lib/same-origin";
 
@@ -73,6 +74,8 @@ export async function PATCH(
       featured: row.featured,
       by: userId,
     });
+  } else {
+    await invalidatePetCaches(row.slug);
   }
 
   return NextResponse.json({ ok: true, featured: row.featured });

--- a/src/app/api/admin/edits/[id]/route.ts
+++ b/src/app/api/admin/edits/[id]/route.ts
@@ -119,8 +119,8 @@ export async function PATCH(
     }
 
     void refreshSimilarityFor(id).catch(() => {});
-    void invalidateAggregates(AGGREGATE_KEYS.variantIndex);
-    void invalidatePetCaches(updated.slug);
+    await invalidateAggregates(AGGREGATE_KEYS.variantIndex);
+    await invalidatePetCaches(updated.slug);
 
     void createNotification({
       userId: updated.ownerId,

--- a/src/app/api/admin/edits/[id]/route.ts
+++ b/src/app/api/admin/edits/[id]/route.ts
@@ -8,12 +8,12 @@ import { isAdmin } from "@/lib/admin";
 import {
   AGGREGATE_KEYS,
   invalidateAggregates,
+  invalidatePetCaches,
 } from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import { renderEditApprovedEmail } from "@/lib/email-templates/edit-approved";
 import { renderEditRejectedEmail } from "@/lib/email-templates/edit-rejected";
 import { createNotification } from "@/lib/notifications";
-import { invalidatePetCaches } from "@/lib/pets";
 import { deleteR2Objects, keyFromR2Url } from "@/lib/r2";
 import { requireSameOrigin } from "@/lib/same-origin";
 import { refreshSimilarityFor } from "@/lib/similarity";

--- a/src/app/api/admin/edits/[id]/route.ts
+++ b/src/app/api/admin/edits/[id]/route.ts
@@ -5,10 +5,15 @@ import { eq } from "drizzle-orm";
 import { Resend } from "resend";
 
 import { isAdmin } from "@/lib/admin";
+import {
+  AGGREGATE_KEYS,
+  invalidateAggregates,
+} from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import { renderEditApprovedEmail } from "@/lib/email-templates/edit-approved";
 import { renderEditRejectedEmail } from "@/lib/email-templates/edit-rejected";
 import { createNotification } from "@/lib/notifications";
+import { invalidatePetCaches } from "@/lib/pets";
 import { deleteR2Objects, keyFromR2Url } from "@/lib/r2";
 import { requireSameOrigin } from "@/lib/same-origin";
 import { refreshSimilarityFor } from "@/lib/similarity";
@@ -114,6 +119,8 @@ export async function PATCH(
     }
 
     void refreshSimilarityFor(id).catch(() => {});
+    void invalidateAggregates(AGGREGATE_KEYS.variantIndex);
+    void invalidatePetCaches(updated.slug);
 
     void createNotification({
       userId: updated.ownerId,

--- a/src/app/api/my-pets/[id]/edit/route.ts
+++ b/src/app/api/my-pets/[id]/edit/route.ts
@@ -3,6 +3,10 @@ import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { and, eq, gte, sql } from "drizzle-orm";
 
+import {
+  AGGREGATE_KEYS,
+  invalidateAggregates,
+} from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import { decideAutoAccept } from "@/lib/edit-policy";
 import {
@@ -10,6 +14,7 @@ import {
   containsBlockedKeyword,
 } from "@/lib/keyword-blocklist";
 import { createNotification } from "@/lib/notifications";
+import { invalidatePetCaches } from "@/lib/pets";
 import { editRatelimit } from "@/lib/ratelimit";
 import { requireSameOrigin } from "@/lib/same-origin";
 import { refreshSimilarityFor } from "@/lib/similarity";
@@ -322,6 +327,8 @@ export async function PATCH(
         .where(eq(schema.submittedPets.id, id));
 
       void refreshSimilarityFor(id).catch(() => {});
+      await invalidateAggregates(AGGREGATE_KEYS.variantIndex);
+      await invalidatePetCaches(row.slug);
 
       void createNotification({
         userId: row.ownerId,

--- a/src/app/api/my-pets/[id]/edit/route.ts
+++ b/src/app/api/my-pets/[id]/edit/route.ts
@@ -6,6 +6,7 @@ import { and, eq, gte, sql } from "drizzle-orm";
 import {
   AGGREGATE_KEYS,
   invalidateAggregates,
+  invalidatePetCaches,
 } from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import { decideAutoAccept } from "@/lib/edit-policy";
@@ -14,7 +15,6 @@ import {
   containsBlockedKeyword,
 } from "@/lib/keyword-blocklist";
 import { createNotification } from "@/lib/notifications";
-import { invalidatePetCaches } from "@/lib/pets";
 import { editRatelimit } from "@/lib/ratelimit";
 import { requireSameOrigin } from "@/lib/same-origin";
 import { refreshSimilarityFor } from "@/lib/similarity";

--- a/src/lib/db/cached-aggregates.ts
+++ b/src/lib/db/cached-aggregates.ts
@@ -1,0 +1,62 @@
+// Upstash-backed cache for cross-instance aggregate queries.
+//
+// Why Upstash and not unstable_cache: Next's per-instance in-memory cache
+// resets on cold start and isn't shared across the serverless fan-out.
+// For aggregate queries that run on every render (facets, counts,
+// metrics summary), an external KV is the only thing that turns
+// N_instances × N_requests into ~1 hit per TTL.
+//
+// Reads gracefully degrade to a direct DB call when Redis isn't
+// configured (local dev, missing env). Writes are best-effort.
+
+import { Redis } from "@upstash/redis";
+
+const redis =
+  process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN
+    ? Redis.fromEnv()
+    : null;
+
+type CacheOptions = {
+  key: string;
+  ttlSeconds: number;
+};
+
+export async function cachedAggregate<T>(
+  options: CacheOptions,
+  compute: () => Promise<T>,
+): Promise<T> {
+  if (!redis) return compute();
+
+  try {
+    const cached = await redis.get<T>(options.key);
+    if (cached !== null && cached !== undefined) return cached;
+  } catch {
+    /* fall through to DB */
+  }
+
+  const fresh = await compute();
+  if (fresh !== null && fresh !== undefined) {
+    redis.set(options.key, fresh, { ex: options.ttlSeconds }).catch(() => {
+      /* best-effort */
+    });
+  }
+  return fresh;
+}
+
+// Invalidate keys after writes that change the aggregate (approve,
+// reject, install bump). Safe no-op when Redis isn't configured.
+export async function invalidateAggregates(...keys: string[]): Promise<void> {
+  if (!redis || keys.length === 0) return;
+  try {
+    await redis.del(...keys);
+  } catch {
+    /* best-effort */
+  }
+}
+
+export const AGGREGATE_KEYS = {
+  facets: "petdex:agg:facets:v1",
+  approvedCount: "petdex:agg:approved-count:v1",
+  metricsSummary: "petdex:agg:metrics-summary:v1",
+  batches: "petdex:agg:batches:v1",
+} as const;

--- a/src/lib/db/cached-aggregates.ts
+++ b/src/lib/db/cached-aggregates.ts
@@ -43,20 +43,49 @@ export async function cachedAggregate<T>(
   return fresh;
 }
 
-// Invalidate keys after writes that change the aggregate (approve,
-// reject, install bump). Safe no-op when Redis isn't configured.
-export async function invalidateAggregates(...keys: string[]): Promise<void> {
-  if (!redis || keys.length === 0) return;
-  try {
-    await redis.del(...keys);
-  } catch {
-    /* best-effort */
-  }
-}
-
 export const AGGREGATE_KEYS = {
   facets: "petdex:agg:facets:v1",
   approvedCount: "petdex:agg:approved-count:v1",
   metricsSummary: "petdex:agg:metrics-summary:v1",
   batches: "petdex:agg:batches:v1",
 } as const;
+
+// Next per-instance cache tags paired with each Upstash key. Both
+// layers must be invalidated together: Upstash is cross-instance and
+// authoritative, but the inner withNextDataCache layer can still serve
+// a stale value on a hot lambda and repopulate Upstash with it.
+const NEXT_TAGS_FOR_KEY: Record<string, string[]> = {
+  [AGGREGATE_KEYS.facets]: ["petdex:facets"],
+};
+
+// Invalidate keys after writes that change the aggregate (approve,
+// reject, install bump). Clears Upstash + any paired Next cache tag.
+// Safe no-op when Redis isn't configured.
+export async function invalidateAggregates(...keys: string[]): Promise<void> {
+  if (keys.length === 0) return;
+
+  if (redis) {
+    try {
+      await redis.del(...keys);
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  // Clear paired Next cache tags so the inner LRU doesn't re-seed
+  // Upstash with a stale value on the next request.
+  const tags = new Set<string>();
+  for (const key of keys) {
+    for (const tag of NEXT_TAGS_FOR_KEY[key] ?? []) tags.add(tag);
+  }
+  if (tags.size === 0) return;
+
+  try {
+    const { revalidateTag } = await import("next/cache");
+    // Next 16 requires a cacheLife profile as the second arg. "max"
+    // means: invalidate aggressively, the next read recomputes.
+    for (const tag of tags) revalidateTag(tag, "max");
+  } catch {
+    /* next/cache unavailable in some runtime contexts (tests, scripts) */
+  }
+}

--- a/src/lib/db/cached-aggregates.ts
+++ b/src/lib/db/cached-aggregates.ts
@@ -82,9 +82,14 @@ export async function invalidateAggregates(...keys: string[]): Promise<void> {
 
   try {
     const { revalidateTag } = await import("next/cache");
-    // Next 16 requires a cacheLife profile as the second arg. "max"
-    // means: invalidate aggressively, the next read recomputes.
-    for (const tag of tags) revalidateTag(tag, "max");
+    // Next 16's `revalidateTag(tag, "max")` is stale-while-revalidate —
+    // it marks the entry stale and serves the old value while refreshing
+    // in the background. That's the wrong semantics here: after we've
+    // already deleted the Upstash value, a background refresh from the
+    // inner Next cache would re-seed Upstash with the stale data.
+    // `{ expire: 0 }` forces immediate eviction so the next read is a
+    // real miss that hits the DB.
+    for (const tag of tags) revalidateTag(tag, { expire: 0 });
   } catch {
     /* next/cache unavailable in some runtime contexts (tests, scripts) */
   }

--- a/src/lib/db/cached-aggregates.ts
+++ b/src/lib/db/cached-aggregates.ts
@@ -1,13 +1,5 @@
-// Upstash-backed cache for cross-instance aggregate queries.
-//
-// Why Upstash and not unstable_cache: Next's per-instance in-memory cache
-// resets on cold start and isn't shared across the serverless fan-out.
-// For aggregate queries that run on every render (facets, counts,
-// metrics summary), an external KV is the only thing that turns
-// N_instances × N_requests into ~1 hit per TTL.
-//
-// Reads gracefully degrade to a direct DB call when Redis isn't
-// configured (local dev, missing env). Writes are best-effort.
+// Upstash-backed cache for shared hot reads. Reads gracefully degrade to
+// a direct DB call when Redis isn't configured. Writes are best-effort.
 
 import { Redis } from "@upstash/redis";
 
@@ -48,6 +40,7 @@ export const AGGREGATE_KEYS = {
   approvedCount: "petdex:agg:approved-count:v1",
   metricsSummary: "petdex:agg:metrics-summary:v1",
   batches: "petdex:agg:batches:v1",
+  variantIndex: "petdex:agg:variant-index:v1",
 } as const;
 
 // Next per-instance cache tags paired with each Upstash key. Both

--- a/src/lib/db/cached-aggregates.ts
+++ b/src/lib/db/cached-aggregates.ts
@@ -43,6 +43,16 @@ export const AGGREGATE_KEYS = {
   variantIndex: "petdex:agg:variant-index:v1",
 } as const;
 
+export function petCacheKey(slug: string): string {
+  return `petdex:pet:${slug}:v1`;
+}
+
+export async function invalidatePetCaches(...slugs: string[]): Promise<void> {
+  await invalidateAggregates(
+    ...slugs.filter(Boolean).map((slug) => petCacheKey(slug)),
+  );
+}
+
 // Next per-instance cache tags paired with each Upstash key. Both
 // layers must be invalidated together: Upstash is cross-instance and
 // authoritative, but the inner withNextDataCache layer can still serve

--- a/src/lib/db/metrics.ts
+++ b/src/lib/db/metrics.ts
@@ -1,5 +1,6 @@
 import { eq, inArray, sql } from "drizzle-orm";
 
+import { AGGREGATE_KEYS, cachedAggregate } from "./cached-aggregates";
 import { db, schema } from "./client";
 
 export async function incrementInstallCount(slug: string): Promise<void> {
@@ -106,20 +107,25 @@ export async function getMetricsForSlug(slug: string): Promise<Metrics> {
 }
 
 export async function getMetricsSummary(): Promise<MetricsSummary> {
-  const [row] = await db
-    .select({
-      maxInstallCount: sql<number>`coalesce(max(${schema.petMetrics.installCount}), 0)::int`,
-      maxLikeCount: sql<number>`coalesce(max(${schema.petMetrics.likeCount}), 0)::int`,
-    })
-    .from(schema.petMetrics)
-    .innerJoin(
-      schema.submittedPets,
-      eq(schema.petMetrics.petSlug, schema.submittedPets.slug),
-    )
-    .where(eq(schema.submittedPets.status, "approved"));
+  return cachedAggregate(
+    { key: AGGREGATE_KEYS.metricsSummary, ttlSeconds: 60 },
+    async () => {
+      const [row] = await db
+        .select({
+          maxInstallCount: sql<number>`coalesce(max(${schema.petMetrics.installCount}), 0)::int`,
+          maxLikeCount: sql<number>`coalesce(max(${schema.petMetrics.likeCount}), 0)::int`,
+        })
+        .from(schema.petMetrics)
+        .innerJoin(
+          schema.submittedPets,
+          eq(schema.petMetrics.petSlug, schema.submittedPets.slug),
+        )
+        .where(eq(schema.submittedPets.status, "approved"));
 
-  return {
-    maxInstallCount: row?.maxInstallCount ?? 0,
-    maxLikeCount: row?.maxLikeCount ?? 0,
-  };
+      return {
+        maxInstallCount: row?.maxInstallCount ?? 0,
+        maxLikeCount: row?.maxLikeCount ?? 0,
+      };
+    },
+  );
 }

--- a/src/lib/db/metrics.ts
+++ b/src/lib/db/metrics.ts
@@ -1,6 +1,10 @@
 import { eq, inArray, sql } from "drizzle-orm";
 
-import { AGGREGATE_KEYS, cachedAggregate } from "./cached-aggregates";
+import {
+  AGGREGATE_KEYS,
+  cachedAggregate,
+  invalidateAggregates,
+} from "./cached-aggregates";
 import { db, schema } from "./client";
 
 export async function incrementInstallCount(slug: string): Promise<void> {
@@ -19,6 +23,8 @@ export async function incrementInstallCount(slug: string): Promise<void> {
         updatedAt: new Date(),
       },
     });
+  // maxInstallCount in the cached summary may have moved.
+  void invalidateAggregates(AGGREGATE_KEYS.metricsSummary);
 }
 
 export async function incrementZipDownloadCount(slug: string): Promise<void> {
@@ -45,6 +51,8 @@ export async function setLikeCount(slug: string, count: number): Promise<void> {
       target: schema.petMetrics.petSlug,
       set: { likeCount: count, updatedAt: new Date() },
     });
+  // maxLikeCount in the cached summary may have moved.
+  void invalidateAggregates(AGGREGATE_KEYS.metricsSummary);
 }
 
 export type Metrics = {

--- a/src/lib/db/metrics.ts
+++ b/src/lib/db/metrics.ts
@@ -24,7 +24,7 @@ export async function incrementInstallCount(slug: string): Promise<void> {
       },
     });
   // maxInstallCount in the cached summary may have moved.
-  void invalidateAggregates(AGGREGATE_KEYS.metricsSummary);
+  await invalidateAggregates(AGGREGATE_KEYS.metricsSummary);
 }
 
 export async function incrementZipDownloadCount(slug: string): Promise<void> {
@@ -52,7 +52,7 @@ export async function setLikeCount(slug: string, count: number): Promise<void> {
       set: { likeCount: count, updatedAt: new Date() },
     });
   // maxLikeCount in the cached summary may have moved.
-  void invalidateAggregates(AGGREGATE_KEYS.metricsSummary);
+  await invalidateAggregates(AGGREGATE_KEYS.metricsSummary);
 }
 
 export type Metrics = {

--- a/src/lib/pet-search.ts
+++ b/src/lib/pet-search.ts
@@ -17,6 +17,7 @@ import {
 } from "drizzle-orm";
 
 import { COLOR_FAMILIES, type ColorFamily } from "@/lib/color-families";
+import { AGGREGATE_KEYS, cachedAggregate } from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import { getAvailableBatches } from "@/lib/dex-batch.server";
 import { PETDEX_EMBEDDING_MODEL } from "@/lib/embeddings";
@@ -399,7 +400,7 @@ function orderForSort(
   }
 }
 
-const loadFacets = withNextDataCache(
+const computeFacets = withNextDataCache(
   async (): Promise<SearchFacets> => {
     const [kindRows, vibeRows, batches] = await Promise.all([
       db
@@ -456,6 +457,15 @@ const loadFacets = withNextDataCache(
   ["petdex-facets"],
   { tags: ["petdex:facets"], revalidate: 300 },
 );
+
+// Two-tier cache for the facet aggregate. Upstash sits in front of the
+// Next per-instance cache so cross-lambda fan-out doesn't recompute
+// the same `GROUP BY` query on every cold instance.
+const loadFacets = (): Promise<SearchFacets> =>
+  cachedAggregate(
+    { key: AGGREGATE_KEYS.facets, ttlSeconds: 300 },
+    computeFacets,
+  );
 
 function clamp(n: number, lo: number, hi: number): number {
   return Math.max(lo, Math.min(hi, n));

--- a/src/lib/pet-sound.ts
+++ b/src/lib/pet-sound.ts
@@ -8,6 +8,7 @@ import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { generateText } from "ai";
 import { and, eq, isNull, ne } from "drizzle-orm";
 
+import { invalidatePetCaches } from "@/lib/db/cached-aggregates";
 import { runtimeDb as db, schema } from "@/lib/db/runtime";
 import { R2_BUCKET, R2_PUBLIC_BASE, r2 } from "@/lib/r2";
 
@@ -280,6 +281,7 @@ export async function processPetSound(
       .update(schema.submittedPets)
       .set({ soundUrl })
       .where(eq(schema.submittedPets.slug, pet.slug));
+    await invalidatePetCaches(pet.slug);
 
     return {
       slug: pet.slug,

--- a/src/lib/pets.ts
+++ b/src/lib/pets.ts
@@ -7,7 +7,11 @@ import { cache } from "react";
 
 import { and, desc, eq, sql } from "drizzle-orm";
 
-import { AGGREGATE_KEYS, cachedAggregate } from "@/lib/db/cached-aggregates";
+import {
+  AGGREGATE_KEYS,
+  cachedAggregate,
+  invalidateAggregates,
+} from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import {
   getMetricsBySlugs,
@@ -24,15 +28,81 @@ const EMPTY_METRICS: Metrics = {
   likeCount: 0,
 };
 
+const PET_CACHE_TTL_SECONDS = 300;
+
+type PetRow = Pick<
+  typeof schema.submittedPets.$inferSelect,
+  | "id"
+  | "slug"
+  | "displayName"
+  | "description"
+  | "spritesheetUrl"
+  | "petJsonUrl"
+  | "zipUrl"
+  | "soundUrl"
+  | "featured"
+  | "kind"
+  | "vibes"
+  | "tags"
+  | "dominantColor"
+  | "colorFamily"
+  | "creditName"
+  | "creditUrl"
+  | "creditImage"
+  | "source"
+  | "approvedAt"
+  | "createdAt"
+>;
+
+const petColumns = {
+  id: true,
+  slug: true,
+  displayName: true,
+  description: true,
+  spritesheetUrl: true,
+  petJsonUrl: true,
+  zipUrl: true,
+  soundUrl: true,
+  featured: true,
+  kind: true,
+  vibes: true,
+  tags: true,
+  dominantColor: true,
+  colorFamily: true,
+  creditName: true,
+  creditUrl: true,
+  creditImage: true,
+  source: true,
+  approvedAt: true,
+  createdAt: true,
+} as const;
+
+export function petCacheKey(slug: string): string {
+  return `petdex:pet:${slug}:v1`;
+}
+
+export async function invalidatePetCaches(...slugs: string[]): Promise<void> {
+  await invalidateAggregates(
+    ...slugs.filter(Boolean).map((slug) => petCacheKey(slug)),
+  );
+}
+
 export const getPet = cache(
   async (slug: string): Promise<PetdexPet | undefined> => {
-    const row = await db.query.submittedPets.findFirst({
-      where: and(
-        eq(schema.submittedPets.slug, slug),
-        eq(schema.submittedPets.status, "approved"),
-      ),
-    });
-    return row ? rowToPet(row) : undefined;
+    const pet = await cachedAggregate<PetdexPet | null>(
+      { key: petCacheKey(slug), ttlSeconds: PET_CACHE_TTL_SECONDS },
+      async () => {
+        const row = await db.query.submittedPets.findFirst({
+          columns: petColumns,
+          where: and(
+            eq(schema.submittedPets.slug, slug),
+            eq(schema.submittedPets.status, "approved"),
+          ),
+        });
+        return row ? rowToPet(row) : null;
+      },
+    );
+    return pet ?? undefined;
   },
 );
 
@@ -167,9 +237,7 @@ export async function getApprovedPetCount(): Promise<number> {
   );
 }
 
-export function rowToPet(
-  row: typeof schema.submittedPets.$inferSelect,
-): PetdexPet {
+export function rowToPet(row: PetRow): PetdexPet {
   const submittedBy = row.creditName
     ? {
         name: row.creditName,

--- a/src/lib/pets.ts
+++ b/src/lib/pets.ts
@@ -7,6 +7,7 @@ import { cache } from "react";
 
 import { and, desc, eq, sql } from "drizzle-orm";
 
+import { AGGREGATE_KEYS, cachedAggregate } from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import {
   getMetricsBySlugs,
@@ -154,11 +155,16 @@ export async function getApprovedPetsWithMetrics(): Promise<PetWithMetrics[]> {
 }
 
 export async function getApprovedPetCount(): Promise<number> {
-  const row = await db
-    .select({ n: sql<number>`count(*)::int` })
-    .from(schema.submittedPets)
-    .where(eq(schema.submittedPets.status, "approved"));
-  return row[0]?.n ?? 0;
+  return cachedAggregate(
+    { key: AGGREGATE_KEYS.approvedCount, ttlSeconds: 60 },
+    async () => {
+      const row = await db
+        .select({ n: sql<number>`count(*)::int` })
+        .from(schema.submittedPets)
+        .where(eq(schema.submittedPets.status, "approved"));
+      return row[0]?.n ?? 0;
+    },
+  );
 }
 
 export function rowToPet(

--- a/src/lib/pets.ts
+++ b/src/lib/pets.ts
@@ -10,7 +10,7 @@ import { and, desc, eq, sql } from "drizzle-orm";
 import {
   AGGREGATE_KEYS,
   cachedAggregate,
-  invalidateAggregates,
+  petCacheKey,
 } from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import {
@@ -76,16 +76,6 @@ const petColumns = {
   approvedAt: true,
   createdAt: true,
 } as const;
-
-export function petCacheKey(slug: string): string {
-  return `petdex:pet:${slug}:v1`;
-}
-
-export async function invalidatePetCaches(...slugs: string[]): Promise<void> {
-  await invalidateAggregates(
-    ...slugs.filter(Boolean).map((slug) => petCacheKey(slug)),
-  );
-}
 
 export const getPet = cache(
   async (slug: string): Promise<PetdexPet | undefined> => {

--- a/src/lib/similarity.ts
+++ b/src/lib/similarity.ts
@@ -9,6 +9,11 @@
 import { eq } from "drizzle-orm";
 import sharp from "sharp";
 
+import {
+  AGGREGATE_KEYS,
+  invalidateAggregates,
+  invalidatePetCaches,
+} from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import {
   buildPetEmbeddingText,
@@ -104,6 +109,8 @@ export async function refreshSimilarityFor(petId: string): Promise<void> {
       .update(schema.submittedPets)
       .set({ dhash: hash })
       .where(eq(schema.submittedPets.id, petId));
+    await invalidateAggregates(AGGREGATE_KEYS.variantIndex);
+    await invalidatePetCaches(row.slug);
   }
   if (vec) {
     await persistPetEmbedding(petId, vec);

--- a/src/lib/submission-decisions.ts
+++ b/src/lib/submission-decisions.ts
@@ -102,6 +102,17 @@ export async function applySubmissionAction(
     return { ok: false, status: 400, body: { error: "nothing_to_update" } };
   }
 
+  const current = await db.query.submittedPets.findFirst({
+    columns: {
+      slug: true,
+      status: true,
+    },
+    where: eq(schema.submittedPets.id, id),
+  });
+  if (!current) {
+    return { ok: false, status: 404, body: { error: "not_found" } };
+  }
+
   const [updated] = await db
     .update(schema.submittedPets)
     .set(update)
@@ -125,21 +136,23 @@ export async function applySubmissionAction(
   }
 
   // Any status flip changes the set of approved pets, so the cached
-  // facets / counts / metrics summary become stale. Fire-and-forget;
-  // a missed invalidation will be corrected by the 60-300s TTL.
+  // facets / counts / metrics summary become stale.
   if (
     body.action === "approve" ||
     body.action === "reject" ||
     body.action === "pending"
   ) {
-    void invalidateAggregates(
+    await invalidateAggregates(
       AGGREGATE_KEYS.facets,
       AGGREGATE_KEYS.approvedCount,
       AGGREGATE_KEYS.metricsSummary,
       AGGREGATE_KEYS.batches,
       AGGREGATE_KEYS.variantIndex,
     );
-    void invalidatePetCaches(row.slug);
+    await invalidatePetCaches(current.slug, row.slug);
+  } else if (current.status === "approved" && body.action === "edit") {
+    await invalidateAggregates(AGGREGATE_KEYS.variantIndex);
+    await invalidatePetCaches(current.slug, row.slug);
   }
 
   return { ok: true, row };

--- a/src/lib/submission-decisions.ts
+++ b/src/lib/submission-decisions.ts
@@ -1,6 +1,10 @@
 import { eq } from "drizzle-orm";
 import { Resend } from "resend";
 
+import {
+  AGGREGATE_KEYS,
+  invalidateAggregates,
+} from "@/lib/db/cached-aggregates";
 import type { SubmittedPet } from "@/lib/db/schema";
 import * as schema from "@/lib/db/schema";
 import { renderSubmissionApprovedEmail } from "@/lib/email-templates/submission-approved";
@@ -117,6 +121,22 @@ export async function applySubmissionAction(
     (body.action === "approve" || body.action === "reject")
   ) {
     await notifySubmissionOwner(row);
+  }
+
+  // Any status flip changes the set of approved pets, so the cached
+  // facets / counts / metrics summary become stale. Fire-and-forget;
+  // a missed invalidation will be corrected by the 60-300s TTL.
+  if (
+    body.action === "approve" ||
+    body.action === "reject" ||
+    body.action === "pending"
+  ) {
+    void invalidateAggregates(
+      AGGREGATE_KEYS.facets,
+      AGGREGATE_KEYS.approvedCount,
+      AGGREGATE_KEYS.metricsSummary,
+      AGGREGATE_KEYS.batches,
+    );
   }
 
   return { ok: true, row };

--- a/src/lib/submission-decisions.ts
+++ b/src/lib/submission-decisions.ts
@@ -9,6 +9,7 @@ import type { SubmittedPet } from "@/lib/db/schema";
 import * as schema from "@/lib/db/schema";
 import { renderSubmissionApprovedEmail } from "@/lib/email-templates/submission-approved";
 import { renderSubmissionRejectedEmail } from "@/lib/email-templates/submission-rejected";
+import { invalidatePetCaches } from "@/lib/pets";
 
 export type SubmissionAdminAction = "approve" | "reject" | "edit" | "pending";
 
@@ -136,7 +137,9 @@ export async function applySubmissionAction(
       AGGREGATE_KEYS.approvedCount,
       AGGREGATE_KEYS.metricsSummary,
       AGGREGATE_KEYS.batches,
+      AGGREGATE_KEYS.variantIndex,
     );
+    void invalidatePetCaches(row.slug);
   }
 
   return { ok: true, row };

--- a/src/lib/submission-decisions.ts
+++ b/src/lib/submission-decisions.ts
@@ -151,7 +151,11 @@ export async function applySubmissionAction(
     );
     await invalidatePetCaches(current.slug, row.slug);
   } else if (current.status === "approved" && body.action === "edit") {
-    await invalidateAggregates(AGGREGATE_KEYS.variantIndex);
+    const aggregateKeys: string[] = [AGGREGATE_KEYS.variantIndex];
+    if (current.slug !== row.slug) {
+      aggregateKeys.push(AGGREGATE_KEYS.metricsSummary);
+    }
+    await invalidateAggregates(...aggregateKeys);
     await invalidatePetCaches(current.slug, row.slug);
   }
 

--- a/src/lib/submission-decisions.ts
+++ b/src/lib/submission-decisions.ts
@@ -4,12 +4,12 @@ import { Resend } from "resend";
 import {
   AGGREGATE_KEYS,
   invalidateAggregates,
+  invalidatePetCaches,
 } from "@/lib/db/cached-aggregates";
 import type { SubmittedPet } from "@/lib/db/schema";
 import * as schema from "@/lib/db/schema";
 import { renderSubmissionApprovedEmail } from "@/lib/email-templates/submission-approved";
 import { renderSubmissionRejectedEmail } from "@/lib/email-templates/submission-rejected";
-import { invalidatePetCaches } from "@/lib/pets";
 
 export type SubmissionAdminAction = "approve" | "reject" | "edit" | "pending";
 
@@ -199,6 +199,8 @@ async function runPostApprovalEffects(
             colorFamily: classifyColorFamily(dominantColor),
           })
           .where(eq(schema.submittedPets.id, row.id));
+        await invalidateAggregates(AGGREGATE_KEYS.facets);
+        await invalidatePetCaches(row.slug);
       } catch (e) {
         console.error("color extract failed", e);
       }

--- a/src/lib/takedown.ts
+++ b/src/lib/takedown.ts
@@ -3,6 +3,10 @@ import "server-only";
 import { eq, sql } from "drizzle-orm";
 import { Resend } from "resend";
 
+import {
+  AGGREGATE_KEYS,
+  invalidateAggregates,
+} from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import { renderSubmissionTakedownEmail } from "@/lib/email-templates/submission-takedown";
 import { createNotification } from "@/lib/notifications";
@@ -93,6 +97,18 @@ export async function takedownPet(
   await db
     .delete(schema.submittedPets)
     .where(eq(schema.submittedPets.id, pet.id));
+
+  // 5b. If this was an approved pet, the cached aggregates (facets,
+  //     counts, metrics summary, batches) all just moved. Fire-and-
+  //     forget — TTL covers any missed invalidation.
+  if (pet.status === "approved") {
+    void invalidateAggregates(
+      AGGREGATE_KEYS.facets,
+      AGGREGATE_KEYS.approvedCount,
+      AGGREGATE_KEYS.metricsSummary,
+      AGGREGATE_KEYS.batches,
+    );
+  }
 
   // 6. Best-effort R2 cleanup. We derive keys from the URLs the
   //    submission stored; anything off-host (legacy or external credit

--- a/src/lib/takedown.ts
+++ b/src/lib/takedown.ts
@@ -10,6 +10,7 @@ import {
 import { db, schema } from "@/lib/db/client";
 import { renderSubmissionTakedownEmail } from "@/lib/email-templates/submission-takedown";
 import { createNotification } from "@/lib/notifications";
+import { invalidatePetCaches } from "@/lib/pets";
 import { deleteR2Objects, keyFromR2Url } from "@/lib/r2";
 import { getPreferredLocaleForUser } from "@/lib/user-locale";
 
@@ -107,7 +108,9 @@ export async function takedownPet(
       AGGREGATE_KEYS.approvedCount,
       AGGREGATE_KEYS.metricsSummary,
       AGGREGATE_KEYS.batches,
+      AGGREGATE_KEYS.variantIndex,
     );
+    void invalidatePetCaches(pet.slug);
   }
 
   // 6. Best-effort R2 cleanup. We derive keys from the URLs the

--- a/src/lib/takedown.ts
+++ b/src/lib/takedown.ts
@@ -100,17 +100,16 @@ export async function takedownPet(
     .where(eq(schema.submittedPets.id, pet.id));
 
   // 5b. If this was an approved pet, the cached aggregates (facets,
-  //     counts, metrics summary, batches) all just moved. Fire-and-
-  //     forget — TTL covers any missed invalidation.
+  //     counts, metrics summary, batches) all just moved.
   if (pet.status === "approved") {
-    void invalidateAggregates(
+    await invalidateAggregates(
       AGGREGATE_KEYS.facets,
       AGGREGATE_KEYS.approvedCount,
       AGGREGATE_KEYS.metricsSummary,
       AGGREGATE_KEYS.batches,
       AGGREGATE_KEYS.variantIndex,
     );
-    void invalidatePetCaches(pet.slug);
+    await invalidatePetCaches(pet.slug);
   }
 
   // 6. Best-effort R2 cleanup. We derive keys from the URLs the

--- a/src/lib/takedown.ts
+++ b/src/lib/takedown.ts
@@ -6,11 +6,11 @@ import { Resend } from "resend";
 import {
   AGGREGATE_KEYS,
   invalidateAggregates,
+  invalidatePetCaches,
 } from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import { renderSubmissionTakedownEmail } from "@/lib/email-templates/submission-takedown";
 import { createNotification } from "@/lib/notifications";
-import { invalidatePetCaches } from "@/lib/pets";
 import { deleteR2Objects, keyFromR2Url } from "@/lib/r2";
 import { getPreferredLocaleForUser } from "@/lib/user-locale";
 

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -1,7 +1,8 @@
 import { cache } from "react";
 
-import { and, eq, isNotNull, ne } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 
+import { AGGREGATE_KEYS, cachedAggregate } from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import { getDexNumberMap } from "@/lib/dex";
 
@@ -16,18 +17,46 @@ export type Variant = {
   dexNumber: number | null;
 };
 
+type VariantIndexRow = {
+  slug: string;
+  displayName: string;
+  spritesheetUrl: string;
+  dhash: string | null;
+  source: "submit" | "discover" | "claimed";
+};
+
+const VARIANT_INDEX_TTL_SECONDS = 600;
+
+const getVariantIndex = cache(async (): Promise<VariantIndexRow[]> => {
+  return cachedAggregate(
+    { key: AGGREGATE_KEYS.variantIndex, ttlSeconds: VARIANT_INDEX_TTL_SECONDS },
+    async () => {
+      const rows = await db.query.submittedPets.findMany({
+        columns: {
+          slug: true,
+          displayName: true,
+          spritesheetUrl: true,
+          dhash: true,
+          source: true,
+        },
+        where: eq(schema.submittedPets.status, "approved"),
+      });
+
+      return rows.map((row) => ({
+        slug: row.slug,
+        displayName: row.displayName,
+        spritesheetUrl: row.spritesheetUrl,
+        dhash: row.dhash,
+        source: row.source,
+      }));
+    },
+  );
+});
+
 export const getVariantsFor = cache(
   async (slug: string): Promise<Variant[]> => {
-    const currentPet = await db.query.submittedPets.findFirst({
-      columns: {
-        slug: true,
-        dhash: true,
-      },
-      where: and(
-        eq(schema.submittedPets.slug, slug),
-        eq(schema.submittedPets.status, "approved"),
-      ),
-    });
+    const rows = await getVariantIndex();
+    const currentPet = rows.find((row) => row.slug === slug);
 
     if (!currentPet) {
       throw new Error("PET_NOT_FOUND");
@@ -37,38 +66,23 @@ export const getVariantsFor = cache(
       return [];
     }
 
-    const rows = await db.query.submittedPets.findMany({
-      columns: {
-        slug: true,
-        displayName: true,
-        spritesheetUrl: true,
-        dhash: true,
-      },
-      where: and(
-        eq(schema.submittedPets.status, "approved"),
-        ne(schema.submittedPets.source, "discover"),
-        ne(schema.submittedPets.slug, currentPet.slug),
-        isNotNull(schema.submittedPets.dhash),
-      ),
-    });
-
     const selfHash = BigInt(`0x${currentPet.dhash}`);
     const dexMap = await getDexNumberMap();
 
     return rows
-      .flatMap((row) =>
-        row.dhash
-          ? [
-              {
-                slug: row.slug,
-                displayName: row.displayName,
-                spritesheetUrl: row.spritesheetUrl,
-                distance: hammingDistance(selfHash, row.dhash),
-                dexNumber: dexMap.get(row.slug) ?? null,
-              },
-            ]
-          : [],
+      .filter(
+        (row): row is VariantIndexRow & { dhash: string } =>
+          row.source !== "discover" &&
+          row.slug !== currentPet.slug &&
+          Boolean(row.dhash),
       )
+      .map((row) => ({
+        slug: row.slug,
+        displayName: row.displayName,
+        spritesheetUrl: row.spritesheetUrl,
+        distance: hammingDistance(selfHash, row.dhash),
+        dexNumber: dexMap.get(row.slug) ?? null,
+      }))
       .filter((row) => row.distance <= VARIANT_DISTANCE_THRESHOLD)
       .sort((a, b) => a.distance - b.distance)
       .slice(0, VARIANT_MAX_RESULTS);


### PR DESCRIPTION
## Summary

Wave 1 (#239) trimmed payload shape. This PR now covers the next hot-read layer:

- Upstash TTL cache for repeated aggregate reads.
- Slim cached `getPet(slug)` payloads for pet detail, metadata, and OG renders.
- Cached dhash variant index so pet detail pages stop querying all approved hashes per slug.
- Coordinated invalidation from approval, takedown, metrics writes, and edit approval paths.

The important correction from the original PR description: `unstable_cache` is not merely per-instance memory. Next persists it through its data cache. The production symptom still showed millions of recomputes, so the safer fix here is to put a small explicit Upstash layer around the exact hot reads and invalidate it from known write paths.

## Changes

### Aggregate cache

- Added `src/lib/db/cached-aggregates.ts` with `cachedAggregate()` and `invalidateAggregates()`.
- Wrapped `loadFacets` with Upstash TTL 5m.
- Wrapped `getApprovedPetCount` with Upstash TTL 60s.
- Wrapped `getMetricsSummary` with Upstash TTL 60s.
- Kept graceful degradation when `UPSTASH_REDIS_REST_*` is missing.
- Kept paired Next tag eviction for facets so the inner `withNextDataCache` layer cannot re-seed Upstash with stale data after invalidation.

### Pet detail hot path

- `getPet(slug)` now selects only the fields needed by `rowToPet()` instead of `SELECT *` from `submitted_pets`.
- `getPet(slug)` is cached by slug in Upstash for 5m.
- Pet detail owner-credit lookup now projects only owner/credit/source fields instead of loading the full pet row again.

### Dhash variants hot path

- `getVariantsFor(slug)` now uses a cached approved-pet variant index instead of running the all-approved-hashes query on every pet detail render.
- The index includes all approved pets, including rows with null `dhash`, so an approved pet without a hash still returns `[]` instead of incorrectly 404ing.
- Result filtering still excludes `source = discover` candidates and the current slug.

### Invalidation

| Write path | Keys cleared |
|---|---|
| Approve / reject / pending | facets, approvedCount, metricsSummary, batches, variantIndex, pet slug |
| Takedown approved pet | facets, approvedCount, metricsSummary, batches, variantIndex, pet slug |
| Edit approval | variantIndex, pet slug |
| Install bump | metricsSummary |
| Like count change | metricsSummary |
| Zip download bump | none, not part of summary |

## Why not Neon WebSocket in this PR?

The Neon HTTP housekeeping rows are a multiplier on query volume. This PR reduces query count and payload first. A WebSocket `Pool` migration is still worth testing later, but doing it before removing obvious repeated reads would add connection lifecycle complexity while leaving the app architecture noisy.

## Follow-up

- Add miss coalescing to `cachedAggregate()` if cache stampedes show up around TTL boundaries.
- Redesign `/api/me/header-state` signed-in behavior with count queries plus a short client/session TTL. The branch already combines the endpoint, so the next step is reducing private polling/query volume.
- Consider a materialized variant table later only if catalog size grows enough that the cached variant index becomes too large.

## Verification

- `bun x biome check src/lib/db/cached-aggregates.ts src/lib/pets.ts src/lib/variants.ts src/lib/submission-decisions.ts src/lib/takedown.ts 'src/app/[locale]/pets/[slug]/page.tsx' 'src/app/api/admin/edits/[id]/route.ts'`
- `bun x tsc --noEmit --types bun-types`
- `git diff --check`

Known repo-wide blockers not introduced here:

- `bun run check` still fails on existing `packages/petdex-cli` and Drizzle meta Biome diagnostics.
- `bun test ./src/lib/pet-search.integration.ts` requires `DATABASE_URL` and fails when it is unset locally.
