### PR TITLE
feat(profile): polish pinned pet card actions

### DIFF
--- a/src/app/[locale]/u/[handle]/page.tsx
+++ b/src/app/[locale]/u/[handle]/page.tsx
@@ -443,6 +443,7 @@ export default async function UserProfilePage({ params }: PageProps) {
             <PinnedReorderGrid
               pets={featuredPets}
               petStateCount={petStates.length}
+              hideAuthor
             />
           ) : (
             <div className="space-y-4">
@@ -480,6 +481,7 @@ export default async function UserProfilePage({ params }: PageProps) {
                         pet={pet}
                         index={index}
                         stateCount={petStates.length}
+                        hideAuthor
                       />
                     </div>
                   ))}

--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -1067,7 +1067,7 @@ function PetCardImpl({
       ) : null}
 
       {usesProfilePinHover ? (
-        <div className="pointer-events-none absolute top-16 right-4 z-20 flex flex-col items-center gap-2 opacity-0 transition group-has-[[aria-expanded=true]]:pointer-events-auto group-has-[[aria-expanded=true]]:opacity-100 group-has-[:focus-visible]:pointer-events-auto group-has-[:focus-visible]:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100">
+        <div className="pointer-events-none absolute top-16 right-4 z-20 flex flex-col items-center gap-2 opacity-0 transition [@media(hover:none)]:pointer-events-auto [@media(hover:none)]:opacity-100 group-has-[[aria-expanded=true]]:pointer-events-auto group-has-[[aria-expanded=true]]:opacity-100 group-has-[:focus-visible]:pointer-events-auto group-has-[:focus-visible]:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100">
           {pinState ? (
             <ProfilePinButton
               slug={pet.slug}

--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -818,6 +818,16 @@ type PetCardProps = {
    * never see this prop populated.
    */
   pinState?: PetCardPinState;
+  /**
+   * Profile pages already establish the creator context, so repeating
+   * "by ..." on every pet card wastes vertical space.
+   */
+  hideAuthor?: boolean;
+  /**
+   * Owner profile pin surfaces use a cleaner preview state: actions reveal
+   * on hover/focus over a light scrim, leaving the card quiet by default.
+   */
+  actionMode?: "default" | "profilePinHover";
 };
 
 function PetCardImpl({
@@ -828,6 +838,8 @@ function PetCardImpl({
   ownerActions,
   statusOverlay,
   pinState,
+  hideAuthor,
+  actionMode = "default",
 }: PetCardProps) {
   const t = useTranslations("gallery");
   const locale = useLocale();
@@ -845,6 +857,7 @@ function PetCardImpl({
   const batchLabel = pet.approvedAt
     ? formatBatchLabel(getBatchKey(new Date(pet.approvedAt)))
     : null;
+  const usesProfilePinHover = actionMode === "profilePinHover";
   // Every card with a dominantColor gets the same accent treatment.
   // Featured cards keep the same look + add a brand badge in the corner
   // (similar to HOT/NEW). Drop the special-case styling — featured no
@@ -864,7 +877,7 @@ function PetCardImpl({
     <article
       data-slot="card"
       style={accentStyle}
-      className="group relative flex h-full flex-col overflow-hidden rounded-3xl border border-black/10 bg-surface/76 shadow-sm shadow-blue-950/5 backdrop-blur transition has-[[aria-expanded=true]]:z-30 hover:-translate-y-0.5 hover:bg-white hover:shadow-xl hover:shadow-blue-950/10 dark:border-white/10 dark:hover:bg-stone-800"
+      className="group relative flex h-full flex-col overflow-hidden rounded-3xl border border-black/10 bg-surface/76 shadow-sm shadow-blue-950/5 backdrop-blur transition has-[[aria-expanded=true]]:z-30 has-[[aria-expanded=true]]:-translate-y-0.5 has-[[aria-expanded=true]]:bg-white has-[[aria-expanded=true]]:shadow-xl has-[[aria-expanded=true]]:shadow-blue-950/10 hover:-translate-y-0.5 hover:bg-white hover:shadow-xl hover:shadow-blue-950/10 dark:border-white/10 dark:has-[[aria-expanded=true]]:bg-stone-800 dark:hover:bg-stone-800"
     >
       {/* Inset accent tab — short bar floating inside the card near the top,
           centered horizontally, like the colored tab on a tab folder or a
@@ -919,6 +932,12 @@ function PetCardImpl({
             scale={0.7}
             label={`${pet.displayName} animated`}
           />
+          {usesProfilePinHover ? (
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-0 bg-black/10 opacity-0 transition group-has-[[aria-expanded=true]]:opacity-100 group-has-[:focus-visible]:opacity-100 group-hover:opacity-100 dark:bg-black/25"
+            />
+          ) : null}
           {/* Featured badge — universal across locales since 'featured' is
               product status, not localization. Sits top-right. The zh-only
               HOT/NEW/etc badges below take top-left to avoid collision. */}
@@ -1002,7 +1021,7 @@ function PetCardImpl({
             </Badge>
           ) : null}
 
-          {pet.submittedBy ? (
+          {pet.submittedBy && !hideAuthor ? (
             <div className="mt-2 flex items-center gap-1.5 border-t border-black/[0.05] pt-2 font-mono text-[10px] tracking-[0.12em] text-muted-3 uppercase dark:border-white/[0.05]">
               {pet.submittedBy.imageUrl &&
               isAllowedAvatarUrl(pet.submittedBy.imageUrl) ? (
@@ -1047,34 +1066,59 @@ function PetCardImpl({
         </Badge>
       ) : null}
 
-      {/* Pin overlay — owner-only on their own /u/[handle]. Sits to the
+      {usesProfilePinHover ? (
+        <div className="pointer-events-none absolute top-16 right-4 z-20 flex flex-col items-center gap-2 opacity-0 transition group-has-[[aria-expanded=true]]:pointer-events-auto group-has-[[aria-expanded=true]]:opacity-100 group-has-[:focus-visible]:pointer-events-auto group-has-[:focus-visible]:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100">
+          {pinState ? (
+            <ProfilePinButton
+              slug={pet.slug}
+              isPinned={pinState.isPinned}
+              pinnedCount={pinState.pinnedCount}
+              maxPins={pinState.maxPins}
+              appearance="subtle"
+            />
+          ) : null}
+          <PetActionMenu
+            pet={{
+              slug: pet.slug,
+              displayName: pet.displayName,
+              zipUrl: pet.zipUrl,
+              description: pet.description,
+            }}
+            ownerActions={ownerActions}
+          />
+        </div>
+      ) : (
+        <>
+          {/* Pin overlay — owner-only on their own /u/[handle]. Sits to the
  left of the action menu so both stay clickable above the card-wide
  Link. The button itself toggles isPinned via /api/profile and
  router.refresh()es. */}
-      {pinState ? (
-        <div className="absolute top-3 right-14 z-20">
-          <ProfilePinButton
-            slug={pet.slug}
-            isPinned={pinState.isPinned}
-            pinnedCount={pinState.pinnedCount}
-            maxPins={pinState.maxPins}
-          />
-        </div>
-      ) : null}
+          {pinState ? (
+            <div className="absolute top-3 right-14 z-20">
+              <ProfilePinButton
+                slug={pet.slug}
+                isPinned={pinState.isPinned}
+                pinnedCount={pinState.pinnedCount}
+                maxPins={pinState.maxPins}
+              />
+            </div>
+          ) : null}
 
-      {/* Action menu lives outside the Link so its clicks don't navigate.
+          {/* Action menu lives outside the Link so its clicks don't navigate.
  Absolute-positioned to overlap the featured badge corner. */}
-      <div className="absolute top-3 right-4 z-20">
-        <PetActionMenu
-          pet={{
-            slug: pet.slug,
-            displayName: pet.displayName,
-            zipUrl: pet.zipUrl,
-            description: pet.description,
-          }}
-          ownerActions={ownerActions}
-        />
-      </div>
+          <div className="absolute top-3 right-4 z-20">
+            <PetActionMenu
+              pet={{
+                slug: pet.slug,
+                displayName: pet.displayName,
+                zipUrl: pet.zipUrl,
+                description: pet.description,
+              }}
+              ownerActions={ownerActions}
+            />
+          </div>
+        </>
+      )}
     </article>
   );
 }

--- a/src/components/pinned-reorder-grid.tsx
+++ b/src/components/pinned-reorder-grid.tsx
@@ -32,11 +32,11 @@ import type { PetWithMetrics } from "@/lib/pets";
 import { MAX_PINNED_PETS } from "@/lib/profiles";
 
 import { PetCard } from "@/components/pet-gallery";
-import { ProfilePinButton } from "@/components/profile-pin-button";
 
 type PinnedReorderGridProps = {
   pets: PetWithMetrics[];
   petStateCount: number;
+  hideAuthor?: boolean;
 };
 
 type SaveState = "idle" | "saving" | "saved" | "error";
@@ -66,6 +66,7 @@ export function movePinnedPets<T>(items: T[], from: number, to: number): T[] {
 export function PinnedReorderGrid({
   pets,
   petStateCount,
+  hideAuthor,
 }: PinnedReorderGridProps) {
   const t = useTranslations("pinnedReorder");
   const orderRef = useRef<PetWithMetrics[]>(pets);
@@ -285,6 +286,7 @@ export function PinnedReorderGrid({
                 oneOnly={oneOnly}
                 petStateCount={petStateCount}
                 pinnedCount={order.length}
+                hideAuthor={hideAuthor}
               />
             ))}
           </div>
@@ -305,6 +307,8 @@ export function PinnedReorderGrid({
                   (pet) => pet.slug === activePet.slug,
                 )}
                 stateCount={petStateCount}
+                hideAuthor={hideAuthor}
+                actionMode="profilePinHover"
               />
             </div>
           ) : null}
@@ -321,6 +325,7 @@ type SortablePinnedPetProps = {
   oneOnly: boolean;
   petStateCount: number;
   pinnedCount: number;
+  hideAuthor?: boolean;
 };
 
 function SortablePinnedPet({
@@ -330,6 +335,7 @@ function SortablePinnedPet({
   oneOnly,
   petStateCount,
   pinnedCount,
+  hideAuthor,
 }: SortablePinnedPetProps) {
   const {
     attributes,
@@ -359,7 +365,14 @@ function SortablePinnedPet({
       }`}
     >
       <div className={isDragging ? "opacity-0" : ""}>
-        <PetCard pet={pet} index={index} stateCount={petStateCount} />
+        <PetCard
+          pet={pet}
+          index={index}
+          stateCount={petStateCount}
+          hideAuthor={hideAuthor}
+          pinState={{ isPinned: true, pinnedCount, maxPins: MAX_PINNED_PETS }}
+          actionMode="profilePinHover"
+        />
       </div>
 
       {!oneOnly && !isDragging ? (
@@ -368,23 +381,12 @@ function SortablePinnedPet({
           type="button"
           disabled={isSaving}
           aria-label={`Drag ${pet.displayName} to reorder`}
-          className="absolute top-3 left-3 z-40 grid size-8 cursor-grab touch-none place-items-center rounded-full bg-surface/95 text-muted-2 shadow-sm ring-1 ring-black/5 transition hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand active:cursor-grabbing disabled:cursor-not-allowed disabled:opacity-50 dark:ring-white/10"
+          className="absolute top-6 right-4 z-40 grid size-8 -translate-y-1/2 cursor-grab touch-none place-items-center rounded-md text-muted-3 transition hover:bg-surface-muted hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand active:cursor-grabbing disabled:cursor-not-allowed disabled:opacity-50"
           {...attributes}
           {...listeners}
         >
           <GripVertical className="size-3.5" />
         </button>
-      ) : null}
-
-      {!isDragging ? (
-        <div className="absolute top-3 right-14">
-          <ProfilePinButton
-            slug={pet.slug}
-            isPinned
-            pinnedCount={pinnedCount}
-            maxPins={MAX_PINNED_PETS}
-          />
-        </div>
       ) : null}
     </div>
   );

--- a/src/components/profile-pin-button.tsx
+++ b/src/components/profile-pin-button.tsx
@@ -13,11 +13,13 @@ export function ProfilePinButton({
   isPinned,
   pinnedCount,
   maxPins,
+  appearance = "default",
 }: {
   slug: string;
   isPinned: boolean;
   pinnedCount: number;
   maxPins: number;
+  appearance?: "default" | "subtle";
 }) {
   const router = useRouter();
   const [busy, setBusy] = useState(false);
@@ -72,9 +74,13 @@ export function ProfilePinButton({
       aria-label={title}
       style={{ zIndex: 30 }}
       className={`inline-flex size-8 items-center justify-center rounded-full border backdrop-blur transition disabled:cursor-not-allowed disabled:opacity-60 ${
-        isPinned
-          ? "border-brand/40 bg-brand text-white hover:bg-brand-deep"
-          : "border-black/10 bg-surface/90 text-muted-2 hover:border-border-strong hover:text-black"
+        appearance === "subtle"
+          ? isPinned
+            ? "border-border-base bg-surface/90 text-brand hover:border-brand/30 hover:bg-brand-tint"
+            : "border-black/10 bg-surface/90 text-muted-2 hover:border-border-strong hover:text-black"
+          : isPinned
+            ? "border-brand/40 bg-brand text-white hover:bg-brand-deep"
+            : "border-black/10 bg-surface/90 text-muted-2 hover:border-border-strong hover:text-black"
       }`}
     >
       {busy ? (

--- a/src/components/profile-tabs.tsx
+++ b/src/components/profile-tabs.tsx
@@ -280,6 +280,7 @@ function PetsPanel({
                     pet={pet}
                     index={index}
                     stateCount={stateCount}
+                    hideAuthor
                     ownerActions={
                       isOwner
                         ? { submissionId: pet.id, status: "approved" }
@@ -337,6 +338,7 @@ function PetsPanel({
                 pet={submissionToPet(submission)}
                 index={index}
                 stateCount={stateCount}
+                hideAuthor
                 statusOverlay={{ label: "Pending", tone: "warning" }}
                 ownerActions={{
                   submissionId: submission.id,
@@ -373,6 +375,7 @@ function PetsPanel({
                 pet={submissionToPet(submission)}
                 index={index}
                 stateCount={stateCount}
+                hideAuthor
                 statusOverlay={{ label: "Rejected", tone: "danger" }}
                 ownerActions={{
                   submissionId: submission.id,


### PR DESCRIPTION

<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/5b2f4877-78f1-4abe-bc24-1fb8bf3cb502" />

## Summary

This PR polishes the owner profile pinned-pet card interactions while keeping the shared gallery card behavior stable elsewhere.

## Motivation

The pet cards felt crowded, especially around the top metadata row. The pinned profile surface has extra owner actions, but showing those controls inline makes the card feel busy and visually heavier than the pet artwork itself.

The goal here is to make pinned cards feel cleaner by default, reveal owner-only controls only when they are useful, and avoid changing the regular gallery cards below the pinned area.

## What changed

- Added a dedicated `profilePinHover` action mode for `PetCard` so pinned profile cards can use hover-revealed owner tools without affecting normal gallery cards.
- Hid repeated author attribution on profile card contexts where the page already establishes the creator.
- Moved pinned-card pin and overflow actions into a right-side hover/focus tool rail.
- Kept drag handles lightweight and aligned with the card number row in pinned reorder mode.
- Added a subtle pin-button appearance for the pinned hover mode so the pin action reads like a utility control, not a primary CTA.
- Preserved default card behavior for non-pinned profile pets and public gallery cards.

## Validation

- `bunx biome check src/components/pet-gallery.tsx src/components/profile-tabs.tsx src/components/pinned-reorder-grid.tsx src/components/profile-pin-button.tsx 'src/app/[locale]/u/[handle]/page.tsx'`
- `git diff --check`

## Notes for Hunter

The hover treatment is intentionally scoped to pinned profile cards. If this still feels too active, the next small iteration would be to make the right-side tools appear only over the sprite stage instead of the full card hover area.