### PR TITLE
chore: add Petdex cost mitigation tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "check": "biome check .",
     "format": "biome check --write .",
     "generate-assets": "bun scripts/generate-assets.ts",
+    "cost:report": "bun scripts/vercel-cost-report.ts --project petdex",
     "auto-tag": "bun scripts/auto-tag.ts",
     "release:desktop": "bun scripts/release-desktop.ts",
     "i18n:check": "bun scripts/i18n-check.ts",

--- a/scripts/vercel-cost-report.ts
+++ b/scripts/vercel-cost-report.ts
@@ -1,0 +1,333 @@
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+type Charge = {
+  ServiceName?: string;
+  ServiceCategory?: string;
+  BilledCost?: number | string;
+  ConsumedQuantity?: number | string;
+  ConsumedUnit?: string;
+  ChargePeriodStart?: string;
+  Tags?: Record<string, string>;
+};
+
+type Bucket = {
+  name: string;
+  billed: number;
+  consumed: number;
+  unit: string;
+  lines: number;
+};
+
+type DailyBucket = {
+  day: string;
+  service: string;
+  billed: number;
+  consumed: number;
+};
+
+const args = parseArgs(process.argv.slice(2));
+const project = args.project ?? "petdex";
+const days = numberArg(args.days ?? "1");
+const to = args.to ?? new Date().toISOString();
+const from =
+  args.from ??
+  new Date(new Date(to).getTime() - days * 24 * 60 * 60 * 1000).toISOString();
+const outDir = args["out-dir"] ?? ".scratch/cost-reports";
+const fromFile = args["from-file"];
+const linkedProject = await readJsonIfExists<{ orgId?: string }>(
+  ".vercel/project.json",
+);
+const teamId =
+  args["team-id"] ?? process.env.VERCEL_TEAM_ID ?? linkedProject?.orgId;
+
+const charges = fromFile
+  ? await readChargesFile(fromFile)
+  : await fetchCharges({
+      teamId: requireTeamId(teamId),
+      token: await readVercelToken(),
+      from,
+      to,
+    });
+const summary = summarize({ charges, project, from, to });
+const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+const targetDir = join(outDir, stamp);
+
+await mkdir(targetDir, { recursive: true });
+await writeFile(
+  join(targetDir, "summary.json"),
+  `${JSON.stringify(summary, null, 2)}\n`,
+);
+await writeFile(join(targetDir, "summary.md"), renderMarkdown(summary));
+
+console.log(`Wrote ${targetDir}/summary.json`);
+console.log(`Wrote ${targetDir}/summary.md`);
+console.log(
+  `${project}: $${summary.project.billed.toFixed(3)} over ${summary.window.days.toFixed(
+    2,
+  )} days, projected $${summary.project.monthlyRunRate.toFixed(2)}/month`,
+);
+
+function parseArgs(argv: string[]): Record<string, string | undefined> {
+  const parsed: Record<string, string | undefined> = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const key = argv[i];
+    if (!key?.startsWith("--")) continue;
+    const value = argv[i + 1];
+    parsed[key.slice(2)] = value?.startsWith("--") ? "true" : value;
+    if (value && !value.startsWith("--")) i += 1;
+  }
+  return parsed;
+}
+
+function numberArg(value: string | undefined): number {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0)
+    throw new Error(`Invalid number: ${value}`);
+  return n;
+}
+
+async function readJsonIfExists<T>(path: string): Promise<T | null> {
+  if (!existsSync(path)) return null;
+  return JSON.parse(await readFile(path, "utf8")) as T;
+}
+
+function requireTeamId(value: string | undefined): string {
+  if (value) return value;
+  throw new Error(
+    "Missing --team-id, VERCEL_TEAM_ID, or .vercel/project.json orgId",
+  );
+}
+
+async function readVercelToken(): Promise<string> {
+  if (process.env.VERCEL_BILLING_TOKEN) return process.env.VERCEL_BILLING_TOKEN;
+  if (process.env.VERCEL_TOKEN) return process.env.VERCEL_TOKEN;
+  const authPath =
+    process.env.VERCEL_AUTH_JSON ??
+    `${process.env.HOME}/Library/Application Support/com.vercel.cli/auth.json`;
+  const auth = await readJsonIfExists<{ token?: string }>(authPath);
+  if (!auth?.token)
+    throw new Error(
+      "Missing VERCEL_BILLING_TOKEN, VERCEL_TOKEN, or Vercel CLI auth token",
+    );
+  return auth.token;
+}
+
+async function readChargesFile(path: string): Promise<Charge[]> {
+  return parseChargeLines(await readFile(path, "utf8"));
+}
+
+async function fetchCharges(input: {
+  teamId: string;
+  token: string;
+  from: string;
+  to: string;
+}): Promise<Charge[]> {
+  const url = new URL("https://api.vercel.com/v1/billing/charges");
+  url.searchParams.set("teamId", input.teamId);
+  url.searchParams.set("from", input.from);
+  url.searchParams.set("to", input.to);
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${input.token}`,
+      "Accept-Encoding": "gzip",
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    if (response.status === 401 || response.status === 403) {
+      throw new Error(
+        `${response.status} Billing API rejected the token. Set VERCEL_BILLING_TOKEN or VERCEL_TOKEN with access to the team's billing charges. Response: ${body}`,
+      );
+    }
+    throw new Error(`${response.status} ${body}`);
+  }
+
+  return parseChargeLines(await response.text());
+}
+
+function parseChargeLines(text: string): Charge[] {
+  return text
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Charge);
+}
+
+function summarize(input: {
+  charges: Charge[];
+  project: string;
+  from: string;
+  to: string;
+}) {
+  const projectTotals = new Map<string, Bucket>();
+  const serviceTotals = new Map<string, Bucket>();
+  const projectServiceTotals = new Map<string, Bucket>();
+  const dailyServiceTotals = new Map<string, DailyBucket>();
+  const tagKeys = new Set<string>();
+  const windowDays =
+    (new Date(input.to).getTime() - new Date(input.from).getTime()) /
+    (24 * 60 * 60 * 1000);
+  const monthlyFactor = 30 / windowDays;
+
+  for (const charge of input.charges) {
+    const billed = numeric(charge.BilledCost);
+    const consumed = numeric(charge.ConsumedQuantity);
+    const projectName = charge.Tags?.ProjectName ?? "(none)";
+    const service = charge.ServiceName ?? charge.ServiceCategory ?? "(none)";
+    const unit = charge.ConsumedUnit ?? "";
+
+    for (const key of Object.keys(charge.Tags ?? {})) tagKeys.add(key);
+    addBucket(projectTotals, projectName, billed, consumed, unit);
+    addBucket(serviceTotals, service, billed, consumed, unit);
+
+    if (projectName === input.project) {
+      addBucket(projectServiceTotals, service, billed, consumed, unit);
+      const day =
+        String(charge.ChargePeriodStart ?? "").slice(0, 10) || "unknown";
+      const key = `${day}|${service}`;
+      const current = dailyServiceTotals.get(key) ?? {
+        day,
+        service,
+        billed: 0,
+        consumed: 0,
+      };
+      current.billed += billed;
+      current.consumed += consumed;
+      dailyServiceTotals.set(key, current);
+    }
+  }
+
+  const projectBilled = projectTotals.get(input.project)?.billed ?? 0;
+  const totalBilled = sum(
+    [...projectTotals.values()].map((item) => item.billed),
+  );
+
+  return {
+    generatedAt: new Date().toISOString(),
+    window: {
+      from: input.from,
+      to: input.to,
+      days: round(windowDays),
+      rows: input.charges.length,
+    },
+    tagKeys: [...tagKeys].sort(),
+    total: {
+      billed: round(totalBilled),
+    },
+    project: {
+      name: input.project,
+      billed: round(projectBilled),
+      share: totalBilled === 0 ? 0 : round(projectBilled / totalBilled),
+      monthlyRunRate: round(projectBilled * monthlyFactor),
+    },
+    topProjects: sortedBuckets(projectTotals).slice(0, 10),
+    topServices: sortedBuckets(projectServiceTotals).slice(0, 15),
+    allServices: sortedBuckets(serviceTotals).slice(0, 15),
+    dailyServiceHotspots: [...dailyServiceTotals.values()]
+      .map(roundDaily)
+      .sort((a, b) => b.billed - a.billed)
+      .slice(0, 20),
+  };
+}
+
+function numeric(value: number | string | undefined): number {
+  return Number(value ?? 0);
+}
+
+function addBucket(
+  map: Map<string, Bucket>,
+  name: string,
+  billed: number,
+  consumed: number,
+  unit: string,
+) {
+  const current = map.get(name) ?? {
+    name,
+    billed: 0,
+    consumed: 0,
+    unit,
+    lines: 0,
+  };
+  current.billed += billed;
+  current.consumed += consumed;
+  current.lines += 1;
+  if (!current.unit) current.unit = unit;
+  map.set(name, current);
+}
+
+function sortedBuckets(map: Map<string, Bucket>): Bucket[] {
+  return [...map.values()]
+    .map((item) => ({
+      ...item,
+      billed: round(item.billed),
+      consumed: round(item.consumed),
+    }))
+    .sort((a, b) => b.billed - a.billed);
+}
+
+function roundDaily(item: DailyBucket): DailyBucket {
+  return {
+    ...item,
+    billed: round(item.billed),
+    consumed: round(item.consumed),
+  };
+}
+
+function round(value: number): number {
+  return Number(value.toFixed(4));
+}
+
+function sum(values: number[]): number {
+  return values.reduce((acc, value) => acc + value, 0);
+}
+
+function renderMarkdown(summary: ReturnType<typeof summarize>): string {
+  const lines = [
+    "# Petdex Vercel Cost Report",
+    "",
+    `Generated: ${summary.generatedAt}`,
+    `Window: ${summary.window.from} to ${summary.window.to}`,
+    `Rows: ${summary.window.rows}`,
+    "",
+    "## Summary",
+    "",
+    `- Team billed: $${summary.total.billed.toFixed(3)}`,
+    `- ${summary.project.name} billed: $${summary.project.billed.toFixed(3)}`,
+    `- ${summary.project.name} share: ${(summary.project.share * 100).toFixed(1)}%`,
+    `- ${summary.project.name} monthly run-rate: $${summary.project.monthlyRunRate.toFixed(2)}`,
+    "",
+    "## Top Project Services",
+    "",
+    "| Service | Billed | Consumed | Unit | Lines |",
+    "| --- | ---: | ---: | --- | ---: |",
+    ...summary.topServices.map(
+      (item) =>
+        `| ${item.name} | $${item.billed.toFixed(3)} | ${formatNumber(
+          item.consumed,
+        )} | ${item.unit} | ${item.lines} |`,
+    ),
+    "",
+    "## Daily Service Hotspots",
+    "",
+    "| Day | Service | Billed | Consumed |",
+    "| --- | --- | ---: | ---: |",
+    ...summary.dailyServiceHotspots.map(
+      (item) =>
+        `| ${item.day} | ${item.service} | $${item.billed.toFixed(
+          3,
+        )} | ${formatNumber(item.consumed)} |`,
+    ),
+    "",
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 3 }).format(
+    value,
+  );
+}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -2,8 +2,6 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { notFound } from "next/navigation";
 
