### PR TITLE
Add route cost attribution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,8 @@ UPSTASH_REDIS_REST_TOKEN=
 # fallbacks would multiply the 60/min ingestion limit by the number
 # of active serverless instances.
 TELEMETRY_RATELIMIT_SECRET=
+PETDEX_ROUTE_COST_SECRET=
+PETDEX_ROUTE_COST_SAMPLE_RATE=
 
 # Email notifications
 RESEND_API_KEY=

--- a/drizzle/0016_route_cost_buckets.sql
+++ b/drizzle/0016_route_cost_buckets.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "route_cost_buckets" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"bucket_start" timestamp with time zone NOT NULL,
+	"route" text NOT NULL,
+	"route_kind" text NOT NULL,
+	"method" text NOT NULL,
+	"sample_count" integer DEFAULT 0 NOT NULL,
+	"estimated_requests" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "route_cost_buckets_bucket_idx" ON "route_cost_buckets" USING btree ("bucket_start");--> statement-breakpoint
+CREATE INDEX "route_cost_buckets_route_idx" ON "route_cost_buckets" USING btree ("route","bucket_start");--> statement-breakpoint
+CREATE UNIQUE INDEX "route_cost_buckets_unique" ON "route_cost_buckets" USING btree ("bucket_start","method","route_kind","route");

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "format": "biome check --write .",
     "generate-assets": "bun scripts/generate-assets.ts",
     "cost:report": "bun scripts/vercel-cost-report.ts --project petdex",
+    "cost:apply-route-buckets": "bun scripts/apply-route-cost-buckets.ts",
     "auto-tag": "bun scripts/auto-tag.ts",
     "release:desktop": "bun scripts/release-desktop.ts",
     "i18n:check": "bun scripts/i18n-check.ts",

