### PR TITLE
fix: harden Petdex desktop activation

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -160,10 +160,13 @@ jobs:
         run: |
           mkdir -p release
           find artifacts -type f -name "petdex-desktop-*" -exec cp {} release/ \;
-          # Rename sidecar so the asset name is unambiguous in GH Releases.
           if [ -f artifacts/petdex-desktop-sidecar/server.js ]; then
             cp artifacts/petdex-desktop-sidecar/server.js release/petdex-desktop-sidecar.js
           fi
+          test -f release/petdex-desktop-sidecar.js
+          test -f release/petdex-desktop-darwin-arm64
+          test -f release/petdex-desktop-darwin-x64
+          test -f release/petdex-desktop-win32-x64.exe
           ls -lh release/
 
       - name: Create GitHub Release

--- a/packages/petdex-cli/bin/petdex.ts
+++ b/packages/petdex-cli/bin/petdex.ts
@@ -108,7 +108,7 @@ async function getAuth(): Promise<ClerkCliAuth> {
   return _auth;
 }
 
-const VERSION = "0.4.0";
+const VERSION = "0.4.1";
 
 // ─── entrypoint ────────────────────────────────────────────────────────────
 main().catch((err) => {

--- a/packages/petdex-cli/bin/petdex.ts
+++ b/packages/petdex-cli/bin/petdex.ts
@@ -11,6 +11,7 @@ import { ClerkCliAuth } from "../src/cli-auth/index.js";
 import { runDoctor } from "../src/desktop/doctor.js";
 import {
   desktopBinPath,
+  ensureStarterPet,
   isTrustedAssetUrl,
   runInstallDesktop,
 } from "../src/desktop/install.js";
@@ -1445,8 +1446,8 @@ function cmdHooksKillswitch(sub: "toggle" | "on" | "off" | "status"): void {
 //      hooks + persist the CLI snapshot + auto-start the mascot.
 //   2. Bare binary already installed      → same as above, no install.
 //   3. Nothing installed                  → run runInstallDesktop
-//      (downloads bare binary + sidecar to ~/.petdex/) so init still
-//      works for users who skipped the DMG.
+//      (uses the best release asset for the current platform) so init
+//      still works for users who skipped the DMG.
 //
 // Then in all paths: install hooks across detected agents, persist
 // petdex.js snapshot to ~/.petdex/bin/, and start the desktop. Hunter
@@ -1467,32 +1468,25 @@ async function cmdInit(): Promise<void> {
   // installed at all.
   const binPath = desktopBinPath();
   const desktopInstalled = existsSync(binPath);
+  let desktopReady = desktopInstalled;
+  let desktopInstallError: string | null = null;
 
   if (!desktopInstalled) {
     console.log(
       pc.dim(
-        `${pc.yellow("!")} No desktop binary found. Installing the bare binary at ${pc.cyan("~/.petdex/bin/")}...`,
-      ),
-    );
-    console.log(
-      pc.dim(
-        `  (For the proper macOS app icon, download the DMG from ${pc.cyan("https://petdex.crafter.run/download")} instead.)`,
+        `${pc.yellow("!")} No desktop app found. Installing Petdex Desktop...`,
       ),
     );
     console.log("");
     try {
       await runInstallDesktop();
+      desktopReady = existsSync(desktopBinPath());
     } catch (err) {
+      desktopInstallError = (err as Error).message;
       console.error(
-        `${pc.red("✗")} Could not install desktop: ${(err as Error).message}`,
+        `${pc.red("✗")} Could not install desktop: ${desktopInstallError}`,
       );
-      console.error(
-        pc.dim(
-          `  You can still proceed by downloading the DMG: ${pc.cyan("https://petdex.crafter.run/download")}`,
-        ),
-      );
-      // Hooks install is still useful even if desktop didn't land,
-      // so we don't bail. The user can drop the .app in later.
+      console.error(pc.dim(`  Continuing with hooks-only setup.`));
     }
   } else {
     const isAppBundle = binPath.includes("/Petdex.app/Contents/MacOS/");
@@ -1501,50 +1495,82 @@ async function cmdInit(): Promise<void> {
     );
   }
 
-  const { installedAgents: _installedAgents } = await runHooksInstall();
+  const starter = await ensureStarterPet();
+  const { installedAgents } = await runHooksInstall();
 
-  // Auto-start the mascot. Skipping this used to leave the user with
-  // a working hook chain but no visible mascot — they'd run /petdex
-  // inside their agent expecting motion, see nothing, and assume
-  // setup failed. Idempotent via desktopStatus check.
-  const status = desktopStatus();
-  if (status.state === "running") {
-    console.log(`${pc.green("●")} Desktop already running (pid ${status.pid})`);
-  } else {
-    const result = await startDesktop();
-    if (result.ok) {
-      if (!result.alreadyRunning) {
-        emit("cli_desktop_start_success", { cli_version: VERSION });
-      }
+  let desktopStarted = false;
+  if (desktopReady) {
+    const status = desktopStatus();
+    if (status.state === "running") {
+      desktopStarted = true;
       console.log(
-        result.alreadyRunning
-          ? `${pc.dim("•")} Desktop already running (pid ${result.pid})`
-          : `${pc.green("✓")} Desktop started (pid ${result.pid})`,
+        `${pc.green("●")} Desktop already running (pid ${status.pid})`,
       );
     } else {
-      // Don't fail init — startup failure usually means the user
-      // hasn't opened the .app for the first time yet (macOS Gatekeeper
-      // wants the manual "Open" before subsequent launches go through).
-      console.log(
-        `${pc.yellow("!")} Could not start desktop: ${result.reason}`,
-      );
-      console.log(
-        pc.dim(
-          `  Open ${pc.cyan("/Applications/Petdex.app")} once manually, then re-run ${pc.cyan("petdex up")}.`,
-        ),
-      );
+      const result = await startDesktop();
+      if (result.ok) {
+        desktopStarted = true;
+        if (!result.alreadyRunning) {
+          emit("cli_desktop_start_success", { cli_version: VERSION });
+        }
+        console.log(
+          result.alreadyRunning
+            ? `${pc.dim("•")} Desktop already running (pid ${result.pid})`
+            : `${pc.green("✓")} Desktop started (pid ${result.pid})`,
+        );
+      } else {
+        console.log(
+          `${pc.yellow("!")} Could not start desktop: ${result.reason}`,
+        );
+        console.log(
+          pc.dim(
+            `  Open ${pc.cyan("/Applications/Petdex.app")} once manually, then re-run ${pc.cyan("petdex up")}.`,
+          ),
+        );
+      }
     }
   }
 
   console.log("");
+  console.log(pc.bold("Setup summary"));
   console.log(
-    `${pc.green("✓")} ${pc.bold("All set.")} Open your agent and run ${pc.cyan("/petdex")} to wake the mascot.`,
+    desktopReady
+      ? `${pc.green("✓")} Desktop installed${desktopStarted ? " and running" : ""}`
+      : `${pc.yellow("!")} Desktop not installed`,
   );
   console.log(
-    pc.dim(
-      `  Or from a shell: ${pc.cyan("petdex up")} (force-wake) · ${pc.cyan("petdex toggle")} (smart wake/sleep)`,
-    ),
+    starter.status === "installed"
+      ? `${pc.green("✓")} Starter pet installed: ${starter.slug}`
+      : starter.status === "present"
+        ? `${pc.green("✓")} Pet library ready`
+        : `${pc.yellow("!")} No starter pet installed`,
   );
+  console.log(
+    installedAgents.length > 0
+      ? `${pc.green("✓")} Hooks installed for ${installedAgents.join(", ")}`
+      : `${pc.yellow("!")} No agent hooks installed`,
+  );
+  if (desktopInstallError) {
+    console.log(pc.dim(`  Desktop install issue: ${desktopInstallError}`));
+  }
+
+  if (desktopReady) {
+    console.log("");
+    console.log(
+      `${pc.green("✓")} ${pc.bold("All set.")} Open your agent and run ${pc.cyan("/petdex")} to wake the mascot.`,
+    );
+    console.log(
+      pc.dim(
+        `  Or from a shell: ${pc.cyan("petdex up")} (force-wake) · ${pc.cyan("petdex toggle")} (smart wake/sleep)`,
+      ),
+    );
+  } else {
+    console.log("");
+    console.log(
+      `${pc.yellow("!")} Hooks-only setup finished. Desktop still needs a supported build for this platform.`,
+    );
+    console.log(pc.dim(`  Try again later with ${pc.cyan("petdex update")}.`));
+  }
 }
 
 function tildeify(p: string): string {

--- a/packages/petdex-cli/package.json
+++ b/packages/petdex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "petdex",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "CLI for Petdex. Install, browse, and submit Codex pets from your terminal.",
   "homepage": "https://petdex.crafter.run",
   "repository": {

--- a/packages/petdex-cli/src/desktop/install.test.ts
+++ b/packages/petdex-cli/src/desktop/install.test.ts
@@ -14,8 +14,10 @@ import {
   _commitStagedForTest,
   _hasAnyInstalledPetForTest,
   _installStarterPetForTest,
+  desktopInstallPlanError,
   fetchLatestRelease,
   isTrustedAssetUrl,
+  resolveDesktopInstallPlan,
   type StagedFile,
 } from "./install";
 
@@ -327,6 +329,95 @@ describe("fetchLatestRelease", () => {
         status: 403,
       })) as unknown as typeof fetch;
     await expect(fetchLatestRelease()).rejects.toThrow(/403/);
+  });
+});
+
+describe("resolveDesktopInstallPlan", () => {
+  test("uses a bare binary when the release has one", () => {
+    const release = {
+      tag_name: "desktop-v0.3.0",
+      assets: [
+        {
+          name: "Petdex-arm64.dmg",
+          browser_download_url: "https://github.test/Petdex-arm64.dmg",
+          size: 10,
+        },
+        {
+          name: "petdex-desktop-darwin-arm64",
+          browser_download_url:
+            "https://github.test/petdex-desktop-darwin-arm64",
+          size: 20,
+        },
+        {
+          name: "petdex-desktop-sidecar.js",
+          browser_download_url: "https://github.test/petdex-desktop-sidecar.js",
+          size: 30,
+        },
+      ],
+    };
+
+    const plan = resolveDesktopInstallPlan(release, {
+      osLabel: "darwin",
+      archLabel: "arm64",
+      assetSuffix: "darwin-arm64",
+    });
+
+    expect(plan.kind).toBe("bare");
+    if (plan.kind !== "bare") throw new Error("expected bare plan");
+    expect(plan.binAsset.name).toBe("petdex-desktop-darwin-arm64");
+    expect(plan.sidecarAsset?.name).toBe("petdex-desktop-sidecar.js");
+  });
+
+  test("falls back to the macOS DMG when a release has no bare binary", () => {
+    const release = {
+      tag_name: "desktop-v0.2.0",
+      assets: [
+        {
+          name: "Petdex-arm64.dmg",
+          browser_download_url: "https://github.test/Petdex-arm64.dmg",
+          size: 10,
+        },
+      ],
+    };
+
+    const plan = resolveDesktopInstallPlan(release, {
+      osLabel: "darwin",
+      archLabel: "arm64",
+      assetSuffix: "darwin-arm64",
+    });
+
+    expect(plan.kind).toBe("macos-dmg");
+    if (plan.kind !== "macos-dmg") throw new Error("expected dmg plan");
+    expect(plan.dmgAsset.name).toBe("Petdex-arm64.dmg");
+  });
+
+  test("returns an explicit hooks-only Linux plan when no Linux binary exists", () => {
+    const release = {
+      tag_name: "desktop-v0.2.0",
+      assets: [
+        {
+          name: "Petdex-arm64.dmg",
+          browser_download_url: "https://github.test/Petdex-arm64.dmg",
+          size: 10,
+        },
+      ],
+    };
+
+    const plan = resolveDesktopInstallPlan(release, {
+      osLabel: "linux",
+      archLabel: "x64",
+      assetSuffix: "linux-x64",
+    });
+
+    expect(plan.kind).toBe("unsupported");
+    if (plan.kind !== "unsupported") {
+      throw new Error("expected unsupported plan");
+    }
+    expect(plan.reason).toContain("No Linux desktop binary");
+    expect(plan.hint).toContain("issue #296");
+    expect(desktopInstallPlanError(plan).message).toContain(
+      "petdex hooks install",
+    );
   });
 });
 

--- a/packages/petdex-cli/src/desktop/install.ts
+++ b/packages/petdex-cli/src/desktop/install.ts
@@ -1,9 +1,9 @@
 /**
- * `petdex install desktop` — downloads the petdex-desktop binary AND the
- * Node sidecar (`server.js`) for the current platform from GitHub Releases
- * and drops them under ~/.petdex/.
+ * `petdex install desktop` installs Petdex Desktop from GitHub Releases.
+ * Bare binary releases land under ~/.petdex/; DMG-only macOS releases land
+ * under ~/Applications/Petdex.app.
  *
- * Layout after install:
+ * Bare layout after install:
  *   ~/.petdex/bin/petdex-desktop          (platform-specific binary, executable)
  *   ~/.petdex/sidecar/server.js           (cross-platform Node script)
  *   ~/.petdex/version                     (tag name of the installed release)
@@ -98,10 +98,11 @@ export function desktopBinPath(): string {
   // work.
   const ext = nodePlatform() === "win32" ? ".exe" : "";
   if (nodePlatform() === "darwin") {
+    const home = homeDir();
     const appCandidates = [
       "/Applications/Petdex.app/Contents/MacOS/petdex-desktop",
       path.join(
-        homedir(),
+        home,
         "Applications",
         "Petdex.app",
         "Contents",
@@ -124,10 +125,11 @@ export function sidecarPath(): string {
   // first when running inside an .app), so `petdex doctor` and the
   // sidecar-status checks find the same file the desktop actually loads.
   if (nodePlatform() === "darwin") {
+    const home = homeDir();
     const appCandidates = [
       "/Applications/Petdex.app/Contents/Resources/sidecar/server.js",
       path.join(
-        homedir(),
+        home,
         "Applications",
         "Petdex.app",
         "Contents",
@@ -202,6 +204,74 @@ export function findBinaryAsset(
 
 export function findSidecarAsset(release: Release): ReleaseAsset | null {
   return release.assets.find((a) => a.name === SIDECAR_ASSET_NAME) ?? null;
+}
+
+export type DesktopInstallPlan =
+  | {
+      kind: "bare";
+      target: Target;
+      binAsset: ReleaseAsset;
+      sidecarAsset: ReleaseAsset | null;
+    }
+  | {
+      kind: "macos-dmg";
+      target: Target;
+      dmgAsset: ReleaseAsset;
+    }
+  | {
+      kind: "unsupported";
+      target: Target;
+      reason: string;
+      hint: string;
+    };
+
+export function resolveDesktopInstallPlan(
+  release: Release,
+  target = detectTarget(),
+): DesktopInstallPlan {
+  const wanted = `petdex-desktop-${target.assetSuffix}`;
+  const binAsset =
+    release.assets.find((a) => a.name === wanted) ??
+    release.assets.find((a) => a.name.startsWith(wanted));
+
+  if (binAsset) {
+    return {
+      kind: "bare",
+      target,
+      binAsset,
+      sidecarAsset: findSidecarAsset(release),
+    };
+  }
+
+  if (target.osLabel === "darwin") {
+    const dmgAsset = findDmgAsset(release, target.archLabel);
+    if (dmgAsset) {
+      return { kind: "macos-dmg", target, dmgAsset };
+    }
+  }
+
+  if (target.osLabel === "linux") {
+    return {
+      kind: "unsupported",
+      target,
+      reason: `No Linux desktop binary for ${target.archLabel} in ${release.tag_name}.`,
+      hint: "Hooks-only setup still works on Linux: run `petdex hooks install`. Desktop Linux support is tracked in issue #296.",
+    };
+  }
+
+  return {
+    kind: "unsupported",
+    target,
+    reason: `No desktop binary for ${target.assetSuffix} in ${release.tag_name}.`,
+    hint: "Run `petdex hooks install` for hooks-only setup, or download a supported desktop build from https://petdex.crafter.run/download.",
+  };
+}
+
+export function desktopInstallPlanError(plan: DesktopInstallPlan): Error {
+  if (plan.kind !== "unsupported") {
+    return new Error("Desktop install plan is supported");
+  }
+  return new Error(`${plan.reason}\n   ${plan.hint}`);
 }
 
 // macOS DMG asset for a given arch. Used by the app-bundle update path
@@ -383,9 +453,15 @@ export type StagedDesktopAssets = {
 export async function stageDesktopAssets(
   release: Release,
 ): Promise<StagedDesktopAssets> {
-  const target = detectTarget();
-  const binAsset = findBinaryAsset(release, target.assetSuffix);
-  const sidecarAsset = findSidecarAsset(release);
+  const plan = resolveDesktopInstallPlan(release);
+  if (plan.kind === "unsupported") throw desktopInstallPlanError(plan);
+  if (plan.kind === "macos-dmg") {
+    throw new Error(
+      `No bare desktop binary for ${plan.target.assetSuffix} in ${release.tag_name}. Use the DMG install path instead.`,
+    );
+  }
+  const binAsset = plan.binAsset;
+  const sidecarAsset = plan.sidecarAsset;
 
   const binPath = desktopBinPath();
   const sidecar = sidecarPath();
@@ -564,6 +640,18 @@ export async function updateAppBundleFromDmg(
   return { appBundleRoot, dmgAsset };
 }
 
+export function defaultUserAppBundleRoot(): string {
+  return path.join(homeDir(), "Applications", "Petdex.app");
+}
+
+export async function installAppBundleFromDmg(
+  release: Release,
+  appBundleRoot = defaultUserAppBundleRoot(),
+): Promise<AppBundleUpdateResult> {
+  await mkdir(path.dirname(appBundleRoot), { recursive: true });
+  return updateAppBundleFromDmg(release, appBundleRoot);
+}
+
 function parseHdiutilMount(stdout: string): string | null {
   // hdiutil attach's plain output is column-aligned with the mount
   // point in the last column. We grep for /Volumes/ and take the
@@ -693,6 +781,17 @@ async function hasAnyInstalledPet(): Promise<boolean> {
     }
   }
   return false;
+}
+
+export type StarterPetResult =
+  | { status: "present" }
+  | { status: "installed"; slug: string }
+  | { status: "missing" };
+
+export async function ensureStarterPet(): Promise<StarterPetResult> {
+  if (await hasAnyInstalledPet()) return { status: "present" };
+  const slug = await installStarterPet();
+  return slug ? { status: "installed", slug } : { status: "missing" };
 }
 
 // Best-effort install of the canonical starter pet. Called at the
@@ -881,46 +980,61 @@ export async function runInstallDesktop(): Promise<RunInstallDesktopResult> {
   }
   s.stop(`${pc.green("✓")} Latest: ${pc.bold(release.tag_name)}`);
 
-  const dl = p.spinner();
-  dl.start("Downloading desktop binary and sidecar");
-  let result: Awaited<ReturnType<typeof downloadDesktopAssets>>;
-  try {
-    result = await downloadDesktopAssets(release);
-  } catch (err) {
-    dl.stop(pc.red("failed"));
-    throw err;
+  const plan = resolveDesktopInstallPlan(release);
+  if (plan.kind === "unsupported") throw desktopInstallPlanError(plan);
+
+  if (plan.kind === "bare") {
+    const dl = p.spinner();
+    dl.start("Downloading desktop binary and sidecar");
+    let result: Awaited<ReturnType<typeof downloadDesktopAssets>>;
+    try {
+      result = await downloadDesktopAssets(release);
+    } catch (err) {
+      dl.stop(pc.red("failed"));
+      throw err;
+    }
+
+    const binPath = desktopBinPath();
+    const sidecarMsg = result.sidecarAsset
+      ? `\n${pc.dim("•")} Sidecar at ${pc.cyan(tildeify(sidecarPath()))} (${formatBytes(result.sidecarAsset.size)})`
+      : `\n${pc.yellow("!")} No sidecar in this release. Hooks won't reach the mascot until a release ships ${SIDECAR_ASSET_NAME}.`;
+    dl.stop(
+      `${pc.green("✓")} Binary at ${pc.cyan(tildeify(binPath))} (${formatBytes(result.binAsset.size)})${sidecarMsg}`,
+    );
+  } else {
+    const dl = p.spinner();
+    dl.start("Installing macOS app from DMG");
+    try {
+      await installAppBundleFromDmg(release);
+    } catch (err) {
+      dl.stop(pc.red("failed"));
+      throw err;
+    }
+    dl.stop(
+      `${pc.green("✓")} App at ${pc.cyan(tildeify(defaultUserAppBundleRoot()))} (${formatBytes(plan.dmgAsset.size)})`,
+    );
   }
 
-  const binPath = desktopBinPath();
-  const versionFile = path.join(homedir(), ".petdex", "version");
+  const versionFile = path.join(homeDir(), ".petdex", "version");
+  await mkdir(path.dirname(versionFile), { recursive: true });
   await writeFile(versionFile, `${release.tag_name}\n`);
-
-  const sidecarMsg = result.sidecarAsset
-    ? `\n${pc.dim("•")} Sidecar at ${pc.cyan(tildeify(sidecarPath()))} (${formatBytes(result.sidecarAsset.size)})`
-    : `\n${pc.yellow("!")} No sidecar in this release. Hooks won't reach the mascot until a release ships ${SIDECAR_ASSET_NAME}.`;
-  dl.stop(
-    `${pc.green("✓")} Binary at ${pc.cyan(tildeify(binPath))} (${formatBytes(result.binAsset.size)})${sidecarMsg}`,
-  );
 
   // Make sure the user has at least one pet to look at when they
   // run `petdex desktop start`. Without this, a fresh install (no
   // ?next=install/<slug> hint, no manual `petdex install <slug>`)
   // exits at startup with "No pets found, install one with..." —
   // the documented happy path silently dead-ends.
-  let starterSlug: string | null = null;
-  if (!(await hasAnyInstalledPet())) {
-    const ps = p.spinner();
-    ps.start("Installing a starter pet so the desktop has something to show");
-    starterSlug = await installStarterPet();
-    if (starterSlug) {
-      ps.stop(`${pc.green("✓")} Starter pet: ${pc.bold(starterSlug)}`);
-    } else {
-      // Non-fatal: binary still landed. Tell the user how to recover
-      // so they don't hit a confusing "No pets found" later.
-      ps.stop(
-        `${pc.yellow("!")} Could not download a starter pet. Run \`petdex install <slug>\` before \`petdex desktop start\`.`,
-      );
-    }
+  const ps = p.spinner();
+  ps.start("Checking starter pet");
+  const starter = await ensureStarterPet();
+  if (starter.status === "installed") {
+    ps.stop(`${pc.green("✓")} Starter pet: ${pc.bold(starter.slug)}`);
+  } else if (starter.status === "present") {
+    ps.stop(`${pc.green("✓")} Pet library ready`);
+  } else {
+    ps.stop(
+      `${pc.yellow("!")} Could not download a starter pet. Run \`petdex install <slug>\` before \`petdex desktop start\`.`,
+    );
   }
 
   const nextLines = [

--- a/packages/petdex-cli/src/desktop/update.test.ts
+++ b/packages/petdex-cli/src/desktop/update.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import {
   createServer,
   type IncomingMessage,
@@ -9,7 +15,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { requestSidecarHandoff } from "./update";
+import { requestSidecarHandoff, runUpdate } from "./update";
 
 // These tests pin the deadlock fix from opencode-bot review:
 // requestSidecarHandoff must POST to /update/handoff with the token
@@ -27,6 +33,66 @@ import { requestSidecarHandoff } from "./update";
 const HOST = "127.0.0.1";
 const PROBE_PORT = 47821;
 const TOKEN_HEADER = "x-petdex-update-token";
+
+describe("runUpdate", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "petdex-update-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("fresh-install DMG path creates the version directory before writing", async () => {
+    const dmgAsset = {
+      name: "Petdex-arm64.dmg",
+      browser_download_url: "https://github.test/Petdex-arm64.dmg",
+      size: 1234,
+    };
+    const release = {
+      tag_name: "desktop-v0.2.1",
+      assets: [dmgAsset],
+    };
+    const versionFile = join(dir, "home", ".petdex", "version");
+    let installedApp = false;
+    let refreshedHooks = false;
+
+    await runUpdate(["--silent", "--force"], "0.4.1", {
+      versionFile,
+      fetchLatestRelease: async () => release,
+      desktopBinPath: () =>
+        join(dir, "home", ".petdex", "bin", "petdex-desktop"),
+      appBundleRootFor: () => null,
+      desktopStatus: () => ({ state: "stopped" }),
+      resolveDesktopInstallPlan: () => ({
+        kind: "macos-dmg",
+        target: {
+          osLabel: "darwin",
+          archLabel: "arm64",
+          assetSuffix: "darwin-arm64",
+        },
+        dmgAsset,
+      }),
+      installAppBundleFromDmg: async () => {
+        installedApp = true;
+        return {
+          appBundleRoot: join(dir, "home", "Applications", "Petdex.app"),
+          dmgAsset,
+        };
+      },
+      hookRefresh: async () => {
+        refreshedHooks = true;
+      },
+    });
+
+    expect(installedApp).toBe(true);
+    expect(refreshedHooks).toBe(true);
+    expect(existsSync(versionFile)).toBe(true);
+    expect(readFileSync(versionFile, "utf8")).toBe("desktop-v0.2.1\n");
+  });
+});
 
 type FakeSidecarOptions = {
   expectedToken: string;

--- a/packages/petdex-cli/src/desktop/update.ts
+++ b/packages/petdex-cli/src/desktop/update.ts
@@ -18,7 +18,7 @@
  * working. If step 4 fails after stop: the user can restart manually.
  */
 import { existsSync, readFileSync } from "node:fs";
-import { writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 
@@ -99,19 +99,64 @@ export async function requestSidecarHandoff(
   }
 }
 
-function readInstalledVersion(): string | null {
-  if (!existsSync(VERSION_FILE)) return null;
+function readInstalledVersion(versionFile = VERSION_FILE): string | null {
+  if (!existsSync(versionFile)) return null;
   try {
-    return readFileSync(VERSION_FILE, "utf8").trim() || null;
+    return readFileSync(versionFile, "utf8").trim() || null;
   } catch {
     return null;
   }
 }
 
+async function writeInstalledVersion(
+  versionFile: string,
+  tagName: string,
+): Promise<void> {
+  await mkdir(path.dirname(versionFile), { recursive: true });
+  await writeFile(versionFile, `${tagName}\n`);
+}
+
+type RunUpdateDeps = {
+  fetchLatestRelease: typeof fetchLatestRelease;
+  desktopBinPath: typeof desktopBinPath;
+  appBundleRootFor: typeof appBundleRootFor;
+  desktopStatus: typeof desktopStatus;
+  stopDesktop: typeof stopDesktop;
+  updateAppBundleFromDmg: typeof updateAppBundleFromDmg;
+  resolveDesktopInstallPlan: typeof resolveDesktopInstallPlan;
+  installAppBundleFromDmg: typeof installAppBundleFromDmg;
+  stageDesktopAssets: typeof stageDesktopAssets;
+  commitDesktopAssets: typeof commitDesktopAssets;
+  requestSidecarHandoff: typeof requestSidecarHandoff;
+  waitForPortRelease: typeof waitForPortRelease;
+  startDesktop: typeof startDesktop;
+  hookRefresh: typeof runHookRefresh;
+  versionFile: string;
+};
+
 export async function runUpdate(
   args: string[] = [],
   cliVersion?: string,
+  overrides: Partial<RunUpdateDeps> = {},
 ): Promise<void> {
+  const deps: RunUpdateDeps = {
+    fetchLatestRelease,
+    desktopBinPath,
+    appBundleRootFor,
+    desktopStatus,
+    stopDesktop,
+    updateAppBundleFromDmg,
+    resolveDesktopInstallPlan,
+    installAppBundleFromDmg,
+    stageDesktopAssets,
+    commitDesktopAssets,
+    requestSidecarHandoff,
+    waitForPortRelease,
+    startDesktop,
+    hookRefresh: runHookRefresh,
+    versionFile: VERSION_FILE,
+    ...overrides,
+  };
   const updateStartedAt = Date.now();
   const force = args.includes("--force");
   // --silent skips the @clack/prompts UI (intro/spinner/outro) and uses
@@ -155,7 +200,7 @@ export async function runUpdate(
 
   intro("petdex update");
 
-  const installed = readInstalledVersion();
+  const installed = readInstalledVersion(deps.versionFile);
   info(
     installed
       ? `Installed: ${silent ? installed : pc.cyan(installed)}`
@@ -166,7 +211,7 @@ export async function runUpdate(
   s.start("Checking GitHub for the latest release");
   let release: Awaited<ReturnType<typeof fetchLatestRelease>>;
   try {
-    release = await fetchLatestRelease();
+    release = await deps.fetchLatestRelease();
   } catch (err) {
     s.stop(silent ? "failed" : pc.red("failed"));
     throw new Error(
@@ -195,10 +240,10 @@ export async function runUpdate(
   // preserving signature and stapler ticket. Bare-binary installs
   // (~/.petdex/bin/) keep using the rename flow because there's no
   // bundle to coordinate.
-  const binPath = desktopBinPath();
-  const appBundleRoot = appBundleRootFor(binPath);
+  const binPath = deps.desktopBinPath();
+  const appBundleRoot = deps.appBundleRootFor(binPath);
 
-  const wasRunning = desktopStatus().state === "running";
+  const wasRunning = deps.desktopStatus().state === "running";
 
   if (appBundleRoot) {
     // App-bundle path. Download + mount + ditto. We stop the desktop
@@ -211,13 +256,13 @@ export async function runUpdate(
           ? "Stopping running petdex-desktop"
           : `${pc.dim("•")} Stopping running petdex-desktop`,
       );
-      await stopDesktop();
+      await deps.stopDesktop();
     }
     const dl = makeSpinner();
     dl.start(`Downloading ${release.tag_name} DMG`);
     let result: Awaited<ReturnType<typeof updateAppBundleFromDmg>>;
     try {
-      result = await updateAppBundleFromDmg(release, appBundleRoot);
+      result = await deps.updateAppBundleFromDmg(release, appBundleRoot);
     } catch (err) {
       dl.stop(silent ? "failed" : pc.red("failed"));
       throw err;
@@ -229,14 +274,14 @@ export async function runUpdate(
     );
     // Skip the bare-binary phases below; jump straight to the version
     // file write + restart logic by setting a sentinel staged value.
-    await writeFile(VERSION_FILE, `${release.tag_name}\n`);
+    await writeInstalledVersion(deps.versionFile, release.tag_name);
     emit("cli_update_applied", {
       cli_version: cliVersion,
       from_version: installed ?? undefined,
       to_version: release.tag_name,
       duration_ms: Date.now() - updateStartedAt,
     });
-    await runHookRefresh(info, warn, silent);
+    await deps.hookRefresh(info, warn, silent);
     const note = installed
       ? `${installed}  ->  ${release.tag_name}`
       : release.tag_name;
@@ -248,7 +293,7 @@ export async function runUpdate(
     return;
   }
 
-  const installPlan = resolveDesktopInstallPlan(release);
+  const installPlan = deps.resolveDesktopInstallPlan(release);
   if (installPlan.kind === "unsupported") {
     throw desktopInstallPlanError(installPlan);
   }
@@ -259,13 +304,13 @@ export async function runUpdate(
           ? "Stopping running petdex-desktop"
           : `${pc.dim("•")} Stopping running petdex-desktop`,
       );
-      await stopDesktop();
+      await deps.stopDesktop();
     }
     const dl = makeSpinner();
     dl.start(`Installing ${release.tag_name} app`);
     let result: Awaited<ReturnType<typeof installAppBundleFromDmg>>;
     try {
-      result = await installAppBundleFromDmg(
+      result = await deps.installAppBundleFromDmg(
         release,
         defaultUserAppBundleRoot(),
       );
@@ -278,14 +323,14 @@ export async function runUpdate(
         ? `Installed ${result.appBundleRoot} (${formatBytes(result.dmgAsset.size)})`
         : `${pc.green("✓")} Installed ${pc.bold(result.appBundleRoot)} (${formatBytes(result.dmgAsset.size)})`,
     );
-    await writeFile(VERSION_FILE, `${release.tag_name}\n`);
+    await writeInstalledVersion(deps.versionFile, release.tag_name);
     emit("cli_update_applied", {
       cli_version: cliVersion,
       from_version: installed ?? undefined,
       to_version: release.tag_name,
       duration_ms: Date.now() - updateStartedAt,
     });
-    await runHookRefresh(info, warn, silent);
+    await deps.hookRefresh(info, warn, silent);
     const note = installed
       ? `${installed}  ->  ${release.tag_name}`
       : release.tag_name;
@@ -307,7 +352,7 @@ export async function runUpdate(
   dl.start(`Downloading ${release.tag_name}`);
   let staged: Awaited<ReturnType<typeof stageDesktopAssets>>;
   try {
-    staged = await stageDesktopAssets(release);
+    staged = await deps.stageDesktopAssets(release);
   } catch (err) {
     dl.stop(silent ? "failed" : pc.red("failed"));
     throw err;
@@ -330,14 +375,14 @@ export async function runUpdate(
         ? "Stopping running petdex-desktop"
         : `${pc.dim("•")} Stopping running petdex-desktop`,
     );
-    const stopResult = await stopDesktop();
+    const stopResult = await deps.stopDesktop();
     // On Windows the running .exe is file-locked until the process
     // fully exits. If stopDesktop() failed AND the process is still
     // alive, the rename in commitDesktopAssets would throw EPERM.
     // Surface this as a clear actionable error rather than a
     // confusing filesystem failure.
     if (process.platform === "win32" && !stopResult.ok) {
-      const recheck = desktopStatus();
+      const recheck = deps.desktopStatus();
       if (recheck.state === "running" && isPetdexPidAlive(recheck.pid)) {
         throw new Error(
           "Cannot replace petdex-desktop-win32-x64.exe: process is still running. " +
@@ -359,9 +404,9 @@ export async function runUpdate(
   // snapshots if any rename fails; we still have the previous
   // coherent install on disk. We let the throw bubble up as-is so
   // the caller's outer error handler reports it.
-  await commitDesktopAssets(staged);
+  await deps.commitDesktopAssets(staged);
 
-  await writeFile(VERSION_FILE, `${release.tag_name}\n`);
+  await writeInstalledVersion(deps.versionFile, release.tag_name);
 
   // Phase 4: restart so the user picks up the new binary + sidecar.
   //
@@ -389,7 +434,7 @@ export async function runUpdate(
         ? "Asking sidecar to release port"
         : `${pc.dim("•")} Asking sidecar to release port`,
     );
-    const handedOff = await requestSidecarHandoff();
+    const handedOff = await deps.requestSidecarHandoff();
     info(
       silent
         ? handedOff
@@ -399,7 +444,7 @@ export async function runUpdate(
           ? `${pc.dim("•")} Sidecar acknowledged handoff`
           : `${pc.dim("•")} Sidecar handoff unavailable, falling back to port wait`,
     );
-    const portFree = await waitForPortRelease(SIDECAR_PORT, {
+    const portFree = await deps.waitForPortRelease(SIDECAR_PORT, {
       timeoutMs: 10_000,
     });
     if (!portFree) {
@@ -419,7 +464,7 @@ export async function runUpdate(
         ? "Restarting petdex-desktop"
         : `${pc.dim("•")} Restarting petdex-desktop`,
     );
-    const startResult = await startDesktop();
+    const startResult = await deps.startDesktop();
     if (startResult.ok) {
       info(
         silent
@@ -442,7 +487,7 @@ export async function runUpdate(
     duration_ms: Date.now() - updateStartedAt,
   });
 
-  await runHookRefresh(info, warn, silent);
+  await deps.hookRefresh(info, warn, silent);
 
   const note = installed
     ? `${installed}  ->  ${release.tag_name}`

--- a/packages/petdex-cli/src/desktop/update.ts
+++ b/packages/petdex-cli/src/desktop/update.ts
@@ -29,8 +29,12 @@ import { emit } from "../telemetry.js";
 import {
   appBundleRootFor,
   commitDesktopAssets,
+  defaultUserAppBundleRoot,
   desktopBinPath,
+  desktopInstallPlanError,
   fetchLatestRelease,
+  installAppBundleFromDmg,
+  resolveDesktopInstallPlan,
   stageDesktopAssets,
   updateAppBundleFromDmg,
 } from "./install.js";
@@ -240,6 +244,55 @@ export async function runUpdate(
       silent
         ? `${note} (relaunch Petdex from /Applications to use it)`
         : `${pc.green("✓")} ${note}\n${pc.dim("  Relaunch Petdex from /Applications to use it.")}`,
+    );
+    return;
+  }
+
+  const installPlan = resolveDesktopInstallPlan(release);
+  if (installPlan.kind === "unsupported") {
+    throw desktopInstallPlanError(installPlan);
+  }
+  if (installPlan.kind === "macos-dmg") {
+    if (wasRunning) {
+      info(
+        silent
+          ? "Stopping running petdex-desktop"
+          : `${pc.dim("•")} Stopping running petdex-desktop`,
+      );
+      await stopDesktop();
+    }
+    const dl = makeSpinner();
+    dl.start(`Installing ${release.tag_name} app`);
+    let result: Awaited<ReturnType<typeof installAppBundleFromDmg>>;
+    try {
+      result = await installAppBundleFromDmg(
+        release,
+        defaultUserAppBundleRoot(),
+      );
+    } catch (err) {
+      dl.stop(silent ? "failed" : pc.red("failed"));
+      throw err;
+    }
+    dl.stop(
+      silent
+        ? `Installed ${result.appBundleRoot} (${formatBytes(result.dmgAsset.size)})`
+        : `${pc.green("✓")} Installed ${pc.bold(result.appBundleRoot)} (${formatBytes(result.dmgAsset.size)})`,
+    );
+    await writeFile(VERSION_FILE, `${release.tag_name}\n`);
+    emit("cli_update_applied", {
+      cli_version: cliVersion,
+      from_version: installed ?? undefined,
+      to_version: release.tag_name,
+      duration_ms: Date.now() - updateStartedAt,
+    });
+    await runHookRefresh(info, warn, silent);
+    const note = installed
+      ? `${installed}  ->  ${release.tag_name}`
+      : release.tag_name;
+    outro(
+      silent
+        ? `${note} (run petdex up to launch the app)`
+        : `${pc.green("✓")} ${note}\n${pc.dim("  Run petdex up to launch the app.")}`,
     );
     return;
   }

--- a/packages/petdex-desktop/scripts/build-release.sh
+++ b/packages/petdex-desktop/scripts/build-release.sh
@@ -112,7 +112,8 @@ EOF
 
 build_arch "aarch64-macos" "arm64" "Petdex-arm64.dmg"
 build_arch "x86_64-macos" "x64" "Petdex-x64.dmg"
+cp sidecar/server.js petdex-desktop-sidecar.js
 
 echo ""
 echo "Done. Artifacts:"
-ls -la Petdex-arm64.dmg Petdex-x64.dmg petdex-desktop-darwin-arm64 petdex-desktop-darwin-x64 2>/dev/null
+ls -la Petdex-arm64.dmg Petdex-x64.dmg petdex-desktop-darwin-arm64 petdex-desktop-darwin-x64 petdex-desktop-sidecar.js 2>/dev/null


### PR DESCRIPTION
## Summary
- make desktop install/update choose the correct release asset shape, including macOS DMG-only releases
- surface explicit hooks-only behavior when Linux desktop assets are unavailable
- make `petdex init` report desktop, starter pet, hooks, and startup state truthfully
- enforce release artifact presence before publishing desktop releases

## Verification
- `bun test packages/petdex-cli/src/desktop packages/petdex-cli/src/hooks`
- `bun run --cwd packages/petdex-cli typecheck`
- `bun run --cwd packages/petdex-cli build`
- scoped `biome check` on touched files
- `git diff --check`
- sensitive pattern audit on diff: 0 matches

## Release notes
After merge, publish a patch CLI release so `npx petdex@latest init` gets the activation fix. Desktop `desktop-v0.2.1` should follow to restore the complete release asset contract.