### PR TITLE
Reduce header state requests

### DIFF
--- a/src/components/header-state-provider.tsx
+++ b/src/components/header-state-provider.tsx
@@ -9,28 +9,26 @@ import {
   useState,
 } from "react";
 
-type HeaderState = {
-  signedIn: boolean;
-  notifications: { unreadCount: number };
-  feedback: { count: number; adminCount: number };
-  caught: string[];
-};
+import { useAuth } from "@clerk/nextjs";
 
-const INITIAL: HeaderState = {
-  signedIn: false,
-  notifications: { unreadCount: 0 },
-  feedback: { count: 0, adminCount: 0 },
-  caught: [],
-};
+import {
+  HEADER_STATE_POLL_MS,
+  type HeaderState,
+  headerStateCacheKey,
+  INITIAL_HEADER_STATE,
+  parseCachedHeaderState,
+  serializeHeaderState,
+  shouldRequestHeaderState,
+  withHeaderUnreadCount,
+} from "@/lib/header-state";
 
 type Ctx = {
   state: HeaderState;
-  refresh: () => Promise<void>;
+  refresh: (options?: { force?: boolean }) => Promise<void>;
+  setUnreadCount: (next: number | ((current: number) => number)) => void;
 };
 
 const HeaderStateContext = createContext<Ctx | null>(null);
-
-const POLL_MS = 90_000;
 
 // Single source of truth for SiteHeader badges + caught-slug set.
 // Replaces 3 separate fetches per page-view (auth-badge feedback unread,
@@ -42,35 +40,108 @@ export function HeaderStateProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const [state, setState] = useState<HeaderState>(INITIAL);
-  const stopped = useRef(false);
+  const { isLoaded, isSignedIn, userId } = useAuth();
+  const [state, setState] = useState<HeaderState>(INITIAL_HEADER_STATE);
+  const cacheKey = headerStateCacheKey(userId);
+  const lastRefreshAt = useRef(0);
+  const mounted = useRef(false);
+  const requestGeneration = useRef(0);
+  const userScope = useRef<string | null>(null);
 
-  const refresh = useCallback(async () => {
-    try {
-      const res = await fetch("/api/me/header-state", { cache: "no-store" });
-      if (!res.ok) return;
-      const json = (await res.json()) as HeaderState;
-      if (!stopped.current) setState(json);
-    } catch {
-      /* offline / network blip — keep last known state */
-    }
-  }, []);
+  const setUnreadCount = useCallback(
+    (next: number | ((current: number) => number)) => {
+      setState((current) => withHeaderUnreadCount(current, next));
+    },
+    [],
+  );
+
+  const refresh = useCallback(
+    async (options?: { force?: boolean }) => {
+      const now = Date.now();
+      const requestUserId = userId ?? null;
+      if (
+        !shouldRequestHeaderState({
+          force: options?.force,
+          isLoaded,
+          isSignedIn,
+          lastRefreshAt: lastRefreshAt.current,
+          now,
+        })
+      ) {
+        return;
+      }
+      const generation = ++requestGeneration.current;
+      lastRefreshAt.current = now;
+      try {
+        const res = await fetch("/api/me/header-state", { cache: "no-store" });
+        if (!res.ok) return;
+        const json = (await res.json()) as HeaderState;
+        if (
+          !mounted.current ||
+          generation !== requestGeneration.current ||
+          userScope.current !== requestUserId
+        ) {
+          return;
+        }
+        setState(json);
+        if (cacheKey) {
+          writeCachedHeaderState(cacheKey, json, now);
+        }
+      } catch {
+        return;
+      }
+    },
+    [cacheKey, isLoaded, isSignedIn, userId],
+  );
 
   useEffect(() => {
-    stopped.current = false;
-    void refresh();
-    const id = window.setInterval(() => void refresh(), POLL_MS);
+    mounted.current = true;
+    userScope.current = userId ?? null;
+    requestGeneration.current += 1;
+    if (!isLoaded) {
+      return () => {
+        mounted.current = false;
+        requestGeneration.current += 1;
+      };
+    }
+    if (!isSignedIn) {
+      setState(INITIAL_HEADER_STATE);
+      lastRefreshAt.current = 0;
+      return () => {
+        mounted.current = false;
+        requestGeneration.current += 1;
+      };
+    }
+    let hasCachedState = false;
+    if (cacheKey) {
+      const cached = parseCachedHeaderState(
+        readCachedHeaderState(cacheKey),
+        Date.now(),
+      );
+      if (cached) {
+        setState(cached.state);
+        lastRefreshAt.current = cached.savedAt;
+        hasCachedState = true;
+      }
+    }
+    if (!hasCachedState) {
+      setState(INITIAL_HEADER_STATE);
+      lastRefreshAt.current = 0;
+    }
+    void refresh({ force: !hasCachedState });
+    const id = window.setInterval(() => void refresh(), HEADER_STATE_POLL_MS);
     const onFocus = () => void refresh();
     window.addEventListener("focus", onFocus);
     return () => {
-      stopped.current = true;
+      mounted.current = false;
+      requestGeneration.current += 1;
       window.clearInterval(id);
       window.removeEventListener("focus", onFocus);
     };
-  }, [refresh]);
+  }, [cacheKey, isLoaded, isSignedIn, refresh, userId]);
 
   return (
-    <HeaderStateContext.Provider value={{ state, refresh }}>
+    <HeaderStateContext.Provider value={{ refresh, setUnreadCount, state }}>
       {children}
     </HeaderStateContext.Provider>
   );
