### PR TITLE
perf(db): cache profile me lookup

### DIFF
--- a/src/app/api/profile/me/route.ts
+++ b/src/app/api/profile/me/route.ts
@@ -3,10 +3,21 @@ import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { eq } from "drizzle-orm";
 
+import {
+  cachedAggregate,
+  publicProfileCacheKey,
+} from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+
+const PROFILE_ME_TTL_SECONDS = 300;
+
+type ProfileMe = {
+  handle: string | null;
+  displayName: string | null;
+};
 
 // Returns the canonical profile fields the client components need
 // (handle, displayName) sourced from our DB, not Clerk metadata.
@@ -19,13 +30,27 @@ export async function GET(): Promise<Response> {
     return NextResponse.json({ handle: null, displayName: null });
   }
 
-  const profile = await db.query.userProfiles.findFirst({
-    where: eq(schema.userProfiles.userId, userId),
-    columns: { handle: true, displayName: true },
-  });
+  const profile = await cachedAggregate<ProfileMe>(
+    {
+      key: publicProfileCacheKey(userId),
+      ttlSeconds: PROFILE_ME_TTL_SECONDS,
+    },
+    async () => {
+      const storedProfile = await db.query.userProfiles.findFirst({
+        where: eq(schema.userProfiles.userId, userId),
+        columns: { handle: true, displayName: true },
+      });
+      return (
+        storedProfile ?? {
+          handle: null,
+          displayName: null,
+        }
+      );
+    },
+  );
 
   return NextResponse.json({
-    handle: profile?.handle ?? null,
-    displayName: profile?.displayName ?? null,
+    handle: profile.handle,
+    displayName: profile.displayName,
   });
 }


### PR DESCRIPTION
## Summary
- reuse the existing public profile Redis key for `/api/profile/me`
- cache missing profile rows as explicit null fields so signed-in page views do not keep hitting Neon
- keep the response shape and dynamic route behavior unchanged

## Verification
- bun x biome check src/app/api/profile/me/route.ts
- bun x tsc --noEmit --types bun-types
- git diff --check