### PR TITLE
fix(download): refine activation hero preview

### DIFF
--- a/src/app/[locale]/download/page.tsx
+++ b/src/app/[locale]/download/page.tsx
@@ -27,6 +27,12 @@ import { hasLocale } from "@/i18n/config";
 import { buildSetupSteps, parsePendingInstallSlugs } from "./setup-steps";
 
 const SITE_URL = "https://petdex.crafter.run";
+const DEFAULT_PREVIEW_PET_SLUG = "boba";
+const DEFAULT_PREVIEW_PET = {
+  displayName: "Boba",
+  spritesheetPath:
+    "https://pub-94495283df974cfea5e98d6a9e3fa462.r2.dev/curated/boba/spritesheet.webp",
+};
 
 // Auto-detected /download/opengraph-image is locale-prefixed
 // (/en/download/opengraph-image) and next-intl rewrites that with a
@@ -96,10 +102,18 @@ export default async function DownloadPage({
         ? pendingInstallSlugs[0]
         : pendingInstallSlugs.join(", ")
       : null;
-  const pendingPreviewPet = pendingInstallSlugs?.[0]
-    ? await getPet(pendingInstallSlugs[0])
-    : undefined;
-  const pendingPreviewName = pendingPreviewPet?.displayName ?? pendingLabel;
+  const previewIsPending = (pendingInstallSlugs?.length ?? 0) > 0;
+  const previewSlug = pendingInstallSlugs?.[0] ?? DEFAULT_PREVIEW_PET_SLUG;
+  const resolvedPreviewPet = await getPet(previewSlug);
+  const previewPet = resolvedPreviewPet
+    ? {
+        displayName: resolvedPreviewPet.displayName,
+        spritesheetPath: resolvedPreviewPet.spritesheetPath,
+      }
+    : previewSlug === DEFAULT_PREVIEW_PET_SLUG
+      ? DEFAULT_PREVIEW_PET
+      : null;
+  const previewPetName = previewPet?.displayName ?? pendingLabel;
 
   const features = [
     {
@@ -209,22 +223,17 @@ export default async function DownloadPage({
           </div>
 
           <DesktopActivationPreview
-            pendingLabel={pendingPreviewName}
-            pendingPet={
-              pendingPreviewPet
-                ? {
-                    displayName: pendingPreviewPet.displayName,
-                    spritesheetPath: pendingPreviewPet.spritesheetPath,
-                  }
-                : null
-            }
+            pendingLabel={previewPetName}
+            pendingPet={previewPet}
             title={t("preview.title")}
             status={t("preview.status")}
             terminalLabel={t("preview.terminalLabel")}
             agentLabel={t("preview.agentLabel")}
             petLabel={
-              pendingPreviewName
-                ? t("preview.pendingPet", { slug: pendingPreviewName })
+              previewPetName
+                ? previewIsPending
+                  ? t("preview.pendingPet", { slug: previewPetName })
+                  : t("preview.demoPet", { slug: previewPetName })
                 : t("preview.defaultPet")
             }
           />

--- a/src/components/download-cta.tsx
+++ b/src/components/download-cta.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { Apple, ArrowDownToLine, Clock, Terminal } from "lucide-react";
+import Image from "next/image";
+
+import { Apple, ArrowDownToLine, Clock } from "lucide-react";
 
 import {
   type MacArch,
@@ -57,23 +59,30 @@ export function DownloadCTA({
   return (
     <div className="mt-8 grid w-full min-w-0 gap-3">
       <div className="min-w-0 overflow-hidden rounded-lg border border-brand/20 bg-surface p-3 shadow-[0_18px_48px_-38px_rgba(15,23,42,0.55)]">
-        <div className="mb-3 flex items-center gap-2 px-1">
-          <span className="grid size-8 shrink-0 place-items-center rounded-lg bg-brand text-on-inverse">
-            <Terminal className="size-4" />
+        <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center">
+          <span className="relative grid size-11 shrink-0 place-items-center overflow-hidden rounded-lg border border-brand/20 bg-background shadow-sm">
+            <Image
+              src="/brand/petdex-desktop-icon.png"
+              alt=""
+              fill
+              className="object-contain p-1"
+              sizes="44px"
+            />
           </span>
-          <div className="min-w-0">
-            <p className="text-sm font-semibold text-foreground">
+          <div className="min-w-0 flex-1">
+            <p className="text-base font-semibold text-foreground">
               {primaryLabel}
             </p>
-            <p className="text-xs text-muted-2">{cliSubtext}</p>
+            <p className="mt-0.5 text-sm leading-5 text-muted-2">
+              {cliSubtext}
+            </p>
           </div>
+          <CommandLine
+            command={cliCommand}
+            source="download-hero-primary"
+            className="!h-10 w-full min-w-0 max-w-full !rounded-lg !border-border-base !bg-background !px-3 !py-2 !text-[12px] sm:w-auto sm:min-w-[260px] sm:max-w-[340px]"
+          />
         </div>
-        <CommandLine
-          command={cliCommand}
-          source="download-hero-primary"
-          wrap
-          className="min-h-14 w-full min-w-0 max-w-full !rounded-lg !border-brand/20 !bg-surface-muted/60 !px-4 !py-3 !text-[12px] sm:!text-sm"
-        />
       </div>
 
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center">

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1490,6 +1490,7 @@
       "terminalLabel": "Terminal",
       "agentLabel": "Agent hooks installed",
       "defaultPet": "Mascot awake",
+      "demoPet": "{slug} awake",
       "pendingPet": "{slug} queued"
     },
     "features": {

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -1490,6 +1490,7 @@
       "terminalLabel": "Terminal",
       "agentLabel": "Hooks de agentes instalados",
       "defaultPet": "Mascota despierta",
+      "demoPet": "{slug} despierta",
       "pendingPet": "{slug} en cola"
     },
     "features": {

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -1703,6 +1703,8 @@
       "agentLabel__fixme": true,
       "defaultPet": "宠物已唤醒",
       "defaultPet__fixme": true,
+      "demoPet": "{slug} 已唤醒",
+      "demoPet__fixme": true,
       "pendingPet": "{slug} 已排队",
       "pendingPet__fixme": true
     },


### PR DESCRIPTION
## Summary
- make the hero CTA compact with the Petdex Desktop logo instead of a terminal icon
- show Boba in the desktop preview by default and for pending installs
- keep the pending install state text specific to queued pets

## Verification
- bunx biome check 'src/app/[locale]/download/page.tsx' src/components/download-cta.tsx src/i18n/messages/en.json src/i18n/messages/es.json src/i18n/messages/zh.json
- bun run i18n:check
- bun test 'src/app/[locale]/download/setup-steps.test.ts' src/components/command-line.test.ts
- TELEMETRY_RATELIMIT_SECRET=petdex-local-build-secret bun --env-file=.env.mock run build