### PR TITLE
perf(db): cache public profile lookups

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import { and, eq, inArray, ne } from "drizzle-orm";
 
+import { invalidatePublicProfileCaches } from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import {
   dedupePins,
@@ -222,6 +223,7 @@ export async function PATCH(req: Request): Promise<Response> {
         updatedAt: new Date(),
       },
     });
+  await invalidatePublicProfileCaches(userId);
 
   // Sync Clerk username with the DB handle so the AuthBadge dropdown,
   // which reads from useUser() in the browser, also lands on the right

--- a/src/lib/db/cached-aggregates.ts
+++ b/src/lib/db/cached-aggregates.ts
@@ -60,6 +60,10 @@ export function petMetricsCacheKey(slug: string): string {
   return `petdex:metrics:${slug}:v1`;
 }
 
+export function publicProfileCacheKey(userId: string): string {
+  return `petdex:profile:${userId}:v1`;
+}
+
 export async function invalidatePetCaches(...slugs: string[]): Promise<void> {
   const keys = slugs.filter(Boolean).map((slug) => petCacheKey(slug));
   if (keys.length > 0) {
@@ -78,6 +82,14 @@ export async function invalidateMetricCaches(
 ): Promise<void> {
   await invalidateAggregates(
     ...slugs.filter(Boolean).map((slug) => petMetricsCacheKey(slug)),
+  );
+}
+
+export async function invalidatePublicProfileCaches(
+  ...userIds: string[]
+): Promise<void> {
+  await invalidateAggregates(
+    ...userIds.filter(Boolean).map((userId) => publicProfileCacheKey(userId)),
   );
 }
 

--- a/src/lib/owner-credit.ts
+++ b/src/lib/owner-credit.ts
@@ -17,6 +17,10 @@ import { cache } from "react";
 import { clerkClient } from "@clerk/nextjs/server";
 import { inArray } from "drizzle-orm";
 
+import {
+  cachedAggregate,
+  publicProfileCacheKey,
+} from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 
 export type OwnerExternal = {
@@ -55,6 +59,13 @@ export type RowCreditFallback = {
    */
   ownerIsProxy?: boolean;
 };
+
+type StoredPublicProfile = {
+  displayName: string | null;
+  handle: string | null;
+};
+
+const PUBLIC_PROFILE_TTL_SECONDS = 300;
 
 function fallbackHandle(userId: string): string {
   return userId.slice(-8).toLowerCase();
@@ -272,18 +283,7 @@ export async function resolveStoredOwnerCreditFor(
     null;
 
   if (!row.ownerIsProxy) {
-    try {
-      const [storedProfile] = await db
-        .select({
-          displayName: schema.userProfiles.displayName,
-          handle: schema.userProfiles.handle,
-        })
-        .from(schema.userProfiles)
-        .where(inArray(schema.userProfiles.userId, [row.ownerId]));
-      profile = storedProfile ?? null;
-    } catch {
-      profile = null;
-    }
+    profile = await getStoredPublicProfile(row.ownerId);
   }
 
   const externals: OwnerExternal[] = [];
@@ -312,4 +312,29 @@ export async function resolveStoredOwnerCreditFor(
     externals,
     imageUrl: row.creditImage,
   };
+}
+
+async function getStoredPublicProfile(
+  userId: string,
+): Promise<StoredPublicProfile | null> {
+  return cachedAggregate(
+    {
+      key: publicProfileCacheKey(userId),
+      ttlSeconds: PUBLIC_PROFILE_TTL_SECONDS,
+    },
+    async () => {
+      try {
+        const [storedProfile] = await db
+          .select({
+            displayName: schema.userProfiles.displayName,
+            handle: schema.userProfiles.handle,
+          })
+          .from(schema.userProfiles)
+          .where(inArray(schema.userProfiles.userId, [userId]));
+        return storedProfile ?? { displayName: null, handle: null };
+      } catch {
+        return null;
+      }
+    },
+  );
 }


### PR DESCRIPTION
## Summary
- cache the single-owner public profile lookup used by pet detail credit rendering
- invalidate cached public profiles after profile updates
- cache real missing-profile results without caching DB errors
- keep batch owner credit resolution unchanged to avoid replacing one DB query with many Redis calls

## Verification
- bun x biome check src/lib/db/cached-aggregates.ts src/lib/owner-credit.ts src/app/api/profile/route.ts
- bun x tsc --noEmit --types bun-types
- git diff --check