### PR TITLE
Pause hidden header state polling

### DIFF
--- a/src/components/header-state-provider.tsx
+++ b/src/components/header-state-provider.tsx
@@ -136,17 +136,24 @@ export function HeaderStateProvider({
       lastRefreshAt.current = 0;
     }
     void refresh({ force: !hasCachedState });
+    const refreshIfVisible = (options?: { force?: boolean }) => {
+      if (document.visibilityState !== "visible") return;
+      void refresh(options);
+    };
     const id = window.setInterval(
-      () => void refresh({ force: true }),
+      () => refreshIfVisible({ force: true }),
       HEADER_STATE_POLL_MS,
     );
-    const onFocus = () => void refresh();
+    const onFocus = () => refreshIfVisible();
+    const onVisibilityChange = () => refreshIfVisible();
     window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onVisibilityChange);
     return () => {
       mounted.current = false;
       requestGeneration.current += 1;
       window.clearInterval(id);
       window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
     };
   }, [cacheKey, isLoaded, isSignedIn, refresh, userId]);
 


### PR DESCRIPTION
## Summary
- skip periodic header-state refreshes while the document is hidden
- refresh again on focus or visibility return when the existing throttle allows it
- keep the initial signed-in refresh behavior unchanged

## Cost rationale
Recent route-cost buckets still show `/api/me/header-state` as the only 15-minute sample after the prefetch reductions. Background tabs do not need forced header-state polling, and avoiding those refreshes reduces edge/function invocations without removing the visible-page refresh path.

## Validation
- `bun x biome check src/components/header-state-provider.tsx`
- `git diff --check`
- `bun run i18n:check`
- `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build`