### PR TITLE
perf(db): cache pet owner credit

### DIFF
--- a/src/app/[locale]/pets/[slug]/page.tsx
+++ b/src/app/[locale]/pets/[slug]/page.tsx
@@ -1,17 +1,15 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
-import { eq } from "drizzle-orm";
 import { Layers, Shuffle, Sparkles } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 
 import { getCollectionsContainingPet } from "@/lib/collections";
-import { db, schema } from "@/lib/db/client";
 import { getMetricsForSlug, getMetricsSummary } from "@/lib/db/metrics";
 import { formatDexNumber, getDexEntryMap } from "@/lib/dex";
 import { formatLocalizedNumber } from "@/lib/format-number";
 import { buildLocaleAlternates } from "@/lib/locale-routing";
-import { resolveStoredOwnerCreditFor } from "@/lib/owner-credit";
+import { resolveStoredOwnerCreditForSlug } from "@/lib/owner-credit";
 import { computeStatsFromSummary } from "@/lib/pet-stats";
 import { getPet, getStaticPetSlugs } from "@/lib/pets";
 import { getVariantsFor } from "@/lib/variants";
@@ -162,23 +160,20 @@ export default async function PetPage({ params }: PageProps) {
         }
       : null;
 
-  const [metrics, metricsSummary, ownerRow, variants, memberOfCollections] =
-    await Promise.all([
-      getMetricsForSlug(slug),
-      getMetricsSummary(),
-      db.query.submittedPets.findFirst({
-        columns: {
-          ownerId: true,
-          creditName: true,
-          creditUrl: true,
-          creditImage: true,
-          source: true,
-        },
-        where: eq(schema.submittedPets.slug, slug),
-      }),
-      getVariantsFor(slug),
-      getCollectionsContainingPet(slug),
-    ]);
+  const [
+    metrics,
+    metricsSummary,
+    ownerCreditResult,
+    variants,
+    memberOfCollections,
+  ] = await Promise.all([
+    getMetricsForSlug(slug),
+    getMetricsSummary(),
+    resolveStoredOwnerCreditForSlug(slug),
+    getVariantsFor(slug),
+    getCollectionsContainingPet(slug),
+  ]);
+  const ownerCredit = ownerCreditResult?.credit ?? null;
   const stats = computeStatsFromSummary(
     {
       importedAt: pet.importedAt,
@@ -186,29 +181,6 @@ export default async function PetPage({ params }: PageProps) {
     },
     metricsSummary,
   );
-
-  // Resolve public credit from local data so the ISR shell is not blocked by
-  // a per-request Clerk lookup. Profile sync keeps userProfiles fresh enough.
-  const ownerCredit = ownerRow
-    ? await resolveStoredOwnerCreditFor({
-        ownerId: ownerRow.ownerId,
-        creditName: ownerRow.creditName,
-        creditUrl: ownerRow.creditUrl,
-        // Discovered rows can carry a stale credit_image from the seed
-        // import that belongs to a *different* user (the importer's
-        // primary login or whichever Clerk profile was active during
-        // the bulk insert). Drop it for discovered rows so we never
-        // show another person's avatar; we still show the right name +
-        // GitHub url because those came from the seed enrichment.
-        creditImage:
-          ownerRow.source === "discover" ? null : ownerRow.creditImage,
-        // For 'discover' rows the ownerId is the admin who imported
-        // on the author's behalf, NOT the author. Use stored credit_*
-        // exclusively so the author keeps the byline. Claimed/submit rows
-        // use stored credit plus local userProfiles so this route stays ISR.
-        ownerIsProxy: ownerRow.source === "discover",
-      })
-    : null;
 
   const url = `${SITE_URL}/pets/${pet.slug}`;
   const jsonLd = [
@@ -515,7 +487,7 @@ export default async function PetPage({ params }: PageProps) {
         {ownerCredit ? (
           <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <SubmittedBy credit={ownerCredit} />
-            {ownerRow?.source === "discover" ? (
+            {ownerCreditResult?.ownerIsProxy ? (
               <ClaimCTA
                 petName={pet.displayName}
                 authorLabel={ownerCredit.name}

--- a/src/app/api/my-pets/claim/route.ts
+++ b/src/app/api/my-pets/claim/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import { and, eq, ne, or, sql } from "drizzle-orm";
 
+import { invalidatePetCaches } from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import { claimRatelimit } from "@/lib/ratelimit";
 import { requireSameOrigin } from "@/lib/same-origin";
@@ -150,6 +151,7 @@ export async function POST(req: Request): Promise<Response> {
     .update(schema.submittedPets)
     .set(update)
     .where(eq(schema.submittedPets.id, id));
+  await invalidatePetCaches(row.slug);
 
   return NextResponse.json({ ok: true, slug: row.slug });
 }

--- a/src/lib/db/cached-aggregates.ts
+++ b/src/lib/db/cached-aggregates.ts
@@ -62,6 +62,10 @@ export function petMetricsCacheKey(slug: string): string {
   return `petdex:metrics:${slug}:v1`;
 }
 
+export function petOwnerCreditCacheKey(slug: string): string {
+  return `petdex:pet-owner-credit:${slug}:v1`;
+}
+
 export function publicProfileCacheKey(userId: string): string {
   return `petdex:profile:${userId}:v1`;
 }
@@ -77,6 +81,9 @@ export function userIdForHandleCacheKey(handle: string): string {
 export async function invalidatePetCaches(...slugs: string[]): Promise<void> {
   const keys = slugs.filter(Boolean).map((slug) => petCacheKey(slug));
   if (keys.length > 0) {
+    keys.push(
+      ...slugs.filter(Boolean).map((slug) => petOwnerCreditCacheKey(slug)),
+    );
     keys.push(
       AGGREGATE_KEYS.approvedCatalog,
       AGGREGATE_KEYS.slimManifest,

--- a/src/lib/db/metrics.ts
+++ b/src/lib/db/metrics.ts
@@ -150,7 +150,12 @@ const getMetricsIndexRows = cache(async (): Promise<MetricsIndexRow[]> => {
       ttlSeconds: METRICS_INDEX_TTL_SECONDS,
     },
     async () => {
-      const rows = await db.select().from(schema.petMetrics);
+      let rows: Array<typeof schema.petMetrics.$inferSelect>;
+      try {
+        rows = await db.select().from(schema.petMetrics);
+      } catch {
+        return [];
+      }
       return rows.map((row) => ({
         petSlug: row.petSlug,
         installCount: row.installCount,

--- a/src/lib/owner-credit.ts
+++ b/src/lib/owner-credit.ts
@@ -15,10 +15,11 @@
 import { cache } from "react";
 
 import { clerkClient } from "@clerk/nextjs/server";
-import { inArray } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import {
   cachedAggregate,
+  petOwnerCreditCacheKey,
   publicProfileCacheKey,
 } from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
@@ -60,12 +61,18 @@ export type RowCreditFallback = {
   ownerIsProxy?: boolean;
 };
 
+export type StoredOwnerCredit = {
+  credit: OwnerCredit;
+  ownerIsProxy: boolean;
+};
+
 type StoredPublicProfile = {
   displayName: string | null;
   handle: string | null;
 };
 
 const PUBLIC_PROFILE_TTL_SECONDS = 300;
+const PET_OWNER_CREDIT_TTL_SECONDS = 300;
 
 function fallbackHandle(userId: string): string {
   return userId.slice(-8).toLowerCase();
@@ -311,6 +318,46 @@ export async function resolveStoredOwnerCreditFor(
     username: null,
     externals,
     imageUrl: row.creditImage,
+  };
+}
+
+export async function resolveStoredOwnerCreditForSlug(
+  slug: string,
+): Promise<StoredOwnerCredit | null> {
+  const row = await cachedAggregate<RowCreditFallback | null>(
+    {
+      key: petOwnerCreditCacheKey(slug),
+      ttlSeconds: PET_OWNER_CREDIT_TTL_SECONDS,
+    },
+    async () => {
+      const stored = await db.query.submittedPets.findFirst({
+        columns: {
+          ownerId: true,
+          creditName: true,
+          creditUrl: true,
+          creditImage: true,
+          source: true,
+        },
+        where: and(
+          eq(schema.submittedPets.slug, slug),
+          eq(schema.submittedPets.status, "approved"),
+        ),
+      });
+      if (!stored) return null;
+      return {
+        ownerId: stored.ownerId,
+        creditName: stored.creditName,
+        creditUrl: stored.creditUrl,
+        creditImage: stored.source === "discover" ? null : stored.creditImage,
+        ownerIsProxy: stored.source === "discover",
+      };
+    },
+  );
+
+  if (!row) return null;
+  return {
+    credit: await resolveStoredOwnerCreditFor(row),
+    ownerIsProxy: Boolean(row.ownerIsProxy),
   };
 }
 


### PR DESCRIPTION
## Summary
- cache the pet detail owner-credit row by slug with the existing pet cache invalidation path
- keep discover/proxy ownership behavior for the claim CTA
- invalidate the new owner-credit cache from the claim flow
- make the batch metrics index fail-soft so prerender does not fail when Neon is briefly unavailable on a cold cache

## Verification
- bun x biome check src/lib/db/cached-aggregates.ts src/lib/owner-credit.ts src/lib/db/metrics.ts src/app/api/my-pets/claim/route.ts src/app/[locale]/pets/[slug]/page.tsx
- bun x tsc --noEmit --types bun-types
- git diff --check