### PR TITLE
feat(cli): add petdex select command

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ If hooks are installed, you can also type `/petdex status` inside a supported ag
 | --- | --- |
 | Browse pets | Visit [petdex.crafter.run](https://petdex.crafter.run) |
 | Install a pet | `npx petdex install <slug>` |
+| Switch active mascot | `npx petdex select` (interactive picker) or `npx petdex select <slug>` |
 | Run the desktop floater | `npx petdex init` (downloads the `.dmg` and wires Codex/Claude Code hooks) |
 | Make a pet | Use the `hatch-pet` skill inside Codex, or build one with the [Petdex creator tools](https://petdex.crafter.run/create) |
 | Submit a pet | `npx petdex submit ./my-pet/` or drop it through the web submitter |
@@ -104,7 +105,7 @@ crafter-station/petdex
 │   ├── app/api/admin/         Admin review surface for submissions, edits, collection requests
 │   └── lib/db/schema.ts       Drizzle schema (Postgres)
 ├── packages/
-│   ├── petdex-cli/            npm `petdex` (auth, list, install, submit, hooks, init)
+│   ├── petdex-cli/            npm `petdex` (auth, list, install, select, submit, hooks, init)
 │   ├── petdex-desktop/        Zig + WebKit floating mascot for macOS
 │   └── discord-bot/           Discord.js bot for the Petdex server
 ├── public/built-with/         Screenshots for the community page

--- a/packages/petdex-cli/README.md
+++ b/packages/petdex-cli/README.md
@@ -24,13 +24,15 @@ Requires Node.js 20+ (also runs on Bun).
 petdex login                       # opens browser, OAuth + PKCE via Clerk
 petdex list                        # browse approved pets
 petdex install boba                # drops boba into ~/.codex/pets/boba/
+petdex select                      # pick active mascot from installed pets (interactive)
+petdex select boba                 # set active mascot directly
 petdex submit ~/.codex/pets/boba   # share a single pet
 petdex submit ~/.codex/pets        # bulk submit every subfolder
 petdex whoami                      # confirm signed-in identity
 petdex logout                      # clear stored credentials
 ```
 
-After installing a pet, activate it inside Codex: **Settings → Appearance → Pets → Select**. Use `/pet` inside Codex to wake or tuck it away.
+After installing a pet, set it as active with `petdex select` or inside Codex: **Settings → Appearance → Pets → Select**. Use `/pet` inside Codex to wake or tuck it away.
 
 ## Commands
 
@@ -40,7 +42,8 @@ After installing a pet, activate it inside Codex: **Settings → Appearance → 
 | `petdex logout` | Clear local credentials. |
 | `petdex whoami` | Print the signed-in user's identity. |
 | `petdex list` | List approved pets in the gallery. |
-| `petdex install <slug>` | Install a pet into `~/.codex/pets/<slug>/`. |
+| `petdex install <slug>` | Install a pet into `~/.codex/pets/<slug>/` and `~/.petdex/pets/<slug>/`. |
+| `petdex select [slug]` | Set the active pet shown by Petdex Desktop. No args = interactive picker; pass a slug to skip the prompt. |
 | `petdex submit <path>` | Submit a pet folder, zip, or parent of pets (bulk). |
 | `petdex --version` | Print the CLI version. |
 

--- a/packages/petdex-cli/bin/petdex.ts
+++ b/packages/petdex-cli/bin/petdex.ts
@@ -178,6 +178,9 @@ async function main() {
     case "list":
       await cmdList();
       break;
+    case "select":
+      await cmdSelect(args.slice(1));
+      break;
     case "hooks":
       await cmdHooks(args.slice(1));
       break;
@@ -238,6 +241,7 @@ function printHelp() {
       `    ${pc.bold("install")} <slug...>  Install one or more pets into ~/.petdex/pets and ~/.codex/pets`,
       `    ${pc.bold("install desktop")}    Install the petdex-desktop binary (alternative to the .dmg)`,
       `    ${pc.bold("list")}               List approved pets`,
+      `    ${pc.bold("select")} [slug]      Set the active pet shown by the desktop mascot`,
       `    ${pc.bold("mcp-server")}          Start the MCP protocol server for Antigravity integration`,
       `    ${pc.bold("hooks install")}      Wire petdex-desktop into your coding agents`,
       `    ${pc.bold("toggle")}             One-shot wake/sleep. Flips the mascot on or off depending on current state`,
@@ -254,6 +258,8 @@ function printHelp() {
       `    ${dim("$")} petdex submit ~/.codex/pets/boba       ${dim("# single folder")}`,
       `    ${dim("$")} petdex install boba                    ${dim("# install a pet by slug")}`,
       `    ${dim("$")} petdex install boba doraemon mochi     ${dim("# install several at once")}`,
+      `    ${dim("$")} petdex select                          ${dim("# pick active mascot from installed pets")}`,
+      `    ${dim("$")} petdex select boba                     ${dim("# set active mascot directly")}`,
       `    ${dim("$")} petdex toggle                          ${dim("# wake or sleep the mascot")}`,
       `    ${dim("$")} petdex doctor                          ${dim("# diagnose install + agents")}`,
       `    ${dim("$")} petdex update                          ${dim("# pull the latest release")}`,
@@ -543,6 +549,53 @@ async function cmdList() {
   console.log(
     `\n${pc.dim("Install with")} ${pc.cyan("petdex install <slug>")}\n${pc.dim("Browse:")} ${pc.underline(PETDEX_URL)}`,
   );
+}
+
+async function cmdSelect(args: string[]) {
+  p.intro(pc.bgMagenta(pc.white(" petdex select ")));
+
+  const petsDir = path.join(homedir(), ".petdex", "pets");
+  let installedSlugs: string[] = [];
+  try {
+    const entries = await readdir(petsDir, { withFileTypes: true });
+    installedSlugs = entries
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort();
+  } catch {
+    // petsDir doesn't exist yet — no pets installed
+  }
+
+  if (installedSlugs.length === 0) {
+    p.cancel(
+      `No pets installed. Run ${pc.cyan("petdex install <slug>")} first.`,
+    );
+    process.exit(1);
+  }
+
+  let slug = args[0];
+
+  if (!slug) {
+    const choice = await p.select({
+      message: "Which pet should the desktop mascot show?",
+      options: installedSlugs.map((s) => ({ value: s, label: s })),
+    });
+    if (p.isCancel(choice)) {
+      p.cancel("Cancelled.");
+      process.exit(0);
+    }
+    slug = choice as string;
+  } else if (!installedSlugs.includes(slug)) {
+    p.cancel(
+      `${pc.cyan(slug)} is not installed. Run ${pc.cyan(`petdex install ${slug}`)} first.`,
+    );
+    process.exit(1);
+  }
+
+  const activeJsonPath = path.join(homedir(), ".petdex", "active.json");
+  await writeFile(activeJsonPath, JSON.stringify({ slug }) + "\n", "utf8");
+
+  p.outro(`${pc.green("✓")} Active pet set to ${pc.cyan(slug)}`);
 }
 
 async function cmdSubmit(args: string[]) {

--- a/packages/petdex-cli/bin/petdex.ts
+++ b/packages/petdex-cli/bin/petdex.ts
@@ -24,6 +24,11 @@ import {
   stopDesktop,
 } from "../src/desktop/process.js";
 import { runUpdate } from "../src/desktop/update.js";
+import {
+  collectSelectableSlugs,
+  reloadDesktopAfterSelect,
+  setActivePet,
+} from "../src/desktop/select.js";
 import { runInstall as runHooksInstall } from "../src/hooks/install.js";
 import {
   getKillswitchState,
@@ -108,7 +113,7 @@ async function getAuth(): Promise<ClerkCliAuth> {
   return _auth;
 }
 
-const VERSION = "0.4.1";
+const VERSION = "0.4.2";
 
 // ─── entrypoint ────────────────────────────────────────────────────────────
 main().catch((err) => {
@@ -554,27 +559,11 @@ async function cmdList() {
 async function cmdSelect(args: string[]) {
   p.intro(pc.bgMagenta(pc.white(" petdex select ")));
 
-  // Scan both pet roots the desktop uses, deduplicated.
-  const petRoots = [
-    path.join(homedir(), ".petdex", "pets"),
-    path.join(homedir(), ".codex", "pets"),
-  ];
-  const slugSet = new Set<string>();
-  for (const dir of petRoots) {
-    try {
-      const entries = await readdir(dir, { withFileTypes: true });
-      for (const e of entries) {
-        if (e.isDirectory()) slugSet.add(e.name);
-      }
-    } catch {
-      // directory doesn't exist — skip
-    }
-  }
-  const installedSlugs = [...slugSet].sort();
+  const installedSlugs = await collectSelectableSlugs();
 
   if (installedSlugs.length === 0) {
     p.cancel(
-      `No pets installed. Run ${pc.cyan("petdex install <slug>")} first.`,
+      `No usable pets installed. Run ${pc.cyan("petdex install <slug>")} first.`,
     );
     process.exit(1);
   }
@@ -598,22 +587,16 @@ async function cmdSelect(args: string[]) {
     process.exit(1);
   }
 
-  const activeJsonPath = path.join(homedir(), ".petdex", "active.json");
-  await mkdir(path.dirname(activeJsonPath), { recursive: true });
-  await writeFile(activeJsonPath, JSON.stringify({ slug }) + "\n", "utf8");
+  await setActivePet(slug);
 
-  // Restart the desktop so the new active pet is visible immediately.
-  // Non-fatal: if the desktop isn't running the stop is a no-op and
-  // the start will launch it fresh.
   const s = p.spinner();
   s.start("Reloading desktop…");
-  try {
-    await stopDesktop();
-    await startDesktop();
+  const reload = await reloadDesktopAfterSelect();
+  if (reload.status === "reloaded") {
     s.stop(`${pc.green("✓")} Active pet set to ${pc.cyan(slug)}`);
-  } catch {
+  } else {
     s.stop(
-      `${pc.green("✓")} Active pet set to ${pc.cyan(slug)} — restart the desktop to see the change`,
+      `${pc.green("✓")} Active pet set to ${pc.cyan(slug)}. ${pc.yellow("Restart the desktop to see the change.")} ${pc.dim(reload.reason)}`,
     );
   }
 }

--- a/packages/petdex-cli/bin/petdex.ts
+++ b/packages/petdex-cli/bin/petdex.ts
@@ -554,17 +554,23 @@ async function cmdList() {
 async function cmdSelect(args: string[]) {
   p.intro(pc.bgMagenta(pc.white(" petdex select ")));
 
-  const petsDir = path.join(homedir(), ".petdex", "pets");
-  let installedSlugs: string[] = [];
-  try {
-    const entries = await readdir(petsDir, { withFileTypes: true });
-    installedSlugs = entries
-      .filter((e) => e.isDirectory())
-      .map((e) => e.name)
-      .sort();
-  } catch {
-    // petsDir doesn't exist yet — no pets installed
+  // Scan both pet roots the desktop uses, deduplicated.
+  const petRoots = [
+    path.join(homedir(), ".petdex", "pets"),
+    path.join(homedir(), ".codex", "pets"),
+  ];
+  const slugSet = new Set<string>();
+  for (const dir of petRoots) {
+    try {
+      const entries = await readdir(dir, { withFileTypes: true });
+      for (const e of entries) {
+        if (e.isDirectory()) slugSet.add(e.name);
+      }
+    } catch {
+      // directory doesn't exist — skip
+    }
   }
+  const installedSlugs = [...slugSet].sort();
 
   if (installedSlugs.length === 0) {
     p.cancel(
@@ -595,7 +601,20 @@ async function cmdSelect(args: string[]) {
   const activeJsonPath = path.join(homedir(), ".petdex", "active.json");
   await writeFile(activeJsonPath, JSON.stringify({ slug }) + "\n", "utf8");
 
-  p.outro(`${pc.green("✓")} Active pet set to ${pc.cyan(slug)}`);
+  // Restart the desktop so the new active pet is visible immediately.
+  // Non-fatal: if the desktop isn't running the stop is a no-op and
+  // the start will launch it fresh.
+  const s = p.spinner();
+  s.start("Reloading desktop…");
+  try {
+    await stopDesktop();
+    await startDesktop();
+    s.stop(`${pc.green("✓")} Active pet set to ${pc.cyan(slug)}`);
+  } catch {
+    s.stop(
+      `${pc.green("✓")} Active pet set to ${pc.cyan(slug)} — restart the desktop to see the change`,
+    );
+  }
 }
 
 async function cmdSubmit(args: string[]) {

--- a/packages/petdex-cli/bin/petdex.ts
+++ b/packages/petdex-cli/bin/petdex.ts
@@ -599,6 +599,7 @@ async function cmdSelect(args: string[]) {
   }
 
   const activeJsonPath = path.join(homedir(), ".petdex", "active.json");
+  await mkdir(path.dirname(activeJsonPath), { recursive: true });
   await writeFile(activeJsonPath, JSON.stringify({ slug }) + "\n", "utf8");
 
   // Restart the desktop so the new active pet is visible immediately.

--- a/packages/petdex-cli/package.json
+++ b/packages/petdex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "petdex",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "CLI for Petdex. Install, browse, and submit Codex pets from your terminal.",
   "homepage": "https://petdex.crafter.run",
   "repository": {

--- a/packages/petdex-cli/src/desktop/install.ts
+++ b/packages/petdex-cli/src/desktop/install.ts
@@ -742,7 +742,7 @@ const MAX_PET_BYTES = 16 * 1024 * 1024;
 // the desktop binary would actually accept: present, openable,
 // stat-able, and within the size cap. Mirrors the validation in
 // main.zig's hasSpritesheet/checkSpritesheetVariant.
-function isPetUsable(slugDir: string): boolean {
+export function isPetUsable(slugDir: string): boolean {
   for (const name of ["spritesheet.webp", "spritesheet.png"]) {
     const file = path.join(slugDir, name);
     try {

--- a/packages/petdex-cli/src/desktop/select.test.ts
+++ b/packages/petdex-cli/src/desktop/select.test.ts
@@ -1,0 +1,136 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  collectSelectableSlugs,
+  reloadDesktopAfterSelect,
+  setActivePet,
+} from "./select.js";
+
+const tmpRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of tmpRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "petdex-select-test-"));
+  tmpRoots.push(root);
+  return root;
+}
+
+function makePet(root: string, slug: string, spriteName: string, bytes: Buffer) {
+  const dir = path.join(root, slug);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, spriteName), bytes);
+}
+
+describe("collectSelectableSlugs", () => {
+  test("returns sorted loadable slugs from both roots", async () => {
+    const petdexRoot = await tempRoot();
+    const codexRoot = await tempRoot();
+    makePet(petdexRoot, "zeta", "spritesheet.webp", Buffer.from("webp"));
+    makePet(codexRoot, "alpha", "spritesheet.png", Buffer.from("png"));
+    makePet(codexRoot, "zeta", "spritesheet.webp", Buffer.from("dupe"));
+
+    expect(await collectSelectableSlugs([petdexRoot, codexRoot])).toEqual([
+      "alpha",
+      "zeta",
+    ]);
+  });
+
+  test("skips missing, empty, and oversized pet directories", async () => {
+    const root = await tempRoot();
+    mkdirSync(path.join(root, "missing-sprite"), { recursive: true });
+    makePet(root, "empty", "spritesheet.webp", Buffer.alloc(0));
+    makePet(root, "huge", "spritesheet.webp", Buffer.alloc(16 * 1024 * 1024 + 1));
+    makePet(root, "good", "spritesheet.webp", Buffer.from("ok"));
+
+    expect(await collectSelectableSlugs([root])).toEqual(["good"]);
+  });
+});
+
+describe("setActivePet", () => {
+  test("creates active.json parent directory", async () => {
+    const root = await tempRoot();
+    const activePath = path.join(root, ".petdex", "active.json");
+
+    await setActivePet("alpha", activePath);
+
+    expect(readFileSync(activePath, "utf8")).toBe('{"slug":"alpha"}\n');
+  });
+});
+
+describe("reloadDesktopAfterSelect", () => {
+  test("starts the desktop when stop reports it was not running", async () => {
+    let started = false;
+    const result = await reloadDesktopAfterSelect({
+      stopDesktop: async () => ({
+        ok: false,
+        reason: "petdex-desktop is not running",
+      }),
+      startDesktop: async () => {
+        started = true;
+        return { ok: true, pid: 123, alreadyRunning: false };
+      },
+    });
+
+    expect(result).toEqual({ status: "reloaded" });
+    expect(started).toBe(true);
+  });
+
+  test("does not start after a real stop failure", async () => {
+    let started = false;
+    const result = await reloadDesktopAfterSelect({
+      stopDesktop: async () => ({ ok: false, reason: "failed to signal pid 7" }),
+      startDesktop: async () => {
+        started = true;
+        return { ok: true, pid: 123, alreadyRunning: false };
+      },
+    });
+
+    expect(result).toEqual({
+      status: "manual_restart_required",
+      reason: "failed to signal pid 7",
+    });
+    expect(started).toBe(false);
+  });
+
+  test("does not start while the old sidecar port is still busy", async () => {
+    let started = false;
+    const result = await reloadDesktopAfterSelect({
+      stopDesktop: async () => ({ ok: true, pid: 99, portReleased: false }),
+      startDesktop: async () => {
+        started = true;
+        return { ok: true, pid: 123, alreadyRunning: false };
+      },
+    });
+
+    expect(result).toEqual({
+      status: "manual_restart_required",
+      reason: "desktop sidecar port is still busy",
+    });
+    expect(started).toBe(false);
+  });
+
+  test("reports start failures instead of claiming reload success", async () => {
+    const result = await reloadDesktopAfterSelect({
+      stopDesktop: async () => ({ ok: true, pid: 99, portReleased: true }),
+      startDesktop: async () => ({
+        ok: false,
+        reason: "petdex-desktop binary not found",
+      }),
+    });
+
+    expect(result).toEqual({
+      status: "manual_restart_required",
+      reason: "petdex-desktop binary not found",
+    });
+  });
+});

--- a/packages/petdex-cli/src/desktop/select.ts
+++ b/packages/petdex-cli/src/desktop/select.ts
@@ -1,0 +1,81 @@
+import { mkdir, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { homeDir, isPetUsable } from "./install.js";
+import {
+  startDesktop,
+  stopDesktop,
+  type StartResult,
+  type StopResult,
+} from "./process.js";
+
+export type DesktopReloadDeps = {
+  stopDesktop: () => Promise<StopResult>;
+  startDesktop: () => Promise<StartResult>;
+};
+
+export type DesktopReloadResult =
+  | { status: "reloaded" }
+  | { status: "manual_restart_required"; reason: string };
+
+export function defaultPetRoots(home = homeDir()): string[] {
+  return [path.join(home, ".petdex", "pets"), path.join(home, ".codex", "pets")];
+}
+
+export function defaultActiveJsonPath(home = homeDir()): string {
+  return path.join(home, ".petdex", "active.json");
+}
+
+export async function collectSelectableSlugs(
+  roots = defaultPetRoots(),
+): Promise<string[]> {
+  const slugSet = new Set<string>();
+  for (const root of roots) {
+    try {
+      const entries = await readdir(root, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        if (isPetUsable(path.join(root, entry.name))) slugSet.add(entry.name);
+      }
+    } catch {
+      continue;
+    }
+  }
+  return [...slugSet].sort();
+}
+
+export async function setActivePet(
+  slug: string,
+  activeJsonPath = defaultActiveJsonPath(),
+): Promise<void> {
+  await mkdir(path.dirname(activeJsonPath), { recursive: true });
+  await writeFile(activeJsonPath, JSON.stringify({ slug }) + "\n", "utf8");
+}
+
+export async function reloadDesktopAfterSelect(
+  deps: DesktopReloadDeps = { stopDesktop, startDesktop },
+): Promise<DesktopReloadResult> {
+  const stopResult = await deps.stopDesktop();
+  if (!stopResult.ok && !stopResult.reason.includes("not running")) {
+    return {
+      status: "manual_restart_required",
+      reason: stopResult.reason,
+    };
+  }
+  if (stopResult.ok && !stopResult.portReleased) {
+    return {
+      status: "manual_restart_required",
+      reason: "desktop sidecar port is still busy",
+    };
+  }
+
+  const startResult = await deps.startDesktop();
+  if (!startResult.ok) {
+    return {
+      status: "manual_restart_required",
+      reason: startResult.reason,
+    };
+  }
+
+  return { status: "reloaded" };
+}


### PR DESCRIPTION
## What this does

Adds `petdex select` — a CLI command to switch the active mascot shown by the desktop app.

### Interactive mode

```
$ petdex select
┌  petdex select
│
◆  Which pet should the desktop mascot show?
│  ● ice-cream-cat
│  ○ loki
│  ○ boba
└
```

### Direct mode

```
$ petdex select loki
┌  petdex select
└  ✓ Active pet set to loki
```

### Guard rails

```
$ petdex select ghost
┌  petdex select
└  ghost is not installed. Run petdex install ghost first.

$ petdex select   # (nothing installed yet)
┌  petdex select
└  No pets installed. Run petdex install <slug> first.
```

## How it works

- Scans both `~/.petdex/pets/` and `~/.codex/pets/` (same roots the desktop uses) to build the selectable set
- Writes `{"slug":"<slug>"}` to `~/.petdex/active.json` — the exact file `petdex-desktop` reads via `readActiveSlug()`
- Restarts the running desktop so the new mascot is visible immediately (non-fatal if desktop isn't running)

## Files changed

| File | Change |
| --- | --- |
| `packages/petdex-cli/bin/petdex.ts` | `cmdSelect()`, switch case, help text |
| `README.md` | Add `petdex select` to "For users" table |
| `packages/petdex-cli/README.md` | Add `select` to quick start and commands table |

## Checklist

- [x] Interactive picker lists pets from both `~/.petdex/pets/` and `~/.codex/pets/`, sorted alphabetically
- [x] Direct `petdex select <slug>` validates slug is installed before writing
- [x] Written format matches `writeActiveSlug()` in `main.zig` exactly (`{"slug":"..."}\n`)
- [x] Desktop is restarted after writing `active.json` so change is visible immediately
- [x] Help text and READMEs updated
- [x] CLI builds + typechecks clean (`bun run build && bun run typecheck`)