### PR TITLE
perf(db): cache random pet pool

### DIFF
--- a/src/app/api/pets/random/route.ts
+++ b/src/app/api/pets/random/route.ts
@@ -1,11 +1,21 @@
 import { NextResponse } from "next/server";
 
-import { sql } from "drizzle-orm";
+import { and, eq, ne } from "drizzle-orm";
 
+import { AGGREGATE_KEYS, cachedAggregate } from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+
+const RANDOM_POOL_TTL_SECONDS = 300;
+
+type RandomPet = {
+  slug: string;
+  displayName: string;
+  description: string;
+  spritesheetPath: string;
+};
 
 // GET /api/pets/random?exclude=current-slug
 //
@@ -23,26 +33,11 @@ export async function GET(req: Request): Promise<Response> {
     "application/json",
   );
 
-  const rows = await db
-    .select({
-      slug: schema.submittedPets.slug,
-      displayName: schema.submittedPets.displayName,
-      description: schema.submittedPets.description,
-      spritesheetPath: schema.submittedPets.spritesheetUrl,
-    })
-    .from(schema.submittedPets)
-    .where(
-      exclude
-        ? sql`${schema.submittedPets.status} = 'approved'
-              AND ${schema.submittedPets.source} <> 'discover'
-              AND ${schema.submittedPets.slug} <> ${exclude}`
-        : sql`${schema.submittedPets.status} = 'approved'
-              AND ${schema.submittedPets.source} <> 'discover'`,
-    )
-    .orderBy(sql`random()`)
-    .limit(1);
-
-  const next = rows[0];
+  const pool = await getRandomPetPool();
+  const candidates = exclude
+    ? pool.filter((pet) => pet.slug !== exclude)
+    : pool;
+  const next = candidates[Math.floor(Math.random() * candidates.length)];
 
   if (wantsJson) {
     if (!next) {
@@ -65,4 +60,28 @@ export async function GET(req: Request): Promise<Response> {
     return NextResponse.redirect(new URL("/", req.url), 302);
   }
   return NextResponse.redirect(new URL(`/pets/${next.slug}`, req.url), 302);
+}
+
+async function getRandomPetPool(): Promise<RandomPet[]> {
+  return cachedAggregate(
+    {
+      key: AGGREGATE_KEYS.randomPetPool,
+      ttlSeconds: RANDOM_POOL_TTL_SECONDS,
+    },
+    async () =>
+      db
+        .select({
+          slug: schema.submittedPets.slug,
+          displayName: schema.submittedPets.displayName,
+          description: schema.submittedPets.description,
+          spritesheetPath: schema.submittedPets.spritesheetUrl,
+        })
+        .from(schema.submittedPets)
+        .where(
+          and(
+            eq(schema.submittedPets.status, "approved"),
+            ne(schema.submittedPets.source, "discover"),
+          ),
+        ),
+  );
 }

--- a/src/lib/db/cached-aggregates.ts
+++ b/src/lib/db/cached-aggregates.ts
@@ -46,6 +46,7 @@ export const AGGREGATE_KEYS = {
   metricsIndex: "petdex:agg:metrics-index:v1",
   featuredPets: "petdex:agg:featured-pets:v1",
   dexNumbers: "petdex:agg:dex-numbers:v1",
+  randomPetPool: "petdex:agg:random-pet-pool:v1",
 } as const;
 
 export function petCacheKey(slug: string): string {
@@ -72,6 +73,7 @@ export async function invalidatePetCaches(...slugs: string[]): Promise<void> {
       AGGREGATE_KEYS.slimManifest,
       AGGREGATE_KEYS.featuredPets,
       AGGREGATE_KEYS.dexNumbers,
+      AGGREGATE_KEYS.randomPetPool,
     );
   }
   await invalidateAggregates(...keys);


### PR DESCRIPTION
## Summary
- replace `/api/pets/random` `ORDER BY random()` reads with a slim Upstash-backed random pool
- keep the response payload unchanged for JSON and redirect consumers
- invalidate the random pool with pet cache invalidation when approved catalog rows change

## Verification
- bun x biome check src/lib/db/cached-aggregates.ts src/app/api/pets/random/route.ts
- bun x tsc --noEmit --types bun-types
- git diff --check