### PR TITLE
Skip initial gallery search refetch

### DIFF
--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -168,6 +168,7 @@ export function PetGallery({
   const [loadingMore, setLoadingMore] = useState(false);
 
   const requestSeq = useRef(0);
+  const hasMountedSearchEffect = useRef(false);
   const shuffleSeedRef = useRef<string | null>(initial.shuffleSeed ?? null);
   const stateCount = petStates.length;
 
@@ -204,6 +205,10 @@ export function PetGallery({
 
   // Re-fetch on filter / sort / query changes (debounced for the query).
   useEffect(() => {
+    if (!hasMountedSearchEffect.current) {
+      hasMountedSearchEffect.current = true;
+      return;
+    }
     const seq = ++requestSeq.current;
     const controller = new AbortController();
     let cancelled = false;


### PR DESCRIPTION
## Summary
- skip the first PetGallery client search effect because the server already provides the initial payload
- keep fetches for actual query, filter, and sort changes unchanged

## Cost impact
- removes one redundant /api/pets/search request per gallery page hydration
- targets the next sampled API hotspot after the page-prefetch changes

## Validation
- bun x biome check src/components/pet-gallery.tsx
- git diff --check
- bun run i18n:check
- TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build
