### PR TITLE
perf(db): reuse pet cache in asset routes

### DIFF
--- a/src/app/api/pets/[slug]/sticker/route.ts
+++ b/src/app/api/pets/[slug]/sticker/route.ts
@@ -16,10 +16,8 @@
 
 import { NextResponse } from "next/server";
 
-import { eq } from "drizzle-orm";
-
-import { db, schema } from "@/lib/db/client";
 import type { PetStateId } from "@/lib/pet-states";
+import { getPet } from "@/lib/pets";
 import { renderSticker, type StickerFormat } from "@/lib/sticker-renderer";
 import { isAllowedAssetUrl } from "@/lib/url-allowlist";
 
@@ -65,22 +63,19 @@ export async function GET(
   const format = parseFormat(url.searchParams.get("format"));
   const isDownload = url.searchParams.get("download") === "1";
 
-  const pet = await db.query.submittedPets.findFirst({
-    where: eq(schema.submittedPets.slug, slug),
-    columns: { spritesheetUrl: true, status: true, displayName: true },
-  });
+  const pet = await getPet(slug);
 
-  if (!pet || pet.status !== "approved") {
+  if (!pet) {
     return new NextResponse("not found", { status: 404 });
   }
 
-  if (!isAllowedAssetUrl(pet.spritesheetUrl)) {
+  if (!isAllowedAssetUrl(pet.spritesheetPath)) {
     return new NextResponse("forbidden", { status: 403 });
   }
 
   let result: Awaited<ReturnType<typeof renderSticker>>;
   try {
-    result = await renderSticker(pet.spritesheetUrl, { state, format });
+    result = await renderSticker(pet.spritesheetPath, { state, format });
   } catch (err) {
     const message =
       err instanceof Error && err.message.startsWith("upstream")

--- a/src/app/api/pets/[slug]/thumb/route.ts
+++ b/src/app/api/pets/[slug]/thumb/route.ts
@@ -10,10 +10,9 @@
 
 import { NextResponse } from "next/server";
 
-import { eq } from "drizzle-orm";
 import sharp from "sharp";
 
-import { db, schema } from "@/lib/db/client";
+import { getPet } from "@/lib/pets";
 import { isAllowedAssetUrl } from "@/lib/url-allowlist";
 
 export const runtime = "nodejs";
@@ -39,22 +38,19 @@ export async function GET(
 ): Promise<Response> {
   const { slug } = await ctx.params;
 
-  const pet = await db.query.submittedPets.findFirst({
-    where: eq(schema.submittedPets.slug, slug),
-    columns: { spritesheetUrl: true, status: true },
-  });
+  const pet = await getPet(slug);
 
-  if (!pet || pet.status !== "approved") {
+  if (!pet) {
     return new NextResponse("not found", { status: 404 });
   }
 
-  if (!isAllowedAssetUrl(pet.spritesheetUrl)) {
+  if (!isAllowedAssetUrl(pet.spritesheetPath)) {
     return new NextResponse("forbidden", { status: 403 });
   }
 
   let buf: Buffer;
   try {
-    const res = await fetch(pet.spritesheetUrl, { redirect: "error" });
+    const res = await fetch(pet.spritesheetPath, { redirect: "error" });
     if (!res.ok) {
       return new NextResponse("upstream", { status: 502 });
     }


### PR DESCRIPTION
## Summary
- route thumbnail metadata through the existing cached `getPet(slug)` lookup
- route sticker metadata through the same cached pet lookup
- remove direct `submitted_pets` reads for asset routes that only need approved slug metadata

## Verification
- bun x biome check src/app/api/pets/[slug]/thumb/route.ts src/app/api/pets/[slug]/sticker/route.ts
- bun x tsc --noEmit --types bun-types
- git diff --check