@@ -79,5 +150,32 @@ export function HeaderStateProvider({
 export function useHeaderState(): Ctx {
   const ctx = useContext(HeaderStateContext);
   if (ctx) return ctx;
-  return { state: INITIAL, refresh: async () => {} };
+  return {
+    refresh: async () => {},
+    setUnreadCount: () => {},
+    state: INITIAL_HEADER_STATE,
+  };
+}
+
+function readCachedHeaderState(cacheKey: string) {
+  try {
+    return window.sessionStorage.getItem(cacheKey);
+  } catch {
+    return null;
+  }
+}
+
+function writeCachedHeaderState(
+  cacheKey: string,
+  state: HeaderState,
+  savedAt: number,
+) {
+  try {
+    window.sessionStorage.setItem(
+      cacheKey,
+      serializeHeaderState(state, savedAt),
+    );
+  } catch {
+    return;
+  }
 }

--- a/src/components/notifications-bell.tsx
+++ b/src/components/notifications-bell.tsx
@@ -130,17 +130,17 @@ function relativeTime(iso: string): string {
 }
 
 export function NotificationsBell({ compact = false }: { compact?: boolean }) {
-  const { state, refresh } = useHeaderState();
+  const { state, refresh, setUnreadCount } = useHeaderState();
   const unread = state.notifications.unreadCount;
   const [items, setItems] = useState<Notif[]>([]);
   const [itemsLoaded, setItemsLoaded] = useState(false);
   const [open, setOpen] = useState(false);
 
   const setUnread = useCallback(
-    (_next: number | ((n: number) => number)) => {
-      void refresh();
+    (next: number | ((n: number) => number)) => {
+      setUnreadCount(next);
     },
-    [refresh],
+    [setUnreadCount],
   );
 
   const loadItems = useCallback(async () => {
@@ -174,6 +174,8 @@ export function NotificationsBell({ compact = false }: { compact?: boolean }) {
       });
     } catch {
       /* silent — next poll will reconcile */
+    } finally {
+      void refresh({ force: true });
     }
   }
 
@@ -194,6 +196,8 @@ export function NotificationsBell({ compact = false }: { compact?: boolean }) {
       });
     } catch {
       /* silent */
+    } finally {
+      void refresh({ force: true });
     }
   }
 

