### PR TITLE
chore(dev): deprecate mock dev server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,14 @@
 # petdex env vars.
 #
-# THREE PATHS to run locally — pick one:
+# TWO SUPPORTED PATHS to run locally:
 #
-#   1. bun run dev:mock     — zero credentials, in-process Postgres + fake Clerk.
-#                             Good for tweaking UI / copy / i18n. Slower HMR.
-#                             You can ignore this whole file.
-#
-#   2. bun run dev:docker   — Postgres + Redis in containers + shared OSS Clerk.
+#   1. bun run dev:docker   - Postgres + Redis in containers + shared OSS Clerk.
 #                             Good for testing DB queries, auth flows, or anything
 #                             that touches a real backend. Defaults are committed
 #                             in .env.dev — copy any value here only if you want
 #                             to override it for yourself.
 #
-#   3. bun run dev          — your own everything. For maintainers.
+#   2. bun run dev          - your own everything. For maintainers.
 #                             Fill in the values below from your private accounts.
 #
 # Anything you set in .env.local wins over .env.dev. Most contributors

--- a/.env.mock
+++ b/.env.mock
@@ -1,6 +1,5 @@
-# PETDEX_MOCK=1 — local QA env for external contributors. No real
-# credentials needed. Boot with `bun run dev:mock` and hit
-# http://localhost:3000.
+# PETDEX_MOCK=1 local test/build env for mock-backed checks.
+# `bun run dev:mock` is deprecated and intentionally exits.
 
 PETDEX_MOCK=1
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,9 @@
 
 ## Commands
 - Use Bun for repo work: `bun install`, not `npm install`. Published CLI docs mention `npm`/`npx` for end users only.
-- Recommended local app dev is `bun run dev:mock`; it needs no `.env.local`, loads `.env.mock`, auto-signs in as `contributor@petdex.local`, seeds PGlite from `pets/ideas.json`, and runs `next dev --webpack` because PGlite wasm/workers break under Turbopack.
-- Real-service dev is `bun dev` with `.env.local` copied from `.env.example`; this path expects Clerk, Postgres/Neon, R2, Upstash, Resend, OpenAI, and ElevenLabs credentials.
+- Recommended local app dev is `bun run dev:docker`; it boots local Postgres and Redis with shared Clerk dev defaults from `.env.dev`.
+- Maintainer dev is `bun dev` with `.env.local` copied from `.env.example`; this path expects Clerk, Postgres/Neon, R2, Upstash, Resend, OpenAI, and ElevenLabs credentials.
+- `bun run dev:mock` is deprecated and intentionally exits. Keep `.env.mock` only for targeted mock-backed tests or build checks.
 - Root checks: `bun run check` for Biome, `bun run format` to write Biome fixes, `bun run build` for the Next app, `bun test` for Bun tests, and `bun run i18n:check` after editing translation messages. There is no root `typecheck` script.
 - Focused tests use `bun test path/to/file.test.ts`. Tests that import `src/lib/db/client.ts` directly or indirectly, including `src/lib/pet-search.test.ts` and `src/lib/security.test.ts`, need a usable `DATABASE_URL` or mock env: `bun test --env-file=.env.mock src/lib/security.test.ts`.
 - `packages/petdex-cli` and `packages/discord-bot` are independent packages, not root workspaces; run their own `bun install` and package scripts from inside each directory. Root `tsconfig.json` excludes `packages`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,41 +1,20 @@
 # Contributing to Petdex
 
-## Three paths for local dev
+## Supported local dev paths
 
 Pick the one that matches what you want to change.
 
 | Goal | Command | Setup |
 |---|---|---|
-| Tweak UI / copy / i18n / CSS | `bun run dev:mock` | 0 credentials |
-| Test DB queries / auth / submit / likes | `bun run dev:docker` | Docker Desktop or Podman, ~30s |
+| Local full stack | `bun run dev:docker` | Docker Desktop or Podman, ~30s |
 | Run against real petdex services | `bun run dev` | `.env.local` filled in (maintainers only) |
 
-`dev:docker` is the new recommended path for almost everyone. It boots
+`dev:docker` is the recommended path for almost everyone. It boots
 a real Postgres + Redis + Clerk dev instance so the app behaves the
-same way it does in production, without any of the in-process shims
-that `dev:mock` ships.
+same way it does in production.
 
-## bun run dev:mock
-
-Zero credentials, zero containers, in-process Postgres (PGlite) and a
-stubbed Clerk session. Slower HMR, no real auth, but boots in 5 seconds.
-
-```bash
-bun install
-bun run dev:mock
-```
-
-Open <http://localhost:3000>. You're auto-signed in as
-`contributor@petdex.local`.
-
-What works: gallery, pet detail pages, search, the `/u/<handle>`
-profile dashboard, status badges. Sign-in flows are bypassed and the
-DB is in-memory.
-
-What does NOT work: real OAuth, real R2 uploads, outbound emails, the
-auto-tag and pet-sound jobs (need API keys).
-
-If your change touches any of those, use `dev:docker` instead.
+`dev:mock` is deprecated and intentionally exits. Use `dev:docker`, or
+`bun dev` if you are a maintainer with complete env vars.
 
 ## bun run dev:docker
 

--- a/README.md
+++ b/README.md
@@ -100,22 +100,21 @@ crafter-station/petdex
 
 ## Develop locally
 
-Three paths, pick the one that matches what you want to change.
+Two paths are supported.
 
 | Goal | Command | Setup |
 | --- | --- | --- |
