### PR TITLE
fix: normalize CLI publish metadata

### DIFF
--- a/packages/petdex-cli/package.json
+++ b/packages/petdex-cli/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://petdex.crafter.run",
   "repository": {
     "type": "git",
-    "url": "https://github.com/crafter-station/petdex",
+    "url": "git+https://github.com/crafter-station/petdex.git",
     "directory": "packages/petdex-cli"
   },
   "license": "MIT",
@@ -14,7 +14,7 @@
     "node": ">=20"
   },
   "bin": {
-    "petdex": "./dist/petdex.js"
+    "petdex": "dist/petdex.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Summary
- normalize the CLI package repository URL and bin path to npm's publish-time format
- prevents npm from rewriting package.json during the real publish

## Verification
- npm publish --dry-run --access public --json from packages/petdex-cli
- git diff --check
- secret-pattern scan on diff