### PR TITLE
fix: improve pet radar label spacing and visibility

### DIFF
--- a/src/components/pet-radar.tsx
+++ b/src/components/pet-radar.tsx
@@ -69,7 +69,7 @@ export function PetRadar(props: PetRadarProps) {
   return (
     <svg
       viewBox={`0 0 ${SIZE} ${SIZE}`}
-      className="mx-auto block aspect-square h-auto w-full max-w-[200px]"
+      className="mx-auto block aspect-square h-auto w-full max-w-[200px] overflow-visible"
       role="img"
       aria-label={props.ariaLabel}
     >

--- a/src/components/pet-radar.tsx
+++ b/src/components/pet-radar.tsx
@@ -28,7 +28,7 @@ const AXES = [
     key: "popularity",
     pointDx: 88,
     pointDy: 0,
-    labelX: 160,
+    labelX: 174,
     labelY: CENTER,
   },
   {
@@ -42,7 +42,7 @@ const AXES = [
     key: "freshness",
     pointDx: -88,
     pointDy: 0,
-    labelX: 40,
+    labelX: 26,
     labelY: CENTER,
   },
 ] as const satisfies ReadonlyArray<{


### PR DESCRIPTION
## Summary

- Allow the pet radar SVG labels to render outside the SVG viewport
- Move the left and right labels farther from the radar diamond
- Improve readability for `FRESHNESS` and `POPULARITY`

## Testing

- Visually verified the pet stats card in the browser

## Visual Proof


- These images show the pet radar at its smallest rendered width. I also checked the layout through the widest rendered width and confirmed the labels stay visible.


Before:

<img width="377" height="331" alt="image" src="https://github.com/user-attachments/assets/bf53cfca-4a2d-4eb5-91c0-bd9578c36203" />

After:
<img width="374" height="323" alt="image" src="https://github.com/user-attachments/assets/b91ef8a9-8ef6-41ef-af49-6d527a62d587" />
