### PR TITLE
Disable collection page prefetches from public cards

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -275,7 +275,11 @@ async function FeaturedCollections({
               key={collection.slug}
               className="group relative flex h-full flex-col gap-0 overflow-hidden rounded-3xl border border-border-base bg-surface/80 py-0 ring-0 transition hover:border-border-strong hover:shadow-xl hover:shadow-blue-950/10 has-[[aria-expanded=true]]:z-30"
             >
-              <Link href={`/collections/${collection.slug}`} className="block">
+              <Link
+                href={`/collections/${collection.slug}`}
+                prefetch={false}
+                className="block"
+              >
                 <CollectionCover
                   pets={collection.pets}
                   coverSlug={collection.coverPetSlug}

--- a/src/components/collections-browser.tsx
+++ b/src/components/collections-browser.tsx
@@ -325,7 +325,7 @@ const CollectionCard = memo(function CollectionCard({
       data-slot="card"
       className="group relative flex h-full flex-col overflow-hidden rounded-3xl border border-black/10 bg-surface/76 shadow-sm shadow-blue-950/5 backdrop-blur transition has-[[aria-expanded=true]]:z-30 hover:-translate-y-0.5 hover:bg-white hover:shadow-xl hover:shadow-blue-950/10 dark:border-white/10 dark:hover:bg-stone-800"
     >
-      <Link href={`/collections/${c.slug}`} className="block">
+      <Link href={`/collections/${c.slug}`} prefetch={false} className="block">
         <CollectionCover
           pets={c.pets}
           coverSlug={c.coverPetSlug}
@@ -355,7 +355,9 @@ const CollectionCard = memo(function CollectionCard({
               </span>
             </div>
             <h3 className="mt-2 text-lg font-semibold tracking-tight text-foreground">
-              <Link href={`/collections/${c.slug}`}>{c.title}</Link>
+              <Link href={`/collections/${c.slug}`} prefetch={false}>
+                {c.title}
+              </Link>
             </h3>
           </div>
           {c.externalUrl ? (

--- a/src/components/profile-tabs.tsx
+++ b/src/components/profile-tabs.tsx
@@ -526,7 +526,11 @@ function CollectionsPanel({
               </span>
             </div>
             <h3 className="mt-2 text-lg font-semibold tracking-tight text-foreground">
-              <Link href={`/collections/${c.slug}`} className="hover:underline">
+              <Link
+                href={`/collections/${c.slug}`}
+                prefetch={false}
+                className="hover:underline"
+              >
                 {c.title}
               </Link>
             </h3>
@@ -557,6 +561,7 @@ function CollectionsPanel({
       <div className="mt-5 flex flex-wrap items-center gap-3">
         <Link
           href={`/collections/${collection?.slug}`}
+          prefetch={false}
           className="inline-flex h-10 items-center rounded-full bg-inverse px-4 text-sm font-medium text-on-inverse transition hover:bg-inverse-hover"
         >
           View collection


### PR DESCRIPTION
## Summary
- disable Next Link prefetch for collection cards in the collections browser
- disable collection page prefetch from the home featured collections strip
- disable collection page prefetch from public profile collection links

## Cost impact
- targets /collections/[slug], currently the next high-volume sampled page route after /pets/[slug]
- avoids speculative collection page requests from list surfaces while keeping click navigation unchanged

## Validation
- bun x biome check src/app/[locale]/page.tsx src/components/collections-browser.tsx src/components/profile-tabs.tsx
- git diff --check
- bun run i18n:check
- TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build
