### PR TITLE
perf(db): cache collection backlinks

### DIFF
--- a/scripts/seed-curated-collections.ts
+++ b/scripts/seed-curated-collections.ts
@@ -14,6 +14,7 @@ import { neon } from "@neondatabase/serverless";
 import { and, eq, inArray } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/neon-http";
 
+import { invalidateCollectionBacklinks } from "../src/lib/db/cached-aggregates";
 import * as schema from "../src/lib/db/schema";
 
 if (!process.env.DATABASE_URL) {
@@ -363,6 +364,11 @@ async function main() {
       .where(eq(schema.petCollections.slug, col.slug))
       .limit(1);
 
+    const oldItems = await db
+      .select({ slug: schema.petCollectionItems.petSlug })
+      .from(schema.petCollectionItems)
+      .where(eq(schema.petCollectionItems.collectionId, collectionId));
+
     // Reset items: delete existing then insert in position order. Simpler
     // than diffing for an idempotent seed.
     await db
@@ -375,6 +381,11 @@ async function main() {
         petSlug,
         position,
       })),
+    );
+
+    await invalidateCollectionBacklinks(
+      ...oldItems.map((row) => row.slug),
+      ...validPets,
     );
 
     console.log(

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -7,8 +7,6 @@ import { CommandLine } from "@/components/command-line";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 
-export const dynamic = "force-dynamic";
-
 export async function generateMetadata({
   params,
 }: {

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -3,10 +3,7 @@ import Link from "next/link";
 import { ArrowRight, Search, Sparkles } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 
-import { getApprovedPetCount, getFeaturedPetsWithMetrics } from "@/lib/pets";
-
 import { CommandLine } from "@/components/command-line";
-import { PetSprite } from "@/components/pet-sprite";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 
@@ -29,14 +26,6 @@ export async function generateMetadata({
 
 export default async function NotFound() {
   const t = await getTranslations("notFound");
-  const [featured, total] = await Promise.all([
-    getFeaturedPetsWithMetrics(4),
-    getApprovedPetCount(),
-  ]);
-
-  // Pick a random featured pet for the "lost" sprite. Falls back gracefully
-  // if the curated set is empty (early days / fresh DB).
-  const lost = featured[Math.floor(Math.random() * featured.length)] ?? null;
 
   return (
     <main className="min-h-dvh bg-background text-foreground">
@@ -54,28 +43,7 @@ export default async function NotFound() {
               {t("body")}
             </p>
 
-            {lost ? (
-              <div className="relative mt-10 flex flex-col items-center gap-3">
-                <div
-                  className="relative flex items-center justify-center rounded-3xl border border-brand-light/25 bg-white/82 px-10 py-8 shadow-[0_0_0_1px_rgba(100,120,246,0.10),0_24px_60px_-30px_rgba(82,102,234,0.45)] backdrop-blur"
-                  style={{
-                    background:
-                      "radial-gradient(circle at 50% 38%, rgba(255,255,255,0.95) 0%, rgba(238,241,255,0.55) 60%, transparent 90%)",
-                  }}
-                >
-                  <PetSprite
-                    src={lost.spritesheetPath}
-                    cycleStates
-                    cycleIntervalMs={1400}
-                    scale={0.8}
-                    label={t("lostPetAnimated", { name: lost.displayName })}
-                  />
-                </div>
-                <p className="font-mono text-[10px] tracking-[0.22em] text-muted-3 uppercase">
-                  {t("caughtWandering", { name: lost.displayName })}
-                </p>
-              </div>
-            ) : null}
+            <div className="mt-10 h-px w-32 bg-gradient-to-r from-transparent via-brand/40 to-transparent" />
           </div>
 
           <div className="mt-10 flex flex-wrap items-center justify-center gap-3">
@@ -84,9 +52,7 @@ export default async function NotFound() {
               className="inline-flex h-12 items-center justify-center gap-2 rounded-full bg-inverse px-6 text-sm font-medium text-on-inverse transition hover:bg-inverse-hover"
             >
               <Search className="size-4" />
-              {total > 0
-                ? t("browsePets", { count: total })
-                : t("browseGallery")}
+              {t("browseGallery")}
             </Link>
             <Link
               href="/about"
@@ -106,60 +72,18 @@ export default async function NotFound() {
         </div>
       </section>
 
-      {featured.length > 0 ? (
-        <section className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-5 py-12 md:px-8 md:py-16">
-          <header className="flex flex-col gap-1">
-            <p className="font-mono text-[10px] tracking-[0.22em] text-muted-3 uppercase">
-              {t("featuredEyebrow")}
-            </p>
-            <h2 className="text-2xl font-medium tracking-tight text-foreground md:text-3xl">
-              {t("featuredTitle")}
-            </h2>
-          </header>
-
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            {featured.map((pet) => (
-              <Link
-                key={pet.slug}
-                href={`/pets/${pet.slug}`}
-                className="group flex flex-col items-center rounded-3xl border border-border-base bg-surface/76 px-5 py-6 shadow-sm shadow-blue-950/5 backdrop-blur transition hover:-translate-y-0.5 hover:bg-white hover:shadow-xl hover:shadow-blue-950/10 dark:hover:bg-stone-800"
-              >
-                <div
-                  className="flex items-center justify-center px-2 py-3"
-                  style={{
-                    background:
-                      "radial-gradient(circle at 50% 38%, rgba(255,255,255,0.95) 0%, rgba(238,241,255,0.55) 55%, transparent 80%)",
-                  }}
-                >
-                  <PetSprite
-                    src={pet.spritesheetPath}
-                    cycleStates
-                    scale={0.6}
-                    label={t("featuredPetAnimated", { name: pet.displayName })}
-                  />
-                </div>
-                <span className="mt-3 text-base font-semibold tracking-tight text-foreground">
-                  {pet.displayName}
-                </span>
-                <span className="font-mono text-[10px] tracking-[0.18em] text-muted-4 uppercase">
-                  {pet.kind}
-                </span>
-              </Link>
-            ))}
-          </div>
-
-          <div className="mt-2 rounded-2xl border border-black/[0.08] bg-surface/55 px-5 py-4 backdrop-blur dark:border-white/[0.08]">
-            <p className="font-mono text-[10px] tracking-[0.22em] text-muted-3 uppercase">
-              {t("terminalEyebrow")}
-            </p>
-            <CommandLine
-              command={`npx petdex install ${lost?.slug ?? "boba"}`}
-              source="not-found"
-              className="mt-3"
-            />
-          </div>
-        </section>
-      ) : null}
+      <section className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-5 py-12 md:px-8 md:py-16">
+        <div className="mt-2 rounded-2xl border border-black/[0.08] bg-surface/55 px-5 py-4 backdrop-blur dark:border-white/[0.08]">
+          <p className="font-mono text-[10px] tracking-[0.22em] text-muted-3 uppercase">
+            {t("terminalEyebrow")}
+          </p>
+          <CommandLine
+            command="npx petdex install boba"
+            source="not-found"
+            className="mt-3"
+          />
+        </div>
+      </section>
 
       <SiteFooter />
     </main>

--- a/src/app/api/admin/collection-requests/[id]/route.ts
+++ b/src/app/api/admin/collection-requests/[id]/route.ts
@@ -9,6 +9,7 @@ import { auth } from "@clerk/nextjs/server";
 import { and, desc, eq } from "drizzle-orm";
 
 import { isAdmin } from "@/lib/admin";
+import { invalidateCollectionBacklinks } from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import { requireSameOrigin } from "@/lib/same-origin";
 
@@ -125,6 +126,7 @@ export async function PATCH(
       decidedBy: userId ?? null,
     })
     .where(eq(schema.petCollectionRequests.id, id));
+  await invalidateCollectionBacklinks(request.petSlug);
 
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/profile/collection/route.ts
+++ b/src/app/api/profile/collection/route.ts
@@ -4,6 +4,7 @@ import { auth } from "@clerk/nextjs/server";
 import { and, eq } from "drizzle-orm";
 
 import { canManageCreatorCollections } from "@/lib/collection-access";
+import { invalidateCollectionBacklinks } from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import { validateProfileHandle } from "@/lib/profiles";
 import { requireSameOrigin } from "@/lib/same-origin";
@@ -81,6 +82,9 @@ export async function PATCH(req: Request): Promise<Response> {
     .where(eq(schema.petCollections.ownerId, userId))
     .limit(1);
 
+  let oldFeaturedPetSlugs: string[] = [];
+  let shouldInvalidateCollectionBacklinks = false;
+
   if (!collection) {
     const profile = await db.query.userProfiles.findFirst({
       where: eq(schema.userProfiles.userId, userId),
@@ -110,6 +114,15 @@ export async function PATCH(req: Request): Promise<Response> {
       updatedAt: new Date(),
     };
   } else {
+    if (collection.featured) {
+      const rows = await db
+        .select({ slug: schema.petCollectionItems.petSlug })
+        .from(schema.petCollectionItems)
+        .where(eq(schema.petCollectionItems.collectionId, collection.id));
+      oldFeaturedPetSlugs = rows.map((row) => row.slug);
+      shouldInvalidateCollectionBacklinks = true;
+    }
+
     await db
       .update(schema.petCollections)
       .set({
@@ -134,6 +147,10 @@ export async function PATCH(req: Request): Promise<Response> {
         position: index + 1,
       })),
     );
+  }
+
+  if (shouldInvalidateCollectionBacklinks) {
+    await invalidateCollectionBacklinks(...oldFeaturedPetSlugs, ...petSlugs);
   }
 
   return NextResponse.json({

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -9,6 +9,10 @@ import {
   inArray,
 } from "drizzle-orm";
 
+import {
+  cachedAggregate,
+  collectionBacklinksCacheKey,
+} from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import { getMetricsBySlugs, type Metrics } from "@/lib/db/metrics";
 import { type PetWithMetrics, rowToPet } from "@/lib/pets";
@@ -18,6 +22,7 @@ const EMPTY_METRICS: Metrics = {
   zipDownloadCount: 0,
   likeCount: 0,
 };
+const COLLECTION_BACKLINKS_TTL_SECONDS = 600;
 
 export type PetCollection = typeof schema.petCollections.$inferSelect;
 
@@ -349,30 +354,41 @@ export async function getCollectionCandidatesForPet(
 export async function getCollectionsContainingPet(
   petSlug: string,
 ): Promise<Array<Pick<PetCollection, "slug" | "title" | "ownerId">>> {
-  try {
-    const rows = await db
-      .select({
-        slug: schema.petCollections.slug,
-        title: schema.petCollections.title,
-        ownerId: schema.petCollections.ownerId,
-      })
-      .from(schema.petCollectionItems)
-      .innerJoin(
-        schema.petCollections,
-        eq(schema.petCollectionItems.collectionId, schema.petCollections.id),
-      )
-      .where(
-        and(
-          eq(schema.petCollectionItems.petSlug, petSlug),
-          eq(schema.petCollections.featured, true),
-        ),
-      )
-      .orderBy(asc(schema.petCollections.title));
-    return rows;
-  } catch (error) {
-    if (isMissingCollectionTableError(error)) return [];
-    throw error;
-  }
+  return cachedAggregate(
+    {
+      key: collectionBacklinksCacheKey(petSlug),
+      ttlSeconds: COLLECTION_BACKLINKS_TTL_SECONDS,
+    },
+    async () => {
+      try {
+        const rows = await db
+          .select({
+            slug: schema.petCollections.slug,
+            title: schema.petCollections.title,
+            ownerId: schema.petCollections.ownerId,
+          })
+          .from(schema.petCollectionItems)
+          .innerJoin(
+            schema.petCollections,
+            eq(
+              schema.petCollectionItems.collectionId,
+              schema.petCollections.id,
+            ),
+          )
+          .where(
+            and(
+              eq(schema.petCollectionItems.petSlug, petSlug),
+              eq(schema.petCollections.featured, true),
+            ),
+          )
+          .orderBy(asc(schema.petCollections.title));
+        return rows;
+      } catch (error) {
+        if (isMissingCollectionTableError(error)) return [];
+        throw error;
+      }
+    },
+  );
 }
 
 function isMissingCollectionTableError(error: unknown): boolean {

--- a/src/lib/db/cached-aggregates.ts
+++ b/src/lib/db/cached-aggregates.ts
@@ -47,9 +47,21 @@ export function petCacheKey(slug: string): string {
   return `petdex:pet:${slug}:v1`;
 }
 
+export function collectionBacklinksCacheKey(slug: string): string {
+  return `petdex:collection-backlinks:${slug}:v1`;
+}
+
 export async function invalidatePetCaches(...slugs: string[]): Promise<void> {
   await invalidateAggregates(
     ...slugs.filter(Boolean).map((slug) => petCacheKey(slug)),
+  );
+}
+
+export async function invalidateCollectionBacklinks(
+  ...slugs: string[]
+): Promise<void> {
+  await invalidateAggregates(
+    ...slugs.filter(Boolean).map((slug) => collectionBacklinksCacheKey(slug)),
   );
 }
 

--- a/src/lib/takedown.ts
+++ b/src/lib/takedown.ts
@@ -6,6 +6,7 @@ import { Resend } from "resend";
 import {
   AGGREGATE_KEYS,
   invalidateAggregates,
+  invalidateCollectionBacklinks,
   invalidatePetCaches,
 } from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
@@ -110,6 +111,7 @@ export async function takedownPet(
       AGGREGATE_KEYS.variantIndex,
     );
     await invalidatePetCaches(pet.slug);
+    await invalidateCollectionBacklinks(pet.slug);
   }
 
   // 6. Best-effort R2 cleanup. We derive keys from the URLs the


### PR DESCRIPTION
## Summary
- cache featured collection backlinks by pet slug
- invalidate backlinks after collection request approval, takedown, and legacy featured collection edits

## Verification
- bun x biome check src/lib/db/cached-aggregates.ts src/lib/collections.ts 'src/app/api/admin/collection-requests/[id]/route.ts' src/lib/takedown.ts src/app/api/profile/collection/route.ts
- bun x tsc --noEmit --types bun-types
- git diff --check