### PR TITLE
fix(security): fix critical vulnerability: harden generated pet install scripts

### DIFF
--- a/src/lib/install-script-render.ts
+++ b/src/lib/install-script-render.ts
@@ -6,18 +6,23 @@ export type ResolvedPet = {
   spriteExt: "webp" | "png";
 };
 
+function singleLine(value: string): string {
+  return String(value).replace(/[\u0000-\u001f\u007f]+/g, " ").trim();
+}
+
+function quotePosix(value: string): string {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
+function quotePowerShell(value: string): string {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
 export function posixInstallScript(pet: ResolvedPet): string {
   const { slug, displayName, petJsonUrl, spritesheetUrl, spriteExt } = pet;
-  // POSIX hard-quote: wrap in single-quotes and replace each ' with '\''.
-  // After this every value, even something like
-  //   "'; rm -rf $HOME; echo '"
-  // is just an opaque string to /bin/sh.
-  const q = (s: string) => `'${String(s).replace(/'/g, "'\\''")}'`;
-  // Comment lines must also strip newlines so a displayName with a literal
-  // \n can't break out into a fresh shell command.
-  const safeName = String(displayName).replace(/[\r\n]+/g, " ");
-  // Filename within $PET_DIR — strict slug already, but pin the regex so a
-  // freak DB row can't produce path traversal.
+  const displayNameText = singleLine(displayName);
+  // Filename within $PET_DIR - strict slug already, but pin the regex so a
+  // bad legacy DB row cannot produce path traversal.
   const safeSlug = String(slug).replace(/[^a-z0-9-]/g, "");
   const safeExt = spriteExt === "png" ? "png" : "webp";
   return [
@@ -28,14 +33,15 @@ export function posixInstallScript(pet: ResolvedPet): string {
     "set -e",
     "",
     `PET_DIR="$HOME/.codex/pets/${safeSlug}"`,
+    `DISPLAY_NAME=${quotePosix(displayNameText)}`,
     "",
-    `echo "Installing ${safeName.replace(/"/g, "")} into $PET_DIR"`,
+    'printf "Installing %s into %s\\n" "$DISPLAY_NAME" "$PET_DIR"',
     'mkdir -p "$PET_DIR"',
     "",
-    `curl -fsSL -o "$PET_DIR/pet.json" ${q(petJsonUrl)}`,
-    `curl -fsSL -o "$PET_DIR/spritesheet.${safeExt}" ${q(spritesheetUrl)}`,
+    `curl -fsSL -o "$PET_DIR/pet.json" ${quotePosix(petJsonUrl)}`,
+    `curl -fsSL -o "$PET_DIR/spritesheet.${safeExt}" ${quotePosix(spritesheetUrl)}`,
     "",
-    `echo "Installed: ${safeName.replace(/"/g, "")}"`,
+    'printf "Installed: %s\\n" "$DISPLAY_NAME"',
     'echo "  Path: $PET_DIR"',
     'echo ""',
     'echo "Activate it inside Codex:"',
@@ -48,27 +54,24 @@ export function posixInstallScript(pet: ResolvedPet): string {
 
 export function powershellInstallScript(pet: ResolvedPet): string {
   const { slug, displayName, petJsonUrl, spritesheetUrl, spriteExt } = pet;
-  // PowerShell single-quoted hard-quote: ' -> ''.
-  const q = (s: string) => `'${String(s).replace(/'/g, "''")}'`;
   const safeSlug = String(slug).replace(/[^a-z0-9-]/g, "");
   const safeExt = spriteExt === "png" ? "png" : "webp";
-  // Strip newlines / quotes from the display name before echoing.
-  const safeName = String(displayName).replace(/[\r\n"]+/g, " ");
+  const displayNameText = singleLine(displayName);
   return [
     "# Petdex installer",
     `# https://petdex.crafter.run/pets/${safeSlug}`,
     "",
     "$ErrorActionPreference = 'Stop'",
-    `$slug = ${q(safeSlug)}`,
+    `$slug = ${quotePowerShell(safeSlug)}`,
     "$petDir = Join-Path $HOME (Join-Path '.codex' (Join-Path 'pets' $slug))",
     "",
-    `Write-Host ${q(`Installing ${safeName} into `)}$petDir`,
+    `Write-Host ${quotePowerShell(`Installing ${displayNameText} into `)}$petDir`,
     "New-Item -ItemType Directory -Force -Path $petDir | Out-Null",
     "",
-    `Invoke-WebRequest -Uri ${q(petJsonUrl)} -OutFile (Join-Path $petDir 'pet.json') -UseBasicParsing`,
-    `Invoke-WebRequest -Uri ${q(spritesheetUrl)} -OutFile (Join-Path $petDir ${q(`spritesheet.${safeExt}`)}) -UseBasicParsing`,
+    `Invoke-WebRequest -Uri ${quotePowerShell(petJsonUrl)} -OutFile (Join-Path $petDir 'pet.json') -UseBasicParsing`,
+    `Invoke-WebRequest -Uri ${quotePowerShell(spritesheetUrl)} -OutFile (Join-Path $petDir ${quotePowerShell(`spritesheet.${safeExt}`)}) -UseBasicParsing`,
     "",
-    `Write-Host ${q(`Installed: ${safeName}`)}`,
+    `Write-Host ${quotePowerShell(`Installed: ${displayNameText}`)}`,
     'Write-Host "  Path: $petDir"',
     'Write-Host ""',
     'Write-Host "Activate it inside Codex:"',

--- a/src/lib/security.test.ts
+++ b/src/lib/security.test.ts
@@ -4,6 +4,16 @@
 
 import { describe, expect, it } from "bun:test";
 import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   posixInstallScript,
@@ -138,9 +148,8 @@ describe("posixInstallScript shell-injection", () => {
   it("escapes single quotes in URLs (sh syntax-checks clean)", () => {
     if (!shAvailable) return;
 
-    // If our hard-quoting was wrong, the script wouldn't parse — `sh -n`
-    // would surface a syntax error. We don't actually run it (would touch
-    // the filesystem); we only prove the tokenization round-trips.
+    // If our hard-quoting was wrong, the script would not parse. `sh -n`
+    // catches that without running the installer body.
     const evilUrl = "https://x.com/a'; rm -rf /; echo '";
     const script = posixInstallScript({ ...safeBase, petJsonUrl: evilUrl });
     const r = spawnSync("sh", ["-n"], { input: script, encoding: "utf8" });
@@ -159,6 +168,58 @@ describe("posixInstallScript shell-injection", () => {
       displayName: "Boba\nrm -rf $HOME",
     });
     expect(script).not.toMatch(/\nrm -rf/);
+  });
+
+  it("treats displayName command substitutions as text", () => {
+    if (!shAvailable) return;
+
+    const tempDir = mkdtempSync(join(tmpdir(), "petdex-install-"));
+    try {
+      const marker = join(tempDir, "pwned");
+      const backtickMarker = `${marker}-backtick`;
+      const binDir = join(tempDir, "bin");
+      mkdirSync(binDir);
+      const curlPath = join(binDir, "curl");
+      writeFileSync(
+        curlPath,
+        [
+          "#!/bin/sh",
+          "out=",
+          'while [ "$#" -gt 0 ]; do',
+          '  if [ "$1" = "-o" ]; then',
+          "    shift",
+          '    out="$1"',
+          "  fi",
+          "  shift",
+          "done",
+          'mkdir -p "$(dirname "$out")"',
+          'printf \'{}\\n\' > "$out"',
+          "",
+        ].join("\n"),
+      );
+      chmodSync(curlPath, 0o755);
+
+      const script = posixInstallScript({
+        ...safeBase,
+        displayName: `Boba $(touch ${marker}) \`touch ${backtickMarker}\``,
+      });
+      const result = spawnSync("sh", [], {
+        input: script,
+        env: {
+          ...process.env,
+          HOME: tempDir,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        },
+        encoding: "utf8",
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(existsSync(marker)).toBe(false);
+      expect(existsSync(backtickMarker)).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("notFound script also strips slug", () => {
@@ -229,7 +290,7 @@ describe("isSameOrigin (CSRF guard)", () => {
   });
 
   it("allows non-browser callers (no Origin, no Sec-Fetch)", () => {
-    // curl, server-to-server fetch — they auth via bearer instead.
+    // curl, server-to-server fetch - they auth via bearer instead.
     expect(isSameOrigin(reqWith({ "user-agent": "curl/8.0" }))).toBe(true);
   });
 


### PR DESCRIPTION
### Motivation

The generated pet installer is intended to be run as `curl ... | sh`, so any untrusted metadata that reaches shell syntax is a critical arbitrary command execution path on the installer's machine.

Current `main` already blocks off-allowlist asset URLs and strips newlines from display names, but POSIX command substitution still runs inside double-quoted `echo` output. A submitted display name such as `Boba $(touch /tmp/pwned)` or one containing backticks is still command execution when a user runs the generated installer.

### Description

- Moves POSIX display names into a hard-quoted shell variable and prints via `printf`, so `$(...)`, backticks, quotes, and shell metacharacters are treated as text.
- Keeps display names out of shell comments and normalizes control characters before user-facing output.
- Keeps installer asset URLs hard-quoted and continues to rely on the existing `isAllowedAssetUrl` check before install scripts are generated.
- Factors POSIX and PowerShell quoting into small helpers in `src/lib/install-script-render.ts`.

### Testing

- Added a regression test that runs the POSIX installer with a stubbed `curl` and a malicious `displayName` containing both `$(touch ...)` and backtick command substitution, then asserts no marker files are created.
- Existing URL quote-break, newline, slug, allowlist, and PowerShell escaping coverage remains in `src/lib/security.test.ts`.

I could not run local tests from this Codex desktop session because the read-only sandbox fails before launching shell commands (`bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`).