### PR TITLE
perf(db): cache dex neighbor names

### DIFF
--- a/src/app/[locale]/pets/[slug]/page.tsx
+++ b/src/app/[locale]/pets/[slug]/page.tsx
@@ -1,14 +1,14 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
-import { eq, inArray } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { Layers, Shuffle, Sparkles } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 
 import { getCollectionsContainingPet } from "@/lib/collections";
 import { db, schema } from "@/lib/db/client";
 import { getMetricsForSlug, getMetricsSummary } from "@/lib/db/metrics";
-import { formatDexNumber, getDexNumberMap } from "@/lib/dex";
+import { formatDexNumber, getDexEntryMap } from "@/lib/dex";
 import { formatLocalizedNumber } from "@/lib/format-number";
 import { buildLocaleAlternates } from "@/lib/locale-routing";
 import { resolveStoredOwnerCreditFor } from "@/lib/owner-credit";
@@ -131,50 +131,34 @@ export default async function PetPage({ params }: PageProps) {
     notFound();
   }
 
-  const dexMap = await getDexNumberMap();
-  const currentDexNumber = dexMap.get(slug) ?? null;
+  const dexMap = await getDexEntryMap();
+  const currentDexNumber = dexMap.get(slug)?.dexNumber ?? null;
 
   let prevSlug: string | null = null;
   let nextSlug: string | null = null;
   if (currentDexNumber != null) {
-    for (const [entrySlug, dexNumber] of dexMap.entries()) {
-      if (dexNumber === currentDexNumber - 1) prevSlug = entrySlug;
-      if (dexNumber === currentDexNumber + 1) nextSlug = entrySlug;
+    for (const [entrySlug, entry] of dexMap.entries()) {
+      if (entry.dexNumber === currentDexNumber - 1) prevSlug = entrySlug;
+      if (entry.dexNumber === currentDexNumber + 1) nextSlug = entrySlug;
     }
   }
 
-  const neighborSlugs = [prevSlug, nextSlug].filter((value): value is string =>
-    Boolean(value),
-  );
-  const neighborRows =
-    neighborSlugs.length > 0
-      ? await db
-          .select({
-            slug: schema.submittedPets.slug,
-            displayName: schema.submittedPets.displayName,
-          })
-          .from(schema.submittedPets)
-          .where(inArray(schema.submittedPets.slug, neighborSlugs))
-      : [];
-  const neighborNameMap = new Map(
-    neighborRows.map((row) => [row.slug, row.displayName]),
-  );
-  const prevDexNumber = prevSlug ? dexMap.get(prevSlug) : undefined;
-  const nextDexNumber = nextSlug ? dexMap.get(nextSlug) : undefined;
+  const prevEntry = prevSlug ? dexMap.get(prevSlug) : undefined;
+  const nextEntry = nextSlug ? dexMap.get(nextSlug) : undefined;
   const prevPet =
-    prevSlug && prevDexNumber !== undefined
+    prevSlug && prevEntry
       ? {
           slug: prevSlug,
-          displayName: neighborNameMap.get(prevSlug) ?? prevSlug,
-          dexNumber: prevDexNumber,
+          displayName: prevEntry.displayName,
+          dexNumber: prevEntry.dexNumber,
         }
       : null;
   const nextPet =
-    nextSlug && nextDexNumber !== undefined
+    nextSlug && nextEntry
       ? {
           slug: nextSlug,
-          displayName: neighborNameMap.get(nextSlug) ?? nextSlug,
-          dexNumber: nextDexNumber,
+          displayName: nextEntry.displayName,
+          dexNumber: nextEntry.dexNumber,
         }
       : null;
 

--- a/src/lib/db/cached-aggregates.ts
+++ b/src/lib/db/cached-aggregates.ts
@@ -45,7 +45,7 @@ export const AGGREGATE_KEYS = {
   slimManifest: "petdex:agg:slim-manifest:v1",
   metricsIndex: "petdex:agg:metrics-index:v1",
   featuredPets: "petdex:agg:featured-pets:v1",
-  dexNumbers: "petdex:agg:dex-numbers:v1",
+  dexNumbers: "petdex:agg:dex-numbers:v2",
   randomPetPool: "petdex:agg:random-pet-pool:v1",
   latestApprovedPets: "petdex:agg:latest-approved-pets:v1",
 } as const;

--- a/src/lib/dex.ts
+++ b/src/lib/dex.ts
@@ -21,7 +21,7 @@ import { AGGREGATE_KEYS, cachedAggregate } from "@/lib/db/cached-aggregates";
 import { db } from "@/lib/db/client";
 import { withNextDataCache } from "@/lib/next-data-cache";
 
-export type DexEntry = { slug: string; dexNumber: number };
+export type DexEntry = { slug: string; displayName: string; dexNumber: number };
 const DEX_NUMBERS_TTL_SECONDS = 300;
 
 const getDexEntries = withNextDataCache(
@@ -34,32 +34,48 @@ const getDexEntries = withNextDataCache(
       async () => {
         const result = (await db.execute(sql`
         SELECT slug,
+               display_name,
                ROW_NUMBER() OVER (ORDER BY approved_at ASC, created_at ASC)::int AS dex_number
         FROM submitted_pets
         WHERE status = 'approved'
           AND source <> 'discover'
       `)) as unknown as {
-          rows: Array<{ slug: string; dex_number: number }>;
+          rows: Array<{
+            slug: string;
+            display_name: string;
+            dex_number: number;
+          }>;
         };
 
         return result.rows.map((row) => ({
           slug: row.slug,
+          displayName: row.display_name,
           dexNumber: row.dex_number,
         }));
       },
     );
   },
-  ["petdex-dex-numbers"],
+  ["petdex-dex-numbers-v2"],
   { tags: ["petdex:dex"], revalidate: 300 },
 );
 
 // Cached for the lifetime of a single render pass — every call inside
 // one request returns the same Map without rebuilding it. The underlying
 // ROW_NUMBER query is cached across requests by Next's data cache.
+export const getDexEntryMap = cache(
+  async (): Promise<Map<string, DexEntry>> => {
+    const out = new Map<string, DexEntry>();
+    for (const row of await getDexEntries()) {
+      out.set(row.slug, row);
+    }
+    return out;
+  },
+);
+
 export const getDexNumberMap = cache(async (): Promise<Map<string, number>> => {
   const out = new Map<string, number>();
-  for (const row of await getDexEntries()) {
-    out.set(row.slug, row.dexNumber);
+  for (const [slug, row] of await getDexEntryMap()) {
+    out.set(slug, row.dexNumber);
   }
   return out;
 });


### PR DESCRIPTION
## Summary
- include display names in the cached dex index and bump the Redis/Next cache keys for the new shape
- derive pet detail prev/next labels from the cached dex index
- remove the per-render `submitted_pets where slug in (...)` neighbor-name query

## Verification
- bun x biome check src/lib/db/cached-aggregates.ts src/lib/dex.ts src/app/[locale]/pets/[slug]/page.tsx
- bun x tsc --noEmit --types bun-types
- git diff --check