### PR TITLE
doc(onboard): update quick start documentation with a structured, ste…

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,33 @@ Every pet is a folder. Every folder is a Pokédex entry. Every entry is one `npx
 
 ## Quick start
 
-```sh
-# Pick a pet. Install it. Your Codex desktop app picks it up automatically.
-npx petdex install boba
+Follow this checklist to get a pet installed, visible in Codex, and connected to the desktop app.
 
-# Or run the full Petdex desktop app with bubble UI and agent hooks.
+1. Install a known pet:
+
+```sh
+npx petdex install boba
+```
+
+You should see `~/.codex/pets/boba/` with `pet.json` and a spritesheet.
+
+2. Initialize Petdex Desktop and agent hooks:
+
+```sh
 npx petdex init
 ```
 
-Open Codex, go to **Settings → Appearance → Pets**, and pick the one you just installed.
+This downloads the desktop app, starts it, and wires supported agents for `/petdex`.
+
+3. Open Codex, go to **Settings → Appearance → Pets**, choose **Boba**, and click **Select**. Use `/pet` inside Codex to wake the pet or tuck it away.
+
+4. Verify the setup:
+
+```sh
+npx petdex doctor
+```
+
+If hooks are installed, you can also type `/petdex status` inside a supported agent.
 
 ## For users
 

