### PR TITLE
perf(db): cache featured pet reads

### DIFF
--- a/src/lib/db/cached-aggregates.ts
+++ b/src/lib/db/cached-aggregates.ts
@@ -44,6 +44,7 @@ export const AGGREGATE_KEYS = {
   approvedCatalog: "petdex:agg:approved-catalog:v1",
   slimManifest: "petdex:agg:slim-manifest:v1",
   metricsIndex: "petdex:agg:metrics-index:v1",
+  featuredPets: "petdex:agg:featured-pets:v1",
 } as const;
 
 export function petCacheKey(slug: string): string {
@@ -61,7 +62,11 @@ export function petMetricsCacheKey(slug: string): string {
 export async function invalidatePetCaches(...slugs: string[]): Promise<void> {
   const keys = slugs.filter(Boolean).map((slug) => petCacheKey(slug));
   if (keys.length > 0) {
-    keys.push(AGGREGATE_KEYS.approvedCatalog, AGGREGATE_KEYS.slimManifest);
+    keys.push(
+      AGGREGATE_KEYS.approvedCatalog,
+      AGGREGATE_KEYS.slimManifest,
+      AGGREGATE_KEYS.featuredPets,
+    );
   }
   await invalidateAggregates(...keys);
 }

--- a/src/lib/pets.ts
+++ b/src/lib/pets.ts
@@ -30,6 +30,7 @@ const EMPTY_METRICS: Metrics = {
 
 const PET_CACHE_TTL_SECONDS = 300;
 const APPROVED_CATALOG_TTL_SECONDS = 300;
+const FEATURED_PETS_TTL_SECONDS = 300;
 
 type PetRow = Pick<
   typeof schema.submittedPets.$inferSelect,
@@ -125,23 +126,34 @@ export async function getStaticPetSlugs(): Promise<string[]> {
 export async function getFeaturedPetsWithMetrics(
   limit = 6,
 ): Promise<PetWithMetrics[]> {
-  const rows = await db
-    .select()
-    .from(schema.submittedPets)
-    .where(
-      and(
-        eq(schema.submittedPets.status, "approved"),
-        eq(schema.submittedPets.featured, true),
-      ),
-    )
-    .limit(limit);
-
-  if (rows.length === 0) return [];
-  const metrics = await getMetricsBySlugs(rows.map((row) => row.slug));
-  return rows.map((row) => ({
-    ...rowToPet(row),
-    metrics: metrics.get(row.slug) ?? EMPTY_METRICS,
+  const pets = (await getFeaturedPets()).slice(0, limit);
+  if (pets.length === 0) return [];
+  const metrics = await getMetricsBySlugs(pets.map((pet) => pet.slug));
+  return pets.map((pet) => ({
+    ...pet,
+    metrics: metrics.get(pet.slug) ?? EMPTY_METRICS,
   }));
+}
+
+async function getFeaturedPets(): Promise<PetdexPet[]> {
+  return cachedAggregate(
+    {
+      key: AGGREGATE_KEYS.featuredPets,
+      ttlSeconds: FEATURED_PETS_TTL_SECONDS,
+    },
+    async () => {
+      const rows = await db
+        .select()
+        .from(schema.submittedPets)
+        .where(
+          and(
+            eq(schema.submittedPets.status, "approved"),
+            eq(schema.submittedPets.featured, true),
+          ),
+        );
+      return rows.map(rowToPet);
+    },
+  );
 }
 
 export async function getAllApprovedPets(): Promise<PetdexPet[]> {


### PR DESCRIPTION
## Summary
- cache the featured approved pet list behind the existing Redis layer
- reuse the cached list in featured pet rendering while keeping metrics fetched separately
- clear the featured list from existing pet cache invalidation paths

## Verification
- bun x biome check src/lib/db/cached-aggregates.ts src/lib/pets.ts
- bun x tsc --noEmit --types bun-types
- git diff --check