### PR TITLE
perf(db): cache public handle lookups

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -3,7 +3,10 @@ import { NextResponse } from "next/server";
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import { and, eq, inArray, ne } from "drizzle-orm";
 
-import { invalidatePublicProfileCaches } from "@/lib/db/cached-aggregates";
+import {
+  invalidatePublicHandleCaches,
+  invalidatePublicProfileCaches,
+} from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import {
   dedupePins,
@@ -205,6 +208,15 @@ export async function PATCH(req: Request): Promise<Response> {
     return NextResponse.json({ error: "nothing_to_update" }, { status: 400 });
   }
 
+  let previousHandle: string | null = null;
+  if (patch.handle !== undefined) {
+    const current = await db.query.userProfiles.findFirst({
+      columns: { handle: true },
+      where: eq(schema.userProfiles.userId, userId),
+    });
+    previousHandle = current?.handle ?? null;
+  }
+
   await db
     .insert(schema.userProfiles)
     .values({
@@ -223,7 +235,10 @@ export async function PATCH(req: Request): Promise<Response> {
         updatedAt: new Date(),
       },
     });
-  await invalidatePublicProfileCaches(userId);
+  await Promise.all([
+    invalidatePublicProfileCaches(userId),
+    invalidatePublicHandleCaches(previousHandle, patch.handle),
+  ]);
 
   // Sync Clerk username with the DB handle so the AuthBadge dropdown,
   // which reads from useUser() in the browser, also lands on the right

--- a/src/lib/db/cached-aggregates.ts
+++ b/src/lib/db/cached-aggregates.ts
@@ -65,6 +65,14 @@ export function publicProfileCacheKey(userId: string): string {
   return `petdex:profile:${userId}:v1`;
 }
 
+export function handleForUserCacheKey(userId: string): string {
+  return `petdex:handle-for-user:${userId}:v1`;
+}
+
+export function userIdForHandleCacheKey(handle: string): string {
+  return `petdex:user-id-for-handle:${handle.trim().toLowerCase()}:v1`;
+}
+
 export async function invalidatePetCaches(...slugs: string[]): Promise<void> {
   const keys = slugs.filter(Boolean).map((slug) => petCacheKey(slug));
   if (keys.length > 0) {
@@ -91,7 +99,22 @@ export async function invalidatePublicProfileCaches(
   ...userIds: string[]
 ): Promise<void> {
   await invalidateAggregates(
-    ...userIds.filter(Boolean).map((userId) => publicProfileCacheKey(userId)),
+    ...userIds
+      .filter(Boolean)
+      .flatMap((userId) => [
+        publicProfileCacheKey(userId),
+        handleForUserCacheKey(userId),
+      ]),
+  );
+}
+
+export async function invalidatePublicHandleCaches(
+  ...handles: Array<string | null | undefined>
+): Promise<void> {
+  await invalidateAggregates(
+    ...handles
+      .filter((handle): handle is string => Boolean(handle))
+      .map((handle) => userIdForHandleCacheKey(handle)),
   );
 }
 

--- a/src/lib/handles.ts
+++ b/src/lib/handles.ts
@@ -5,7 +5,14 @@
 
 import { clerkClient } from "@clerk/nextjs/server";
 
+import {
+  cachedAggregate,
+  handleForUserCacheKey,
+  userIdForHandleCacheKey,
+} from "@/lib/db/cached-aggregates";
+
 export const FALLBACK_HANDLE_LENGTH = 8;
+const HANDLE_CACHE_TTL_SECONDS = 300;
 
 export function fallbackHandle(userId: string): string {
   return userId.slice(-FALLBACK_HANDLE_LENGTH).toLowerCase();
@@ -14,6 +21,24 @@ export function fallbackHandle(userId: string): string {
 // Forward: userId -> handle. Used to build /u/<handle> URLs from a
 // pet's ownerId (e.g. credit chip, /my-pets header).
 export async function handleForUser(userId: string): Promise<string> {
+  const cached = await cachedAggregate(
+    {
+      key: handleForUserCacheKey(userId),
+      ttlSeconds: HANDLE_CACHE_TTL_SECONDS,
+    },
+    async () => resolveHandleForUser(userId, true),
+  );
+  return (
+    cached ??
+    (await resolveHandleForUser(userId, false)) ??
+    fallbackHandle(userId)
+  );
+}
+
+async function resolveHandleForUser(
+  userId: string,
+  cacheableOnly: boolean,
+): Promise<string | null> {
   try {
     const { db, schema } = await import("@/lib/db/client");
     const { eq } = await import("drizzle-orm");
@@ -23,6 +48,7 @@ export async function handleForUser(userId: string): Promise<string> {
     });
     if (profile?.handle) return profile.handle;
   } catch {
+    if (cacheableOnly) return null;
     /* ignore */
   }
 
@@ -31,6 +57,7 @@ export async function handleForUser(userId: string): Promise<string> {
     const u = await client.users.getUser(userId);
     if (u.username) return u.username.toLowerCase();
   } catch {
+    if (cacheableOnly) return null;
     /* ignore */
   }
   return fallbackHandle(userId);
@@ -46,6 +73,20 @@ export async function handleForUser(userId: string): Promise<string> {
 export async function userIdForHandle(handle: string): Promise<string | null> {
   const normalized = handle.trim().toLowerCase();
 
+  const cached = await cachedAggregate(
+    {
+      key: userIdForHandleCacheKey(normalized),
+      ttlSeconds: HANDLE_CACHE_TTL_SECONDS,
+    },
+    async () => resolveUserIdForHandle(normalized, true),
+  );
+  return cached ?? resolveUserIdForHandle(normalized, false);
+}
+
+async function resolveUserIdForHandle(
+  normalized: string,
+  cacheableOnly: boolean,
+): Promise<string | null> {
   try {
     const { db, schema } = await import("@/lib/db/client");
     const { eq } = await import("drizzle-orm");
@@ -55,6 +96,7 @@ export async function userIdForHandle(handle: string): Promise<string | null> {
     });
     if (profile?.userId) return profile.userId;
   } catch {
+    if (cacheableOnly) return null;
     /* fall through */
   }
 
@@ -67,6 +109,7 @@ export async function userIdForHandle(handle: string): Promise<string | null> {
     });
     if (list.data.length > 0) return list.data[0].id;
   } catch {
+    if (cacheableOnly) return null;
     /* fall through */
   }
 
@@ -78,55 +121,59 @@ export async function userIdForHandle(handle: string): Promise<string | null> {
     normalized.length === FALLBACK_HANDLE_LENGTH &&
     /^[a-z0-9]+$/.test(normalized)
   ) {
-    const { db, schema } = await import("@/lib/db/client");
-    const { sql } = await import("drizzle-orm");
-    // Same predicate against four tables. We use a single query per
-    // table because cross-table UNION through Drizzle is awkward, and
-    // four cheap indexed scans is plenty fast at our row counts.
-    const candidates = new Set<string>();
-    const fromPets = await db
-      .selectDistinct({ id: schema.submittedPets.ownerId })
-      .from(schema.submittedPets)
-      .where(
-        sql`lower(right(${schema.submittedPets.ownerId}, ${FALLBACK_HANDLE_LENGTH})) = ${normalized}`,
-      )
-      .limit(2);
-    for (const r of fromPets) candidates.add(r.id);
-
-    if (candidates.size < 2) {
-      const fromRequests = await db
-        .selectDistinct({ id: schema.petRequests.requestedBy })
-        .from(schema.petRequests)
+    try {
+      const { db, schema } = await import("@/lib/db/client");
+      const { sql } = await import("drizzle-orm");
+      // Same predicate against four tables. We use a single query per
+      // table because cross-table UNION through Drizzle is awkward, and
+      // four cheap indexed scans is plenty fast at our row counts.
+      const candidates = new Set<string>();
+      const fromPets = await db
+        .selectDistinct({ id: schema.submittedPets.ownerId })
+        .from(schema.submittedPets)
         .where(
-          sql`${schema.petRequests.requestedBy} IS NOT NULL AND lower(right(${schema.petRequests.requestedBy}, ${FALLBACK_HANDLE_LENGTH})) = ${normalized}`,
+          sql`lower(right(${schema.submittedPets.ownerId}, ${FALLBACK_HANDLE_LENGTH})) = ${normalized}`,
         )
         .limit(2);
-      for (const r of fromRequests) if (r.id) candidates.add(r.id);
-    }
+      for (const r of fromPets) candidates.add(r.id);
 
-    if (candidates.size < 2) {
-      const fromFeedback = await db
-        .selectDistinct({ id: schema.feedback.userId })
-        .from(schema.feedback)
-        .where(
-          sql`${schema.feedback.userId} IS NOT NULL AND lower(right(${schema.feedback.userId}, ${FALLBACK_HANDLE_LENGTH})) = ${normalized}`,
-        )
-        .limit(2);
-      for (const r of fromFeedback) if (r.id) candidates.add(r.id);
-    }
+      if (candidates.size < 2) {
+        const fromRequests = await db
+          .selectDistinct({ id: schema.petRequests.requestedBy })
+          .from(schema.petRequests)
+          .where(
+            sql`${schema.petRequests.requestedBy} IS NOT NULL AND lower(right(${schema.petRequests.requestedBy}, ${FALLBACK_HANDLE_LENGTH})) = ${normalized}`,
+          )
+          .limit(2);
+        for (const r of fromRequests) if (r.id) candidates.add(r.id);
+      }
 
-    if (candidates.size < 2) {
-      const fromProfiles = await db
-        .selectDistinct({ id: schema.userProfiles.userId })
-        .from(schema.userProfiles)
-        .where(
-          sql`lower(right(${schema.userProfiles.userId}, ${FALLBACK_HANDLE_LENGTH})) = ${normalized}`,
-        )
-        .limit(2);
-      for (const r of fromProfiles) candidates.add(r.id);
-    }
+      if (candidates.size < 2) {
+        const fromFeedback = await db
+          .selectDistinct({ id: schema.feedback.userId })
+          .from(schema.feedback)
+          .where(
+            sql`${schema.feedback.userId} IS NOT NULL AND lower(right(${schema.feedback.userId}, ${FALLBACK_HANDLE_LENGTH})) = ${normalized}`,
+          )
+          .limit(2);
+        for (const r of fromFeedback) if (r.id) candidates.add(r.id);
+      }
 
-    if (candidates.size === 1) return [...candidates][0];
+      if (candidates.size < 2) {
+        const fromProfiles = await db
+          .selectDistinct({ id: schema.userProfiles.userId })
+          .from(schema.userProfiles)
+          .where(
+            sql`lower(right(${schema.userProfiles.userId}, ${FALLBACK_HANDLE_LENGTH})) = ${normalized}`,
+          )
+          .limit(2);
+        for (const r of fromProfiles) candidates.add(r.id);
+      }
+
+      if (candidates.size === 1) return [...candidates][0];
+    } catch {
+      return null;
+    }
   }
 
   return null;


### PR DESCRIPTION
## Summary
- cache public userId-to-handle and handle-to-userId lookups with the existing Upstash helper
- invalidate user profile and handle caches together after profile handle edits
- avoid caching fallback values produced by transient DB or Clerk lookup failures

## Verification
- bun x biome check src/lib/db/cached-aggregates.ts src/lib/handles.ts src/app/api/profile/route.ts
- bun x tsc --noEmit --types bun-types
- git diff --check