### PR TITLE
perf(db): cache latest approved pets

### DIFF
--- a/src/lib/db/cached-aggregates.ts
+++ b/src/lib/db/cached-aggregates.ts
@@ -47,6 +47,7 @@ export const AGGREGATE_KEYS = {
   featuredPets: "petdex:agg:featured-pets:v1",
   dexNumbers: "petdex:agg:dex-numbers:v1",
   randomPetPool: "petdex:agg:random-pet-pool:v1",
+  latestApprovedPets: "petdex:agg:latest-approved-pets:v1",
 } as const;
 
 export function petCacheKey(slug: string): string {
@@ -82,6 +83,7 @@ export async function invalidatePetCaches(...slugs: string[]): Promise<void> {
       AGGREGATE_KEYS.featuredPets,
       AGGREGATE_KEYS.dexNumbers,
       AGGREGATE_KEYS.randomPetPool,
+      AGGREGATE_KEYS.latestApprovedPets,
     );
   }
   await invalidateAggregates(...keys);

--- a/src/lib/pets.ts
+++ b/src/lib/pets.ts
@@ -31,6 +31,7 @@ const EMPTY_METRICS: Metrics = {
 const PET_CACHE_TTL_SECONDS = 300;
 const APPROVED_CATALOG_TTL_SECONDS = 300;
 const FEATURED_PETS_TTL_SECONDS = 300;
+const LATEST_APPROVED_PETS_TTL_SECONDS = 300;
 
 type PetRow = Pick<
   typeof schema.submittedPets.$inferSelect,
@@ -216,6 +217,19 @@ export async function getApprovedPetsForManifest(): Promise<ApprovedPetSlim[]> {
 }
 
 export async function getLatestApprovedPets(limit = 5): Promise<PetdexPet[]> {
+  if (limit === 5) {
+    return cachedAggregate(
+      {
+        key: AGGREGATE_KEYS.latestApprovedPets,
+        ttlSeconds: LATEST_APPROVED_PETS_TTL_SECONDS,
+      },
+      async () => queryLatestApprovedPets(limit),
+    );
+  }
+  return queryLatestApprovedPets(limit);
+}
+
+async function queryLatestApprovedPets(limit: number): Promise<PetdexPet[]> {
   // approved_at is nullable (older curated rows have NULL). NULLS LAST so
   // freshly approved pets surface first; coalesce-on-tie via created_at.
   const rows = await db


### PR DESCRIPTION
## Summary
- cache the hot `getLatestApprovedPets(5)` read used by the zh promo strip
- keep non-default limits uncached instead of creating unbounded cache keys
- invalidate the latest approved pets cache with approved pet cache invalidation

## Verification
- bun x biome check src/lib/db/cached-aggregates.ts src/lib/pets.ts
- bun x tsc --noEmit --types bun-types
- git diff --check