--- a/src/lib/header-state.test.ts
+++ b/src/lib/header-state.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  headerStateCacheKey,
+  INITIAL_HEADER_STATE,
+  parseCachedHeaderState,
+  serializeHeaderState,
+  shouldRequestHeaderState,
+  withHeaderUnreadCount,
+} from "@/lib/header-state";
+
+describe("header state helpers", () => {
+  it("does not request header state before auth resolves or for signed-out users", () => {
+    expect(
+      shouldRequestHeaderState({
+        isLoaded: false,
+        isSignedIn: undefined,
+        lastRefreshAt: 0,
+        now: 1_000,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRequestHeaderState({
+        isLoaded: true,
+        isSignedIn: false,
+        lastRefreshAt: 0,
+        now: 1_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("throttles signed-in refreshes unless forced", () => {
+    expect(
+      shouldRequestHeaderState({
+        isLoaded: true,
+        isSignedIn: true,
+        lastRefreshAt: 0,
+        now: 1_000,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRequestHeaderState({
+        isLoaded: true,
+        isSignedIn: true,
+        lastRefreshAt: 1_000,
+        minRefreshMs: 60_000,
+        now: 30_000,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRequestHeaderState({
+        force: true,
+        isLoaded: true,
+        isSignedIn: true,
+        lastRefreshAt: 1_000,
+        minRefreshMs: 60_000,
+        now: 30_000,
+      }),
+    ).toBe(true);
+  });
+
+  it("parses only fresh cached header state", () => {
+    const state = {
+      ...INITIAL_HEADER_STATE,
+      signedIn: true,
+      notifications: { unreadCount: 2 },
+      feedback: { count: 1, adminCount: 0 },
+      caught: ["byte"],
+    };
+    const raw = serializeHeaderState(state, 1_000);
+
+    expect(parseCachedHeaderState(raw, 30_000)?.state).toEqual(state);
+    expect(parseCachedHeaderState(raw, 90_000)).toBeNull();
+    expect(parseCachedHeaderState(raw, 500)).toBeNull();
+  });
+
+  it("scopes cache keys by signed-in user", () => {
+    expect(headerStateCacheKey(null)).toBeNull();
+    expect(headerStateCacheKey("user_123")).toBe(
+      "petdex:header-state:user_123",
+    );
+  });
+
+  it("updates unread count without mutating the current header state", () => {
+    const current = {
+      ...INITIAL_HEADER_STATE,
+      notifications: { unreadCount: 3 },
+    };
+
+    expect(withHeaderUnreadCount(current, (n) => n - 1)).toEqual({
+      ...current,
+      notifications: { unreadCount: 2 },
+    });
+    expect(withHeaderUnreadCount(current, -10).notifications.unreadCount).toBe(
+      0,
+    );
+    expect(current.notifications.unreadCount).toBe(3);
+  });
+});

--- a/src/lib/header-state.ts
+++ b/src/lib/header-state.ts
@@ -1,0 +1,118 @@
+export type HeaderState = {
+  signedIn: boolean;
+  notifications: { unreadCount: number };
+  feedback: { count: number; adminCount: number };
+  caught: string[];
+};
+
+export const INITIAL_HEADER_STATE: HeaderState = {
+  signedIn: false,
+  notifications: { unreadCount: 0 },
+  feedback: { count: 0, adminCount: 0 },
+  caught: [],
+};
+
+export const HEADER_STATE_POLL_MS = 300_000;
+export const HEADER_STATE_MIN_REFRESH_MS = 60_000;
+export const HEADER_STATE_CACHE_TTL_MS = 60_000;
+
+type CachedHeaderState = {
+  savedAt: number;
+  state: HeaderState;
+};
+
+export function headerStateCacheKey(userId: string | null | undefined) {
+  return userId ? `petdex:header-state:${userId}` : null;
+}
+
+export function shouldRequestHeaderState(input: {
+  force?: boolean;
+  isLoaded: boolean;
+  isSignedIn: boolean | undefined;
+  lastRefreshAt: number;
+  minRefreshMs?: number;
+  now: number;
+}) {
+  if (!input.isLoaded || !input.isSignedIn) return false;
+  if (input.force) return true;
+  return (
+    input.lastRefreshAt === 0 ||
+    input.now - input.lastRefreshAt >=
+      (input.minRefreshMs ?? HEADER_STATE_MIN_REFRESH_MS)
+  );
+}
+
+export function parseCachedHeaderState(
+  raw: string | null,
+  now: number,
+  ttlMs = HEADER_STATE_CACHE_TTL_MS,
+): CachedHeaderState | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<CachedHeaderState>;
+    if (
+      typeof parsed.savedAt !== "number" ||
+      !parsed.state ||
+      parsed.savedAt > now ||
+      now - parsed.savedAt > ttlMs
+    ) {
+      return null;
+    }
+    return {
+      savedAt: parsed.savedAt,
+      state: normalizeHeaderState(parsed.state),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function serializeHeaderState(state: HeaderState, savedAt: number) {
+  return JSON.stringify({ savedAt, state });
+}
+
+export function withHeaderUnreadCount(
+  state: HeaderState,
+  next: number | ((current: number) => number),
+): HeaderState {
+  const unreadCount =
+    typeof next === "function" ? next(state.notifications.unreadCount) : next;
+  return {
+    ...state,
+    notifications: {
+      ...state.notifications,
+      unreadCount: Math.max(0, toNumber(unreadCount)),
+    },
+  };
+}
+
+function normalizeHeaderState(value: unknown): HeaderState {
+  const input = isRecord(value) ? value : {};
+  const notifications = isRecord(input.notifications)
+    ? input.notifications
+    : {};
+  const feedback = isRecord(input.feedback) ? input.feedback : {};
+  return {
+    signedIn: input.signedIn === true,
+    notifications: {
+      unreadCount: toNumber(notifications.unreadCount),
+    },
+    feedback: {
+      count: toNumber(feedback.count),
+      adminCount: toNumber(feedback.adminCount),
+    },
+    caught: Array.isArray(input.caught) ? input.caught.filter(isString) : [],
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function toNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}


### PR DESCRIPTION
## Summary
- skip /api/me/header-state fetches until Clerk auth is loaded and the visitor is signed in
- add a signed-in session cache and refresh throttle for header state
- slow idle polling from 90s to 5m while keeping force refresh for notification actions

## Cost impact
- removes anonymous client calls to /api/me/header-state entirely
- reduces signed-in idle polling by about 70 percent per open tab
- keeps the endpoint available for signed-in badge, feedback, notification, and caught-slug state

## Validation
- bun test src/lib/header-state.test.ts
- bun x biome check src/lib/header-state.ts src/lib/header-state.test.ts src/components/header-state-provider.tsx src/components/notifications-bell.tsx
- git diff --check
- bun run i18n:check
- TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build

## Known repo check state
- bun run check still fails on pre-existing global Biome findings outside this PR: mailing non-null assertions, unused telemetry and url-blocklist types, pending-edit img warnings, drizzle meta formatting, and src/lib/security.test.ts formatting
