### PR TITLE
perf(db): cache pet metrics reads

### DIFF
--- a/src/lib/db/cached-aggregates.ts
+++ b/src/lib/db/cached-aggregates.ts
@@ -53,12 +53,24 @@ export function collectionBacklinksCacheKey(slug: string): string {
   return `petdex:collection-backlinks:${slug}:v1`;
 }
 
+export function petMetricsCacheKey(slug: string): string {
+  return `petdex:metrics:${slug}:v1`;
+}
+
 export async function invalidatePetCaches(...slugs: string[]): Promise<void> {
   const keys = slugs.filter(Boolean).map((slug) => petCacheKey(slug));
   if (keys.length > 0) {
     keys.push(AGGREGATE_KEYS.approvedCatalog, AGGREGATE_KEYS.slimManifest);
   }
   await invalidateAggregates(...keys);
+}
+
+export async function invalidateMetricCaches(
+  ...slugs: string[]
+): Promise<void> {
+  await invalidateAggregates(
+    ...slugs.filter(Boolean).map((slug) => petMetricsCacheKey(slug)),
+  );
 }
 
 export async function invalidateCollectionBacklinks(

--- a/src/lib/db/cached-aggregates.ts
+++ b/src/lib/db/cached-aggregates.ts
@@ -43,6 +43,7 @@ export const AGGREGATE_KEYS = {
   variantIndex: "petdex:agg:variant-index:v1",
   approvedCatalog: "petdex:agg:approved-catalog:v1",
   slimManifest: "petdex:agg:slim-manifest:v1",
+  metricsIndex: "petdex:agg:metrics-index:v1",
 } as const;
 
 export function petCacheKey(slug: string): string {

--- a/src/lib/db/metrics.ts
+++ b/src/lib/db/metrics.ts
@@ -4,8 +4,12 @@ import {
   AGGREGATE_KEYS,
   cachedAggregate,
   invalidateAggregates,
+  invalidateMetricCaches,
+  petMetricsCacheKey,
 } from "./cached-aggregates";
 import { db, schema } from "./client";
+
+const PET_METRICS_TTL_SECONDS = 60;
 
 export async function incrementInstallCount(slug: string): Promise<void> {
   await db
@@ -24,7 +28,10 @@ export async function incrementInstallCount(slug: string): Promise<void> {
       },
     });
   // maxInstallCount in the cached summary may have moved.
-  await invalidateAggregates(AGGREGATE_KEYS.metricsSummary);
+  await Promise.all([
+    invalidateAggregates(AGGREGATE_KEYS.metricsSummary),
+    invalidateMetricCaches(slug),
+  ]);
 }
 
 export async function incrementZipDownloadCount(slug: string): Promise<void> {
@@ -41,6 +48,7 @@ export async function incrementZipDownloadCount(slug: string): Promise<void> {
         updatedAt: new Date(),
       },
     });
+  await invalidateMetricCaches(slug);
 }
 
 export async function setLikeCount(slug: string, count: number): Promise<void> {
@@ -52,7 +60,10 @@ export async function setLikeCount(slug: string, count: number): Promise<void> {
       set: { likeCount: count, updatedAt: new Date() },
     });
   // maxLikeCount in the cached summary may have moved.
-  await invalidateAggregates(AGGREGATE_KEYS.metricsSummary);
+  await Promise.all([
+    invalidateAggregates(AGGREGATE_KEYS.metricsSummary),
+    invalidateMetricCaches(slug),
+  ]);
 }
 
 export type Metrics = {
@@ -104,14 +115,19 @@ export async function getMetricsBySlugs(
 }
 
 export async function getMetricsForSlug(slug: string): Promise<Metrics> {
-  const row = await db.query.petMetrics.findFirst({
-    where: (t, { eq }) => eq(t.petSlug, slug),
-  });
-  return {
-    installCount: row?.installCount ?? 0,
-    zipDownloadCount: row?.zipDownloadCount ?? 0,
-    likeCount: row?.likeCount ?? 0,
-  };
+  return cachedAggregate(
+    { key: petMetricsCacheKey(slug), ttlSeconds: PET_METRICS_TTL_SECONDS },
+    async () => {
+      const row = await db.query.petMetrics.findFirst({
+        where: (t, { eq }) => eq(t.petSlug, slug),
+      });
+      return {
+        installCount: row?.installCount ?? 0,
+        zipDownloadCount: row?.zipDownloadCount ?? 0,
+        likeCount: row?.likeCount ?? 0,
+      };
+    },
+  );
 }
 
 export async function getMetricsSummary(): Promise<MetricsSummary> {

--- a/src/lib/db/metrics.ts
+++ b/src/lib/db/metrics.ts
@@ -1,3 +1,5 @@
+import { cache } from "react";
+
 import { eq, inArray, sql } from "drizzle-orm";
 
 import {
@@ -10,6 +12,15 @@ import {
 import { db, schema } from "./client";
 
 const PET_METRICS_TTL_SECONDS = 60;
+const METRICS_INDEX_TTL_SECONDS = 60;
+const METRICS_INDEX_MIN_BATCH_SIZE = 50;
+
+type MetricsIndexRow = {
+  petSlug: string;
+  installCount: number;
+  zipDownloadCount: number;
+  likeCount: number;
+};
 
 export async function incrementInstallCount(slug: string): Promise<void> {
   await db
@@ -29,7 +40,10 @@ export async function incrementInstallCount(slug: string): Promise<void> {
     });
   // maxInstallCount in the cached summary may have moved.
   await Promise.all([
-    invalidateAggregates(AGGREGATE_KEYS.metricsSummary),
+    invalidateAggregates(
+      AGGREGATE_KEYS.metricsSummary,
+      AGGREGATE_KEYS.metricsIndex,
+    ),
     invalidateMetricCaches(slug),
   ]);
 }
@@ -48,7 +62,10 @@ export async function incrementZipDownloadCount(slug: string): Promise<void> {
         updatedAt: new Date(),
       },
     });
-  await invalidateMetricCaches(slug);
+  await Promise.all([
+    invalidateAggregates(AGGREGATE_KEYS.metricsIndex),
+    invalidateMetricCaches(slug),
+  ]);
 }
 
 export async function setLikeCount(slug: string, count: number): Promise<void> {
@@ -61,7 +78,10 @@ export async function setLikeCount(slug: string, count: number): Promise<void> {
     });
   // maxLikeCount in the cached summary may have moved.
   await Promise.all([
-    invalidateAggregates(AGGREGATE_KEYS.metricsSummary),
+    invalidateAggregates(
+      AGGREGATE_KEYS.metricsSummary,
+      AGGREGATE_KEYS.metricsIndex,
+    ),
     invalidateMetricCaches(slug),
   ]);
 }