-| UI, copy, i18n, CSS | `bun run dev:mock` | Zero credentials. In-process Postgres + stubbed Clerk. |
-| DB queries, auth, submit, likes | `bun run dev:docker` | Docker or Podman, ~30s warm-up. |
+| Local full stack | `bun run dev:docker` | Docker or Podman, ~30s warm-up. |
 | Run against real services | `bun run dev` | `.env.local` filled (maintainers only). |
 
 ```sh
 git clone https://github.com/crafter-station/petdex.git
 cd petdex
 bun install
-bun run dev:mock
+bun run dev:docker
 ```
 
-Open [localhost:3000](http://localhost:3000). You're auto-signed-in as `contributor@petdex.local`. Full guide in [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+Open [localhost:3000](http://localhost:3000). Full guide in [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 
 ## Pet package format
 

--- a/scripts/dev-mock.ts
+++ b/scripts/dev-mock.ts
@@ -1,57 +1,11 @@
-// Boots `next dev` with the mock environment loaded. We don't rely on
-// Next's automatic .env.local discovery because that file may already
-// hold real maintainer credentials — we want .env.mock to win regardless.
-
-import { spawn } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
-
-const envFile = ".env.mock";
-if (!existsSync(envFile)) {
-  console.error(`[dev:mock] ${envFile} not found in cwd`);
-  process.exit(1);
-}
-
-const env: Record<string, string> = {};
-for (const line of readFileSync(envFile, "utf8").split("\n")) {
-  const trimmed = line.trim();
-  if (!trimmed || trimmed.startsWith("#")) continue;
-  const eq = trimmed.indexOf("=");
-  if (eq === -1) continue;
-  env[trimmed.slice(0, eq)] = trimmed.slice(eq + 1);
-}
-
-console.log(
-  "[dev:mock] PETDEX_MOCK=1 — booting in-process mocks (db, clerk, redis)",
+console.error(
+  [
+    "[dev:mock] deprecated and disabled.",
+    "",
+    "Use one of these instead:",
+    "  bun run dev:docker  # local Postgres, Redis, and shared Clerk dev app",
+    "  bun dev             # maintainers with complete .env.local credentials",
+  ].join("\n"),
 );
 
-// Strip a maintainer's real .env.local out of the inherited env so it
-// can't override our mock values. Next still reads .env.local from disk,
-// so we also point it at a different file via NODE_ENV-aware overrides.
-const stripped: NodeJS.ProcessEnv = { ...process.env };
-for (const key of Object.keys(stripped)) {
-  if (
-    key.startsWith("CLERK_") ||
-    key.startsWith("NEXT_PUBLIC_CLERK_") ||
-    key.startsWith("UPSTASH_") ||
-    key.startsWith("R2_") ||
-    key.startsWith("RESEND_") ||
-    key === "DATABASE_URL" ||
-    key === "OPENAI_API_KEY" ||
-    key === "ELEVENLABS_API_KEY"
-  ) {
-    delete stripped[key];
-  }
-}
-
-// PGlite's wasm bindings choke under turbopack bundling — fall back to
-// the webpack dev server which resolves them correctly.
-const child = spawn(
-  "bun",
-  ["x", "next", "dev", "--webpack", ...process.argv.slice(2)],
-  {
-    stdio: "inherit",
-    env: { ...stripped, ...env, PETDEX_MOCK: "1" },
-  },
-);
-
-child.on("exit", (code) => process.exit(code ?? 0));
+process.exit(1);

--- a/scripts/seed-dev.ts
+++ b/scripts/seed-dev.ts
@@ -8,9 +8,6 @@
 // real bucket (CORS open). The image element happily fetches them and
 // the gallery looks like the real thing without anyone copying assets.
 //
-// If you're offline or want zero external requests, run dev:mock
-// instead — it ships its own PGlite seed.
-
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 

--- a/src/lib/mock/db.ts
+++ b/src/lib/mock/db.ts
@@ -304,7 +304,7 @@ async function seed(client: PGlite): Promise<void> {
       ? `${assetBase}/spritesheet.webp`
       : fallbackSpritesheet;
     // Non-curated mocks have no real pet.json or zip on R2. Point at a
-    // recognizable mock:// URI so dev:mock testers see an honest 404 if
+    // recognizable mock:// URI so mock-backed checks see an honest 404 if
     // they try install/download instead of receiving the SVG markup.
     // pet_json_url and zip_url are NOT NULL in schema so we cannot null.
     const petJsonUrl = isCurated

--- a/src/lib/mock/index.ts
+++ b/src/lib/mock/index.ts
@@ -1,9 +1,6 @@
 // Single source of truth for "are we in mock mode?". Every shim file imports
 // IS_MOCK from here so the rest of the app doesn't need to know which env
-// var triggers it. Set PETDEX_MOCK=1 (or the bun dev:mock script does it for
-// you) to flip every shim into a no-network, in-process equivalent. The
-// goal is `bun install && bun dev:mock` working with zero credentials, not
-// production fidelity.
+// var triggers it. Set PETDEX_MOCK=1 only for targeted mock-backed checks.
 
 export const IS_MOCK = process.env.PETDEX_MOCK === "1";
 


### PR DESCRIPTION
## Summary

- make `bun run dev:mock` exit immediately with migration guidance
- point local dev docs at `bun run dev:docker` and maintainer `bun dev`
- keep `.env.mock` documented only for mock-backed tests and build checks

## Validation

- `bun install --frozen-lockfile`
- `bun run dev:mock` exits 1 with the expected deprecation message
- `bunx --bun biome check scripts/dev-mock.ts scripts/seed-dev.ts src/lib/mock/index.ts src/lib/mock/db.ts`
- `git diff --check`
- `bun run i18n:check`
- `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build`

Known baseline failures, not from this diff:

- `bun run check` fails on existing Biome issues in admin mailing, telemetry, url-blocklist, pending edit images, drizzle snapshots, and security test formatting
- `bun test` fails on existing text assertions and missing `@clack/prompts` inside `packages/petdex-cli` without its package-local install