### PR TITLE
Disable nav link prefetches

### DIFF
--- a/src/components/petdex-logo.tsx
+++ b/src/components/petdex-logo.tsx
@@ -28,7 +28,12 @@ export function PetdexLogo({
 
   if (href) {
     return (
-      <Link href={href} className={classes} aria-label={ariaLabel}>
+      <Link
+        href={href}
+        prefetch={false}
+        className={classes}
+        aria-label={ariaLabel}
+      >
         {content}
       </Link>
     );

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -15,24 +15,28 @@ export function SiteFooter() {
         <div className="flex flex-wrap items-center gap-4">
           <Link
             href="/leaderboard"
+            prefetch={false}
             className="underline underline-offset-4 transition hover:text-foreground"
           >
             {t("topCreators")}
           </Link>
           <Link
             href="/legal/takedown"
+            prefetch={false}
             className="underline underline-offset-4 transition hover:text-foreground"
           >
             {t("takedown")}
           </Link>
           <Link
             href="/advertise"
+            prefetch={false}
             className="underline underline-offset-4 transition hover:text-foreground"
           >
             {t("advertise")}
           </Link>
           <Link
             href="/brand"
+            prefetch={false}
             className="underline underline-offset-4 transition hover:text-foreground"
           >
             {t("brand")}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -441,7 +441,7 @@ function NavGrid({ items }: { items: NavItem[] }) {
         return (
           <li key={item.href}>
             <NavigationMenuLink
-              render={<Link href={item.href} />}
+              render={<Link href={item.href} prefetch={false} />}
               closeOnClick
               className="group/item flex items-center gap-3 rounded-2xl p-2 pr-4 transition hover:bg-surface-muted focus:bg-surface-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
             >
@@ -494,6 +494,7 @@ function MobileLink({
   return (
     <Link
       href={href}
+      prefetch={false}
       onClick={onClick}
       className="rounded-2xl px-4 py-3 text-foreground transition hover:bg-white dark:hover:bg-stone-800"
     >

--- a/src/components/submit-cta.tsx
+++ b/src/components/submit-cta.tsx
@@ -46,7 +46,7 @@ export function SubmitCTA({
       variant="petdex-cta"
       size="petdex-pill"
       className={className}
-      render={<Link href={href} />}
+      render={<Link href={href} prefetch={false} />}
     >
       {children}
     </Button>


### PR DESCRIPTION
## Summary
- disable speculative prefetch on desktop nav menu links
- disable prefetch on mobile menu, footer links, logo home link, and submit CTA link
- reduce incidental page requests for secondary routes like leaderboard, advertise, docs, download, brand, and home

## Validation
- bun x biome check src/components/site-header.tsx src/components/site-footer.tsx src/components/petdex-logo.tsx src/components/submit-cta.tsx
- git diff --check
- bun run i18n:check
- TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build