### PR TITLE
feat: install desktop --from-path + fix window size on relaunch (desktop v0.2.2)

### DIFF
--- a/packages/petdex-cli/bin/petdex.ts
+++ b/packages/petdex-cli/bin/petdex.ts
@@ -14,6 +14,7 @@ import {
   ensureStarterPet,
   isTrustedAssetUrl,
   runInstallDesktop,
+  runInstallDesktopFromPath,
 } from "../src/desktop/install.js";
 import {
   cmdDesktopStart,
@@ -237,6 +238,7 @@ function printHelp() {
       `    ${pc.bold("edit")} <slug>        Edit a pet you own (--desc, --displayName, --sprite, --meta, --zip)`,
       `    ${pc.bold("install")} <slug...>  Install one or more pets into ~/.petdex/pets and ~/.codex/pets`,
       `    ${pc.bold("install desktop")}    Install the petdex-desktop binary (alternative to the .dmg)`,
+      `    ${pc.bold("install desktop --from-path <bin>")}  Install a locally-built binary (e.g. from zig build)`,
       `    ${pc.bold("list")}               List approved pets`,
       `    ${pc.bold("mcp-server")}          Start the MCP protocol server for Antigravity integration`,
       `    ${pc.bold("hooks install")}      Wire petdex-desktop into your coding agents`,
@@ -384,6 +386,13 @@ async function installOne(pet: ManifestPet): Promise<void> {
   );
 }
 
+function flagValue(args: string[], flag: string): string | null {
+  const idx = args.indexOf(flag);
+  if (idx === -1) return null;
+  const val = args[idx + 1];
+  return typeof val === "string" && !val.startsWith("--") ? val : null;
+}
+
 async function cmdInstall(args: string[]) {
   const first = args[0];
   if (!first) {
@@ -393,6 +402,30 @@ async function cmdInstall(args: string[]) {
     process.exit(1);
   }
   if (first === "desktop") {
+    const fromPath = flagValue(args, "--from-path");
+    if (fromPath) {
+      const versionLabel = flagValue(args, "--version-label") ?? undefined;
+      p.intro(pc.bgMagenta(pc.white(" petdex install desktop --from-path ")));
+      const s = p.spinner();
+      s.start(`Staging ${pc.cyan(path.resolve(fromPath))}`);
+      let result: { tag: string };
+      try {
+        result = await runInstallDesktopFromPath(path.resolve(fromPath), { versionLabel });
+      } catch (err) {
+        s.stop(pc.red("failed"));
+        throw err;
+      }
+      s.stop(
+        `${pc.green("✓")} Installed — version label: ${pc.bold(result.tag)}`,
+      );
+      emit("cli_install_desktop_local_success", {
+        cli_version: VERSION,
+        os: process.platform,
+        arch: process.arch,
+        version_label: result.tag,
+      });
+      return;
+    }
     const { tag } = await runInstallDesktop();
     emit("cli_install_desktop_success", {
       cli_version: VERSION,
@@ -735,18 +768,11 @@ async function cmdEdit(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  function flagValue(flag: string): string | null {
-    const idx = args.indexOf(flag);
-    if (idx === -1) return null;
-    const val = args[idx + 1];
-    return typeof val === "string" && !val.startsWith("--") ? val : null;
-  }
-
-  const descArg = flagValue("--desc");
-  const displayNameArg = flagValue("--displayName");
-  const spritePath = flagValue("--sprite");
-  const metaPath = flagValue("--meta");
-  const zipPath = flagValue("--zip");
+  const descArg = flagValue(args, "--desc");
+  const displayNameArg = flagValue(args, "--displayName");
+  const spritePath = flagValue(args, "--sprite");
+  const metaPath = flagValue(args, "--meta");
+  const zipPath = flagValue(args, "--zip");
 
   if (!descArg && !displayNameArg && !spritePath && !metaPath && !zipPath) {
     p.cancel("Nothing to edit. Provide at least one flag.");

--- a/packages/petdex-cli/src/desktop/install-from-path.test.ts
+++ b/packages/petdex-cli/src/desktop/install-from-path.test.ts
@@ -1,0 +1,359 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  chmodSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  _runInstallFromPathForTest,
+  type RunInstallFromPathDeps,
+} from "./install.js";
+
+// ─── shared fixtures ────────────────────────────────────────────────────────
+
+const realHome = process.env.HOME;
+let tmpHome: string;
+let tmpSrcDir: string;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), "petdex-fp-home-"));
+  tmpSrcDir = mkdtempSync(join(tmpdir(), "petdex-fp-src-"));
+  process.env.HOME = tmpHome;
+});
+
+afterEach(() => {
+  process.env.HOME = realHome;
+  rmSync(tmpHome, { recursive: true, force: true });
+  rmSync(tmpSrcDir, { recursive: true, force: true });
+});
+
+/** Write a file at tmpSrcDir/name with mode 0o755 and return its path. */
+function makeExecFile(name = "petdex-desktop"): string {
+  const p = join(tmpSrcDir, name);
+  writeFileSync(p, "ELF-STUB");
+  chmodSync(p, 0o755);
+  return p;
+}
+
+/** Partial deps — only what the test cares about; rest are no-ops. */
+function nopDeps(overrides: Partial<RunInstallFromPathDeps> = {}): Partial<RunInstallFromPathDeps> {
+  return {
+    lstat: lstatSync,
+    copyFile: async () => {},
+    rename: async () => {},
+    chmod: async () => {},
+    rm: async () => {},
+    mkdir: async () => {},
+    writeFile: async () => {},
+    stripQuarantine: () => {},
+    stopDesktop: async () => {},
+    startDesktop: async () => {},
+    hookRefresh: async () => {},
+    platform: () => "linux",
+    ...overrides,
+  };
+}
+
+// ─── lstat validation ───────────────────────────────────────────────────────
+
+describe("runInstallDesktopFromPath – lstat validation", () => {
+  test("1. rejects a path that does not exist", async () => {
+    const missing = join(tmpSrcDir, "nonexistent");
+    await expect(
+      _runInstallFromPathForTest(missing, {}, nopDeps()),
+    ).rejects.toThrow();
+  });
+
+  test("2. rejects a symlink", async () => {
+    const real = makeExecFile();
+    const link = join(tmpSrcDir, "link");
+    symlinkSync(real, link);
+    await expect(
+      _runInstallFromPathForTest(link, {}, nopDeps()),
+    ).rejects.toThrow(/symlink/i);
+  });
+
+  test("3. rejects a directory", async () => {
+    await expect(
+      _runInstallFromPathForTest(tmpSrcDir, {}, nopDeps()),
+    ).rejects.toThrow(/directory/i);
+  });
+
+  test("4. rejects a non-executable file on linux", async () => {
+    const f = join(tmpSrcDir, "noexec");
+    writeFileSync(f, "data");
+    chmodSync(f, 0o644);
+    await expect(
+      _runInstallFromPathForTest(f, {}, nopDeps({ platform: () => "linux" })),
+    ).rejects.toThrow(/executable/i);
+  });
+
+  test("5. accepts a non-executable file on win32 (no mode-bits check)", async () => {
+    const f = join(tmpSrcDir, "noexec.exe");
+    writeFileSync(f, "data");
+    chmodSync(f, 0o644);
+    // .resolves.not.toThrow() is broken in bun 1.3.x — use resolves.toBeDefined() instead
+    await expect(
+      _runInstallFromPathForTest(f, {}, nopDeps({ platform: () => "win32" })),
+    ).resolves.toBeDefined();
+  });
+
+  test("6. accepts a regular executable file (smoke)", async () => {
+    const p = makeExecFile();
+    const result = await _runInstallFromPathForTest(p, {}, nopDeps());
+    expect(result).toEqual({ tag: "local-build" });
+  });
+});
+
+// ─── staging and commit ─────────────────────────────────────────────────────
+
+describe("runInstallDesktopFromPath – staging and commit", () => {
+  test("7. copies binary to destPath + '.tmp' then renames into place", async () => {
+    const src = makeExecFile();
+    const copyArgs: string[] = [];
+    const renameArgs: string[] = [];
+    await _runInstallFromPathForTest(
+      src, {},
+      nopDeps({
+        copyFile: async (_s, d) => { copyArgs.push(d); },
+        rename: async (s, d) => { renameArgs.push(s); renameArgs.push(d); },
+      }),
+    );
+    expect(copyArgs[0]).toMatch(/\.tmp$/);
+    expect(renameArgs[0]).toMatch(/\.tmp$/);
+    expect(renameArgs[1]).not.toMatch(/\.tmp$/);
+  });
+
+  test("8. chmods destination to 0o755 after rename", async () => {
+    const src = makeExecFile();
+    const order: string[] = [];
+    const chmodArgs: [string, number][] = [];
+    await _runInstallFromPathForTest(
+      src, {},
+      nopDeps({
+        rename: async () => { order.push("rename"); },
+        chmod: async (p, m) => { order.push("chmod"); chmodArgs.push([p, m]); },
+      }),
+    );
+    const renameIdx = order.lastIndexOf("rename");
+    const chmodIdx = order.lastIndexOf("chmod");
+    expect(chmodIdx).toBeGreaterThan(renameIdx);
+    expect(chmodArgs[0][1]).toBe(0o755);
+    expect(chmodArgs[0][0]).not.toMatch(/\.tmp$/);
+  });
+
+  test("9. .tmp file is not left on disk after success", async () => {
+    const src = makeExecFile();
+    const destDir = join(tmpHome, ".petdex", "bin");
+    mkdirSync(destDir, { recursive: true });
+    await _runInstallFromPathForTest(
+      src, {},
+      nopDeps({
+        copyFile: async (s, d) => {
+          const { copyFile: fsCopyFile } = await import("node:fs/promises");
+          await fsCopyFile(s, d);
+        },
+        rename: async (s, d) => {
+          const { rename: fsRename } = await import("node:fs/promises");
+          await fsRename(s, d);
+        },
+        mkdir: async (p, opts) => {
+          const { mkdir: fsMkdir } = await import("node:fs/promises");
+          await fsMkdir(p, opts);
+        },
+      }),
+    );
+    const destPath = join(tmpHome, ".petdex", "bin", "petdex-desktop");
+    const tmpPath = destPath + ".tmp";
+    const { existsSync } = await import("node:fs");
+    expect(existsSync(tmpPath)).toBe(false);
+  });
+
+  test("10. rolls back (.tmp deleted) when rename fails", async () => {
+    const src = makeExecFile();
+    const rmArgs: string[] = [];
+    await expect(
+      _runInstallFromPathForTest(
+        src, {},
+        nopDeps({
+          copyFile: async () => {},
+          rename: async () => { throw new Error("EXDEV"); },
+          rm: async (p) => { rmArgs.push(p); },
+        }),
+      ),
+    ).rejects.toThrow("EXDEV");
+    expect(rmArgs.some((p) => p.endsWith(".tmp"))).toBe(true);
+  });
+});
+
+// ─── sidecar copy ───────────────────────────────────────────────────────────
+
+describe("runInstallDesktopFromPath – sidecar copy", () => {
+  test("11. copies server.js sibling to ~/.petdex/sidecar/server.js when present", async () => {
+    const src = makeExecFile();
+    writeFileSync(join(tmpSrcDir, "server.js"), "SERVER");
+    const copyArgs: Array<[string, string]> = [];
+    await _runInstallFromPathForTest(
+      src, {},
+      nopDeps({
+        copyFile: async (s, d) => { copyArgs.push([s, d]); },
+      }),
+    );
+    const sidecarCopy = copyArgs.find(([, d]) => d.includes("sidecar/server.js") || d.includes("sidecar\\server.js"));
+    expect(sidecarCopy).toBeDefined();
+  });
+
+  test("12. skips sidecar copy when no server.js sibling exists", async () => {
+    const src = makeExecFile();
+    const copyArgs: Array<[string, string]> = [];
+    await _runInstallFromPathForTest(
+      src, {},
+      nopDeps({
+        copyFile: async (s, d) => { copyArgs.push([s, d]); },
+      }),
+    );
+    const sidecarCopy = copyArgs.find(([, d]) => d.includes("sidecar"));
+    expect(sidecarCopy).toBeUndefined();
+    expect(copyArgs.length).toBe(1);
+  });
+});
+
+// ─── quarantine strip ───────────────────────────────────────────────────────
+
+describe("runInstallDesktopFromPath – quarantine strip", () => {
+  test("13. calls stripQuarantine on dest binary on darwin", async () => {
+    const src = makeExecFile();
+    const stripped: string[] = [];
+    await _runInstallFromPathForTest(
+      src, {},
+      nopDeps({
+        platform: () => "darwin",
+        stripQuarantine: (p) => { stripped.push(p); },
+      }),
+    );
+    expect(stripped.length).toBe(1);
+    expect(stripped[0]).not.toMatch(/\.tmp$/);
+  });
+
+  test("14. does not call stripQuarantine on linux", async () => {
+    const src = makeExecFile();
+    const stripped: string[] = [];
+    await _runInstallFromPathForTest(
+      src, {},
+      nopDeps({
+        platform: () => "linux",
+        stripQuarantine: (p) => { stripped.push(p); },
+      }),
+    );
+    expect(stripped.length).toBe(0);
+  });
+});
+
+// ─── version file ───────────────────────────────────────────────────────────
+
+describe("runInstallDesktopFromPath – version file", () => {
+  test("15. writes 'local-build' to ~/.petdex/version when versionLabel is omitted", async () => {
+    const src = makeExecFile();
+    const written: Array<[string, string]> = [];
+    await _runInstallFromPathForTest(
+      src, {},
+      nopDeps({
+        writeFile: async (p, d) => { written.push([p, d]); },
+      }),
+    );
+    const versionEntry = written.find(([p]) => p.endsWith("version"));
+    expect(versionEntry).toBeDefined();
+    expect(versionEntry![1]).toBe("local-build\n");
+  });
+
+  test("16. writes the supplied versionLabel to ~/.petdex/version", async () => {
+    const src = makeExecFile();
+    const written: Array<[string, string]> = [];
+    await _runInstallFromPathForTest(
+      src, { versionLabel: "my-tag" },
+      nopDeps({
+        writeFile: async (p, d) => { written.push([p, d]); },
+      }),
+    );
+    const versionEntry = written.find(([p]) => p.endsWith("version"));
+    expect(versionEntry![1]).toBe("my-tag\n");
+  });
+
+  test("17. rejects a versionLabel that fails the allowlist regex", async () => {
+    const src = makeExecFile();
+    const copyArgs: string[] = [];
+    await expect(
+      _runInstallFromPathForTest(
+        src, { versionLabel: "bad label!" },
+        nopDeps({ copyFile: async (_, d) => { copyArgs.push(d); } }),
+      ),
+    ).rejects.toThrow(/invalid/i);
+    expect(copyArgs.length).toBe(0);
+  });
+
+  test("18. rejects a versionLabel longer than 80 characters", async () => {
+    const src = makeExecFile();
+    const copyArgs: string[] = [];
+    await expect(
+      _runInstallFromPathForTest(
+        src, { versionLabel: "a".repeat(81) },
+        nopDeps({ copyFile: async (_, d) => { copyArgs.push(d); } }),
+      ),
+    ).rejects.toThrow();
+    expect(copyArgs.length).toBe(0);
+  });
+});
+
+// ─── return value ───────────────────────────────────────────────────────────
+
+describe("runInstallDesktopFromPath – return value", () => {
+  test("19. returns { tag: 'local-build' } when no versionLabel is given", async () => {
+    const src = makeExecFile();
+    const result = await _runInstallFromPathForTest(src, {}, nopDeps());
+    expect(result).toEqual({ tag: "local-build" });
+  });
+
+  test("20. returns { tag: versionLabel } when a valid custom label is given", async () => {
+    const src = makeExecFile();
+    const result = await _runInstallFromPathForTest(
+      src, { versionLabel: "zig-main" }, nopDeps(),
+    );
+    expect(result).toEqual({ tag: "zig-main" });
+  });
+});
+
+// ─── stopDesktop / startDesktop ─────────────────────────────────────────────
+
+describe("runInstallDesktopFromPath – stopDesktop / startDesktop", () => {
+  test("21. calls stopDesktop before the file copy", async () => {
+    const src = makeExecFile();
+    const order: string[] = [];
+    await _runInstallFromPathForTest(
+      src, {},
+      nopDeps({
+        stopDesktop: async () => { order.push("stop"); },
+        copyFile: async () => { order.push("copy"); },
+      }),
+    );
+    expect(order.indexOf("stop")).toBeLessThan(order.indexOf("copy"));
+  });
+
+  test("22. does not throw when startDesktop rejects (non-fatal)", async () => {
+    const src = makeExecFile();
+    await expect(
+      _runInstallFromPathForTest(
+        src, {},
+        nopDeps({
+          startDesktop: async () => { throw new Error("cannot start"); },
+        }),
+      ),
+    ).resolves.toBeDefined();
+  });
+});

--- a/packages/petdex-cli/src/desktop/install.ts
+++ b/packages/petdex-cli/src/desktop/install.ts
@@ -16,8 +16,8 @@
  * `petdex-desktop-sidecar.js`.
  */
 import { randomBytes } from "node:crypto";
-import { existsSync, statSync } from "node:fs";
-import { chmod, mkdir, rename, rm, writeFile } from "node:fs/promises";
+import { existsSync, lstatSync, statSync } from "node:fs";
+import { chmod, copyFile, mkdir, rename, rm, writeFile } from "node:fs/promises";
 import { homedir, arch as nodeArch, platform as nodePlatform } from "node:os";
 import path from "node:path";
 import { Readable } from "node:stream";
@@ -1074,4 +1074,170 @@ export async function _streamDownload(
   const reader = Readable.fromWeb(res.body as never);
   const { createWriteStream } = await import("node:fs");
   await pipeline(reader, createWriteStream(destPath));
+}
+
+// ─── install from local path ────────────────────────────────────────────────
+
+export interface RunInstallFromPathDeps {
+  lstat: (p: string) => import("node:fs").Stats;
+  copyFile: (src: string, dest: string) => Promise<void>;
+  rename: (src: string, dest: string) => Promise<void>;
+  chmod: (p: string, mode: number) => Promise<void>;
+  rm: (p: string, opts?: { force?: boolean }) => Promise<void>;
+  mkdir: (p: string, opts?: { recursive?: boolean }) => Promise<string | undefined>;
+  writeFile: (p: string, data: string) => Promise<void>;
+  stripQuarantine: (p: string) => void;
+  stopDesktop: () => Promise<unknown>;
+  startDesktop: () => Promise<unknown>;
+  hookRefresh: () => Promise<unknown>;
+  platform: () => string;
+}
+
+export type RunInstallDesktopFromPathResult = { tag: string };
+
+const VERSION_LABEL_RE = /^[a-zA-Z0-9._-]{1,80}$/;
+
+function sanitizeVersionLabel(label: string | undefined): string {
+  const resolved = (label ?? "local-build").trim();
+  if (!VERSION_LABEL_RE.test(resolved)) {
+    throw new Error(
+      `--version-label "${resolved}" is invalid. ` +
+        `Must match ^[a-zA-Z0-9._-]{1,80}$ (allowed: letters, digits, . _ -; max 80 chars).`,
+    );
+  }
+  return resolved;
+}
+
+async function stageLocalBinary(
+  fromPath: string,
+  destPath: string,
+  deps: RunInstallFromPathDeps,
+): Promise<void> {
+  const tmpPath = `${destPath}.tmp`;
+  try {
+    await deps.copyFile(fromPath, tmpPath);
+    await deps.rename(tmpPath, destPath);
+  } catch (err) {
+    try {
+      await deps.rm(tmpPath, { force: true });
+    } catch {
+      // best-effort
+    }
+    throw err;
+  }
+}
+
+export async function _runInstallFromPathForTest(
+  fromPath: string,
+  opts?: { versionLabel?: string },
+  deps?: Partial<RunInstallFromPathDeps>,
+): Promise<RunInstallDesktopFromPathResult> {
+  // Validation — all checks happen BEFORE any filesystem mutation.
+  const stat = (deps?.lstat ?? lstatSync)(fromPath);
+  if (stat.isSymbolicLink()) {
+    throw new Error(`--from-path must not be a symlink: ${fromPath}`);
+  }
+  if (stat.isDirectory()) {
+    throw new Error(`--from-path expected a file, got a directory: ${fromPath}`);
+  }
+  if (!stat.isFile()) {
+    throw new Error(`--from-path expected a regular file: ${fromPath}`);
+  }
+  const platform = (deps?.platform ?? nodePlatform)();
+  if (platform !== "win32" && (stat.mode & 0o111) === 0) {
+    throw new Error(
+      `--from-path file is not executable: ${fromPath} (run chmod +x first)`,
+    );
+  }
+  const label = sanitizeVersionLabel(opts?.versionLabel);
+
+  // Real deps for any not overridden by the caller.
+  const realDeps: RunInstallFromPathDeps = {
+    lstat: lstatSync,
+    copyFile,
+    rename,
+    chmod,
+    rm,
+    mkdir,
+    writeFile: (p, data) => writeFile(p, data),
+    stripQuarantine: (p) => {
+      if (nodePlatform() !== "darwin") return;
+      try {
+        const { spawnSync: sp } = require("node:child_process") as typeof import("node:child_process");
+        sp("xattr", ["-d", "com.apple.quarantine", p], { stdio: "ignore" });
+      } catch {
+        // best-effort
+      }
+    },
+    stopDesktop: async () => {
+      const { stopDesktop: sd } = await import("./process.js");
+      return sd();
+    },
+    startDesktop: async () => {
+      const { startDesktop: sd } = await import("./process.js");
+      return sd();
+    },
+    hookRefresh: async () => {
+      const { runRefresh } = await import("../hooks/refresh.js");
+      return runRefresh();
+    },
+    platform: nodePlatform,
+  };
+
+  const d: RunInstallFromPathDeps = { ...realDeps, ...deps };
+
+  // Mutation begins here.
+  await d.stopDesktop();
+
+  const destPath = desktopBinPath();
+  await d.mkdir(path.dirname(destPath), { recursive: true });
+  await stageLocalBinary(fromPath, destPath, d);
+  await d.chmod(destPath, 0o755);
+
+  if (d.platform() === "darwin") {
+    d.stripQuarantine(destPath);
+  }
+
+  // Sidecar: copy server.js sibling if present (and not a symlink).
+  const serverJsSrc = path.join(path.dirname(fromPath), "server.js");
+  let sidecarPresent = false;
+  try {
+    const sjs = lstatSync(serverJsSrc);
+    if (sjs.isFile() && !sjs.isSymbolicLink()) sidecarPresent = true;
+  } catch {
+    // does not exist — skip
+  }
+  if (sidecarPresent) {
+    const sidecarDest = sidecarPath();
+    await d.mkdir(path.dirname(sidecarDest), { recursive: true });
+    await d.copyFile(serverJsSrc, sidecarDest);
+  }
+
+  // Version file.
+  const versionFile = path.join(homeDir(), ".petdex", "version");
+  await d.mkdir(path.dirname(versionFile), { recursive: true });
+  await d.writeFile(versionFile, `${label}\n`);
+
+  // Hook refresh — non-fatal.
+  try {
+    await d.hookRefresh();
+  } catch (err) {
+    console.warn(`[petdex] hook refresh failed: ${(err as Error).message}`);
+  }
+
+  // Start desktop — non-fatal.
+  try {
+    await d.startDesktop();
+  } catch (err) {
+    console.warn(`[petdex] desktop start failed: ${(err as Error).message}`);
+  }
+
+  return { tag: label };
+}
+
+export async function runInstallDesktopFromPath(
+  fromPath: string,
+  opts?: { versionLabel?: string },
+): Promise<RunInstallDesktopFromPathResult> {
+  return _runInstallFromPathForTest(fromPath, opts);
 }

--- a/packages/petdex-cli/src/telemetry.ts
+++ b/packages/petdex-cli/src/telemetry.ts
@@ -48,6 +48,7 @@ type TelemetryConfig = {
 
 export type TelemetryEvent =
   | "cli_install_desktop_success"
+  | "cli_install_desktop_local_success"
   | "cli_hooks_install_success"
   | "cli_desktop_start_success"
   | "cli_update_applied"
@@ -58,6 +59,7 @@ export type TelemetryEvent =
 export type TelemetryPayload = {
   cli_version?: string;
   binary_version?: string;
+  version_label?: string;
   os?: string;
   arch?: string;
   agents?: string[];

--- a/packages/petdex-desktop/build.zig.zon
+++ b/packages/petdex-desktop/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .petdex_desktop,
     .fingerprint = 0x8bf769b722fabe52,
-    .version = "0.2.1",
+    .version = "0.2.2",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{},
     .paths = .{ "build.zig", "build.zig.zon", "src", "assets", "frontend", "app.zon", "README.md" },

--- a/packages/petdex-desktop/src/runner.zig
+++ b/packages/petdex-desktop/src/runner.zig
@@ -180,7 +180,12 @@ fn prepareStateStore(io: std.Io, env_map: *std.process.Environ.Map, app_info: *z
     const store = zero_native.window_state.Store.init(io, paths.state_dir, paths.file_path);
     if (app_info.main_window.restore_state) {
         if (store.loadWindow(app_info.main_window.label, &buffers.read) catch null) |saved| {
-            app_info.main_window.default_frame = saved.frame;
+            // Restore position only — keep the default compact dimensions so a
+            // quit while the picker was open never relaunches at menu size (480×420).
+            var f = app_info.main_window.default_frame;
+            f.x = saved.frame.x;
+            f.y = saved.frame.y;
+            app_info.main_window.default_frame = f;
         }
     }
     return store;


### PR DESCRIPTION
Closes #301

## Summary

Bundles two related changes that improve the local desktop development workflow:

1. **`petdex install desktop --from-path <binary>`** — install a locally-built binary without going through GitHub Releases
2. **Desktop window size fix** — mascot no longer relaunches at picker-expanded size (480×420) after being quit while the picker was open

These belong together: the `--from-path` feature is the ergonomic layer on top of the desktop fix — you rebuild, you install, done.
---
## Visual Change:
<img width="271" height="341" alt="image" src="https://github.com/user-attachments/assets/a53c3e3d-859e-4cec-812b-d7749ab3518c" />

---

## `petdex install desktop --from-path` (`packages/petdex-cli`)

```sh
# After zig build -Doptimize=ReleaseFast
petdex install desktop --from-path packages/petdex-desktop/zig-out/bin/petdex-desktop

# With a custom version label (default: local-build)
petdex install desktop --from-path ./zig-out/bin/petdex-desktop --version-label my-build
```

- Validates path with `lstatSync` — rejects symlinks, directories, non-executable files, invalid labels — all **before** any fs mutation
- Stages atomically via `.tmp` rename with rollback on failure
- Strips `com.apple.quarantine` xattr on macOS post-copy
- Co-installs `server.js` sidecar if present alongside the binary
- Writes sanitised version label to `~/.petdex/version` (allowlist `^[a-zA-Z0-9._-]{1,80}$`)
- Stops → installs → refreshes hooks → starts (start failure non-fatal)
- Emits `cli_install_desktop_local_success` telemetry (separate from the GitHub-release event)
- **22 TDD test cases** — validation, staging/rollback, sidecar copy, quarantine strip, version file, lifecycle order

## Desktop window fix (`packages/petdex-desktop`)

**Root cause:** `prepareStateStore` in `runner.zig` restored the full saved `NSWindow` frame on launch, including width/height. If the user quit while the picker was open (480×420), that size was persisted and reloaded next launch — causing the window to clip against the screen edge on smaller MacBooks.

**Fix:** restore `x`/`y` position only — keep the default compact dimensions:

```zig
// Before
app_info.main_window.default_frame = saved.frame;

// After
var f = app_info.main_window.default_frame;
f.x = saved.frame.x;
f.y = saved.frame.y;
app_info.main_window.default_frame = f;
```

`RectF` field names verified against `Railly/zero-native@feature/window-resize`. Binary builds clean with `zig build -Doptimize=ReleaseFast` on macOS arm64. Bumps `petdex-desktop` to **v0.2.2**.

---

## Test plan

- [ ] `bun test src/desktop/install-from-path.test.ts` — 22 tests pass ✓
- [ ] `bun test` — 62 tests pass (22 new + 40 existing) ✓
- [ ] `bun run build && bun run typecheck` — clean ✓
- [ ] Symlink rejection: `ln -sf /tmp/x /tmp/link && petdex install desktop --from-path /tmp/link` → error, nothing installed
- [ ] Label validation: `--version-label "bad label!"` → error before any copy
- [ ] Desktop: quit with picker open → relaunch → window opens at 140×180 ✓
- [ ] Desktop: drag mascot → quit → relaunch → reopens at dragged position ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)