### PR TITLE
feat(download): reframe desktop activation flow

### DIFF
--- a/src/app/[locale]/download/page.tsx
+++ b/src/app/[locale]/download/page.tsx
@@ -5,18 +5,23 @@ import {
   ArrowRight,
   CheckCircle,
   Clock,
+  Command,
   MonitorSmartphone,
   Pointer,
+  ShieldCheck,
+  Sparkles,
   Zap,
 } from "lucide-react";
 import { getLocale, getTranslations } from "next-intl/server";
 
 import { buildLocaleAlternates } from "@/lib/locale-routing";
+import { getPet } from "@/lib/pets";
 
 import { CommandLine } from "@/components/command-line";
 import { DownloadCTA } from "@/components/download-cta";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
+import { StaticPetSprite } from "@/components/static-pet-sprite";
 
 import { hasLocale } from "@/i18n/config";
 import { buildSetupSteps, parsePendingInstallSlugs } from "./setup-steps";
@@ -81,6 +86,20 @@ export default async function DownloadPage({
   const locale = await getLocale();
   const params = await searchParams;
   const pendingInstallSlugs = parsePendingInstallSlugs(params.next);
+  const activationCommand =
+    pendingInstallSlugs && pendingInstallSlugs.length > 0
+      ? `npx petdex init && npx petdex install ${pendingInstallSlugs.join(" ")}`
+      : "npx petdex init";
+  const pendingLabel =
+    pendingInstallSlugs && pendingInstallSlugs.length > 0
+      ? pendingInstallSlugs.length === 1
+        ? pendingInstallSlugs[0]
+        : pendingInstallSlugs.join(", ")
+      : null;
+  const pendingPreviewPet = pendingInstallSlugs?.[0]
+    ? await getPet(pendingInstallSlugs[0])
+    : undefined;
+  const pendingPreviewName = pendingPreviewPet?.displayName ?? pendingLabel;
 
   const features = [
     {
@@ -118,69 +137,96 @@ export default async function DownloadPage({
     },
   ];
 
+  const activationItems = [
+    {
+      icon: Command,
+      label: t("activation.items.hooks"),
+    },
+    {
+      icon: ShieldCheck,
+      label: t("activation.items.desktop"),
+    },
+    {
+      icon: Sparkles,
+      label: t("activation.items.pet"),
+    },
+  ];
+
   return (
     <main className="relative min-h-dvh bg-background text-foreground">
-      <div
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-x-0 top-0 h-[760px] overflow-clip"
-      >
-        <div className="absolute -top-40 left-1/2 size-[900px] -translate-x-1/2 rounded-full bg-[radial-gradient(closest-side,oklch(from_var(--brand)_l_c_h/0.18),transparent_70%)] blur-3xl dark:bg-[radial-gradient(closest-side,oklch(from_var(--brand)_l_c_h/0.16),transparent_70%)]" />
-        <div className="absolute top-32 left-[8%] size-[480px] rounded-full bg-[radial-gradient(closest-side,oklch(from_var(--brand-light)_l_c_h/0.22),transparent_75%)] blur-3xl dark:bg-[radial-gradient(closest-side,oklch(from_var(--gradient-a)_l_c_h/0.3),transparent_75%)] dark:opacity-50" />
-        <div className="absolute top-52 right-[6%] size-[420px] rounded-full bg-[radial-gradient(closest-side,oklch(from_var(--brand-deep)_l_c_h/0.18),transparent_75%)] blur-3xl dark:bg-[radial-gradient(closest-side,oklch(from_var(--gradient-b)_l_c_h/0.25),transparent_75%)] dark:opacity-50" />
-      </div>
-
       <SiteHeader />
 
-      {pendingInstallSlugs && pendingInstallSlugs.length > 0 ? (
-        <div className="relative z-10 border-border-base/60 border-b bg-brand/10 backdrop-blur-sm">
-          <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-1 px-5 py-3 md:flex-row md:items-center md:gap-3 md:px-8">
-            <p className="text-sm text-foreground">
-              <span className="font-semibold text-brand">
-                {t("pendingPet.eyebrow")}
-              </span>{" "}
-              {t("pendingPet.messageBefore")}{" "}
-              <code className="rounded bg-surface-muted px-1.5 py-0.5 font-mono text-xs">
-                {pendingInstallSlugs.length === 1
-                  ? pendingInstallSlugs[0]
-                  : pendingInstallSlugs.join(", ")}
-              </code>{" "}
-              {t("pendingPet.messageAfter")}
+      <section className="mx-auto w-full max-w-[1440px] px-5 pt-10 pb-12 md:px-8 md:pt-16">
+        <div className="grid min-w-0 items-center gap-10 lg:grid-cols-[minmax(0,0.95fr)_minmax(420px,1fr)]">
+          <div className="min-w-0 max-w-2xl">
+            <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
+              {t("eyebrow")}
             </p>
-            <p className="text-xs text-muted-2 md:ml-auto">
-              {t("pendingPet.hint")}
+            <h1 className="mt-3 text-pretty text-[40px] leading-[0.98] font-semibold tracking-tight sm:text-[52px] md:text-[72px]">
+              {t("title")}
+            </h1>
+            <p className="mt-5 max-w-xl text-pretty text-base leading-7 text-muted-1 md:text-lg">
+              {t("subtitle")}
             </p>
-          </div>
-        </div>
-      ) : null}
 
-      <section className="mx-auto w-full max-w-[1440px] px-5 pt-16 pb-12 md:px-8 md:pt-24">
-        <div className="flex flex-col items-center text-center">
-          <div className="relative size-40 drop-shadow-2xl md:size-64">
-            <Image
-              src="/brand/petdex-desktop-icon.png"
-              alt="Petdex Desktop"
-              fill
-              className="object-contain"
-              priority
+            {pendingLabel ? (
+              <div className="mt-6 inline-flex max-w-full items-center gap-2 rounded-lg border border-brand/20 bg-brand-tint px-3 py-2 text-sm text-brand-deep dark:bg-brand-tint-dark dark:text-brand-light">
+                <Sparkles className="size-4 shrink-0" />
+                <span className="min-w-0">
+                  {t("pendingPet.messageBefore")}{" "}
+                  <code className="rounded bg-surface/80 px-1.5 py-0.5 font-mono text-xs">
+                    {pendingLabel}
+                  </code>{" "}
+                  {t("pendingPet.messageAfter")}
+                </span>
+              </div>
+            ) : null}
+
+            <DownloadCTA
+              primaryLabel={t("hero.primaryTitle")}
+              cliCommand={activationCommand}
+              cliSubtext={t("hero.cliSubtext")}
+              manualLabel={t("hero.manualLabel")}
+              manualSubtext={t("hero.manualSubtext")}
+              comingSoonLabel={t("hero.comingSoon")}
+              desktopOnlyLabel={t("hero.desktopOnly")}
             />
+
+            <div className="mt-5 grid gap-2 sm:grid-cols-3">
+              {activationItems.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <div
+                    key={item.label}
+                    className="flex min-w-0 items-center gap-2 rounded-lg border border-border-base bg-surface px-3 py-2 text-sm text-muted-1"
+                  >
+                    <Icon className="size-4 shrink-0 text-brand" />
+                    <span className="truncate">{item.label}</span>
+                  </div>
+                );
+              })}
+            </div>
           </div>
 
-          <p className="mt-8 font-mono text-xs tracking-[0.22em] text-brand uppercase">
-            {t("eyebrow")}
-          </p>
-          <h1 className="mt-3 text-[48px] leading-[0.98] font-semibold tracking-tight md:text-[72px]">
-            {t("title")}
-          </h1>
-          <p className="mt-5 max-w-lg text-balance text-base leading-7 text-muted-1 md:text-lg">
-            {t("subtitle")}
-          </p>
-
-          <DownloadCTA
-            primaryLabel={t("hero.downloadCta")}
-            cliCommand="npx petdex init"
-            cliSubtext={t("hero.cliSubtext")}
-            comingSoonLabel={t("hero.comingSoon")}
-            desktopOnlyLabel={t("hero.desktopOnly")}
+          <DesktopActivationPreview
+            pendingLabel={pendingLabel}
+            pendingPet={
+              pendingPreviewPet
+                ? {
+                    displayName: pendingPreviewPet.displayName,
+                    spritesheetPath: pendingPreviewPet.spritesheetPath,
+                  }
+                : null
+            }
+            title={t("preview.title")}
+            status={t("preview.status")}
+            terminalLabel={t("preview.terminalLabel")}
+            agentLabel={t("preview.agentLabel")}
+            petLabel={
+              pendingPreviewName
+                ? t("preview.pendingPet", { slug: pendingPreviewName })
+                : t("preview.defaultPet")
+            }
           />
         </div>
       </section>
@@ -316,5 +362,103 @@ export default async function DownloadPage({
 
       <SiteFooter />
     </main>
+  );
+}
+
+function DesktopActivationPreview({
+  pendingLabel,
+  pendingPet,
+  title,
+  status,
+  terminalLabel,
+  agentLabel,
+  petLabel,
+}: {
+  pendingLabel: string | null;
+  pendingPet: { displayName: string; spritesheetPath: string } | null;
+  title: string;
+  status: string;
+  terminalLabel: string;
+  agentLabel: string;
+  petLabel: string;
+}) {
+  return (
+    <div className="relative min-w-0 overflow-hidden rounded-lg border border-border-base bg-surface p-4 shadow-[0_32px_90px_-60px_rgba(15,23,42,0.6)]">
+      <div className="absolute inset-x-0 top-0 h-1 bg-brand" />
+      <div className="flex items-center gap-2 border-border-base border-b pb-3">
+        <span className="size-3 rounded-full bg-rose-400" />
+        <span className="size-3 rounded-full bg-amber-400" />
+        <span className="size-3 rounded-full bg-emerald-400" />
+        <span className="ml-2 truncate text-xs font-medium text-muted-3">
+          Petdex Desktop
+        </span>
+      </div>
+
+      <div className="grid gap-4 pt-5 sm:grid-cols-[1fr_160px]">
+        <div className="space-y-3">
+          <div className="rounded-lg border border-border-base bg-background p-4">
+            <p className="text-xs font-medium text-muted-3">{terminalLabel}</p>
+            <div className="mt-3 space-y-2 font-mono text-xs">
+              <p>
+                <span className="text-brand">$</span>{" "}
+                <span className="text-foreground">npx petdex init</span>
+              </p>
+              <p className="text-muted-3">✓ {agentLabel}</p>
+              <p className="text-muted-3">✓ {petLabel}</p>
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-border-base bg-background p-4">
+            <div className="flex items-start gap-3">
+              <div className="relative size-12 shrink-0">
+                <Image
+                  src="/brand/petdex-desktop-icon.png"
+                  alt=""
+                  fill
+                  className="object-contain"
+                  sizes="48px"
+                />
+              </div>
+              <div className="min-w-0">
+                <p className="font-semibold text-foreground">{title}</p>
+                <p className="mt-1 text-sm leading-5 text-muted-2">{status}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="relative min-h-[210px] overflow-hidden rounded-lg border border-border-base bg-[linear-gradient(135deg,var(--surface-muted),var(--surface))] p-3">
+          <div className="absolute inset-x-3 top-3 rounded-lg border border-border-base bg-surface/80 p-3">
+            <div className="h-2 w-24 rounded-full bg-border-base" />
+            <div className="mt-2 h-2 w-16 rounded-full bg-border-base/70" />
+          </div>
+          {pendingPet ? (
+            <div className="pet-sprite-stage absolute right-4 bottom-7 grid size-28 place-items-center rounded-lg border border-brand/20 bg-surface shadow-xl">
+              <StaticPetSprite
+                src={pendingPet.spritesheetPath}
+                state="idle"
+                scale={0.46}
+                label={pendingPet.displayName}
+              />
+            </div>
+          ) : (
+            <div className="absolute right-5 bottom-7 grid size-24 place-items-center rounded-lg border border-brand/20 bg-surface shadow-xl">
+              <Image
+                src="/brand/petdex-desktop-icon.png"
+                alt="Petdex Desktop"
+                width={80}
+                height={80}
+                className="object-contain"
+              />
+            </div>
+          )}
+          {pendingLabel ? (
+            <span className="absolute bottom-3 left-3 max-w-[120px] truncate rounded-lg bg-brand px-2 py-1 text-xs font-medium text-on-inverse">
+              {pendingLabel}
+            </span>
+          ) : null}
+        </div>
+      </div>
+    </div>
   );
 }

--- a/src/app/[locale]/download/page.tsx
+++ b/src/app/[locale]/download/page.tsx
@@ -209,7 +209,7 @@ export default async function DownloadPage({
           </div>
 
           <DesktopActivationPreview
-            pendingLabel={pendingLabel}
+            pendingLabel={pendingPreviewName}
             pendingPet={
               pendingPreviewPet
                 ? {

--- a/src/components/command-line.test.ts
+++ b/src/components/command-line.test.ts
@@ -8,12 +8,15 @@ import { describe, expect, test } from "bun:test";
 // preserve every case below.
 
 function pinToLatest(command: string): string {
-  if (command.includes("petdex@")) return command;
-  const npxMatch = command.match(/^(.*?\bnpx\s+)petdex(\b.*)$/);
-  if (npxMatch) return `${npxMatch[1]}petdex@latest${npxMatch[2]}`;
-  const bareMatch = command.match(/^petdex(\b.*)$/);
-  if (bareMatch) return `npx petdex@latest${bareMatch[1]}`;
-  return command;
+  return command
+    .split(/(\s*(?:&&|\|\||;|\|)\s*)/g)
+    .map((segment) => {
+      if (/^\s*(?:&&|\|\||;|\|)\s*$/.test(segment)) return segment;
+      return segment
+        .replace(/\bnpx\s+petdex(?!@)\b/g, "npx petdex@latest")
+        .replace(/^(\s*)petdex(?!@)\b/, "$1npx petdex@latest");
+    })
+    .join("");
 }
 
 describe("pinToLatest", () => {
@@ -55,6 +58,15 @@ describe("pinToLatest", () => {
     // `cd path && npx petdex install` — still pin the petdex.
     expect(pinToLatest("cd ~/work && npx petdex install desktop")).toBe(
       "cd ~/work && npx petdex@latest install desktop",
+    );
+  });
+
+  test("pins every petdex command in chained setup snippets", () => {
+    expect(pinToLatest("npx petdex init && npx petdex install boba")).toBe(
+      "npx petdex@latest init && npx petdex@latest install boba",
+    );
+    expect(pinToLatest("petdex init && petdex install boba")).toBe(
+      "npx petdex@latest init && npx petdex@latest install boba",
     );
   });
 

--- a/src/components/command-line.tsx
+++ b/src/components/command-line.tsx
@@ -33,21 +33,19 @@ type CommandLineProps = {
  * (without npx) so a user copying from a globally-installed
  * snippet still gets the latest tag.
  *
- * Only rewrites the FIRST occurrence — no risk of accidentally
- * rewriting embedded references in flags or paths.
+ * Rewrites each shell command segment so chained setup snippets keep
+ * every Petdex invocation on the newest release.
  */
 function pinToLatest(command: string): string {
-  // Already pinned? Leave it alone.
-  if (command.includes("petdex@")) return command;
-  // npx petdex ... → npx petdex@latest ...
-  const npxMatch = command.match(/^(.*?\bnpx\s+)petdex(\b.*)$/);
-  if (npxMatch) return `${npxMatch[1]}petdex@latest${npxMatch[2]}`;
-  // bare leading `petdex ...` (e.g. when the user has it on PATH)
-  // → `npx petdex@latest ...`. We add npx so the pinned form
-  // works even without a global install.
-  const bareMatch = command.match(/^petdex(\b.*)$/);
-  if (bareMatch) return `npx petdex@latest${bareMatch[1]}`;
-  return command;
+  return command
+    .split(/(\s*(?:&&|\|\||;|\|)\s*)/g)
+    .map((segment) => {
+      if (/^\s*(?:&&|\|\||;|\|)\s*$/.test(segment)) return segment;
+      return segment
+        .replace(/\bnpx\s+petdex(?!@)\b/g, "npx petdex@latest")
+        .replace(/^(\s*)petdex(?!@)\b/, "$1npx petdex@latest");
+    })
+    .join("");
 }
 
 async function writeClipboard(text: string) {

--- a/src/components/command-line.tsx
+++ b/src/components/command-line.tsx
@@ -22,6 +22,7 @@ type CommandLineProps = {
    * runs the install without the user needing a terminal.
    */
   codexPrompt?: string;
+  wrap?: boolean;
 };
 
 /**
@@ -134,6 +135,7 @@ export function CommandLine({
   source,
   className = "",
   codexPrompt,
+  wrap = false,
 }: CommandLineProps) {
   const t = useTranslations("commandLine");
   const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">(
@@ -141,6 +143,10 @@ export function CommandLine({
   );
   const copied = copyState === "copied";
   const failed = copyState === "failed";
+  const rootLayoutClass = wrap ? "items-start" : "items-center";
+  const commandClass = wrap
+    ? "flex-1 whitespace-normal break-words leading-5"
+    : "flex-1 truncate";
 
   async function handleCopy() {
     // Display the natural `npx petdex` form, but copy the
@@ -171,7 +177,7 @@ export function CommandLine({
         style={{
           fontFamily: "var(--font-geist-mono), ui-monospace, monospace",
         }}
-        className={`group inline-flex items-center gap-2 rounded-xl border border-border-base bg-surface/80 px-3 py-2 text-left text-[12px] text-foreground backdrop-blur transition hover:border-brand-light/40 hover:bg-surface ${className}`}
+        className={`group inline-flex ${rootLayoutClass} gap-2 rounded-xl border border-border-base bg-surface/80 px-3 py-2 text-left text-[12px] text-foreground backdrop-blur transition hover:border-brand-light/40 hover:bg-surface ${className}`}
       >
         <button
           type="button"
@@ -179,10 +185,10 @@ export function CommandLine({
           aria-label={
             copied ? t("copiedAria") : failed ? t("failedAria") : t("copyAria")
           }
-          className="flex flex-1 items-center gap-2 truncate text-left"
+          className={`flex flex-1 ${rootLayoutClass} gap-2 text-left`}
         >
           <span className="select-none text-brand">{prefix}</span>
-          <span className="flex-1 truncate">{tokenize(command)}</span>
+          <span className={commandClass}>{tokenize(command)}</span>
           <span className="grid size-6 shrink-0 place-items-center rounded-md text-muted-3 transition group-hover:bg-brand-tint group-hover:text-brand-deep">
             {copied ? (
               <Check className="size-3.5 text-brand-deep" />
@@ -218,10 +224,10 @@ export function CommandLine({
         copied ? t("copiedAria") : failed ? t("failedAria") : t("copyAria")
       }
       style={{ fontFamily: "var(--font-geist-mono), ui-monospace, monospace" }}
-      className={`group inline-flex items-center gap-2 rounded-xl border border-border-base bg-surface/80 px-3 py-2 text-left text-[12px] text-foreground backdrop-blur transition hover:border-brand-light/40 hover:bg-surface ${className}`}
+      className={`group inline-flex ${rootLayoutClass} gap-2 rounded-xl border border-border-base bg-surface/80 px-3 py-2 text-left text-[12px] text-foreground backdrop-blur transition hover:border-brand-light/40 hover:bg-surface ${className}`}
     >
       <span className="select-none text-brand">{prefix}</span>
-      <span className="flex-1 truncate">{tokenize(command)}</span>
+      <span className={commandClass}>{tokenize(command)}</span>
       <span className="grid size-6 shrink-0 place-items-center rounded-md text-muted-3 transition group-hover:bg-brand-tint group-hover:text-brand-deep">
         {copied ? (
           <Check className="size-3.5 text-brand-deep" />

--- a/src/components/download-cta.tsx
+++ b/src/components/download-cta.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowRight, Clock } from "lucide-react";
+import { Apple, ArrowDownToLine, Clock, Terminal } from "lucide-react";
 
 import {
   type MacArch,
@@ -38,12 +38,16 @@ export function DownloadCTA({
   primaryLabel,
   cliCommand,
   cliSubtext,
+  manualLabel,
+  manualSubtext,
   comingSoonLabel,
   desktopOnlyLabel,
 }: {
   primaryLabel: string;
   cliCommand: string;
   cliSubtext: string;
+  manualLabel: string;
+  manualSubtext: string;
   comingSoonLabel: string;
   desktopOnlyLabel: string;
 }) {
@@ -51,36 +55,53 @@ export function DownloadCTA({
   const arch = useMacArch();
 
   return (
-    <div className="mt-10 flex w-full flex-col items-center gap-3">
-      <div className="flex w-full flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center">
-        <PrimaryButton
+    <div className="mt-8 grid w-full min-w-0 gap-3">
+      <div className="min-w-0 overflow-hidden rounded-lg border border-brand/20 bg-surface p-3 shadow-[0_18px_48px_-38px_rgba(15,23,42,0.55)]">
+        <div className="mb-3 flex items-center gap-2 px-1">
+          <span className="grid size-8 shrink-0 place-items-center rounded-lg bg-brand text-on-inverse">
+            <Terminal className="size-4" />
+          </span>
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-foreground">
+              {primaryLabel}
+            </p>
+            <p className="text-xs text-muted-2">{cliSubtext}</p>
+          </div>
+        </div>
+        <CommandLine
+          command={cliCommand}
+          source="download-hero-primary"
+          wrap
+          className="min-h-14 w-full min-w-0 max-w-full !rounded-lg !border-brand/20 !bg-surface-muted/60 !px-4 !py-3 !text-[12px] sm:!text-sm"
+        />
+      </div>
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <ManualDownloadButton
           platform={platform}
           arch={arch}
-          primaryLabel={primaryLabel}
+          manualLabel={manualLabel}
           comingSoonLabel={comingSoonLabel}
           desktopOnlyLabel={desktopOnlyLabel}
         />
-        <CommandLine
-          command={cliCommand}
-          source="download-hero"
-          className="!h-12 w-full !rounded-full !px-5 !text-[13px] sm:w-auto sm:min-w-[280px]"
-        />
+        <p className="text-xs leading-5 text-muted-3 sm:max-w-[260px]">
+          {manualSubtext}
+        </p>
       </div>
-      <p className="text-xs text-muted-3">{cliSubtext}</p>
     </div>
   );
 }
 
-function PrimaryButton({
+function ManualDownloadButton({
   platform,
   arch,
-  primaryLabel,
+  manualLabel,
   comingSoonLabel,
   desktopOnlyLabel,
 }: {
   platform: Platform;
   arch: MacArch;
-  primaryLabel: string;
+  manualLabel: string;
   comingSoonLabel: string;
   desktopOnlyLabel: string;
 }) {
@@ -91,7 +112,7 @@ function PrimaryButton({
     return (
       <span
         aria-hidden="true"
-        className="inline-flex h-12 w-[180px] animate-pulse items-center justify-center rounded-full bg-surface-muted text-sm text-muted-3"
+        className="inline-flex h-11 w-full animate-pulse items-center justify-center rounded-lg bg-surface-muted text-sm text-muted-3 sm:w-[220px]"
       />
     );
   }
@@ -113,13 +134,13 @@ function PrimaryButton({
       <a
         href={href}
         rel="noreferrer"
-        className="inline-flex h-12 items-center justify-center gap-2 rounded-full bg-inverse px-6 text-sm font-medium text-on-inverse transition hover:bg-inverse-hover"
+        className="inline-flex h-11 w-full items-center justify-center gap-2 rounded-lg border border-border-base bg-surface px-4 text-sm font-medium text-foreground transition hover:border-border-strong hover:bg-surface-muted sm:w-auto sm:min-w-[220px]"
       >
-        {primaryLabel}
+        <ArrowDownToLine className="size-4" />
+        {manualLabel}
         {labelSuffix ? (
           <span className="ml-1 text-xs opacity-75">{labelSuffix}</span>
         ) : null}
-        <ArrowRight className="size-4" />
       </a>
     );
   }
@@ -129,7 +150,7 @@ function PrimaryButton({
     return (
       <span
         aria-disabled="true"
-        className="inline-flex h-12 cursor-not-allowed items-center justify-center gap-2 rounded-full border border-border-base bg-surface-muted px-6 text-sm font-medium text-muted-2"
+        className="inline-flex h-11 w-full cursor-not-allowed items-center justify-center gap-2 rounded-lg border border-border-base bg-surface-muted px-4 text-sm font-medium text-muted-2 sm:w-auto sm:min-w-[220px]"
       >
         <Clock className="size-4" />
         {comingSoonLabel.replace(
@@ -144,9 +165,9 @@ function PrimaryButton({
   return (
     <span
       aria-disabled="true"
-      className="inline-flex h-12 cursor-not-allowed items-center justify-center gap-2 rounded-full border border-border-base bg-surface-muted px-6 text-sm font-medium text-muted-2"
+      className="inline-flex h-11 w-full cursor-not-allowed items-center justify-center gap-2 rounded-lg border border-border-base bg-surface-muted px-4 text-sm font-medium text-muted-2 sm:w-auto sm:min-w-[220px]"
     >
-      <Clock className="size-4" />
+      <Apple className="size-4" />
       {desktopOnlyLabel}
     </span>
   );

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1465,14 +1465,32 @@
     "backToCollections": "← All collections"
   },
   "download": {
-    "eyebrow": "Desktop app",
-    "title": "Petdex Desktop",
-    "subtitle": "Your pet, floating beside every coding agent.",
+    "eyebrow": "Terminal-first setup",
+    "title": "Run one command. Petdex does the rest.",
+    "subtitle": "Install the desktop app, wire your coding agents, and wake your pet from the terminal.",
     "hero": {
       "downloadCta": "Download for macOS",
-      "cliSubtext": "Then run this to wire up your agents",
-      "comingSoon": "Coming to {os}",
+      "primaryTitle": "Install & Wire Petdex",
+      "cliSubtext": "Copies the recommended terminal setup",
+      "manualLabel": "Download .dmg",
+      "manualSubtext": "For blocked terminals, manual macOS installs, or keeping the installer locally.",
+      "comingSoon": "Coming soon",
       "desktopOnly": "Desktop only. Visit on a Mac"
+    },
+    "activation": {
+      "items": {
+        "hooks": "Agent hooks",
+        "desktop": "Desktop app",
+        "pet": "Pet wake-up"
+      }
+    },
+    "preview": {
+      "title": "Petdex Desktop",
+      "status": "A floating pet stays beside Codex, Claude, Gemini, and OpenCode.",
+      "terminalLabel": "Terminal",
+      "agentLabel": "Agent hooks installed",
+      "defaultPet": "Mascot awake",
+      "pendingPet": "{slug} queued"
     },
     "features": {
       "eyebrow": "What it does",
@@ -1532,8 +1550,8 @@
     "docsLink": "Read the docs",
     "pendingPet": {
       "eyebrow": "Almost there.",
-      "messageBefore": "Install Petdex Desktop to test",
-      "messageAfter": "in 1 click.",
+      "messageBefore": "Queued pet:",
+      "messageAfter": "after setup.",
       "hint": "macOS only for now"
     }
   },

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -1465,14 +1465,32 @@
     "backToCollections": "← Ver todas las colecciones"
   },
   "download": {
-    "eyebrow": "App de escritorio",
-    "title": "Petdex Desktop",
-    "subtitle": "Tu mascota, flotando junto a cada agente de programacion.",
+    "eyebrow": "Setup desde la terminal",
+    "title": "Corre un comando. Petdex hace el resto.",
+    "subtitle": "Instala la app de escritorio, conecta tus agentes y despierta tu mascota desde la terminal.",
     "hero": {
       "downloadCta": "Descargar para macOS",
-      "cliSubtext": "Despues corre esto para conectar tus agentes",
-      "comingSoon": "Pronto en {os}",
+      "primaryTitle": "Instalar y conectar Petdex",
+      "cliSubtext": "Copia el setup recomendado para terminal",
+      "manualLabel": "Descargar .dmg",
+      "manualSubtext": "Para terminales bloqueadas, instalacion manual en macOS o guardar el instalador localmente.",
+      "comingSoon": "Proximamente",
       "desktopOnly": "Solo escritorio. Visita desde una Mac"
+    },
+    "activation": {
+      "items": {
+        "hooks": "Hooks de agentes",
+        "desktop": "App de escritorio",
+        "pet": "Mascota despierta"
+      }
+    },
+    "preview": {
+      "title": "Petdex Desktop",
+      "status": "Una mascota flotante se queda junto a Codex, Claude, Gemini y OpenCode.",
+      "terminalLabel": "Terminal",
+      "agentLabel": "Hooks de agentes instalados",
+      "defaultPet": "Mascota despierta",
+      "pendingPet": "{slug} en cola"
     },
     "features": {
       "eyebrow": "Que hace",
@@ -1532,8 +1550,8 @@
     "docsLink": "Leer la documentacion",
     "pendingPet": {
       "eyebrow": "Casi listo.",
-      "messageBefore": "Instala Petdex Desktop para probar",
-      "messageAfter": "en 1 clic.",
+      "messageBefore": "Mascota en cola:",
+      "messageAfter": "despues del setup.",
       "hint": "Solo macOS por ahora"
     }
   },

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -1661,20 +1661,50 @@
     "backToCollections": "← 返回全部合集"
   },
   "download": {
-    "eyebrow": "桌面应用",
+    "eyebrow": "终端优先安装",
     "eyebrow__fixme": true,
-    "title": "Petdex Desktop",
-    "subtitle": "你的宠物，漂浮在每个 Agent 身旁。",
+    "title": "运行一个命令，Petdex 完成剩下的事。",
+    "subtitle": "从终端安装桌面应用、连接你的 Agent，并唤醒宠物。",
     "subtitle__fixme": true,
     "hero": {
       "downloadCta": "下载 macOS 版本",
       "downloadCta__fixme": true,
-      "cliSubtext": "然后运行这个命令连接你的 AI Agent",
+      "primaryTitle": "安装并连接 Petdex",
+      "primaryTitle__fixme": true,
+      "cliSubtext": "复制推荐的终端安装命令",
       "cliSubtext__fixme": true,
-      "comingSoon": "即将支持 {os}",
+      "manualLabel": "下载 .dmg",
+      "manualLabel__fixme": true,
+      "manualSubtext": "适用于终端受限、手动安装 macOS 应用，或需要本地保存安装包的场景。",
+      "manualSubtext__fixme": true,
+      "comingSoon": "即将支持",
       "comingSoon__fixme": true,
       "desktopOnly": "仅桌面版，请用 Mac 访问",
       "desktopOnly__fixme": true
+    },
+    "activation": {
+      "items": {
+        "hooks": "Agent hooks",
+        "hooks__fixme": true,
+        "desktop": "桌面应用",
+        "desktop__fixme": true,
+        "pet": "唤醒宠物",
+        "pet__fixme": true
+      }
+    },
+    "preview": {
+      "title": "Petdex Desktop",
+      "title__fixme": true,
+      "status": "一只漂浮宠物会陪在 Codex、Claude、Gemini 和 OpenCode 旁边。",
+      "status__fixme": true,
+      "terminalLabel": "终端",
+      "terminalLabel__fixme": true,
+      "agentLabel": "Agent hooks 已安装",
+      "agentLabel__fixme": true,
+      "defaultPet": "宠物已唤醒",
+      "defaultPet__fixme": true,
+      "pendingPet": "{slug} 已排队",
+      "pendingPet__fixme": true
     },
     "features": {
       "eyebrow": "功能介绍",
@@ -1762,9 +1792,9 @@
     "pendingPet": {
       "eyebrow": "马上就好。",
       "eyebrow__fixme": true,
-      "messageBefore": "安装 Petdex Desktop 即可一键测试",
+      "messageBefore": "待安装宠物：",
       "messageBefore__fixme": true,
-      "messageAfter": "。",
+      "messageAfter": "会在设置后安装。",
       "messageAfter__fixme": true,
       "hint": "目前仅支持 macOS",
       "hint__fixme": true


### PR DESCRIPTION
## Summary
- Reframes `/download` around the recommended terminal activation command
- Makes manual `.dmg` download secondary while keeping platform-specific handling
- Shows queued install context with the real pending pet sprite, including Boba from the catalog

## Verification
- bun run i18n:check
- bunx biome check `src/app/[locale]/download/page.tsx` src/components/download-cta.tsx src/components/command-line.tsx src/i18n/messages/en.json src/i18n/messages/es.json src/i18n/messages/zh.json
- bun test `src/app/[locale]/download/setup-steps.test.ts` src/components/command-line.test.ts
- TELEMETRY_RATELIMIT_SECRET=petdex-local-build-secret bun --env-file=.env.mock run build
- agent-browser QA on `/es/download?next=install/boba`: no horizontal overflow, command visible, Boba sprite loaded from curated spritesheet