### PR TITLE
Share pet metrics client fetches

### DIFF
--- a/src/components/like-button.tsx
+++ b/src/components/like-button.tsx
@@ -8,6 +8,7 @@ import { Heart } from "lucide-react";
 import { useLocale } from "next-intl";
 
 import { formatLocalizedNumber } from "@/lib/format-number";
+import { loadPetMetrics } from "@/lib/pet-metrics-client";
 
 import { Button } from "@/components/ui/button";
 
@@ -37,6 +38,7 @@ export function LikeButton({ slug }: LikeButtonProps) {
 
     const mutationVersion = mutationVersionRef.current;
     const controller = new AbortController();
+    let active = true;
     setLikeStateLoading(true);
 
     // Signed-in users hit /like (returns authoritative count + their
@@ -47,16 +49,20 @@ export function LikeButton({ slug }: LikeButtonProps) {
       ? `/api/pets/${slug}/like`
       : `/api/pets/${slug}/metrics`;
 
-    void fetch(url, {
-      signal: controller.signal,
-      headers: { accept: "application/json" },
-    })
-      .then((res) => (res.ok ? res.json() : null))
+    void (
+      isSignedIn
+        ? fetch(url, {
+            signal: controller.signal,
+            headers: { accept: "application/json" },
+          }).then((res) => (res.ok ? res.json() : null))
+        : loadPetMetrics(slug)
+    )
       .then(
         (
           data: { liked?: boolean; count?: number; likeCount?: number } | null,
         ) => {
           if (!data) return;
+          if (!active) return;
           if (loadVersionRef.current !== loadVersion) return;
           if (mutationVersionRef.current !== mutationVersion) return;
           if (isSignedIn) {
@@ -69,18 +75,23 @@ export function LikeButton({ slug }: LikeButtonProps) {
         },
       )
       .catch((error: unknown) => {
+        if (!active) return;
         if (loadVersionRef.current !== loadVersion) return;
         if ((error as Error).name !== "AbortError") {
           setLiked(false);
         }
       })
       .finally(() => {
+        if (!active) return;
         if (loadVersionRef.current === loadVersion) {
           setLikeStateLoading(false);
         }
       });
 
-    return () => controller.abort();
+    return () => {
+      active = false;
+      controller.abort();
+    };
   }, [isLoaded, isSignedIn, slug]);
 
   function handleClick() {

--- a/src/components/pet-counters-bar.tsx
+++ b/src/components/pet-counters-bar.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { useLocale } from "next-intl";
 
 import { formatLocalizedNumber } from "@/lib/format-number";
+import { loadPetMetrics } from "@/lib/pet-metrics-client";
 
 type PetCountersBarProps = {
   slug: string;
@@ -20,12 +21,10 @@ export function PetCountersBar({ slug }: PetCountersBarProps) {
   const [counts, setCounts] = useState<CountersResponse | null>(null);
 
   useEffect(() => {
-    const controller = new AbortController();
-    void fetch(`/api/pets/${slug}/metrics`, { signal: controller.signal })
-      .then((res) =>
-        res.ok ? (res.json() as Promise<CountersResponse>) : null,
-      )
+    let active = true;
+    void loadPetMetrics(slug)
       .then((data) => {
+        if (!active) return;
         if (!data) return;
         setCounts({
           installCount: data.installCount,
@@ -35,7 +34,9 @@ export function PetCountersBar({ slug }: PetCountersBarProps) {
       .catch(() => {
         /* network/abort — keep skeleton */
       });
-    return () => controller.abort();
+    return () => {
+      active = false;
+    };
   }, [slug]);
 
   return (

--- a/src/components/pet-radar-client.tsx
+++ b/src/components/pet-radar-client.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 
+import { loadPetMetrics } from "@/lib/pet-metrics-client";
 import { computeStatsFromSummary, type PetStats } from "@/lib/pet-stats";
 
 import { PetRadar } from "@/components/pet-radar";
@@ -16,12 +17,6 @@ type PetRadarClientProps = {
     loved: string;
     freshness: string;
   };
-};
-
-type MetricsResponse = {
-  installCount: number;
-  likeCount: number;
-  summary: { maxInstallCount: number; maxLikeCount: number };
 };
 
 const PLACEHOLDER_STATS: PetStats = {
@@ -40,10 +35,10 @@ export function PetRadarClient({
   const [stats, setStats] = useState<PetStats | null>(null);
 
   useEffect(() => {
-    const controller = new AbortController();
-    void fetch(`/api/pets/${slug}/metrics`, { signal: controller.signal })
-      .then((res) => (res.ok ? (res.json() as Promise<MetricsResponse>) : null))
+    let active = true;
+    void loadPetMetrics(slug)
       .then((data) => {
+        if (!active) return;
         if (!data) return;
         setStats(
           computeStatsFromSummary(
@@ -61,7 +56,9 @@ export function PetRadarClient({
       .catch(() => {
         /* keep placeholder */
       });
-    return () => controller.abort();
+    return () => {
+      active = false;
+    };
   }, [slug, importedAt]);
 
   const display = stats ?? PLACEHOLDER_STATS;

--- a/src/lib/pet-metrics-client.ts
+++ b/src/lib/pet-metrics-client.ts
@@ -1,0 +1,38 @@
+export type PetMetricsResponse = {
+  installCount: number;
+  zipDownloadCount: number;
+  likeCount: number;
+  summary: { maxInstallCount: number; maxLikeCount: number };
+};
+
+const PET_METRICS_CACHE_TTL_MS = 60_000;
+const petMetricsCache = new Map<
+  string,
+  { promise: Promise<PetMetricsResponse | null>; savedAt: number }
+>();
+
+export function loadPetMetrics(slug: string) {
+  const now = Date.now();
+  const cached = petMetricsCache.get(slug);
+  if (cached && now - cached.savedAt < PET_METRICS_CACHE_TTL_MS) {
+    return cached.promise;
+  }
+
+  const promise = fetch(`/api/pets/${slug}/metrics`, {
+    headers: { accept: "application/json" },
+  })
+    .then((res) =>
+      res.ok ? (res.json() as Promise<PetMetricsResponse>) : null,
+    )
+    .catch(() => null);
+
+  petMetricsCache.set(slug, { promise, savedAt: now });
+  setTimeout(() => {
+    const cached = petMetricsCache.get(slug);
+    if (cached?.promise === promise) petMetricsCache.delete(slug);
+  }, PET_METRICS_CACHE_TTL_MS);
+  void promise.then((data) => {
+    if (!data) petMetricsCache.delete(slug);
+  });
+  return promise;
+}


### PR DESCRIPTION
## Summary
- add a short-lived client metrics loader shared by slug
- reuse the shared metrics request from anon like state, counters, and radar widgets
- preserve signed-in /like behavior for authoritative liked state

## Cost impact
- reduces anonymous pet detail metrics reads from up to 3 /api/pets/[slug]/metrics requests per page mount to 1 shared request
- keeps the existing CDN cache headers and click behavior unchanged

## Validation
- bun x biome check src/lib/pet-metrics-client.ts src/components/like-button.tsx src/components/pet-counters-bar.tsx src/components/pet-radar-client.tsx
- git diff --check
- bun run i18n:check
- TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build