@@ -83,7 +103,7 @@ export type MetricsSummary = {
  * which only loads the rows you actually need.
  */
 export async function getAllMetrics(): Promise<Map<string, Metrics>> {
-  const rows = await db.select().from(schema.petMetrics);
+  const rows = await getMetricsIndexRows();
   const map = new Map<string, Metrics>();
   for (const row of rows) {
     map.set(row.petSlug, {
@@ -99,6 +119,15 @@ export async function getMetricsBySlugs(
   slugs: string[],
 ): Promise<Map<string, Metrics>> {
   if (slugs.length === 0) return new Map();
+  if (slugs.length >= METRICS_INDEX_MIN_BATCH_SIZE) {
+    const index = await getAllMetrics();
+    const map = new Map<string, Metrics>();
+    for (const slug of slugs) {
+      const metrics = index.get(slug);
+      if (metrics) map.set(slug, metrics);
+    }
+    return map;
+  }
   const rows = await db
     .select()
     .from(schema.petMetrics)
@@ -113,6 +142,24 @@ export async function getMetricsBySlugs(
   }
   return map;
 }
+
+const getMetricsIndexRows = cache(async (): Promise<MetricsIndexRow[]> => {
+  return cachedAggregate(
+    {
+      key: AGGREGATE_KEYS.metricsIndex,
+      ttlSeconds: METRICS_INDEX_TTL_SECONDS,
+    },
+    async () => {
+      const rows = await db.select().from(schema.petMetrics);
+      return rows.map((row) => ({
+        petSlug: row.petSlug,
+        installCount: row.installCount,
+        zipDownloadCount: row.zipDownloadCount,
+        likeCount: row.likeCount,
+      }));
+    },
+  );
+});
 
 export async function getMetricsForSlug(slug: string): Promise<Metrics> {
   return cachedAggregate(

--- a/src/lib/takedown.ts
+++ b/src/lib/takedown.ts
@@ -108,14 +108,14 @@ export async function takedownPet(
       AGGREGATE_KEYS.facets,
       AGGREGATE_KEYS.approvedCount,
       AGGREGATE_KEYS.metricsSummary,
-      AGGREGATE_KEYS.metricsIndex,
       AGGREGATE_KEYS.batches,
       AGGREGATE_KEYS.variantIndex,
     );
     await invalidatePetCaches(pet.slug);
     await invalidateCollectionBacklinks(pet.slug);
-    await invalidateMetricCaches(pet.slug);
   }
+  await invalidateAggregates(AGGREGATE_KEYS.metricsIndex);
+  await invalidateMetricCaches(pet.slug);
 
   // 6. Best-effort R2 cleanup. We derive keys from the URLs the
   //    submission stored; anything off-host (legacy or external credit

--- a/src/lib/takedown.ts
+++ b/src/lib/takedown.ts
@@ -108,6 +108,7 @@ export async function takedownPet(
       AGGREGATE_KEYS.facets,
       AGGREGATE_KEYS.approvedCount,
       AGGREGATE_KEYS.metricsSummary,
+      AGGREGATE_KEYS.metricsIndex,
       AGGREGATE_KEYS.batches,
       AGGREGATE_KEYS.variantIndex,
     );

--- a/src/lib/takedown.ts
+++ b/src/lib/takedown.ts
@@ -7,6 +7,7 @@ import {
   AGGREGATE_KEYS,
   invalidateAggregates,
   invalidateCollectionBacklinks,
+  invalidateMetricCaches,
   invalidatePetCaches,
 } from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
@@ -112,6 +113,7 @@ export async function takedownPet(
     );
     await invalidatePetCaches(pet.slug);
     await invalidateCollectionBacklinks(pet.slug);
+    await invalidateMetricCaches(pet.slug);
   }
 
   // 6. Best-effort R2 cleanup. We derive keys from the URLs the


### PR DESCRIPTION
## Summary
- cache per-slug pet metrics reads for the pet detail path
- invalidate metric keys after install, zip download, like count writes, and takedown
- keep batch metrics reads unchanged to avoid adding many Redis calls for list pages

## Verification
- bun x biome check src/lib/db/cached-aggregates.ts src/lib/db/metrics.ts src/lib/takedown.ts
- bun x tsc --noEmit --types bun-types
- git diff --check