### PR TITLE
chore(desktop): add dev launcher scripts

### DIFF
--- a/scripts/macos-dev-app.sh
+++ b/scripts/macos-dev-app.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build a local macOS app wrapper for the desktop binary.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DESKTOP_DIR="$ROOT/packages/petdex-desktop"
+APP_PATH="${PETDEX_DEV_APP_PATH:-$HOME/Applications/Petdex Dev.app}"
+EXECUTABLE="$DESKTOP_DIR/zig-out/bin/petdex-desktop"
+CONTENTS_DIR="$APP_PATH/Contents"
+MACOS_DIR="$CONTENTS_DIR/MacOS"
+RESOURCES_DIR="$CONTENTS_DIR/Resources"
+LAUNCHER="$MACOS_DIR/PetdexDev"
+
+mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
+
+if [[ -f "$DESKTOP_DIR/assets/icon.icns" ]]; then
+  cp "$DESKTOP_DIR/assets/icon.icns" "$RESOURCES_DIR/icon.icns"
+fi
+
+cat > "$CONTENTS_DIR/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleDisplayName</key>
+  <string>Petdex Dev</string>
+  <key>CFBundleExecutable</key>
+  <string>PetdexDev</string>
+  <key>CFBundleIconFile</key>
+  <string>icon.icns</string>
+  <key>CFBundleIdentifier</key>
+  <string>run.crafter.petdex-desktop.dev</string>
+  <key>CFBundleName</key>
+  <string>Petdex Dev</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.0.0-dev</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>13.0</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+</dict>
+</plist>
+PLIST
+
+cat > "$LAUNCHER" <<LAUNCHER
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$DESKTOP_DIR"
+exec "$EXECUTABLE"
+LAUNCHER
+chmod +x "$LAUNCHER"
+
+echo "Petdex Dev.app ready: $APP_PATH"

--- a/scripts/macos-dev-restart.sh
+++ b/scripts/macos-dev-restart.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Rebuild and relaunch the local macOS desktop app.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DESKTOP_DIR="$ROOT/packages/petdex-desktop"
+SIDECAR_DIR="$DESKTOP_DIR/sidecar"
+APP_PATH="${PETDEX_DEV_APP_PATH:-$HOME/Applications/Petdex Dev.app}"
+ZERO_NATIVE_PATH="${ZERO_NATIVE_PATH:-$(cd "$ROOT/../zero-native" 2>/dev/null && pwd || true)}"
+ZIG="${ZIG:-$(command -v zig || true)}"
+
+if [[ -z "$ZERO_NATIVE_PATH" || ! -d "$ZERO_NATIVE_PATH" ]]; then
+  echo "macos-dev-restart: ZERO_NATIVE_PATH is not set and ../zero-native was not found" >&2
+  exit 1
+fi
+
+if [[ -z "$ZIG" || ! -x "$ZIG" ]]; then
+  echo "macos-dev-restart: zig not found. Set ZIG=/path/to/zig" >&2
+  exit 1
+fi
+
+echo "==> Build sidecar"
+(cd "$SIDECAR_DIR" && npm exec --yes --package bun -- bun run build)
+
+echo "==> Build desktop"
+(cd "$DESKTOP_DIR" && ZERO_NATIVE_PATH="$ZERO_NATIVE_PATH" "$ZIG" build)
+
+echo "==> Sync sidecar runtime"
+mkdir -p "$HOME/.petdex/sidecar"
+cp "$SIDECAR_DIR/server.js" "$HOME/.petdex/sidecar/server.js"
+
+echo "==> Ensure Petdex Dev.app"
+"$ROOT/scripts/macos-dev-app.sh" >/dev/null
+
+echo "==> Stop existing dev desktop"
+for pid in $(pgrep -x petdex-desktop || true); do
+  cwd="$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' || true)"
+  if [[ "$cwd" == "$DESKTOP_DIR" ]]; then
+    kill "$pid" || true
+  fi
+done
+
+sidecar_pids="$(pgrep -f "$HOME/.petdex/sidecar/server.js" || true)"
+if [[ -n "$sidecar_pids" ]]; then
+  # shellcheck disable=SC2086
+  kill $sidecar_pids || true
+fi
+
+sleep 0.4
+
+echo "==> Launch $APP_PATH"
+open -n "$APP_PATH"
+
+echo "==> Wait for sidecar health"
+for _ in {1..25}; do
+  if curl -fsS http://127.0.0.1:7777/health >/dev/null 2>&1; then
+    curl -fsS http://127.0.0.1:7777/health
+    printf "\n"
+    echo "Petdex Dev.app is running."
+    exit 0
+  fi
+  sleep 0.2
+done
+
+echo "macos-dev-restart: app launched, but sidecar health did not respond yet" >&2
+exit 1


### PR DESCRIPTION
## Summary

Adds macOS desktop development helper scripts:

- `scripts/macos-dev-app.sh` creates a local `Petdex Dev.app` wrapper for the desktop binary.
- `scripts/macos-dev-restart.sh` rebuilds the sidecar and desktop binary, syncs the local sidecar runtime, relaunches `Petdex Dev.app`, and waits for sidecar health.

This helps speed up local desktop iteration without changing production runtime behavior.

## Notes

The restart helper expects macOS, Node/npm, Zig, and a local `zero-native` checkout via `ZERO_NATIVE_PATH` or `../zero-native`.

## Testing

- `bash -n scripts/macos-dev-app.sh scripts/macos-dev-restart.sh`
- `ZIG=/path/to/zig ./scripts/macos-dev-restart.sh`
- Confirmed sidecar health returns `{"ok":true,"port":7777}`