-import { Analytics } from "@vercel/analytics/next";
-import { SpeedInsights } from "@vercel/speed-insights/next";
 import { NextIntlClientProvider } from "next-intl";
 import {
   getMessages,
@@ -17,6 +15,7 @@ import { FeedbackWidget } from "@/components/feedback-widget";
 import { HeaderStateProvider } from "@/components/header-state-provider";
 import { ProfileAnnouncementModal } from "@/components/profile-announcement-modal";
 import { AppProviders } from "@/components/theme-providers";
+import { VercelObservability } from "@/components/vercel-observability";
 import { TopPromoStrip } from "@/components/zh/top-promo-strip";
 import { ZhLayoutSpacer } from "@/components/zh/zh-layout-spacer";
 
@@ -120,8 +119,7 @@ export default async function LocaleLayout({ children, params }: Props) {
               <AnnouncementQueue />
               <ProfileAnnouncementModal />
               <BuildVersionWatcher />
-              <Analytics />
-              <SpeedInsights />
+              <VercelObservability />
             </HeaderStateProvider>
           </AppProviders>
         </NextIntlClientProvider>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -89,10 +89,7 @@ export default async function Home({
   const [heroPets, initialSearch, dexEntries, collections, feedAds] =
     await Promise.all([
       getFeaturedPetsWithMetrics(6),
-      // No shuffleSeed → searchPets falls back to alpha order, which is
-      // the same for every visitor and therefore safe to cache. The
-      // client re-fetches with the visitor's seed on hydration.
-      searchPets({ sort: "curated" }),
+      searchPets({ sort: "alpha" }),
       getDexNumberMap(),
       getCollectionsBySlugs(LANDING_COLLECTION_ORDER, 6),
       getActiveFeedAds(6),

--- a/src/app/api/pets/search/route.test.ts
+++ b/src/app/api/pets/search/route.test.ts
@@ -9,14 +9,14 @@ const testMock = (
 
 const TEST_SEED = "0123456789abcdef";
 const calls: Array<{
-  input: { cursor?: number; shuffleSeed?: string };
+  input: { cursor?: number; q?: string; shuffleSeed?: string; sort?: string };
   options: { includeTotal?: boolean; includeFacets?: boolean };
 }> = [];
 
 testMock.module("@/lib/pet-search", () => ({
   SEARCH_LIMITS: { DEFAULT_LIMIT: 24, MAX_LIMIT: 60 },
   searchPets: async (
-    input: { cursor?: number; shuffleSeed?: string },
+    input: { cursor?: number; q?: string; shuffleSeed?: string; sort?: string },
     options: { includeTotal?: boolean; includeFacets?: boolean },
   ) => {
     calls.push({ input, options });
@@ -53,8 +53,39 @@ describe("GET /api/pets/search", () => {
     calls.length = 0;
   });
 
+  it("defaults anonymous search to a cacheable deterministic response", async () => {
+    const response = await search("https://petdex.local/api/pets/search");
+    const body = (await response.json()) as { shuffleSeed?: string };
+    const call = calls[0];
+
+    expect(body.shuffleSeed).toBeUndefined();
+    expect(response.headers.get("Cache-Control")).toContain("public");
+    expect(response.headers.get("Set-Cookie")).toBeNull();
+    expect(call?.input.shuffleSeed).toBeUndefined();
+    expect(call?.input.sort).toBe("alpha");
+  });
+
+  it("defaults text search to curated so vibe search still runs", async () => {
+    const response = await search(
+      "https://petdex.local/api/pets/search?q=cozy",
+    );
+    const body = (await response.json()) as { shuffleSeed?: string };
+    const call = calls[0];
+
+    expect(body.shuffleSeed).toBe(TEST_SEED);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(response.headers.get("Set-Cookie") ?? "").toContain(
+      `petdex_shuffle_seed=${TEST_SEED}`,
+    );
+    expect(call?.input.q).toBe("cozy");
+    expect(call?.input.sort).toBe("curated");
+    expect(call?.input.shuffleSeed).toBe(TEST_SEED);
+  });
+
   it("returns the minted curated seed so no-cookie pagination can reuse it", async () => {
-    const first = await search("https://petdex.local/api/pets/search");
+    const first = await search(
+      "https://petdex.local/api/pets/search?sort=curated",
+    );
     const firstBody = (await first.json()) as { shuffleSeed?: string };
     const firstCall = calls[0];
 
@@ -67,7 +98,7 @@ describe("GET /api/pets/search", () => {
 
     calls.length = 0;
     const second = await search(
-      `https://petdex.local/api/pets/search?cursor=24&includeMeta=0&shuffleSeed=${TEST_SEED}`,
+      `https://petdex.local/api/pets/search?sort=curated&cursor=24&includeMeta=0&shuffleSeed=${TEST_SEED}`,
     );
     const secondBody = (await second.json()) as { shuffleSeed?: string };
     const secondCall = calls[0];

--- a/src/app/api/pets/search/route.ts
+++ b/src/app/api/pets/search/route.ts
@@ -33,7 +33,7 @@ export async function GET(req: Request): Promise<Response> {
   const url = new URL(req.url);
   const params = url.searchParams;
 
-  const q = params.get("q") ?? undefined;
+  const q = params.get("q")?.trim() || undefined;
 
   const kinds = parseList(params.get("kinds")).filter((k) =>
     KIND_SET.has(k),
@@ -46,10 +46,11 @@ export async function GET(req: Request): Promise<Response> {
   ) as ColorFamily[];
   const batches = parseBatchList(params.get("batches"));
 
-  const sortRaw = (params.get("sort") ?? "curated").toLowerCase();
+  const defaultSort: SortKey = q ? "curated" : "alpha";
+  const sortRaw = (params.get("sort") ?? defaultSort).toLowerCase();
   const sort: SortKey = SORT_SET.has(sortRaw as SortKey)
     ? (sortRaw as SortKey)
-    : "curated";
+    : defaultSort;
 
   const cursor = parseIntSafe(params.get("cursor"), 0);
   const limit = parseIntSafe(params.get("limit"), SEARCH_LIMITS.DEFAULT_LIMIT);

--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -145,7 +145,8 @@ export function PetGallery({
   const [activeVibes, setActiveVibes] = useState<Set<PetVibe>>(new Set());
   const [activeColors, setActiveColors] = useState<Set<ColorFamily>>(new Set());
   const [activeBatches, setActiveBatches] = useState<Set<string>>(new Set());
-  const [sort, setSort] = useState<SortKey>("curated");
+  const [sort, setSort] = useState<SortKey>("alpha");
+  const [sortTouched, setSortTouched] = useState(false);
   // The home page no longer ships caughtSlugs server-side — that would
   // make every SSR render per-visitor and kill ISR. We pull the caught
   // slug set from the shared HeaderStateProvider (one polled aggregate
@@ -181,6 +182,7 @@ export function PetGallery({
         p.set("batches", [...activeBatches].join(","));
       }
       if (sort === "curated") {
+        p.set("sort", sort);
         if (shuffleSeedRef.current) {
           p.set("shuffleSeed", shuffleSeedRef.current);
         }
@@ -194,6 +196,11 @@ export function PetGallery({
     },
     [trimmedQuery, activeKinds, activeVibes, activeColors, activeBatches, sort],
   );
+
+  useEffect(() => {
+    if (sortTouched) return;
+    setSort(trimmedQuery ? "curated" : "alpha");
+  }, [sortTouched, trimmedQuery]);
 
   // Re-fetch on filter / sort / query changes (debounced for the query).
   useEffect(() => {
@@ -376,6 +383,7 @@ export function PetGallery({
             value={sort}
             onValueChange={(next) => {
               track("sort_changed", { sort: next });
+              setSortTouched(true);
               setSort(next as SortKey);
             }}
           >

--- a/src/components/vercel-observability.tsx
+++ b/src/components/vercel-observability.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import type { ComponentProps } from "react";
+
+import { Analytics } from "@vercel/analytics/next";
+import { SpeedInsights } from "@vercel/speed-insights/next";
+
+type AnalyticsEvent = Parameters<
+  NonNullable<ComponentProps<typeof Analytics>["beforeSend"]>
+>[0];
+type SpeedInsightsEvent = Parameters<
+  NonNullable<ComponentProps<typeof SpeedInsights>["beforeSend"]>
+>[0];
+
+const LOW_VALUE_PATHS = [
+  /^\/api(?:\/|$)/,
+  /^\/(?:en|es|zh)?\/?admin(?:\/|$)/,
+  /^\/(?:en|es|zh)?\/?collaborator(?:\/|$)/,
+  /^\/(?:en|es|zh)?\/?my-feedback(?:\/|$)/,
+  /^\/(?:en|es|zh)?\/?unsubscribe(?:\/|$)/,
+];
+
+export function VercelObservability() {
+  return (
+    <>
+      <Analytics beforeSend={filterAnalyticsEvent} />
+      <SpeedInsights
+        sampleRate={speedInsightsSampleRate()}
+        beforeSend={filterSpeedInsightsEvent}
+      />
+    </>
+  );
+}
+
+function filterAnalyticsEvent(event: AnalyticsEvent): AnalyticsEvent | null {
+  return shouldDropEvent(event) ? null : event;
+}
+
+function filterSpeedInsightsEvent(
+  event: SpeedInsightsEvent,
+): SpeedInsightsEvent | null {
+  return shouldDropEvent(event) ? null : event;
+}
+
+function shouldDropEvent(event: { url?: string; path?: string }): boolean {
+  const pathname = pathnameFrom(event.url ?? event.path);
+  return pathname
+    ? LOW_VALUE_PATHS.some((pattern) => pattern.test(pathname))
+    : false;
+}
+
+function pathnameFrom(value: string | undefined): string | null {
+  if (!value) return null;
+  try {
+    return new URL(value, window.location.origin).pathname;
+  } catch {
+    return null;
+  }
+}
+
+function speedInsightsSampleRate(): number {
+  const raw = Number(
+    process.env.NEXT_PUBLIC_PETDEX_SPEED_INSIGHTS_SAMPLE_RATE ?? 0.1,
+  );
+  if (!Number.isFinite(raw)) return 0.1;
+  return Math.max(0, Math.min(1, raw));
+}


### PR DESCRIPTION
## Summary

- add `bun run cost:report` for Vercel Billing Charges API JSONL reports, with markdown and JSON output under ignored `.scratch/cost-reports`
- filter low-value Vercel Analytics and Speed Insights paths, and sample Speed Insights at `NEXT_PUBLIC_PETDEX_SPEED_INSIGHTS_SAMPLE_RATE` or `0.1`
- make anonymous pet search deterministic by default so the cacheable path stays `sort=alpha`; curated shuffle remains explicit via `sort=curated`

## Live cost read

From the live Vercel Billing Charges API, 2026-05-19T17:42:23Z to 2026-06-03T17:42:23Z:

- Team billed: `$254.87`
- Petdex billed: `$174.94`, `68.6%` of team spend
- Petdex projected run rate: `$349.88/month`
- Top Petdex services: Edge Requests `$50.67`, Fast Origin Transfer `$37.16`, Speed Insights `$22.75`, Function Invocations `$21.93`, Fluid Active CPU `$21.58`, Web Analytics `$11.05`

## Verification

- `bun test src/app/api/pets/search/route.test.ts`
- `bun x biome check package.json scripts/vercel-cost-report.ts src/components/vercel-observability.tsx 'src/app/[locale]/layout.tsx' 'src/app/[locale]/page.tsx' src/app/api/pets/search/route.ts src/app/api/pets/search/route.test.ts src/components/pet-gallery.tsx`
- `bun run i18n:check`
- `bun run cost:report -- --from-file .scratch/cost-fixtures/sample.jsonl --from 2026-06-02T00:00:00Z --to 2026-06-03T00:00:00Z --out-dir .scratch/cost-reports-fixture`
- `bun run cost:report -- --days 1 --out-dir .scratch/cost-reports-smoke --team-id <team id>`
- `bun run cost:report -- --days 15 --out-dir .scratch/cost-reports-cycle --team-id <team id>`
- `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build`

Known existing failures outside this patch:

- `bun run check` fails on existing Biome issues in mailing, telemetry, pending edits images, URL blocklist, Drizzle snapshots, and `src/lib/security.test.ts` formatting
- `bun test` fails on existing stale source-string assertions in desktop announcement and pinned reorder tests, plus missing `@clack/prompts` for CLI desktop/hooks tests
