### PR TITLE
fix desktop resize release guard

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -39,16 +39,19 @@ jobs:
         #
         # Source defaults to Railly/zero-native:feature/window-resize because
         # the floating-window options + window.resize + focusable flag aren't
-        # in vercel-labs/main yet. The feature/window-resize branch builds on
-        # top of feature/floating-window (the PR currently in review). Update
-        # ZERO_NATIVE_REMOTE / ZERO_NATIVE_BRANCH once everything merges
-        # upstream so CI can switch to vercel-labs/main.
+        # in vercel-labs/main yet. Pin the commit so a mutable fork branch
+        # cannot silently produce a desktop release without window.resize.
+        # Update ZERO_NATIVE_REMOTE / ZERO_NATIVE_BRANCH / ZERO_NATIVE_REF once
+        # everything merges upstream so CI can switch to vercel-labs/main.
         env:
           ZERO_NATIVE_REMOTE: "https://github.com/Railly/zero-native.git"
           ZERO_NATIVE_BRANCH: "feature/window-resize"
+          ZERO_NATIVE_REF: "c85ec92a170c5b1304543ffcbf0c1d6d3e413498"
         run: |
           set -euo pipefail
           git clone --depth 1 --branch "$ZERO_NATIVE_BRANCH" "$ZERO_NATIVE_REMOTE" "$GITHUB_WORKSPACE/zero-native"
+          git -C "$GITHUB_WORKSPACE/zero-native" fetch --depth 1 origin "$ZERO_NATIVE_REF"
+          git -C "$GITHUB_WORKSPACE/zero-native" checkout --detach "$ZERO_NATIVE_REF"
           echo "ZERO_NATIVE_PATH=$GITHUB_WORKSPACE/zero-native/" >> "$GITHUB_ENV"
 
       - name: Install Zig 0.16.0

--- a/packages/petdex-desktop/src/main.zig
+++ b/packages/petdex-desktop/src/main.zig
@@ -6,6 +6,14 @@ const zero_native = @import("zero-native");
 
 pub const panic = std.debug.FullPanic(zero_native.debug.capturePanic);
 
+comptime {
+    if (!@hasDecl(zero_native.platform, "ResizeAnchor") or
+        !@hasField(zero_native.platform.PlatformServices, "resize_window_fn"))
+    {
+        @compileError("petdex-desktop requires zero-native with zero-native.window.resize support; use Railly/zero-native feature/window-resize at c85ec92 or newer");
+    }
+}
+
 const WINDOW_W: f32 = 140;
 // 180px tall: pet at top:34 + 78px sprite = 112; +16 bottom margin
 // after gravity-throw recovery. The bubble sits in the 30px strip


### PR DESCRIPTION
## Summary

- Pin desktop release CI to the zero-native commit that includes `zero-native.window.resize`
- Add a compile-time guard so `petdex-desktop` fails fast when built against an older zero-native checkout without resize support

## Root Cause

The desktop picker calls `zero-native.window.resize` before opening the right-click menu. If a release is built against a zero-native checkout without that built-in bridge command, the app stays in the compact `140x180` window and the picker/menu gets clipped.

## Validation

- `git diff --check`
- Parsed `.github/workflows/desktop-release.yml` with Ruby YAML
- Verified `Railly/zero-native@c85ec92a170c5b1304543ffcbf0c1d6d3e413498` contains the runtime handler, platform service, and AppKit resize implementation

Not run:

- `bun run check`
- `bun test`
- `zig build`

Reason: this local environment does not have `bun`, `zig`, or `node_modules` installed.

Fixes #321 https://github.com/crafter-station/petdex/issues/321