--- a/src/app/[locale]/docs/page.tsx
+++ b/src/app/[locale]/docs/page.tsx
@@ -143,17 +143,62 @@ export default async function DocsPage({
 
           <Section id="quick-start" title={t("sections.quickStart.title")}>
             <p>{t("sections.quickStart.intro")}</p>
-            <CommandLine
-              command="npx petdex install boba"
-              source="docs-quickstart"
-              className="w-full max-w-xl"
-            />
-            <p>
-              {t.rich("sections.quickStart.afterCommand", {
-                code: (chunks) => <code>{chunks}</code>,
-                strong: (chunks) => <strong>{chunks}</strong>,
-              })}
-            </p>
+            <ol className="grid gap-3">
+              <QuickStartStep
+                number="1"
+                title={t("sections.quickStart.steps.install.title")}
+                body={t.rich("sections.quickStart.steps.install.body", rich)}
+                result={t.rich(
+                  "sections.quickStart.steps.install.result",
+                  rich,
+                )}
+              >
+                <CommandLine
+                  command="npx petdex install boba"
+                  source="docs-quickstart-install"
+                  className="w-full max-w-xl"
+                />
+              </QuickStartStep>
+              <QuickStartStep
+                number="2"
+                title={t("sections.quickStart.steps.desktop.title")}
+                body={t.rich("sections.quickStart.steps.desktop.body", rich)}
+                result={t.rich(
+                  "sections.quickStart.steps.desktop.result",
+                  rich,
+                )}
+              >
+                <CommandLine
+                  command="npx petdex init"
+                  source="docs-quickstart-init"
+                  className="w-full max-w-xl"
+                />
+              </QuickStartStep>
+              <QuickStartStep
+                number="3"
+                title={t("sections.quickStart.steps.select.title")}
+                body={t.rich("sections.quickStart.steps.select.body", rich)}
+                result={t.rich(
+                  "sections.quickStart.steps.select.result",
+                  rich,
+                )}
+              />
+              <QuickStartStep
+                number="4"
+                title={t("sections.quickStart.steps.verify.title")}
+                body={t.rich("sections.quickStart.steps.verify.body", rich)}
+                result={t.rich(
+                  "sections.quickStart.steps.verify.result",
+                  rich,
+                )}
+              >
+                <CommandLine
+                  command="npx petdex doctor"
+                  source="docs-quickstart-doctor"
+                  className="w-full max-w-xl"
+                />
+              </QuickStartStep>
+            </ol>
             <Callout>
               {t.rich("sections.quickStart.callout", {
                 code: (chunks) => <code>{chunks}</code>,
@@ -620,6 +665,39 @@ export default async function DocsPage({
 
       <SiteFooter />
     </main>
+  );
+}
+
+function QuickStartStep({
+  number,
+  title,
+  body,
+  result,
+  children,
+}: {
+  number: string;
+  title: string;
+  body: React.ReactNode;
+  result: React.ReactNode;
+  children?: React.ReactNode;
+}) {
+  return (
+    <li className="grid gap-3 rounded-lg border border-border-base bg-surface p-4">
+      <div className="flex items-start gap-3">
+        <span className="grid size-7 shrink-0 place-items-center rounded-full bg-brand-tint font-mono text-xs font-semibold text-brand-deep dark:bg-brand-tint-dark dark:text-brand-light">
+          {number}
+        </span>
+        <div className="min-w-0 space-y-2">
+          <h3 className="text-base font-semibold text-foreground">{title}</h3>
+          <p>{body}</p>
+          <p className="flex items-start gap-2 text-sm text-muted-2">
+            <Check className="mt-1 size-4 shrink-0 text-brand" />
+            <span className="min-w-0">{result}</span>
+          </p>
+        </div>
+      </div>
+      {children ? <div className="min-w-0 sm:pl-10">{children}</div> : null}
+    </li>
   );
 }
 

--- a/src/app/[locale]/docs/page.tsx
+++ b/src/app/[locale]/docs/page.tsx
@@ -178,19 +178,13 @@ export default async function DocsPage({
                 number="3"
                 title={t("sections.quickStart.steps.select.title")}
                 body={t.rich("sections.quickStart.steps.select.body", rich)}
-                result={t.rich(
-                  "sections.quickStart.steps.select.result",
-                  rich,
-                )}
+                result={t.rich("sections.quickStart.steps.select.result", rich)}
               />
               <QuickStartStep
                 number="4"
                 title={t("sections.quickStart.steps.verify.title")}
                 body={t.rich("sections.quickStart.steps.verify.body", rich)}
-                result={t.rich(
-                  "sections.quickStart.steps.verify.result",
-                  rich,
-                )}
+                result={t.rich("sections.quickStart.steps.verify.result", rich)}
               >
                 <CommandLine
                   command="npx petdex doctor"

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1996,8 +1996,29 @@
     "sections": {
       "quickStart": {
         "title": "Quick start",
-        "intro": "Install a curated pet into your Codex setup with one command. No account required to install. Sign in only when you submit.",
-        "afterCommand": "The CLI fetches the pet pack and drops it into <code>~/.codex/pets/boba/</code>. To activate it inside Codex go to <strong>Settings → Appearance → Pets</strong> and click <strong>Select</strong>. Use <code>/pet</code> inside Codex to wake or tuck it away.",
+        "intro": "Follow this checklist to get a pet installed, visible in Codex, and connected to the desktop app. No account required to install. Sign in only when you submit.",
+        "steps": {
+          "install": {
+            "title": "Install a known pet",
+            "body": "Start with Boba so you have a real pet folder to select in Codex.",
+            "result": "You should see <code>~/.codex/pets/boba/</code> with <code>pet.json</code> and a spritesheet."
+          },
+          "desktop": {
+            "title": "Initialize desktop and hooks",
+            "body": "Run the full setup when you want the floating desktop mascot and agent activity hooks.",
+            "result": "Petdex downloads the desktop app, starts it, and wires supported agents for <code>/petdex</code>."
+          },
+          "select": {
+            "title": "Select the pet in Codex",
+            "body": "Open Codex, go to <strong>Settings → Appearance → Pets</strong>, choose <strong>Boba</strong>, and click <strong>Select</strong>.",
+            "result": "Use <code>/pet</code> inside Codex to wake the pet or tuck it away."
+          },
+          "verify": {
+            "title": "Verify the setup",
+            "body": "Run diagnostics if the pet does not appear, or type <code>/petdex status</code> inside a supported agent after hooks are installed.",
+            "result": "The doctor reports any missing binary, hook, token, or pet folder with a concrete fix."
+          }
+        },
         "callout": "Don't have a pet idea yet? <link>Hatch your own</link> with the Codex Hatch Pet skill, then come back to <code>petdex submit</code>."
       },
       "install": {

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -1995,10 +1995,31 @@
     },
     "sections": {
       "quickStart": {
-        "title": "Quick start",
-        "intro": "Install a curated pet into your Codex setup with one command. No account required to install. Sign in only when you submit.",
-        "afterCommand": "The CLI fetches the pet pack and drops it into <code>~/.codex/pets/boba/</code>. To activate it inside Codex go to <strong>Settings → Appearance → Pets</strong> and click <strong>Select</strong>. Use <code>/pet</code> inside Codex to wake or tuck it away.",
-        "callout": "Don't have a pet idea yet? <link>Hatch your own</link> with the Codex Hatch Pet skill, then come back to <code>petdex submit</code>."
+        "title": "Inicio rápido",
+        "intro": "Sigue esta lista para instalar una mascota, verla en Codex y conectarla con la app de escritorio. No necesitas una cuenta para instalar. Inicia sesión solo cuando quieras enviar una mascota.",
+        "steps": {
+          "install": {
+            "title": "Instala una mascota conocida",
+            "body": "Empieza con Boba para tener una carpeta real que puedas seleccionar en Codex.",
+            "result": "Deberías ver <code>~/.codex/pets/boba/</code> con <code>pet.json</code> y un spritesheet."
+          },
+          "desktop": {
+            "title": "Inicializa escritorio y hooks",
+            "body": "Ejecuta la configuración completa si quieres la mascota flotante de escritorio y los hooks de actividad del agente.",
+            "result": "Petdex descarga la app de escritorio, la inicia y conecta los agentes compatibles con <code>/petdex</code>."
+          },
+          "select": {
+            "title": "Selecciona la mascota en Codex",
+            "body": "Abre Codex, ve a <strong>Settings → Appearance → Pets</strong>, elige <strong>Boba</strong> y haz clic en <strong>Select</strong>.",
+            "result": "Usa <code>/pet</code> dentro de Codex para despertar la mascota o guardarla."
+          },
+          "verify": {
+            "title": "Verifica la configuración",
+            "body": "Ejecuta el diagnóstico si la mascota no aparece, o escribe <code>/petdex status</code> dentro de un agente compatible después de instalar los hooks.",
+            "result": "Doctor informa cualquier binario, hook, token o carpeta de mascota faltante con una corrección concreta."
+          }
+        },
+        "callout": "¿Aún no tienes una idea de mascota? <link>Crea la tuya</link> con el skill Codex Hatch Pet y vuelve para ejecutar <code>petdex submit</code>."
       },
       "install": {
         "title": "Install",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -2248,8 +2248,29 @@
     "sections": {
       "quickStart": {
         "title": "快速开始",
-        "intro": "一条命令就能把精选宠物装进 Codex。安装不需要账号，只有提交作品时才需要登录。",
-        "afterCommand": "CLI 会拉取宠物包，并放到 <code>~/.codex/pets/boba/</code>。要在 Codex 里启用它，打开 <strong>Settings → Appearance → Pets</strong>，然后点击 <strong>Select</strong>。在 Codex 里使用 <code>/pet</code> 可以让宠物 wake 或 sleep。",
+        "intro": "按这份清单走完，就能把宠物装好、在 Codex 里看到它，并接上桌面应用。安装不需要账号，只有提交作品时才需要登录。",
+        "steps": {
+          "install": {
+            "title": "先安装一只已知宠物",
+            "body": "建议先用 Boba，这样 Codex 里一定有一个可以选择的宠物目录。",
+            "result": "你应该能看到 <code>~/.codex/pets/boba/</code>，里面包含 <code>pet.json</code> 和 spritesheet。"
+          },
+          "desktop": {
+            "title": "初始化桌面应用和 hooks",
+            "body": "如果你想让宠物浮在桌面上，并响应 coding agent 的活动，就运行完整初始化。",
+            "result": "Petdex 会下载并启动桌面应用，同时给支持的 agent 接上 <code>/petdex</code>。"
+          },
+          "select": {
+            "title": "在 Codex 里选择宠物",
+            "body": "打开 Codex，进入 <strong>Settings → Appearance → Pets</strong>，选择 <strong>Boba</strong>，然后点击 <strong>Select</strong>。",
+            "result": "在 Codex 里使用 <code>/pet</code> 可以唤醒宠物，也可以把它收起来。"
+          },
+          "verify": {
+            "title": "验证配置是否正常",
+            "body": "如果宠物没有出现，运行诊断命令；安装 hooks 后，也可以在支持的 agent 里输入 <code>/petdex status</code>。",
+            "result": "doctor 会指出缺失的 binary、hook、token 或宠物目录，并给出具体修复提示。"
+          }
+        },
         "callout": "还没有宠物点子？先用 Codex Hatch Pet skill <link>孵化一只</link>，再回来运行 <code>petdex submit</code>。"
       },
       "install": {


### PR DESCRIPTION
## Summary

- turns the `/docs` quick start into a step-by-step checklist for first-time Petdex users
- covers installing Boba, initializing Petdex Desktop/hooks, selecting the pet in Codex, and verifying with `petdex doctor`
- syncs the quick-start copy across `en`, `es`, and `zh`
- updates the root README quick start to match the docs flow

Closes #297

## Local dev path

This is a UI/copy/i18n documentation change, so the intended verification path from `CONTRIBUTING.md` is:

- `bun run dev:mock`
- `bun run i18n:check`
- `bun run check`

## Validation

- `git diff --check`
- JSON parse check for `src/i18n/messages/{en,es,zh}.json`
- `docsPage` i18n key parity check across `en`, `es`, and `zh`

I could not run the Bun-based checks in this environment because `bun` and local project dependencies were not available.