### PR TITLE
perf(db): cache dex number index

### DIFF
--- a/src/lib/db/cached-aggregates.ts
+++ b/src/lib/db/cached-aggregates.ts
@@ -45,6 +45,7 @@ export const AGGREGATE_KEYS = {
   slimManifest: "petdex:agg:slim-manifest:v1",
   metricsIndex: "petdex:agg:metrics-index:v1",
   featuredPets: "petdex:agg:featured-pets:v1",
+  dexNumbers: "petdex:agg:dex-numbers:v1",
 } as const;
 
 export function petCacheKey(slug: string): string {
@@ -66,6 +67,7 @@ export async function invalidatePetCaches(...slugs: string[]): Promise<void> {
       AGGREGATE_KEYS.approvedCatalog,
       AGGREGATE_KEYS.slimManifest,
       AGGREGATE_KEYS.featuredPets,
+      AGGREGATE_KEYS.dexNumbers,
     );
   }
   await invalidateAggregates(...keys);
@@ -93,6 +95,7 @@ export async function invalidateCollectionBacklinks(
 // a stale value on a hot lambda and repopulate Upstash with it.
 const NEXT_TAGS_FOR_KEY: Record<string, string[]> = {
   [AGGREGATE_KEYS.facets]: ["petdex:facets"],
+  [AGGREGATE_KEYS.dexNumbers]: ["petdex:dex"],
 };
 
 // Invalidate keys after writes that change the aggregate (approve,

--- a/src/lib/dex.ts
+++ b/src/lib/dex.ts
@@ -17,27 +17,37 @@ import { cache } from "react";
 
 import { sql } from "drizzle-orm";
 
+import { AGGREGATE_KEYS, cachedAggregate } from "@/lib/db/cached-aggregates";
 import { db } from "@/lib/db/client";
 import { withNextDataCache } from "@/lib/next-data-cache";
 
 export type DexEntry = { slug: string; dexNumber: number };
+const DEX_NUMBERS_TTL_SECONDS = 300;
 
 const getDexEntries = withNextDataCache(
   async (): Promise<DexEntry[]> => {
-    const result = (await db.execute(sql`
+    return cachedAggregate(
+      {
+        key: AGGREGATE_KEYS.dexNumbers,
+        ttlSeconds: DEX_NUMBERS_TTL_SECONDS,
+      },
+      async () => {
+        const result = (await db.execute(sql`
         SELECT slug,
                ROW_NUMBER() OVER (ORDER BY approved_at ASC, created_at ASC)::int AS dex_number
         FROM submitted_pets
         WHERE status = 'approved'
           AND source <> 'discover'
       `)) as unknown as {
-      rows: Array<{ slug: string; dex_number: number }>;
-    };
+          rows: Array<{ slug: string; dex_number: number }>;
+        };
 
-    return result.rows.map((row) => ({
-      slug: row.slug,
-      dexNumber: row.dex_number,
-    }));
+        return result.rows.map((row) => ({
+          slug: row.slug,
+          dexNumber: row.dex_number,
+        }));
+      },
+    );
   },
   ["petdex-dex-numbers"],
   { tags: ["petdex:dex"], revalidate: 300 },


### PR DESCRIPTION
## Summary
- cache the dex number index in the shared Redis layer
- keep the existing Next tag paired with the Redis key
- clear the dex key from existing pet cache invalidation paths

## Verification
- bun x biome check src/lib/db/cached-aggregates.ts src/lib/dex.ts
- bun x tsc --noEmit --types bun-types
- git diff --check