### PR TITLE
Throttle header state refreshes

### DIFF
--- a/src/components/header-state-provider.tsx
+++ b/src/components/header-state-provider.tsx
@@ -47,6 +47,7 @@ export function HeaderStateProvider({
   const mounted = useRef(false);
   const requestGeneration = useRef(0);
   const userScope = useRef<string | null>(null);
+  const inFlightUser = useRef<string | null>(null);
 
   const setUnreadCount = useCallback(
     (next: number | ((current: number) => number)) => {
@@ -70,8 +71,9 @@ export function HeaderStateProvider({
       ) {
         return;
       }
+      if (!options?.force && inFlightUser.current === requestUserId) return;
       const generation = ++requestGeneration.current;
-      lastRefreshAt.current = now;
+      inFlightUser.current = requestUserId;
       try {
         const res = await fetch("/api/me/header-state", { cache: "no-store" });
         if (!res.ok) return;
@@ -84,11 +86,16 @@ export function HeaderStateProvider({
           return;
         }
         setState(json);
+        lastRefreshAt.current = now;
         if (cacheKey) {
           writeCachedHeaderState(cacheKey, json, now);
         }
       } catch {
         return;
+      } finally {
+        if (inFlightUser.current === requestUserId) {
+          inFlightUser.current = null;
+        }
       }
     },
     [cacheKey, isLoaded, isSignedIn, userId],
@@ -129,7 +136,10 @@ export function HeaderStateProvider({
       lastRefreshAt.current = 0;
     }
     void refresh({ force: !hasCachedState });
-    const id = window.setInterval(() => void refresh(), HEADER_STATE_POLL_MS);
+    const id = window.setInterval(
+      () => void refresh({ force: true }),
+      HEADER_STATE_POLL_MS,
+    );
     const onFocus = () => void refresh();
     window.addEventListener("focus", onFocus);
     return () => {

--- a/src/lib/header-state.test.ts
+++ b/src/lib/header-state.test.ts
@@ -43,17 +43,23 @@ describe("header state helpers", () => {
         isLoaded: true,
         isSignedIn: true,
         lastRefreshAt: 1_000,
-        minRefreshMs: 60_000,
-        now: 30_000,
+        now: 120_000,
       }),
     ).toBe(false);
+    expect(
+      shouldRequestHeaderState({
+        isLoaded: true,
+        isSignedIn: true,
+        lastRefreshAt: 1_000,
+        now: 302_000,
+      }),
+    ).toBe(true);
     expect(
       shouldRequestHeaderState({
         force: true,
         isLoaded: true,
         isSignedIn: true,
         lastRefreshAt: 1_000,
-        minRefreshMs: 60_000,
         now: 30_000,
       }),
     ).toBe(true);

--- a/src/lib/header-state.ts
+++ b/src/lib/header-state.ts
@@ -13,7 +13,7 @@ export const INITIAL_HEADER_STATE: HeaderState = {
 };
 
 export const HEADER_STATE_POLL_MS = 300_000;
-export const HEADER_STATE_MIN_REFRESH_MS = 60_000;
+export const HEADER_STATE_MIN_REFRESH_MS = 300_000;
 export const HEADER_STATE_CACHE_TTL_MS = 60_000;
 
 type CachedHeaderState = {


### PR DESCRIPTION
## Summary
- keep automatic header-state poll at 5 minutes and let interval refreshes bypass the focus/mount throttle
- throttle focus and reused-tab refreshes to avoid bursty `/api/me/header-state` calls
- coalesce same-user non-forced refreshes while still allowing forced refreshes and user-scope changes through
- keep session-cache TTL short so reused tabs do not compound stale state with the fixed poll
- only advance the refresh throttle after a successful header-state response so transient failures can retry before the full floor

## Validation
- bun test src/lib/header-state.test.ts
- bun x biome check src/components/header-state-provider.tsx src/lib/header-state.ts src/lib/header-state.test.ts
- git diff --check
- bun run i18n:check
- TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build