--- a/scripts/apply-route-cost-buckets.ts
+++ b/scripts/apply-route-cost-buckets.ts
@@ -1,0 +1,66 @@
+import { neon } from "@neondatabase/serverless";
+
+import { requiredEnv } from "./env";
+
+const sql = neon(requiredEnv("DATABASE_URL"));
+
+async function tryRun(label: string, fn: () => Promise<unknown>) {
+  try {
+    await fn();
+    console.log(`ok   ${label}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (
+      /already exists/i.test(msg) ||
+      /duplicate column/i.test(msg) ||
+      /duplicate object/i.test(msg)
+    ) {
+      console.log(`skip ${label} (already exists)`);
+    } else {
+      throw err;
+    }
+  }
+}
+
+await tryRun(
+  "route_cost_buckets table",
+  () => sql`
+    CREATE TABLE route_cost_buckets (
+      id serial PRIMARY KEY,
+      bucket_start timestamp with time zone NOT NULL,
+      route text NOT NULL,
+      route_kind text NOT NULL,
+      method text NOT NULL,
+      sample_count integer NOT NULL DEFAULT 0,
+      estimated_requests integer NOT NULL DEFAULT 0,
+      created_at timestamp with time zone NOT NULL DEFAULT now(),
+      updated_at timestamp with time zone NOT NULL DEFAULT now()
+    )
+  `,
+);
+
+await tryRun(
+  "route_cost_buckets_bucket_idx",
+  () => sql`
+    CREATE INDEX route_cost_buckets_bucket_idx
+    ON route_cost_buckets (bucket_start)
+  `,
+);
+
+await tryRun(
+  "route_cost_buckets_route_idx",
+  () => sql`
+    CREATE INDEX route_cost_buckets_route_idx
+    ON route_cost_buckets (route, bucket_start)
+  `,
+);
+
+await tryRun(
+  "route_cost_buckets_unique",
+  () => sql`
+    CREATE UNIQUE INDEX route_cost_buckets_unique
+    ON route_cost_buckets (bucket_start, method, route_kind, route)
+  `,
+);
+
+console.log("done");

--- a/src/app/[locale]/admin/telemetry/page.tsx
+++ b/src/app/[locale]/admin/telemetry/page.tsx
@@ -79,6 +79,27 @@ export default async function AdminTelemetryPage({
         />
       </div>
 
+      <Card>
+        <CardHeader>
+          <p className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.22em] text-brand uppercase">
+            <BarChart2 className="size-3" />
+            Cost attribution
+          </p>
+          <CardTitle className="text-base md:text-lg">
+            Estimated route requests, last 24 hours
+          </CardTitle>
+          <CardDescription>
+            Top contributors by estimated request volume.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <RouteCostList
+            items={summary.routeCostTop}
+            emptyLabel={t("noData")}
+          />
+        </CardContent>
+      </Card>
+
       <div className="grid gap-6 lg:grid-cols-2">
         <Card>
           <CardHeader>
@@ -272,6 +293,65 @@ function StatCard({
         </CardTitle>
       </CardHeader>
     </Card>
+  );
+}
+
+function RouteCostList({
+  items,
+  emptyLabel,
+}: {
+  items: {
+    estimatedRequests: number;
+    method: string;
+    route: string;
+    routeKind: string;
+    samples: number;
+  }[];
+  emptyLabel: string;
+}) {
+  const max = Math.max(...items.map((item) => item.estimatedRequests), 0);
+  if (items.length === 0 || max === 0) {
+    return <p className="text-sm text-muted-3">{emptyLabel}</p>;
+  }
+
+  return (
+    <ul className="space-y-2">
+      {items.map((item) => {
+        const pct =
+          max > 0
+            ? Math.max(4, Math.round((item.estimatedRequests / max) * 100))
+            : 0;
+        return (
+          <li
+            key={`${item.method}:${item.routeKind}:${item.route}`}
+            className="grid gap-2 rounded-md border border-border-base px-3 py-2 text-sm md:grid-cols-[minmax(0,1fr)_160px]"
+          >
+            <div className="min-w-0">
+              <div className="flex min-w-0 items-center gap-2">
+                <Badge variant="outline">{item.method}</Badge>
+                <span className="truncate font-mono text-xs text-foreground">
+                  {item.route}
+                </span>
+              </div>
+              <p className="mt-1 font-mono text-[10px] tracking-[0.14em] text-muted-4 uppercase">
+                {item.routeKind} - {item.samples.toLocaleString()} samples
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="relative h-2 flex-1 overflow-hidden rounded-full bg-border-base">
+                <div
+                  className="absolute inset-y-0 left-0 rounded-full bg-brand/60"
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+              <span className="w-16 text-right font-mono text-xs text-muted-2">
+                {item.estimatedRequests.toLocaleString()}
+              </span>
+            </div>
+          </li>
+        );
+      })}
+    </ul>
   );
 }
 

--- a/src/app/api/internal/route-cost/route.ts
+++ b/src/app/api/internal/route-cost/route.ts
@@ -1,0 +1,204 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+import { sql } from "drizzle-orm";
+
+import { db, schema } from "@/lib/db/client";
+import { type RouteCostKind, routeCostSecret } from "@/lib/route-cost";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MAX_BODY_BYTES = 2048;
+const KIND_SET = new Set<RouteCostKind>([
+  "api",
+  "asset-api",
+  "metadata",
+  "page",
+]);
+const METHOD_SET = new Set([
+  "GET",
+  "HEAD",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "OPTIONS",
+]);
+
+type Body = {
+  at?: unknown;
+  method?: unknown;
+  route?: unknown;
+  routeKind?: unknown;
+  sampleWeight?: unknown;
+};
+
+class PayloadTooLargeError extends Error {
+  constructor() {
+    super("payload_too_large");
+  }
+}
+
+export async function POST(req: Request): Promise<Response> {
+  const secret = routeCostSecret();
+  if (!secret) return new Response(null, { status: 404 });
+
+  const contentLength = Number(req.headers.get("content-length") ?? "0");
+  if (contentLength > MAX_BODY_BYTES) {
+    return Response.json({ error: "payload_too_large" }, { status: 413 });
+  }
+
+  let bodyText: string;
+  try {
+    bodyText = await readBodyCapped(req.body, MAX_BODY_BYTES);
+  } catch (err) {
+    if (!(err instanceof PayloadTooLargeError)) throw err;
+    return Response.json({ error: "payload_too_large" }, { status: 413 });
+  }
+
+  if (
+    !verifySignature(bodyText, secret, req.headers.get("x-petdex-signature"))
+  ) {
+    return new Response(null, { status: 404 });
+  }
+
+  let body: Body;
+  try {
+    body = JSON.parse(bodyText) as Body;
+  } catch {
+    return Response.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const parsed = parseBody(body);
+  if (!parsed.ok) {
+    return Response.json({ error: parsed.error }, { status: 400 });
+  }
+
+  try {
+    await db
+      .insert(schema.routeCostBuckets)
+      .values({
+        bucketStart: parsed.data.bucketStart,
+        method: parsed.data.method,
+        route: parsed.data.route,
+        routeKind: parsed.data.routeKind,
+        sampleCount: 1,
+        estimatedRequests: parsed.data.sampleWeight,
+      })
+      .onConflictDoUpdate({
+        target: [
+          schema.routeCostBuckets.bucketStart,
+          schema.routeCostBuckets.method,
+          schema.routeCostBuckets.routeKind,
+          schema.routeCostBuckets.route,
+        ],
+        set: {
+          sampleCount: sql`${schema.routeCostBuckets.sampleCount} + 1`,
+          estimatedRequests: sql`${schema.routeCostBuckets.estimatedRequests} + ${parsed.data.sampleWeight}`,
+          updatedAt: new Date(),
+        },
+      });
+  } catch (err) {
+    console.error(
+      "[route-cost] upsert failed:",
+      err instanceof Error ? err.message : "unknown error",
+    );
+  }
+
+  return new Response(null, { status: 204 });
+}
+
+async function readBodyCapped(
+  body: ReadableStream<Uint8Array> | null,
+  maxBytes: number,
+): Promise<string> {
+  if (!body) return "";
+  const reader = body.getReader();
+  const decoder = new TextDecoder("utf-8");
+  let total = 0;
+  let out = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel().catch(() => undefined);
+        throw new PayloadTooLargeError();
+      }
+      out += decoder.decode(value, { stream: true });
+    }
+    out += decoder.decode();
+  } finally {
+    reader.releaseLock();
+  }
+  return out;
+}
+
+function parseBody(body: Body):
+  | {
+      ok: true;
+      data: {
+        bucketStart: Date;
+        method: string;
+        route: string;
+        routeKind: RouteCostKind;
+        sampleWeight: number;
+      };
+    }
+  | { ok: false; error: string } {
+  const route =
+    typeof body.route === "string" && body.route.startsWith("/")
+      ? body.route.slice(0, 180)
+      : null;
+  const method =
+    typeof body.method === "string" ? body.method.toUpperCase() : null;
+  const routeKind =
+    typeof body.routeKind === "string" &&
+    KIND_SET.has(body.routeKind as RouteCostKind)
+      ? (body.routeKind as RouteCostKind)
+      : null;
+  const at = typeof body.at === "string" ? new Date(body.at) : new Date();
+  const sampleWeight =
+    typeof body.sampleWeight === "number" &&
+    Number.isFinite(body.sampleWeight) &&
+    body.sampleWeight >= 1 &&
+    body.sampleWeight <= 1_000_000
+      ? Math.round(body.sampleWeight)
+      : null;
+
+  if (!route) return { ok: false, error: "invalid_route" };
+  if (!method || !METHOD_SET.has(method))
+    return { ok: false, error: "invalid_method" };
+  if (!routeKind) return { ok: false, error: "invalid_route_kind" };
+  if (!Number.isFinite(at.getTime())) return { ok: false, error: "invalid_at" };
+  if (!sampleWeight) return { ok: false, error: "invalid_sample_weight" };
+
+  return {
+    ok: true,
+    data: {
+      bucketStart: bucketStart(at),
+      method,
+      route,
+      routeKind,
+      sampleWeight,
+    },
+  };
+}
+
+function bucketStart(date: Date): Date {
+  const bucketMs = 15 * 60 * 1000;
+  return new Date(Math.floor(date.getTime() / bucketMs) * bucketMs);
+}
+
+function verifySignature(
+  body: string,
+  secret: string,
+  signature: string | null,
+): boolean {
+  if (!signature) return false;
+  const expected = createHmac("sha256", secret).update(body).digest("hex");
+  const a = Buffer.from(signature, "hex");
+  const b = Buffer.from(expected, "hex");
+  return a.length === b.length && timingSafeEqual(a, b);
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -827,6 +827,41 @@ export const telemetryEvents = pgTable(
 export type TelemetryEvent = typeof telemetryEvents.$inferSelect;
 export type NewTelemetryEvent = typeof telemetryEvents.$inferInsert;
 
+export const routeCostBuckets = pgTable(
+  "route_cost_buckets",
+  {
+    id: serial("id").primaryKey(),
+    bucketStart: timestamp("bucket_start", { withTimezone: true }).notNull(),
+    route: text("route").notNull(),
+    routeKind: text("route_kind").notNull(),
+    method: text("method").notNull(),
+    sampleCount: integer("sample_count").notNull().default(0),
+    estimatedRequests: integer("estimated_requests").notNull().default(0),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => ({
+    bucketIdx: index("route_cost_buckets_bucket_idx").on(table.bucketStart),
+    routeIdx: index("route_cost_buckets_route_idx").on(
+      table.route,
+      table.bucketStart,
+    ),
+    uniqueBucket: uniqueIndex("route_cost_buckets_unique").on(
+      table.bucketStart,
+      table.method,
+      table.routeKind,
+      table.route,
+    ),
+  }),
+);
+
+export type RouteCostBucket = typeof routeCostBuckets.$inferSelect;
+export type NewRouteCostBucket = typeof routeCostBuckets.$inferInsert;
+
 export const wechatQrUploads = pgTable(
   "wechat_qr_uploads",
   {

--- a/src/lib/route-cost.test.ts
+++ b/src/lib/route-cost.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  buildRouteCostSample,
+  normalizeRouteCostPath,
+  routeCostKind,
+  routeCostSampleRate,
+  routeCostSecret,
+} from "@/lib/route-cost";
+
+describe("route cost helpers", () => {
+  it("normalizes localized page paths without keeping user slugs", () => {
+    expect(normalizeRouteCostPath("/en/pets/byte-bunny")).toBe("/pets/[slug]");
+    expect(normalizeRouteCostPath("/zh/u/henryjing96")).toBe("/u/[handle]");
+  });
+
+  it("normalizes app dynamic route ids before storing buckets", () => {
+    expect(normalizeRouteCostPath("/en/admin/feedback/fbk_abc123def")).toBe(
+      "/admin/feedback/[id]",
+    );
+    expect(
+      normalizeRouteCostPath("/en/advertise/dashboard/ad_abc123def/edit"),
+    ).toBe("/advertise/dashboard/[campaignId]/edit");
+    expect(normalizeRouteCostPath("/api/my-pets/pet_abc123def/edit")).toBe(
+      "/api/my-pets/[id]/edit",
+    );
+    expect(normalizeRouteCostPath("/api/ads/ad_abc123def")).toBe(
+      "/api/ads/[id]",
+    );
+    expect(normalizeRouteCostPath("/api/admin/edits/edit_abc123def")).toBe(
+      "/api/admin/edits/[id]",
+    );
+  });
+
+  it("keeps static API search paths distinct from pet slug routes", () => {
+    expect(normalizeRouteCostPath("/api/pets/search")).toBe("/api/pets/search");
+    expect(normalizeRouteCostPath("/api/pets/random")).toBe("/api/pets/random");
+    expect(normalizeRouteCostPath("/api/pets/byte-bunny/metrics")).toBe(
+      "/api/pets/[slug]/metrics",
+    );
+  });
+
+  it("keeps static API routes ahead of dynamic patterns", () => {
+    expect(normalizeRouteCostPath("/en/collections/opengraph-image")).toBe(
+      "/collections/opengraph-image",
+    );
+    expect(normalizeRouteCostPath("/api/feedback/unread")).toBe(
+      "/api/feedback/unread",
+    );
+    expect(normalizeRouteCostPath("/api/admin/request-candidates")).toBe(
+      "/api/admin/request-candidates",
+    );
+    expect(normalizeRouteCostPath("/api/ads/checkout")).toBe(
+      "/api/ads/checkout",
+    );
+    expect(normalizeRouteCostPath("/api/ads/event")).toBe("/api/ads/event");
+  });
+
+  it("buckets unmatched paths without preserving random segments", () => {
+    expect(normalizeRouteCostPath("/x/random-404-path")).toBe("/[unmatched]");
+    expect(normalizeRouteCostPath("/api/x/ad_random_123456")).toBe(
+      "/api/[unmatched]",
+    );
+  });
+
+  it("classifies asset-heavy API routes separately", () => {
+    expect(routeCostKind("/api/pets/[slug]/thumb")).toBe("asset-api");
+    expect(routeCostKind("/api/pets/search")).toBe("api");
+    expect(routeCostKind("/pets/[slug]")).toBe("page");
+  });
+
+  it("builds weighted samples and skips the ingestion route", () => {
+    expect(
+      buildRouteCostSample({
+        method: "get",
+        pathname: "/api/internal/route-cost",
+        sampleRate: 0.001,
+      }),
+    ).toBeNull();
+    expect(
+      buildRouteCostSample({
+        method: "get",
+        pathname: "/api/pets/byte-bunny/thumb",
+        sampleRate: 0.001,
+      }),
+    ).toMatchObject({
+      method: "GET",
+      route: "/api/pets/[slug]/thumb",
+      routeKind: "asset-api",
+      sampleWeight: 1000,
+    });
+  });
+
+  it("requires explicit route cost env values", () => {
+    const previousSecret = process.env.PETDEX_ROUTE_COST_SECRET;
+    const previousTelemetrySecret = process.env.TELEMETRY_RATELIMIT_SECRET;
+    const previousUpstashToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+    const previousRate = process.env.PETDEX_ROUTE_COST_SAMPLE_RATE;
+
+    try {
+      process.env.PETDEX_ROUTE_COST_SECRET = "";
+      process.env.TELEMETRY_RATELIMIT_SECRET = " telemetry-secret ";
+      process.env.UPSTASH_REDIS_REST_TOKEN = "upstash-token";
+      process.env.PETDEX_ROUTE_COST_SAMPLE_RATE = "";
+
+      expect(routeCostSecret()).toBeNull();
+      expect(routeCostSampleRate()).toBe(0);
+
+      process.env.PETDEX_ROUTE_COST_SECRET = " route-secret ";
+      process.env.PETDEX_ROUTE_COST_SAMPLE_RATE = "0.001";
+      expect(routeCostSecret()).toBe("route-secret");
+      expect(routeCostSampleRate()).toBe(0.001);
+
+      process.env.PETDEX_ROUTE_COST_SAMPLE_RATE = "0.2";
+      expect(routeCostSampleRate()).toBe(0.05);
+
+      process.env.PETDEX_ROUTE_COST_SAMPLE_RATE = "0.000000001";
+      expect(routeCostSampleRate()).toBe(0.000001);
+    } finally {
+      restoreEnv("PETDEX_ROUTE_COST_SECRET", previousSecret);
+      restoreEnv("TELEMETRY_RATELIMIT_SECRET", previousTelemetrySecret);
+      restoreEnv("UPSTASH_REDIS_REST_TOKEN", previousUpstashToken);
+      restoreEnv("PETDEX_ROUTE_COST_SAMPLE_RATE", previousRate);
+    }
+  });
+});
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}

--- a/src/lib/route-cost.ts
+++ b/src/lib/route-cost.ts
@@ -1,0 +1,256 @@
+export type RouteCostKind = "api" | "asset-api" | "metadata" | "page";
+
+export type RouteCostSample = {
+  method: string;
+  route: string;
+  routeKind: RouteCostKind;
+  sampleWeight: number;
+  at: string;
+};
+
+const LOCALE_SET = new Set(["en", "es", "zh"]);
+const DYNAMIC_ROUTE_PATTERNS = [
+  ["admin", "feedback", "[id]"],
+  ["advertise", "dashboard", "[campaignId]", "edit"],
+  ["collections", "[slug]"],
+  ["collections", "[slug]", "opengraph-image"],
+  ["install", "[slug]"],
+  ["kind", "[kind]"],
+  ["my-feedback", "[id]"],
+  ["pets", "[slug]"],
+  ["pets", "[slug]", "opengraph-image"],
+  ["u", "[handle]"],
+  ["u", "[handle]", "opengraph-image"],
+  ["vibe", "[vibe]"],
+  ["api", "admin", "[id]"],
+  ["api", "admin", "[id]", "feature"],
+  ["api", "admin", "collection-requests", "[id]"],
+  ["api", "admin", "edits", "[id]"],
+  ["api", "admin", "feedback", "[id]"],
+  ["api", "admin", "requests", "[id]"],
+  ["api", "ads", "[id]"],
+  ["api", "collections", "[slug]", "request"],
+  ["api", "feedback", "[id]"],
+  ["api", "feedback", "[id]", "replies"],
+  ["api", "install-pet", "[slug]"],
+  ["api", "internal", "submissions", "[id]", "review"],
+  ["api", "my-pets", "[id]", "edit"],
+  ["api", "my-pets", "[id]", "edit-presign"],
+  ["api", "my-pets", "[id]", "withdraw"],
+  ["api", "pet-requests", "[id]", "candidates"],
+  ["api", "pets", "[slug]", "can-delete"],
+  ["api", "pets", "[slug]", "codex-theme"],
+  ["api", "pets", "[slug]", "like"],
+  ["api", "pets", "[slug]", "metrics"],
+  ["api", "pets", "[slug]", "owner"],
+  ["api", "pets", "[slug]", "owner-state"],
+  ["api", "pets", "[slug]", "sticker"],
+  ["api", "pets", "[slug]", "thumb"],
+  ["api", "pets", "[slug]", "track-zip"],
+  ["api", "pets", "[slug]", "variants"],
+  ["api", "pets", "[slug]", "wastickers"],
+  ["api", "profile", "collections", "[id]"],
+];
+const STATIC_ROUTE_SET = new Set([
+  "-/collections/-/opengraph-image",
+  "-/collections/opengraph-image",
+  "-/download/opengraph-image",
+  "-/pets/-/opengraph-image",
+  "-/u/-/opengraph-image",
+  "about",
+  "admin",
+  "admin/campaigns",
+  "admin/collection-requests",
+  "admin/edits",
+  "admin/feedback",
+  "admin/insights",
+  "admin/mailing",
+  "admin/mailing/new",
+  "admin/mailing/subscribers",
+  "admin/manifest",
+  "admin/requests",
+  "admin/telemetry",
+  "advertise",
+  "advertise/dashboard",
+  "advertise/new",
+  "api/admin/request-candidates",
+  "api/admin/telemetry/summary",
+  "api/ads",
+  "collections/opengraph-image",
+  "api/ads/checkout",
+  "api/ads/event",
+  "api/ads/image/presign",
+  "api/ads/impression",
+  "api/cli/auth-config",
+  "api/cli/edit-presign",
+  "api/cli/submit",
+  "api/cli/submit/check",
+  "api/cli/submit/register",
+  "api/desktop/latest-release",
+  "api/feedback",
+  "api/feedback/unread",
+  "api/internal/route-cost",
+  "api/manifest",
+  "api/manifest/full",
+  "api/me/caught-slugs",
+  "api/me/header-state",
+  "api/my-pets/approved",
+  "api/my-pets/claim",
+  "api/notifications",
+  "api/notifications/read",
+  "api/og",
+  "api/pet-requests",
+  "api/pet-requests/image",
+  "api/pets/random",
+  "api/pets/search",
+  "api/profile",
+  "api/profile/collection",
+  "api/profile/collections",
+  "api/profile/gallery-order",
+  "api/profile/me",
+  "api/r2/presign",
+  "api/stripe/webhook",
+  "api/submit",
+  "api/telemetry/event",
+  "api/uploadthing",
+  "api/webhooks/resend",
+  "api/wechat-qr",
+  "brand",
+  "built-with",
+  "collaborator",
+  "collaborator/collection-requests",
+  "collaborator/edits",
+  "collaborator/moderation",
+  "collaborator/requests",
+  "collaborator/wechat-qr",
+  "collections",
+  "community",
+  "create",
+  "docs",
+  "download",
+  "download/opengraph-image",
+  "favicon.ico",
+  "leaderboard",
+  "legal/takedown",
+  "legal/telemetry",
+  "my-feedback",
+  "requests",
+  "robots.txt",
+  "sitemap.xml",
+  "submit",
+  "unsubscribe",
+]);
+const ASSET_API_SEGMENTS = new Set([
+  "codex-theme",
+  "latest-release",
+  "og",
+  "sticker",
+  "thumb",
+  "variants",
+  "wastickers",
+  "wechat-qr",
+]);
+
+export function routeCostSampleRate(): number {
+  const configured = process.env.PETDEX_ROUTE_COST_SAMPLE_RATE?.trim();
+  if (!configured) return 0;
+  const raw = Number(configured);
+  if (!Number.isFinite(raw) || raw <= 0) return 0;
+  return Math.min(Math.max(raw, 0.000001), 0.05);
+}
+
+export function routeCostSecret(): string | null {
+  return firstNonEmpty(process.env.PETDEX_ROUTE_COST_SECRET);
+}
+
+export function shouldSampleRouteCost(rate = routeCostSampleRate()): boolean {
+  return rate > 0 && Math.random() < rate;
+}
+
+export function buildRouteCostSample(input: {
+  method: string;
+  pathname: string;
+  sampleRate?: number;
+}): RouteCostSample | null {
+  if (input.pathname === "/api/internal/route-cost") return null;
+  const sampleRate = input.sampleRate ?? routeCostSampleRate();
+  if (sampleRate <= 0) return null;
+  const route = normalizeRouteCostPath(input.pathname);
+  return {
+    method: normalizeMethod(input.method),
+    route,
+    routeKind: routeCostKind(route),
+    sampleWeight: Math.max(1, Math.round(1 / sampleRate)),
+    at: new Date().toISOString(),
+  };
+}
+
+export function normalizeRouteCostPath(pathname: string): string {
+  const parts = pathname.split("/").filter(Boolean);
+  const routeParts = LOCALE_SET.has(parts[0] ?? "") ? parts.slice(1) : parts;
+  if (routeParts.length === 0) return "/";
+  if (STATIC_ROUTE_SET.has(routeParts.join("/"))) {
+    return `/${routeParts.join("/")}`;
+  }
+  const pattern = matchDynamicRoutePattern(routeParts);
+  if (pattern) return `/${pattern.join("/")}`;
+  return routeParts[0] === "api" ? "/api/[unmatched]" : "/[unmatched]";
+}
+
+export function routeCostKind(route: string): RouteCostKind {
+  if (route.includes("opengraph-image")) return "metadata";
+  if (route.startsWith("/api/")) {
+    return [...ASSET_API_SEGMENTS].some((segment) =>
+      route.includes(`/${segment}`),
+    )
+      ? "asset-api"
+      : "api";
+  }
+  return "page";
+}
+
+export async function signRouteCostPayload(
+  body: string,
+  secret: string,
+): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(body));
+  return [...new Uint8Array(signature)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function normalizeMethod(method: string): string {
+  const upper = method.toUpperCase();
+  return upper.length <= 12 ? upper : "OTHER";
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | null {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+function matchDynamicRoutePattern(parts: string[]): string[] | null {
+  for (const pattern of DYNAMIC_ROUTE_PATTERNS) {
+    if (pattern.length !== parts.length) continue;
+    const matches = pattern.every((part, index) => {
+      return isDynamicPart(part) || part === parts[index];
+    });
+    if (matches) return pattern;
+  }
+  return null;
+}
+
+function isDynamicPart(part: string): boolean {
+  return part.startsWith("[") && part.endsWith("]");
+}

--- a/src/lib/telemetry/queries.ts
+++ b/src/lib/telemetry/queries.ts
@@ -10,6 +10,13 @@ export type ArchRow = { arch: string; count: number };
 export type VersionRow = { binary_version: string; count: number };
 export type AgentRow = { agent: string; count: number };
 export type CountryRow = { country: string; count: number };
+export type RouteCostRow = {
+  estimatedRequests: number;
+  method: string;
+  route: string;
+  routeKind: string;
+  samples: number;
+};
 export type VersionAdoptionRow = {
   day: string;
   version: string;
@@ -26,6 +33,7 @@ export type TelemetrySummary = {
   versionDistribution: VersionRow[];
   topAgents: AgentRow[];
   countryTop10: CountryRow[];
+  routeCostTop: RouteCostRow[];
   funnel: {
     install: number;
     hooks: number;
@@ -54,6 +62,7 @@ export async function getTelemetrySummary(): Promise<TelemetrySummary> {
     versionResult,
     agentsResult,
     countryResult,
+    routeCostResult,
     funnelResult,
   ] = await Promise.all([
     db.execute(sql`
@@ -120,6 +129,7 @@ export async function getTelemetrySummary(): Promise<TelemetrySummary> {
       ORDER BY count DESC
       LIMIT 10
     `),
+    getRouteCostTop(),
     db.execute(sql`
       SELECT
         COUNT(DISTINCT CASE WHEN event = 'cli_install_desktop_success' THEN install_id END) AS install,
@@ -191,6 +201,26 @@ export async function getTelemetrySummary(): Promise<TelemetrySummary> {
     ).rows ?? []
   ).map((r) => ({ country: r.country, count: toNum(r.count) }));
 
+  const routeCostTop = (
+    (
+      routeCostResult as unknown as {
+        rows: Array<{
+          estimated_requests: unknown;
+          method: string;
+          route: string;
+          route_kind: string;
+          samples: unknown;
+        }>;
+      }
+    ).rows ?? []
+  ).map((r) => ({
+    estimatedRequests: toNum(r.estimated_requests),
+    method: r.method,
+    route: r.route,
+    routeKind: r.route_kind,
+    samples: toNum(r.samples),
+  }));
+
   const funnelRow = (
     funnelResult as unknown as {
       rows: Array<{
@@ -220,6 +250,7 @@ export async function getTelemetrySummary(): Promise<TelemetrySummary> {
     versionDistribution,
     topAgents,
     countryTop10,
+    routeCostTop,
     funnel: {
       install: fInstall,
       hooks: fHooks,
@@ -230,6 +261,26 @@ export async function getTelemetrySummary(): Promise<TelemetrySummary> {
       startToFirstPct: pct(fFirst, fStart),
     },
   };
+}
+
+async function getRouteCostTop() {
+  try {
+    return await db.execute(sql`
+      SELECT
+        method,
+        route,
+        route_kind,
+        SUM(sample_count) AS samples,
+        SUM(estimated_requests) AS estimated_requests
+      FROM route_cost_buckets
+      WHERE bucket_start >= now() - interval '24 hours'
+      GROUP BY method, route, route_kind
+      ORDER BY estimated_requests DESC
+      LIMIT 20
+    `);
+  } catch {
+    return { rows: [] };
+  }
 }
 
 export async function versionAdoptionOverTime(): Promise<VersionAdoptionRow[]> {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,19 @@
-import { NextResponse } from "next/server";
+import {
+  type NextFetchEvent,
+  type NextRequest,
+  NextResponse,
+} from "next/server";
 
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import createMiddleware from "next-intl/middleware";
+
+import {
+  buildRouteCostSample,
+  routeCostSampleRate,
+  routeCostSecret,
+  shouldSampleRouteCost,
+  signRouteCostPayload,
+} from "@/lib/route-cost";
 
 import { defaultLocale, locales } from "@/i18n/config";
 
@@ -37,7 +49,8 @@ const handleI18nRouting = createMiddleware({
 // clerkMiddleware entirely (it would otherwise try to validate a real
 // backend secret before our shims have a chance to short-circuit).
 // Everything else — next-intl routing, the shuffle cookie — keeps working.
-const baseMiddleware = (req: Request) => {
+const baseMiddleware = (req: NextRequest, event?: NextFetchEvent) => {
+  scheduleRouteCostSample(req, event);
   if (new URL(req.url).pathname.startsWith("/api")) {
     return NextResponse.next();
   }
@@ -46,7 +59,9 @@ const baseMiddleware = (req: Request) => {
 
 export default IS_MOCK_AUTH
   ? baseMiddleware
-  : clerkMiddleware(async (auth, req) => {
+  : clerkMiddleware(async (auth, req, event) => {
+      scheduleRouteCostSample(req, event);
+
       if (isProtected(req)) {
         await auth.protect();
       }
@@ -65,3 +80,34 @@ export const config = {
     "/(api|trpc)(.*)",
   ],
 };
+
+function scheduleRouteCostSample(req: NextRequest, event?: NextFetchEvent) {
+  if (!event) return;
+  const secret = routeCostSecret();
+  const sampleRate = routeCostSampleRate();
+  if (!secret || !shouldSampleRouteCost(sampleRate)) return;
+  const sample = buildRouteCostSample({
+    method: req.method,
+    pathname: req.nextUrl.pathname,
+    sampleRate,
+  });
+  if (!sample) return;
+
+  const body = JSON.stringify(sample);
+  event.waitUntil(
+    signRouteCostPayload(body, secret)
+      .then((signature) =>
+        fetch(new URL("/api/internal/route-cost", req.url), {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-petdex-signature": signature,
+          },
+          body,
+          cache: "no-store",
+        }),
+      )
+      .then(() => undefined)
+      .catch(() => undefined),
+  );
+}


### PR DESCRIPTION
## Summary
- sample requests in proxy via `waitUntil` and HMAC-post aggregate route samples to `/api/internal/route-cost`
- keep rollout opt-in through explicit `PETDEX_ROUTE_COST_SECRET` and `PETDEX_ROUTE_COST_SAMPLE_RATE`
- add `route_cost_buckets` schema, migration, and an idempotent production apply script
- surface top normalized route request estimates on admin telemetry

## Validation
- `bun test src/lib/route-cost.test.ts`
- `bun x biome check package.json .env.example src/proxy.ts src/lib/route-cost.ts src/lib/route-cost.test.ts src/lib/db/schema.ts src/lib/telemetry/queries.ts 'src/app/[locale]/admin/telemetry/page.tsx' src/app/api/internal/route-cost/route.ts scripts/apply-route-cost-buckets.ts`
- `git diff --check`
- `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build`
- `bun run i18n:check`

## Known repo check state
- `bun run check` still fails on pre-existing main issues: admin mailing non-null assertions, unused `RawBody`, pending-edits `<img>` warnings, unused `UrlCheckResult`, and existing formatting drift in drizzle snapshots/security test.
