### PR TITLE
fix(desktop): keep pet visible across spaces

### DIFF
--- a/packages/petdex-desktop/src/main.zig
+++ b/packages/petdex-desktop/src/main.zig
@@ -21,6 +21,20 @@ const MAX_INSTALL_SLUGS: usize = 24;
 // Room for `slugs=a,b,c` query values (24 slugs × ~65 chars, matches web cap).
 const MAX_SLUGS_QUERY_BYTES: usize = MAX_INSTALL_SLUGS * (MAX_SLUG_LEN + 1);
 
+fn petWindowOptions() zero_native.WindowOptions {
+    return .{
+        .label = "pet",
+        .title = "Petdex",
+        .default_frame = zero_native.geometry.RectF.init(0, 0, WINDOW_W, WINDOW_H),
+        .resizable = false,
+        .restore_state = true,
+        .frameless = true,
+        .transparent = true,
+        .always_on_top = true,
+        .focusable = false,
+    };
+}
+
 const DeepLink = union(enum) {
     none,
     activate: []const u8,
@@ -3006,16 +3020,7 @@ pub fn main(init: std.process.Init) !void {
 
     var app = PetDesktopApp{ .asset_root = asset_root };
 
-    const main_window: zero_native.WindowOptions = .{
-        .label = "pet",
-        .title = "Petdex",
-        .default_frame = zero_native.geometry.RectF.init(0, 0, WINDOW_W, WINDOW_H),
-        .resizable = false,
-        .restore_state = true,
-        .frameless = true,
-        .transparent = true,
-        .always_on_top = true,
-    };
+    const main_window = petWindowOptions();
 
     const security_policy: zero_native.SecurityPolicy = .{
         .navigation = .{ .allowed_origins = &.{ "zero://app", "zero://inline" } },
@@ -3050,6 +3055,16 @@ pub fn main(init: std.process.Init) !void {
 
 const testing = std.testing;
 const testing_io = std.testing.io;
+
+test "petWindowOptions: desktop pet uses nonactivating always-on-top window" {
+    const options = petWindowOptions();
+
+    try testing.expect(options.frameless);
+    try testing.expect(options.transparent);
+    try testing.expect(options.always_on_top);
+    try testing.expect(!options.focusable);
+    try testing.expect(!options.resizable);
+}
 
 fn writeTestFile(dir: std.Io.Dir, name: []const u8, contents: []const u8) !void {
     var f = try dir.createFile(testing_io, name, .{ .truncate = true });


### PR DESCRIPTION
## Summary

Fix a desktop visibility regression in `desktop-v0.2.1`: after switching between macOS Spaces or app surfaces, the Petdex desktop pet can disappear while the native Codex pet remains visible.

This PR keeps the manifest changes from #299 intact, and applies the pet-specific non-activating always-on-top behavior only when creating the runtime pet window.

## Bug

In `desktop-v0.2.1`, the desktop window option cleanup in #299 removed stale manifest-level window options. After that cleanup, the Petdex pet no longer consistently follows the user across app surfaces / Spaces on macOS.

Observed behavior:

- Petdex pet is visible on one surface
- User switches to another app surface / Space
- Native Codex pet remains visible
- Petdex pet may disappear or fail to stay attached to the visible desktop context

Expected behavior:

- Petdex pet remains visible after switching app surfaces / Spaces

## Relationship to #299

#299 cleaned up desktop window options and removed stale manifest-level configuration from `app.zon`.

This PR does not revert that cleanup.

Instead, it keeps `app.zon` aligned with #299 and moves the pet-specific behavior into runtime window creation:

- `app.zon` remains unchanged
- `petWindowOptions()` centralizes the runtime pet window contract
- the pet window is created as frameless, transparent, always-on-top, non-resizable, and non-focusable

That means #299 remains the source of truth for manifest cleanup, while this PR restores the runtime behavior needed by the floating pet window.

## Changes

- Centralize pet window options in `petWindowOptions()`
- Keep the desktop pet window non-focusable at runtime so it behaves like a floating, non-activating pet overlay
- Add regression coverage for the pet window option contract

## Testing

- Built and manually tested `Petdex Dev.app`
- Verified the pet remains visible after switching between app surfaces / Spaces
- Ran desktop tests against a clean `zero-native` checkout:

```bash
ZERO_NATIVE_PATH=/path/to/clean/zero-native zig build test --summary all
Result: 18/18 tests passed
```