### PR TITLE
Disable pet page prefetches from public cards

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -340,6 +340,7 @@ async function HeroPetParade({ pets, isZh }: HeroPetParadeProps) {
           <Link
             key={pet.slug}
             href={`/pets/${pet.slug}`}
+            prefetch={false}
             aria-label={t("openPet", { name: pet.displayName })}
             className={`group relative flex flex-col items-center rounded-2xl border border-border-base bg-surface/60 px-3 pt-3 pb-2 shadow-lg shadow-blue-900/10 backdrop-blur-md transition hover:-translate-y-1 hover:bg-surface ${tilt} ${lift}`}
           >

--- a/src/app/[locale]/u/[handle]/page.tsx
+++ b/src/app/[locale]/u/[handle]/page.tsx
@@ -542,6 +542,7 @@ function FeaturedPin({
   return (
     <Link
       href={`/pets/${pet.slug}`}
+      prefetch={false}
       aria-label={`Open ${pet.displayName}`}
       className="featured-pin-card group relative flex flex-col overflow-hidden rounded-3xl border border-brand-light/45 bg-surface/80 backdrop-blur transition hover:bg-white md:flex-row md:items-stretch dark:hover:bg-stone-800"
     >

--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -904,6 +904,7 @@ function PetCardImpl({
       />
       <Link
         href={href}
+        prefetch={false}
         aria-label={`Open ${pet.displayName}`}
         className="flex flex-1 flex-col rounded-3xl"
       >

--- a/src/components/zh/top-promo-strip-client.tsx
+++ b/src/components/zh/top-promo-strip-client.tsx
@@ -114,6 +114,7 @@ export function TopPromoStripClient({ items, intervalMs = 4000 }: Props) {
     <div className={baseClasses}>
       <Link
         href={href}
+        prefetch={false}
         className="group flex min-h-[44px] items-center gap-1 px-3 text-xs font-medium text-white hover:text-amber-400 transition-colors sm:min-h-0 sm:px-0"
       >
         <span>{copy.emoji}</span>


### PR DESCRIPTION
## Summary
- disable Next Link prefetch for public pet card links in gallery and collection grids
- disable speculative pet-page prefetch from the homepage pet parade, profile featured pin, and zh promo strip

## Cost impact
- targets the current top page route, /pets/[slug]
- avoids loading pet pages that users only scroll past, while preserving normal click navigation
- keeps ISR/page caching behavior unchanged

## Validation
- bun x biome check src/app/[locale]/page.tsx src/app/[locale]/u/[handle]/page.tsx src/components/pet-gallery.tsx src/components/zh/top-promo-strip-client.tsx
- git diff --check
- bun run i18n:check
- TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build
