### PR TITLE
perf(db): cache approved pet manifests

### DIFF
--- a/scripts/admin-import-pet.ts
+++ b/scripts/admin-import-pet.ts
@@ -23,6 +23,7 @@ import { eq } from "drizzle-orm";
 import JSZip from "jszip";
 import sharp from "sharp";
 
+import { invalidatePetCaches } from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import { R2_BUCKET, R2_PUBLIC_BASE, r2 } from "@/lib/r2";
 
@@ -219,6 +220,9 @@ async function main() {
     creditImage: null,
     approvedAt: args.approve ? new Date() : null,
   });
+  if (args.approve) {
+    await invalidatePetCaches(slug);
+  }
 
   console.log(
     `\nDB row inserted: ${id} (slug=${slug}, status=${args.approve ? "approved" : "pending"})`,

--- a/scripts/backfill-credits.ts
+++ b/scripts/backfill-credits.ts
@@ -10,6 +10,7 @@
 
 import { and, eq, isNull, or } from "drizzle-orm";
 
+import { invalidatePetCaches } from "../src/lib/db/cached-aggregates";
 import { db, schema } from "../src/lib/db/client";
 
 const args = new Set(process.argv.slice(2));
@@ -117,6 +118,7 @@ async function main() {
   // Cache per ownerId — many pets share owners (vl.tansky, serhatandic, etc.)
   const cache = new Map<string, ClerkUser | null>();
 
+  const touchedSlugs: string[] = [];
   for (const row of rows) {
     let user = cache.get(row.ownerId);
     if (user === undefined) {
@@ -144,7 +146,10 @@ async function main() {
         creditImage: credit.imageUrl,
       })
       .where(eq(schema.submittedPets.id, row.id));
+    touchedSlugs.push(row.slug);
   }
+
+  await invalidatePetCaches(...touchedSlugs);
 
   console.log("done.");
 }

--- a/scripts/revive-rejected-pets.ts
+++ b/scripts/revive-rejected-pets.ts
@@ -7,6 +7,8 @@
 import { neon } from "@neondatabase/serverless";
 import { Resend } from "resend";
 
+import { invalidatePetCaches } from "../src/lib/db/cached-aggregates";
+
 const PROD_URL = "https://petdex.crafter.run";
 const databaseUrl = process.env.DATABASE_URL;
 if (!databaseUrl) {
@@ -38,6 +40,7 @@ async function main() {
   console.log(`Found ${rows.length} rejected pets to revive.`);
   if (rows.length === 0) return;
 
+  const revivedSlugs: string[] = [];
   for (const row of rows) {
     const installCmd = `curl -sSf ${PROD_URL}/install/${row.slug} | sh`;
     const url = `${PROD_URL}/pets/${row.slug}`;
@@ -57,6 +60,7 @@ async function main() {
           rejection_reason = NULL
       WHERE id = ${row.id}
     `;
+    revivedSlugs.push(row.slug);
 
     if (resend && row.owner_email) {
       try {
@@ -94,6 +98,7 @@ async function main() {
 
   // Best-effort embedding refresh so the revived pets show up in vibe search.
   if (!dryRun) {
+    await invalidatePetCaches(...revivedSlugs);
     console.log("\nKick off similarity refresh via /api/admin/edits is not");
     console.log("strictly needed — the daily auto-tag cron picks them up.");
     console.log(

--- a/src/lib/db/cached-aggregates.ts
+++ b/src/lib/db/cached-aggregates.ts
@@ -41,6 +41,8 @@ export const AGGREGATE_KEYS = {
   metricsSummary: "petdex:agg:metrics-summary:v1",
   batches: "petdex:agg:batches:v1",
   variantIndex: "petdex:agg:variant-index:v1",
+  approvedCatalog: "petdex:agg:approved-catalog:v1",
+  slimManifest: "petdex:agg:slim-manifest:v1",
 } as const;
 
 export function petCacheKey(slug: string): string {
@@ -52,9 +54,11 @@ export function collectionBacklinksCacheKey(slug: string): string {
 }
 
 export async function invalidatePetCaches(...slugs: string[]): Promise<void> {
-  await invalidateAggregates(
-    ...slugs.filter(Boolean).map((slug) => petCacheKey(slug)),
-  );
+  const keys = slugs.filter(Boolean).map((slug) => petCacheKey(slug));
+  if (keys.length > 0) {
+    keys.push(AGGREGATE_KEYS.approvedCatalog, AGGREGATE_KEYS.slimManifest);
+  }
+  await invalidateAggregates(...keys);
 }
 
 export async function invalidateCollectionBacklinks(

--- a/src/lib/pets.ts
+++ b/src/lib/pets.ts
@@ -29,6 +29,7 @@ const EMPTY_METRICS: Metrics = {
 };
 
 const PET_CACHE_TTL_SECONDS = 300;
+const APPROVED_CATALOG_TTL_SECONDS = 300;
 
 type PetRow = Pick<
   typeof schema.submittedPets.$inferSelect,
@@ -144,11 +145,19 @@ export async function getFeaturedPetsWithMetrics(
 }
 
 export async function getAllApprovedPets(): Promise<PetdexPet[]> {
-  const rows = await db
-    .select()
-    .from(schema.submittedPets)
-    .where(eq(schema.submittedPets.status, "approved"));
-  return rows.map(rowToPet);
+  return cachedAggregate(
+    {
+      key: AGGREGATE_KEYS.approvedCatalog,
+      ttlSeconds: APPROVED_CATALOG_TTL_SECONDS,
+    },
+    async () => {
+      const rows = await db
+        .select()
+        .from(schema.submittedPets)
+        .where(eq(schema.submittedPets.status, "approved"));
+      return rows.map(rowToPet);
+    },
+  );
 }
 
 export type ApprovedPetSlim = {
@@ -166,27 +175,32 @@ export type ApprovedPetSlim = {
 // this shape is ~200 bytes, which compounds across the CLI traffic that
 // hits the slim manifest on every `petdex list` / `petdex install`.
 export async function getApprovedPetsForManifest(): Promise<ApprovedPetSlim[]> {
-  const rows = await db
-    .select({
-      slug: schema.submittedPets.slug,
-      displayName: schema.submittedPets.displayName,
-      kind: schema.submittedPets.kind,
-      spritesheetUrl: schema.submittedPets.spritesheetUrl,
-      petJsonUrl: schema.submittedPets.petJsonUrl,
-      zipUrl: schema.submittedPets.zipUrl,
-      creditName: schema.submittedPets.creditName,
-    })
-    .from(schema.submittedPets)
-    .where(eq(schema.submittedPets.status, "approved"));
-  return rows.map((row) => ({
-    slug: row.slug,
-    displayName: row.displayName,
-    kind: row.kind as PetKind,
-    spritesheetUrl: row.spritesheetUrl,
-    petJsonUrl: row.petJsonUrl,
-    zipUrl: row.zipUrl,
-    creditName: row.creditName,
-  }));
+  return cachedAggregate(
+    { key: AGGREGATE_KEYS.slimManifest, ttlSeconds: 300 },
+    async () => {
+      const rows = await db
+        .select({
+          slug: schema.submittedPets.slug,
+          displayName: schema.submittedPets.displayName,
+          kind: schema.submittedPets.kind,
+          spritesheetUrl: schema.submittedPets.spritesheetUrl,
+          petJsonUrl: schema.submittedPets.petJsonUrl,
+          zipUrl: schema.submittedPets.zipUrl,
+          creditName: schema.submittedPets.creditName,
+        })
+        .from(schema.submittedPets)
+        .where(eq(schema.submittedPets.status, "approved"));
+      return rows.map((row) => ({
+        slug: row.slug,
+        displayName: row.displayName,
+        kind: row.kind as PetKind,
+        spritesheetUrl: row.spritesheetUrl,
+        petJsonUrl: row.petJsonUrl,
+        zipUrl: row.zipUrl,
+        creditName: row.creditName,
+      }));
+    },
+  );
 }
 
 export async function getLatestApprovedPets(limit = 5): Promise<PetdexPet[]> {


### PR DESCRIPTION
## Summary
- cache the approved catalog used by sitemap/full manifest/facet pages
- cache the slim public manifest payload source
- clear those shared keys from existing pet cache invalidation paths and relevant scripts

## Verification
- bun x biome check src/lib/db/cached-aggregates.ts src/lib/pets.ts scripts/admin-import-pet.ts scripts/backfill-credits.ts scripts/revive-rejected-pets.ts
- bun x tsc --noEmit --types bun-types
- git diff --check