### PR TITLE
perf(isr): hoist metrics off SSR shells + tag-based invalidation

### DIFF
--- a/src/app/[locale]/collections/page.tsx
+++ b/src/app/[locale]/collections/page.tsx
@@ -12,9 +12,10 @@ import { SiteHeader } from "@/components/site-header";
 import { hasLocale } from "@/i18n/config";
 
 // /collections is fully public — no auth, no cookies, no per-visitor
-// data. ISR with 5 minute revalidation lets featured-collection
-// rotations show up quickly without waking a function on every visit.
-export const revalidate = 300;
+// data. 24h ceiling + revalidateTag('collection:list') from admin
+// write paths keeps the page fresh on actual changes without burning
+// a function on every visit.
+export const revalidate = 86400;
 
 const SITE_URL = "https://petdex.crafter.run";
 const MIN_PETS = 4;

--- a/src/app/[locale]/kind/[kind]/page.tsx
+++ b/src/app/[locale]/kind/[kind]/page.tsx
@@ -14,7 +14,7 @@ const SITE_URL = "https://petdex.crafter.run";
 
 type Props = { params: Promise<{ kind: string; locale: string }> };
 
-export const revalidate = 600;
+export const revalidate = 86400;
 
 export function generateStaticParams() {
   return PET_KINDS.map((kind) => ({ kind }));

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -36,15 +36,14 @@ import {
 
 import { hasLocale, locales } from "@/i18n/config";
 
-// ISR. The home page used to be force-dynamic because it pulled the
-// visitor's shuffle seed cookie and caught-slug set. Both moved to
-// the client: PetGallery re-fetches /api/pets/search after hydration
-// (which picks up the cookie) and /api/me/caught-slugs feeds the
-// "caught" highlight. The server now renders an alpha-ordered, anon
-// shell that the edge can cache for 60s — enough to keep new pets
-// surfacing without waking a function on every visit.
+// ISR. The home page renders an alpha-ordered, anon shell — the
+// visitor's shuffle seed and caught-slug set are pulled client-side
+// (PetGallery re-fetches /api/pets/search; /api/me/caught-slugs feeds
+// the "caught" highlight). With a 24h ceiling and tag-based
+// invalidation on submit/feature/withdraw, the page stays fresh for
+// editorial changes without burning a function on every visit.
 export const dynamic = "force-static";
-export const revalidate = 60;
+export const revalidate = 86400;
 
 export async function generateMetadata({
   params,

--- a/src/app/[locale]/pets/[slug]/page.tsx
+++ b/src/app/[locale]/pets/[slug]/page.tsx
@@ -5,12 +5,9 @@ import { Layers, Shuffle, Sparkles } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 
 import { getCollectionsContainingPet } from "@/lib/collections";
-import { getMetricsForSlug, getMetricsSummary } from "@/lib/db/metrics";
 import { formatDexNumber, getDexEntryMap } from "@/lib/dex";
-import { formatLocalizedNumber } from "@/lib/format-number";
 import { buildLocaleAlternates } from "@/lib/locale-routing";
 import { resolveStoredOwnerCreditForSlug } from "@/lib/owner-credit";
-import { computeStatsFromSummary } from "@/lib/pet-stats";
 import { getPet, getStaticPetSlugs } from "@/lib/pets";
 import { getVariantsFor } from "@/lib/variants";
 
@@ -25,9 +22,10 @@ import {
   PetActionMenu,
   PetTakedownReportButton,
 } from "@/components/pet-action-menu";
+import { PetCountersBar } from "@/components/pet-counters-bar";
 import { PetFloater } from "@/components/pet-floater";
 import { PetKeyboardNav } from "@/components/pet-keyboard-nav";
-import { PetRadar } from "@/components/pet-radar";
+import { PetRadarClient } from "@/components/pet-radar-client";
 import { PetSoundButton } from "@/components/pet-sound-button";
 import { PetSprite } from "@/components/pet-sprite";
 import { PetStateViewer } from "@/components/pet-state-viewer";
@@ -50,7 +48,11 @@ type PageProps = {
 };
 
 export const dynamicParams = true;
-export const revalidate = 60;
+// Long ISR window — the shell is byte-stable (metrics fetched
+// client-side), so the page only needs to regenerate when its
+// editorial fields change. Write paths call revalidateTag('pet:${slug}')
+// to flush immediately on edit/withdraw/claim/feature.
+export const revalidate = 86400;
 
 type DexNavPet = {
   slug: string;
@@ -121,7 +123,7 @@ export async function generateMetadata({ params }: PageProps) {
 }
 
 export default async function PetPage({ params }: PageProps) {
-  const { slug, locale } = await params;
+  const { slug } = await params;
   const pet = await getPet(slug);
   const tPet = await getTranslations("pet");
 
@@ -160,27 +162,12 @@ export default async function PetPage({ params }: PageProps) {
         }
       : null;
 
-  const [
-    metrics,
-    metricsSummary,
-    ownerCreditResult,
-    variants,
-    memberOfCollections,
-  ] = await Promise.all([
-    getMetricsForSlug(slug),
-    getMetricsSummary(),
+  const [ownerCreditResult, variants, memberOfCollections] = await Promise.all([
     resolveStoredOwnerCreditForSlug(slug),
     getVariantsFor(slug),
     getCollectionsContainingPet(slug),
   ]);
   const ownerCredit = ownerCreditResult?.credit ?? null;
-  const stats = computeStatsFromSummary(
-    {
-      importedAt: pet.importedAt,
-      metrics,
-    },
-    metricsSummary,
-  );
 
   const url = `${SITE_URL}/pets/${pet.slug}`;
   const jsonLd = [
@@ -205,15 +192,6 @@ export default async function PetPage({ params }: PageProps) {
                 ? { url: ownerCredit.externals[0].url }
                 : {}),
               ...(ownerCredit.imageUrl ? { image: ownerCredit.imageUrl } : {}),
-            },
-          }
-        : {}),
-      ...(metrics.likeCount > 0
-        ? {
-            interactionStatistic: {
-              "@type": "InteractionCounter",
-              interactionType: "https://schema.org/LikeAction",
-              userInteractionCount: metrics.likeCount,
             },
           }
         : {}),
@@ -374,7 +352,7 @@ export default async function PetPage({ params }: PageProps) {
 
               {/* Quick actions row + stats. */}
               <div className="flex flex-wrap items-center gap-3 pt-1">
-                <LikeButton slug={pet.slug} initialCount={metrics.likeCount} />
+                <LikeButton slug={pet.slug} />
                 {pet.soundUrl ? (
                   <PetSoundButton
                     soundUrl={pet.soundUrl}
@@ -395,12 +373,7 @@ export default async function PetPage({ params }: PageProps) {
                 <PetTakedownReportButton
                   pet={{ slug: pet.slug, displayName: pet.displayName }}
                 />
-                <span className="font-mono text-[11px] tracking-[0.18em] text-muted-3 uppercase">
-                  {formatLocalizedNumber(metrics.installCount, locale)} installs
-                  {" · "}
-                  {formatLocalizedNumber(metrics.zipDownloadCount, locale)}{" "}
-                  downloads
-                </span>
+                <PetCountersBar slug={pet.slug} />
               </div>
 
               {/* Tags + collections collapsed into compact metadata. */}
@@ -513,8 +486,9 @@ export default async function PetPage({ params }: PageProps) {
             icon={<Sparkles className="size-4" />}
           >
             <div className="flex items-center justify-center py-2">
-              <PetRadar
-                {...stats}
+              <PetRadarClient
+                slug={pet.slug}
+                importedAt={pet.importedAt}
                 ariaLabel={tPet("stats.ariaLabel")}
                 labels={{
                   vibrance: tPet("stats.vibrance"),

--- a/src/app/[locale]/vibe/[vibe]/page.tsx
+++ b/src/app/[locale]/vibe/[vibe]/page.tsx
@@ -23,7 +23,7 @@ const SITE_URL = "https://petdex.crafter.run";
 
 type Props = { params: Promise<{ locale: string; vibe: string }> };
 
-export const revalidate = 600;
+export const revalidate = 86400;
 
 export function generateStaticParams() {
   return PET_VIBES.map((vibe) => ({ vibe }));

--- a/src/app/api/admin/[id]/feature/route.ts
+++ b/src/app/api/admin/[id]/feature/route.ts
@@ -1,3 +1,4 @@
+import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { auth } from "@clerk/nextjs/server";
@@ -77,6 +78,9 @@ export async function PATCH(
   } else {
     await invalidatePetCaches(row.slug);
   }
+
+  revalidateTag(`pet:${row.slug}`, "max");
+  revalidateTag("pet:list", "max");
 
   return NextResponse.json({ ok: true, featured: row.featured });
 }

--- a/src/app/api/admin/[id]/feature/route.ts
+++ b/src/app/api/admin/[id]/feature/route.ts
@@ -1,4 +1,3 @@
-import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { auth } from "@clerk/nextjs/server";
@@ -75,12 +74,10 @@ export async function PATCH(
       featured: row.featured,
       by: userId,
     });
-  } else {
-    await invalidatePetCaches(row.slug);
   }
 
-  revalidateTag(`pet:${row.slug}`, "max");
-  revalidateTag("pet:list", "max");
+  // Flushes both Upstash + Next page tags (pet:${slug}, pet:list).
+  await invalidatePetCaches(row.slug);
 
   return NextResponse.json({ ok: true, featured: row.featured });
 }

--- a/src/app/api/admin/collection-requests/[id]/route.ts
+++ b/src/app/api/admin/collection-requests/[id]/route.ts
@@ -9,7 +9,10 @@ import { auth } from "@clerk/nextjs/server";
 import { and, desc, eq } from "drizzle-orm";
 
 import { isAdmin } from "@/lib/admin";
-import { invalidateCollectionBacklinks } from "@/lib/db/cached-aggregates";
+import {
+  invalidateCollectionBacklinks,
+  revalidateCollectionTags,
+} from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import { requireSameOrigin } from "@/lib/same-origin";
 
@@ -127,6 +130,17 @@ export async function PATCH(
     })
     .where(eq(schema.petCollectionRequests.id, id));
   await invalidateCollectionBacklinks(request.petSlug);
+
+  // Flush the affected collection's ISR caches so the public detail
+  // page picks up the new pet in its grid without waiting on the 24h
+  // revalidate ceiling.
+  const collection = await db.query.petCollections.findFirst({
+    where: eq(schema.petCollections.id, request.collectionId),
+    columns: { slug: true },
+  });
+  if (collection) {
+    await revalidateCollectionTags(collection.slug);
+  }
 
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/admin/edits/[id]/route.ts
+++ b/src/app/api/admin/edits/[id]/route.ts
@@ -1,4 +1,3 @@
-import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { auth, clerkClient } from "@clerk/nextjs/server";
@@ -111,12 +110,6 @@ export async function PATCH(
       .where(eq(schema.submittedPets.id, id))
       .returning();
 
-    // Flush ISR caches for this pet's detail page and any list that
-    // contains it. Approving an edit changes user-visible fields
-    // (displayName/description/tags/sprite).
-    revalidateTag(`pet:${updated.slug}`, "max");
-    revalidateTag("pet:list", "max");
-
     // GC old R2 keys after the DB is updated (best-effort, non-fatal).
     const keysToDelete = [oldSpritesheetKey, oldPetJsonKey, oldZipKey].filter(
       (k): k is string => k !== null,
@@ -127,6 +120,9 @@ export async function PATCH(
 
     void refreshSimilarityFor(id).catch(() => {});
     await invalidateAggregates(AGGREGATE_KEYS.variantIndex);
+    // Flushes both Upstash + Next page tags (pet:${slug}, pet:list)
+    // so the public detail page picks up the new copy without
+    // waiting on the 24h revalidate ceiling.
     await invalidatePetCaches(updated.slug);
 
     void createNotification({

--- a/src/app/api/admin/edits/[id]/route.ts
+++ b/src/app/api/admin/edits/[id]/route.ts
@@ -1,3 +1,4 @@
+import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { auth, clerkClient } from "@clerk/nextjs/server";
@@ -109,6 +110,12 @@ export async function PATCH(
       .set(update)
       .where(eq(schema.submittedPets.id, id))
       .returning();
+
+    // Flush ISR caches for this pet's detail page and any list that
+    // contains it. Approving an edit changes user-visible fields
+    // (displayName/description/tags/sprite).
+    revalidateTag(`pet:${updated.slug}`, "max");
+    revalidateTag("pet:list", "max");
 
     // GC old R2 keys after the DB is updated (best-effort, non-fatal).
     const keysToDelete = [oldSpritesheetKey, oldPetJsonKey, oldZipKey].filter(

--- a/src/app/api/my-pets/[id]/edit/route.ts
+++ b/src/app/api/my-pets/[id]/edit/route.ts
@@ -1,4 +1,3 @@
-import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { auth } from "@clerk/nextjs/server";
@@ -327,14 +326,12 @@ export async function PATCH(
         .set(liveUpdate)
         .where(eq(schema.submittedPets.id, id));
 
-      // Auto-approve writes through to the live row — flush the
-      // pet's ISR caches so the new copy shows up immediately
-      // instead of waiting on the 24h ceiling.
-      revalidateTag(`pet:${row.slug}`, "max");
-      revalidateTag("pet:list", "max");
-
       void refreshSimilarityFor(id).catch(() => {});
       await invalidateAggregates(AGGREGATE_KEYS.variantIndex);
+      // Auto-approve writes through to the live row —
+      // invalidatePetCaches flushes both Upstash + Next page tags
+      // (pet:${slug}, pet:list) so the new copy shows up without
+      // waiting on the 24h revalidate ceiling.
       await invalidatePetCaches(row.slug);
 
       void createNotification({

--- a/src/app/api/my-pets/[id]/edit/route.ts
+++ b/src/app/api/my-pets/[id]/edit/route.ts
@@ -1,3 +1,4 @@
+import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { auth } from "@clerk/nextjs/server";
@@ -325,6 +326,12 @@ export async function PATCH(
         .update(schema.submittedPets)
         .set(liveUpdate)
         .where(eq(schema.submittedPets.id, id));
+
+      // Auto-approve writes through to the live row — flush the
+      // pet's ISR caches so the new copy shows up immediately
+      // instead of waiting on the 24h ceiling.
+      revalidateTag(`pet:${row.slug}`, "max");
+      revalidateTag("pet:list", "max");
 
       void refreshSimilarityFor(id).catch(() => {});
       await invalidateAggregates(AGGREGATE_KEYS.variantIndex);

--- a/src/app/api/my-pets/claim/route.ts
+++ b/src/app/api/my-pets/claim/route.ts
@@ -1,3 +1,4 @@
+import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { auth, clerkClient } from "@clerk/nextjs/server";
@@ -152,6 +153,11 @@ export async function POST(req: Request): Promise<Response> {
     .set(update)
     .where(eq(schema.submittedPets.id, id));
   await invalidatePetCaches(row.slug);
+
+  // Claim rewrites ownerId/ownerEmail which feed the SubmittedBy
+  // credit on /pets/[slug]. Flush so the new owner's name shows up.
+  revalidateTag(`pet:${row.slug}`, "max");
+  revalidateTag("pet:list", "max");
 
   return NextResponse.json({ ok: true, slug: row.slug });
 }

--- a/src/app/api/my-pets/claim/route.ts
+++ b/src/app/api/my-pets/claim/route.ts
@@ -1,4 +1,3 @@
-import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { auth, clerkClient } from "@clerk/nextjs/server";
@@ -152,12 +151,10 @@ export async function POST(req: Request): Promise<Response> {
     .update(schema.submittedPets)
     .set(update)
     .where(eq(schema.submittedPets.id, id));
-  await invalidatePetCaches(row.slug);
-
   // Claim rewrites ownerId/ownerEmail which feed the SubmittedBy
-  // credit on /pets/[slug]. Flush so the new owner's name shows up.
-  revalidateTag(`pet:${row.slug}`, "max");
-  revalidateTag("pet:list", "max");
+  // credit on /pets/[slug]. invalidatePetCaches flushes both Upstash
+  // and Next page tags so the new owner's name shows up immediately.
+  await invalidatePetCaches(row.slug);
 
   return NextResponse.json({ ok: true, slug: row.slug });
 }

--- a/src/app/api/pets/[slug]/metrics/route.ts
+++ b/src/app/api/pets/[slug]/metrics/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+
+import { getMetricsForSlug, getMetricsSummary } from "@/lib/db/metrics";
+import { metricsReadRatelimit } from "@/lib/ratelimit";
+import { requireSameOrigin } from "@/lib/same-origin";
+
+export const runtime = "nodejs";
+
+// Public read of per-pet counters + global summary used by the radar.
+// Hoisted off the ISR shell so pet detail pages stay byte-stable
+// between regenerations — every counter tick used to invalidate the
+// rendered HTML and bill an ISR write. CDN caches this response per
+// slug, so bot traffic flattens out at the edge instead of touching
+// the function.
+const CACHE_HEADERS = {
+  "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+};
+
+type Params = { slug: string };
+
+export async function GET(
+  req: Request,
+  ctx: { params: Promise<Params> },
+): Promise<Response> {
+  const csrf = requireSameOrigin(req);
+  if (csrf) return csrf;
+
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+  const lim = await metricsReadRatelimit.limit(ip);
+  if (!lim.success) {
+    return NextResponse.json({ error: "rate_limited" }, { status: 429 });
+  }
+
+  const { slug } = await ctx.params;
+  if (!/^[a-z0-9-]{1,60}$/.test(slug)) {
+    return NextResponse.json({ error: "invalid_slug" }, { status: 400 });
+  }
+
+  const [metrics, summary] = await Promise.all([
+    getMetricsForSlug(slug),
+    getMetricsSummary(),
+  ]);
+
+  return NextResponse.json({ ...metrics, summary }, { headers: CACHE_HEADERS });
+}

--- a/src/app/api/profile/collection/route.ts
+++ b/src/app/api/profile/collection/route.ts
@@ -4,7 +4,10 @@ import { auth } from "@clerk/nextjs/server";
 import { and, eq } from "drizzle-orm";
 
 import { canManageCreatorCollections } from "@/lib/collection-access";
-import { invalidateCollectionBacklinks } from "@/lib/db/cached-aggregates";
+import {
+  invalidateCollectionBacklinks,
+  revalidateCollectionTags,
+} from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import { validateProfileHandle } from "@/lib/profiles";
 import { requireSameOrigin } from "@/lib/same-origin";
@@ -152,6 +155,8 @@ export async function PATCH(req: Request): Promise<Response> {
   if (shouldInvalidateCollectionBacklinks) {
     await invalidateCollectionBacklinks(...oldFeaturedPetSlugs, ...petSlugs);
   }
+
+  await revalidateCollectionTags(collection.slug);
 
   return NextResponse.json({
     ok: true,

--- a/src/app/api/profile/collections/[id]/route.ts
+++ b/src/app/api/profile/collections/[id]/route.ts
@@ -4,6 +4,7 @@ import { auth } from "@clerk/nextjs/server";
 import { and, eq } from "drizzle-orm";
 
 import { canManageCreatorCollections } from "@/lib/collection-access";
+import { revalidateCollectionTags } from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import { requireSameOrigin } from "@/lib/same-origin";
 
@@ -149,6 +150,8 @@ export async function PATCH(
     .set(patch)
     .where(eq(schema.petCollections.id, id));
 
+  await revalidateCollectionTags(collection.slug);
+
   return NextResponse.json({ ok: true });
 }
 
@@ -179,7 +182,11 @@ export async function DELETE(
     );
   }
 
-  await db.delete(schema.petCollections).where(eq(schema.petCollections.id, id));
+  await db
+    .delete(schema.petCollections)
+    .where(eq(schema.petCollections.id, id));
+
+  await revalidateCollectionTags(collection.slug);
 
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/profile/collections/route.ts
+++ b/src/app/api/profile/collections/route.ts
@@ -7,6 +7,7 @@ import {
   canManageCreatorCollections,
   MAX_OWNER_COLLECTIONS,
 } from "@/lib/collection-access";
+import { revalidateCollectionTags } from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import { validateProfileHandle } from "@/lib/profiles";
 import { requireSameOrigin } from "@/lib/same-origin";
@@ -123,6 +124,8 @@ export async function POST(req: Request): Promise<Response> {
       })),
     );
   }
+
+  await revalidateCollectionTags(slug);
 
   return NextResponse.json({
     ok: true,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -8,7 +8,7 @@ import {
 import { getAllApprovedPets } from "@/lib/pets";
 import { PET_KINDS, PET_VIBES } from "@/lib/types";
 
-export const revalidate = 3600;
+export const revalidate = 86400;
 
 type EntryInput = {
   pathname: string;

--- a/src/components/like-button.tsx
+++ b/src/components/like-button.tsx
@@ -13,11 +13,10 @@ import { Button } from "@/components/ui/button";
 
 type LikeButtonProps = {
   slug: string;
-  initialCount: number;
 };
 
-export function LikeButton({ slug, initialCount }: LikeButtonProps) {
-  const [count, setCount] = useState(initialCount);
+export function LikeButton({ slug }: LikeButtonProps) {
+  const [count, setCount] = useState<number | null>(null);
   const [liked, setLiked] = useState(false);
   const [likeStateLoading, setLikeStateLoading] = useState(false);
   const [pending, start] = useTransition();
@@ -36,34 +35,45 @@ export function LikeButton({ slug, initialCount }: LikeButtonProps) {
       return;
     }
 
-    if (!isLoaded || !isSignedIn) {
-      setLiked(false);
-      setCount(initialCount);
-      setLikeStateLoading(false);
-      return;
-    }
-
     const mutationVersion = mutationVersionRef.current;
     const controller = new AbortController();
     setLikeStateLoading(true);
 
-    void fetch(`/api/pets/${slug}/like`, {
+    // Signed-in users hit /like (returns authoritative count + their
+    // liked state). Anon visitors hit /metrics (CDN-cached, just the
+    // count). Both endpoints are safe to ignore on abort/error — the
+    // button stays in its skeleton state.
+    const url = isSignedIn
+      ? `/api/pets/${slug}/like`
+      : `/api/pets/${slug}/metrics`;
+
+    void fetch(url, {
       signal: controller.signal,
       headers: { accept: "application/json" },
     })
       .then((res) => (res.ok ? res.json() : null))
-      .then((data: { liked: boolean; count: number } | null) => {
-        if (!data) return;
-        if (loadVersionRef.current !== loadVersion) return;
-        if (mutationVersionRef.current !== mutationVersion) return;
-        setLiked(data.liked);
-        setCount(data.count);
-      })
+      .then(
+        (
+          data:
+            | { liked?: boolean; count?: number; likeCount?: number }
+            | null,
+        ) => {
+          if (!data) return;
+          if (loadVersionRef.current !== loadVersion) return;
+          if (mutationVersionRef.current !== mutationVersion) return;
+          if (isSignedIn) {
+            setLiked(Boolean(data.liked));
+            setCount(typeof data.count === "number" ? data.count : 0);
+          } else {
+            setLiked(false);
+            setCount(typeof data.likeCount === "number" ? data.likeCount : 0);
+          }
+        },
+      )
       .catch((error: unknown) => {
         if (loadVersionRef.current !== loadVersion) return;
         if ((error as Error).name !== "AbortError") {
           setLiked(false);
-          setCount(initialCount);
         }
       })
       .finally(() => {
@@ -73,7 +83,7 @@ export function LikeButton({ slug, initialCount }: LikeButtonProps) {
       });
 
     return () => controller.abort();
-  }, [initialCount, isLoaded, isSignedIn, slug]);
+  }, [isLoaded, isSignedIn, slug]);
 
   function handleClick() {
     if (!isLoaded || !isSignedIn) {
@@ -86,7 +96,7 @@ export function LikeButton({ slug, initialCount }: LikeButtonProps) {
     const mutationVersion = mutationVersionRef.current + 1;
     mutationVersionRef.current = mutationVersion;
     setLiked(nextLiked);
-    setCount((c) => Math.max(0, c + (nextLiked ? 1 : -1)));
+    setCount((c) => Math.max(0, (c ?? 0) + (nextLiked ? 1 : -1)));
 
     start(async () => {
       try {
@@ -106,12 +116,12 @@ export function LikeButton({ slug, initialCount }: LikeButtonProps) {
       } catch {
         if (mutationVersionRef.current !== mutationVersion) return;
         setLiked(!nextLiked);
-        setCount((c) => Math.max(0, c + (nextLiked ? -1 : 1)));
+        setCount((c) => Math.max(0, (c ?? 0) + (nextLiked ? -1 : 1)));
       }
     });
   }
 
-  const disabled = pending || !isLoaded || (isSignedIn && likeStateLoading);
+  const disabled = pending || !isLoaded || likeStateLoading;
 
   return (
     <Button
@@ -130,7 +140,7 @@ export function LikeButton({ slug, initialCount }: LikeButtonProps) {
         className={`size-4 transition ${liked ? "fill-rose-500 text-rose-500" : ""}`}
       />
       <span className="font-mono text-xs tracking-[0.08em]">
-        {formatLocalizedNumber(count, locale)}
+        {count === null ? "—" : formatLocalizedNumber(count, locale)}
       </span>
     </Button>
   );

--- a/src/components/pet-counters-bar.tsx
+++ b/src/components/pet-counters-bar.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { useLocale } from "next-intl";
+
+import { formatLocalizedNumber } from "@/lib/format-number";
+
+type PetCountersBarProps = {
+  slug: string;
+};
+
+type CountersResponse = {
+  installCount: number;
+  zipDownloadCount: number;
+};
+
+export function PetCountersBar({ slug }: PetCountersBarProps) {
+  const locale = useLocale();
+  const [counts, setCounts] = useState<CountersResponse | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetch(`/api/pets/${slug}/metrics`, { signal: controller.signal })
+      .then((res) => (res.ok ? (res.json() as Promise<CountersResponse>) : null))
+      .then((data) => {
+        if (!data) return;
+        setCounts({
+          installCount: data.installCount,
+          zipDownloadCount: data.zipDownloadCount,
+        });
+      })
+      .catch(() => {
+        /* network/abort — keep skeleton */
+      });
+    return () => controller.abort();
+  }, [slug]);
+
+  return (
+    <span
+      className="font-mono text-[11px] tracking-[0.18em] text-muted-3 uppercase"
+      aria-live="polite"
+    >
+      {counts ? (
+        <>
+          {formatLocalizedNumber(counts.installCount, locale)} installs
+          {" · "}
+          {formatLocalizedNumber(counts.zipDownloadCount, locale)} downloads
+        </>
+      ) : (
+        <span className="opacity-50">— installs · — downloads</span>
+      )}
+    </span>
+  );
+}

--- a/src/components/pet-radar-client.tsx
+++ b/src/components/pet-radar-client.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { computeStatsFromSummary, type PetStats } from "@/lib/pet-stats";
+
+import { PetRadar } from "@/components/pet-radar";
+
+type PetRadarClientProps = {
+  slug: string;
+  importedAt: string;
+  ariaLabel: string;
+  labels: {
+    vibrance: string;
+    popularity: string;
+    loved: string;
+    freshness: string;
+  };
+};
+
+type MetricsResponse = {
+  installCount: number;
+  likeCount: number;
+  summary: { maxInstallCount: number; maxLikeCount: number };
+};
+
+const PLACEHOLDER_STATS: PetStats = {
+  vibrance: 0,
+  popularity: 0,
+  loved: 0,
+  freshness: 0,
+};
+
+export function PetRadarClient({
+  slug,
+  importedAt,
+  ariaLabel,
+  labels,
+}: PetRadarClientProps) {
+  const [stats, setStats] = useState<PetStats | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetch(`/api/pets/${slug}/metrics`, { signal: controller.signal })
+      .then((res) => (res.ok ? (res.json() as Promise<MetricsResponse>) : null))
+      .then((data) => {
+        if (!data) return;
+        setStats(
+          computeStatsFromSummary(
+            {
+              importedAt,
+              metrics: {
+                installCount: data.installCount,
+                likeCount: data.likeCount,
+              },
+            },
+            data.summary,
+          ),
+        );
+      })
+      .catch(() => {
+        /* keep placeholder */
+      });
+    return () => controller.abort();
+  }, [slug, importedAt]);
+
+  const display = stats ?? PLACEHOLDER_STATS;
+
+  return (
+    <PetRadar
+      vibrance={display.vibrance}
+      popularity={display.popularity}
+      loved={display.loved}
+      freshness={display.freshness}
+      ariaLabel={ariaLabel}
+      labels={labels}
+    />
+  );
+}

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import { getMetricsBySlugs, type Metrics } from "@/lib/db/metrics";
+import { withNextDataCache } from "@/lib/next-data-cache";
 import { type PetWithMetrics, rowToPet } from "@/lib/pets";
 
 const EMPTY_METRICS: Metrics = {
@@ -58,36 +59,48 @@ export async function getCollectionsBySlugs(
   petsPerCollection = 6,
 ): Promise<PetCollectionWithPets[]> {
   if (slugs.length === 0) return [];
-  let rows: PetCollection[];
-  try {
-    rows = await db
-      .select()
-      .from(schema.petCollections)
-      .where(inArray(schema.petCollections.slug, slugs));
-  } catch (error) {
-    if (isMissingCollectionTableError(error)) return [];
-    throw error;
-  }
-  const order = new Map(slugs.map((s, i) => [s, i]));
-  rows = rows
-    .filter((r) => order.has(r.slug))
-    .sort((a, b) => (order.get(a.slug) ?? 0) - (order.get(b.slug) ?? 0));
-  return hydrateCollections(rows, petsPerCollection);
+  return withNextDataCache(
+    async () => {
+      let rows: PetCollection[];
+      try {
+        rows = await db
+          .select()
+          .from(schema.petCollections)
+          .where(inArray(schema.petCollections.slug, slugs));
+      } catch (error) {
+        if (isMissingCollectionTableError(error)) return [];
+        throw error;
+      }
+      const order = new Map(slugs.map((s, i) => [s, i]));
+      rows = rows
+        .filter((r) => order.has(r.slug))
+        .sort((a, b) => (order.get(a.slug) ?? 0) - (order.get(b.slug) ?? 0));
+      return hydrateCollections(rows, petsPerCollection);
+    },
+    ["petdex-collections-by-slugs", slugs.join(","), String(petsPerCollection)],
+    { tags: ["collection:list"], revalidate: 86400 },
+  )();
 }
 
 export async function getAllCollections(): Promise<PetCollectionWithPets[]> {
-  let rows: PetCollection[];
-  try {
-    rows = await db
-      .select()
-      .from(schema.petCollections)
-      .orderBy(asc(schema.petCollections.title));
-  } catch (error) {
-    if (isMissingCollectionTableError(error)) return [];
-    throw error;
-  }
+  return withNextDataCache(
+    async () => {
+      let rows: PetCollection[];
+      try {
+        rows = await db
+          .select()
+          .from(schema.petCollections)
+          .orderBy(asc(schema.petCollections.title));
+      } catch (error) {
+        if (isMissingCollectionTableError(error)) return [];
+        throw error;
+      }
 
-  return hydrateCollections(rows);
+      return hydrateCollections(rows);
+    },
+    ["petdex-all-collections"],
+    { tags: ["collection:list"], revalidate: 86400 },
+  )();
 }
 
 // Returns featured collections that have at least `minPets` approved
@@ -98,62 +111,84 @@ export async function getCollectionsForListing(
   minPets = 4,
   petsPerPreview = 6,
 ): Promise<(PetCollectionWithPets & { petCount: number })[]> {
-  let rows: (PetCollection & { petCount: number })[];
-  try {
-    const result = await db
-      .select({
-        ...getTableColumns(schema.petCollections),
-        petCount: dsql<number>`count(${schema.petCollectionItems.petSlug})`.as(
-          "pet_count",
-        ),
-      })
-      .from(schema.petCollections)
-      .leftJoin(
-        schema.petCollectionItems,
-        eq(schema.petCollectionItems.collectionId, schema.petCollections.id),
-      )
-      .where(eq(schema.petCollections.featured, true))
-      .groupBy(schema.petCollections.id)
-      .having(
-        gte(dsql<number>`count(${schema.petCollectionItems.petSlug})`, minPets),
-      )
-      .orderBy(
-        desc(dsql`count(${schema.petCollectionItems.petSlug})`),
-        asc(schema.petCollections.title),
-      );
-    rows = result.map((r) => ({
-      ...r,
-      petCount: Number(r.petCount),
-    }));
-  } catch (error) {
-    if (isMissingCollectionTableError(error)) return [];
-    throw error;
-  }
+  return withNextDataCache(
+    async () => {
+      let rows: (PetCollection & { petCount: number })[];
+      try {
+        const result = await db
+          .select({
+            ...getTableColumns(schema.petCollections),
+            petCount:
+              dsql<number>`count(${schema.petCollectionItems.petSlug})`.as(
+                "pet_count",
+              ),
+          })
+          .from(schema.petCollections)
+          .leftJoin(
+            schema.petCollectionItems,
+            eq(
+              schema.petCollectionItems.collectionId,
+              schema.petCollections.id,
+            ),
+          )
+          .where(eq(schema.petCollections.featured, true))
+          .groupBy(schema.petCollections.id)
+          .having(
+            gte(
+              dsql<number>`count(${schema.petCollectionItems.petSlug})`,
+              minPets,
+            ),
+          )
+          .orderBy(
+            desc(dsql`count(${schema.petCollectionItems.petSlug})`),
+            asc(schema.petCollections.title),
+          );
+        rows = result.map((r) => ({
+          ...r,
+          petCount: Number(r.petCount),
+        }));
+      } catch (error) {
+        if (isMissingCollectionTableError(error)) return [];
+        throw error;
+      }
 
-  const hydrated = await hydrateCollections(rows, petsPerPreview);
-  // Re-attach the pet count we computed (hydrate doesn't carry it).
-  const countBySlug = new Map(rows.map((r) => [r.slug, r.petCount]));
-  return hydrated.map((c) => ({
-    ...c,
-    petCount: countBySlug.get(c.slug) ?? c.pets.length,
-  }));
+      const hydrated = await hydrateCollections(rows, petsPerPreview);
+      // Re-attach the pet count we computed (hydrate doesn't carry it).
+      const countBySlug = new Map(rows.map((r) => [r.slug, r.petCount]));
+      return hydrated.map((c) => ({
+        ...c,
+        petCount: countBySlug.get(c.slug) ?? c.pets.length,
+      }));
+    },
+    ["petdex-collections-for-listing", String(minPets), String(petsPerPreview)],
+    { tags: ["collection:list"], revalidate: 86400 },
+  )();
 }
 
 export async function getCollection(
   slug: string,
 ): Promise<PetCollectionWithPets | null> {
-  let row: PetCollection | undefined;
-  try {
-    row = await db.query.petCollections.findFirst({
-      where: eq(schema.petCollections.slug, slug.toLowerCase()),
-    });
-  } catch (error) {
-    if (isMissingCollectionTableError(error)) return null;
-    throw error;
-  }
-  if (!row) return null;
-  const [collection] = await hydrateCollections([row]);
-  return collection ?? null;
+  return withNextDataCache(
+    async () => {
+      let row: PetCollection | undefined;
+      try {
+        row = await db.query.petCollections.findFirst({
+          where: eq(schema.petCollections.slug, slug.toLowerCase()),
+        });
+      } catch (error) {
+        if (isMissingCollectionTableError(error)) return null;
+        throw error;
+      }
+      if (!row) return null;
+      const [collection] = await hydrateCollections([row]);
+      return collection ?? null;
+    },
+    ["petdex-collection", slug],
+    {
+      tags: [`collection:${slug}`, "collection:list"],
+      revalidate: 86400,
+    },
+  )();
 }
 
 export async function getOwnerCollection(

--- a/src/lib/db/cached-aggregates.ts
+++ b/src/lib/db/cached-aggregates.ts
@@ -94,6 +94,43 @@ export async function invalidatePetCaches(...slugs: string[]): Promise<void> {
     );
   }
   await invalidateAggregates(...keys);
+  await revalidatePetTags(...slugs);
+}
+
+// Page-level ISR invalidation for the pet detail + listing pages. Paired
+// with invalidatePetCaches so any caller that flushes Upstash also flushes
+// the Next data cache tags (`pet:${slug}`, `pet:list`) used to wrap getPet,
+// getApprovedPetsWithMetrics, getFeaturedPetsWithMetrics, getAllApprovedPets
+// in src/lib/pets.ts. Without this the 24h revalidate ceiling held stale
+// shells even after the Upstash layer was cleared.
+export async function revalidatePetTags(...slugs: string[]): Promise<void> {
+  const cleanSlugs = slugs.filter(Boolean);
+  if (cleanSlugs.length === 0) return;
+  try {
+    const { revalidateTag } = await import("next/cache");
+    for (const slug of cleanSlugs) revalidateTag(`pet:${slug}`, "max");
+    revalidateTag("pet:list", "max");
+  } catch {
+    /* next/cache unavailable in some runtime contexts (tests, scripts) */
+  }
+}
+
+// Page-level ISR invalidation for the collections list + detail pages.
+// Pair with any pet_collections / pet_collection_items write path that
+// changes user-visible content. Without this the same 24h ceiling
+// problem applies to /collections and /collections/[slug].
+export async function revalidateCollectionTags(
+  ...slugs: string[]
+): Promise<void> {
+  try {
+    const { revalidateTag } = await import("next/cache");
+    for (const slug of slugs.filter(Boolean)) {
+      revalidateTag(`collection:${slug}`, "max");
+    }
+    revalidateTag("collection:list", "max");
+  } catch {
+    /* next/cache unavailable in some runtime contexts (tests, scripts) */
+  }
 }
 
 export async function invalidateMetricCaches(

--- a/src/lib/pets.ts
+++ b/src/lib/pets.ts
@@ -18,6 +18,7 @@ import {
   getMetricsForSlug,
   type Metrics,
 } from "@/lib/db/metrics";
+import { withNextDataCache } from "@/lib/next-data-cache";
 import type { PetdexPet, PetKind, PetVibe } from "@/lib/types";
 
 export type PetWithMetrics = PetdexPet & { metrics: Metrics };
@@ -80,22 +81,32 @@ const petColumns = {
   createdAt: true,
 } as const;
 
+// Two-layer cache: Upstash (cross-instance, 5min TTL, invalidated by
+// invalidatePetCaches) wrapped in Next's data cache so write paths can
+// also call revalidateTag('pet:${slug}', 'max') and flush the page-
+// level ISR copy without waiting on the 24h ceiling.
 export const getPet = cache(
   async (slug: string): Promise<PetdexPet | undefined> => {
-    const pet = await cachedAggregate<PetdexPet | null>(
-      { key: petCacheKey(slug), ttlSeconds: PET_CACHE_TTL_SECONDS },
+    return withNextDataCache(
       async () => {
-        const row = await db.query.submittedPets.findFirst({
-          columns: petColumns,
-          where: and(
-            eq(schema.submittedPets.slug, slug),
-            eq(schema.submittedPets.status, "approved"),
-          ),
-        });
-        return row ? rowToPet(row) : null;
+        const pet = await cachedAggregate<PetdexPet | null>(
+          { key: petCacheKey(slug), ttlSeconds: PET_CACHE_TTL_SECONDS },
+          async () => {
+            const row = await db.query.submittedPets.findFirst({
+              columns: petColumns,
+              where: and(
+                eq(schema.submittedPets.slug, slug),
+                eq(schema.submittedPets.status, "approved"),
+              ),
+            });
+            return row ? rowToPet(row) : null;
+          },
+        );
+        return pet ?? undefined;
       },
-    );
-    return pet ?? undefined;
+      ["petdex-pet", slug],
+      { tags: [`pet:${slug}`, "pet:list"], revalidate: 86400 },
+    )();
   },
 );
 
@@ -127,13 +138,19 @@ export async function getStaticPetSlugs(): Promise<string[]> {
 export async function getFeaturedPetsWithMetrics(
   limit = 6,
 ): Promise<PetWithMetrics[]> {
-  const pets = (await getFeaturedPets()).slice(0, limit);
-  if (pets.length === 0) return [];
-  const metrics = await getMetricsBySlugs(pets.map((pet) => pet.slug));
-  return pets.map((pet) => ({
-    ...pet,
-    metrics: metrics.get(pet.slug) ?? EMPTY_METRICS,
-  }));
+  return withNextDataCache(
+    async () => {
+      const pets = (await getFeaturedPets()).slice(0, limit);
+      if (pets.length === 0) return [];
+      const metrics = await getMetricsBySlugs(pets.map((pet) => pet.slug));
+      return pets.map((pet) => ({
+        ...pet,
+        metrics: metrics.get(pet.slug) ?? EMPTY_METRICS,
+      }));
+    },
+    ["petdex-featured-pets-with-metrics", String(limit)],
+    { tags: ["pet:list"], revalidate: 86400 },
+  )();
 }
 
 async function getFeaturedPets(): Promise<PetdexPet[]> {
@@ -158,19 +175,24 @@ async function getFeaturedPets(): Promise<PetdexPet[]> {
 }
 
 export async function getAllApprovedPets(): Promise<PetdexPet[]> {
-  return cachedAggregate(
-    {
-      key: AGGREGATE_KEYS.approvedCatalog,
-      ttlSeconds: APPROVED_CATALOG_TTL_SECONDS,
-    },
-    async () => {
-      const rows = await db
-        .select()
-        .from(schema.submittedPets)
-        .where(eq(schema.submittedPets.status, "approved"));
-      return rows.map(rowToPet);
-    },
-  );
+  return withNextDataCache(
+    async () =>
+      cachedAggregate(
+        {
+          key: AGGREGATE_KEYS.approvedCatalog,
+          ttlSeconds: APPROVED_CATALOG_TTL_SECONDS,
+        },
+        async () => {
+          const rows = await db
+            .select()
+            .from(schema.submittedPets)
+            .where(eq(schema.submittedPets.status, "approved"));
+          return rows.map(rowToPet);
+        },
+      ),
+    ["petdex-all-approved-pets"],
+    { tags: ["pet:list"], revalidate: 86400 },
+  )();
 }
 
 export type ApprovedPetSlim = {
@@ -245,13 +267,19 @@ async function queryLatestApprovedPets(limit: number): Promise<PetdexPet[]> {
 }
 
 export async function getApprovedPetsWithMetrics(): Promise<PetWithMetrics[]> {
-  const pets = await getAllApprovedPets();
-  if (pets.length === 0) return [];
-  const metrics = await getMetricsBySlugs(pets.map((p) => p.slug));
-  return pets.map((p) => ({
-    ...p,
-    metrics: metrics.get(p.slug) ?? EMPTY_METRICS,
-  }));
+  return withNextDataCache(
+    async () => {
+      const pets = await getAllApprovedPets();
+      if (pets.length === 0) return [];
+      const metrics = await getMetricsBySlugs(pets.map((p) => p.slug));
+      return pets.map((p) => ({
+        ...p,
+        metrics: metrics.get(p.slug) ?? EMPTY_METRICS,
+      }));
+    },
+    ["petdex-approved-pets-with-metrics"],
+    { tags: ["pet:list"], revalidate: 86400 },
+  )();
 }
 
 export async function getApprovedPetCount(): Promise<number> {

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -69,6 +69,16 @@ export const wastickersRatelimit = createRatelimit({
   prefix: "petdex:wastickers",
 });
 
+// Public metrics reads — `/api/pets/[slug]/metrics`. Browser pages hit
+// this on every visit, and the CDN caches the response for 60s so the
+// hot path is free. The limit only kicks in for direct bot/script
+// hammering against an uncached slug. Keyed by IP.
+export const metricsReadRatelimit = createRatelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(240, "1 h"),
+  prefix: "petdex:metrics-read",
+});
+
 // Likes — generous so legit users browsing the gallery never hit the cap,
 // but stops a 100-account brigade from inflating one pet to the top.
 export const likeRatelimit = createRatelimit({


### PR DESCRIPTION
## Summary

Vercel bill last cycle was \$208 — dominated by ISR writes (8.83M / \$35), Active CPU + Function Invocations + Fast Origin Transfer (~\$85 combined).

Per [Vercel's ISR pricing docs](https://vercel.com/docs/incremental-static-regeneration/limits-and-pricing): *"When revalidation runs and the content hasn't changed from the previous version, no ISR write units are incurred."* Our pet pages baked install/download/like counters straight into the SSR shell, so every metric tick produced a different byte-string and burned a write. Combined with `revalidate = 60` on most pages, this caused the write storm.

This PR addresses it with three coordinated changes.

## Phase 1 — Hoist volatile data off SSR shells

- New endpoint `src/app/api/pets/[slug]/metrics/route.ts` — returns counters + global summary, same-origin gated, IP-rate-limited (240/hr), CDN-cached (`s-maxage=60, stale-while-revalidate=300`).
- New client components: `PetCountersBar` (install/download text) and `PetRadarClient` (radar with client-side stat compute). Both fetch the new endpoint and skeleton briefly on first paint.
- `LikeButton` drops the `initialCount` prop; it fetches its own count (anon via `/metrics`, signed-in via `/like` for the liked state).
- `/pets/[slug]` page strips `getMetricsForSlug` + `getMetricsSummary` from the SSR `Promise.all`, drops the JSON-LD `interactionStatistic` block (was \`metrics.likeCount\`), and removes \`stats\` computation. Shell is now byte-stable between editorial edits.

## Phase 2 — Long ISR windows

Bumped \`revalidate\` ceilings:

| Page | Before | After |
|---|---|---|
| /pets/[slug] | 60s | 86400s |
| /[locale] (home) | 60s | 86400s |
| /collections | 300s | 86400s |
| /kind/[kind] | 600s | 86400s |
| /vibe/[vibe] | 600s | 86400s |
| sitemap.ts | 3600s | 86400s |

## Phase 3 — Tag-based on-demand invalidation

Wrapped key fetches in \`unstable_cache\` with tags so write paths can flush instantly via \`revalidateTag\`:

- \`getPet(slug)\` → \`pet:\${slug}\`, \`pet:list\`
- \`getApprovedPetsWithMetrics\`, \`getFeaturedPetsWithMetrics\`, \`getAllApprovedPets\` → \`pet:list\`
- \`getCollection(slug)\` → \`collection:\${slug}\`, \`collection:list\`
- \`getCollectionsBySlugs\`, \`getCollectionsForListing\`, \`getAllCollections\` → \`collection:list\`

Calls to \`revalidateTag(tag, 'max')\` (Next 16's stale-while-revalidate signature) added in four endpoints that change displayed pet content:

- \`api/admin/[id]/feature/route.ts\` — toggle featured
- \`api/admin/edits/[id]/route.ts\` — approve queued edit
- \`api/my-pets/claim/route.ts\` — claim ownership
- \`api/my-pets/[id]/edit/route.ts\` — auto-approve branch

Skipped: submit/withdraw (status=pending pets don't appear on listings), reject/queue branches (pending fields only — no displayed change), gallery-order (only profile pages).

## Expected cost impact

| Line | Before | Target |
|---|---|---|
| ISR Writes | \$35.33 | <\$1 |
| Active CPU | \$23.70 | \$4–6 |
| Function Invocations | \$20.76 | \$4–6 |
| Fast Origin Transfer | \$40.11 | \$7–10 |
| **Subtotal** | **\$120** | **\$15–25** |

Edge Requests (\$46) and Web Analytics (\$15) are not addressed here — left for follow-up (AI crawler wall in proxy.ts, drop Analytics if not used). SpeedInsights kept intact for before/after Web Vitals comparison.

## What's deliberately left for follow-up

- \`/collections/[slug]\` is still \`force-dynamic\` — per-user \`caughtSlugs\` + auth needs Tier-1-style refactor.
- \`PetCard\` SSR'd metrics on listing pages (home/kind/vibe). At 86400s ceilings the residual writes are bounded to a handful per page per day, so it's no longer a fire — but a full refactor would zero it out.

## Test plan

- [ ] \`bun run dev:mock\` and load /en/pets/<slug>: counters flash "—" briefly then hydrate; radar fills after fetch; like button shows "—" then real count.
- [ ] Network tab: one GET /api/pets/<slug>/metrics with \`Cache-Control: public, s-maxage=60, stale-while-revalidate=300\`.
- [ ] Owner-edit a pet via My Pets (auto-approve path) — change shows up on /pets/<slug> on next visit (stale-while-revalidate).
- [ ] Admin: flip a pet's featured flag — appears on home page after next visit.
- [ ] Anon visitor sees correct like count on first paint (after small hydration delay).
- [ ] Rate limit kicks in for direct /api/pets/<slug>/metrics flood (240/hr per IP).
- [ ] Watch Vercel usage dashboard for a few days post-deploy to confirm ISR writes collapse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)