### PR TITLE
Disable menu link prefetches

### DIFF
--- a/src/components/auth-badge.tsx
+++ b/src/components/auth-badge.tsx
@@ -201,11 +201,15 @@ function UserDropdown({ compact = false }: { compact?: boolean }) {
         <DropdownMenuSeparator />
 
         <DropdownMenuGroup>
-          <DropdownMenuItem render={<Link href={`/u/${handle}`} />}>
+          <DropdownMenuItem
+            render={<Link href={`/u/${handle}`} prefetch={false} />}
+          >
             <IdentificationCardIcon weight="duotone" className="size-4" />
             {t("myProfile")}
           </DropdownMenuItem>
-          <DropdownMenuItem render={<Link href="/my-feedback" />}>
+          <DropdownMenuItem
+            render={<Link href="/my-feedback" prefetch={false} />}
+          >
             <ChatCircleDotsIcon weight="duotone" className="size-4" />
             {t("myFeedback")}
             {unread > 0 ? (
@@ -215,13 +219,15 @@ function UserDropdown({ compact = false }: { compact?: boolean }) {
             ) : null}
           </DropdownMenuItem>
           {showAdmin ? (
-            <DropdownMenuItem render={<Link href="/admin" />}>
+            <DropdownMenuItem render={<Link href="/admin" prefetch={false} />}>
               <ShieldCheckIcon weight="duotone" className="size-4" />
               {t("admin")}
             </DropdownMenuItem>
           ) : null}
           {showCollaborator ? (
-            <DropdownMenuItem render={<Link href={href(collaboratorHref)} />}>
+            <DropdownMenuItem
+              render={<Link href={href(collaboratorHref)} prefetch={false} />}
+            >
               <QrCodeIcon weight="duotone" className="size-4" />
               {t("collaborator")}
             </DropdownMenuItem>
@@ -231,11 +237,15 @@ function UserDropdown({ compact = false }: { compact?: boolean }) {
         <DropdownMenuSeparator />
 
         <DropdownMenuGroup>
-          <DropdownMenuItem render={<Link href={href("/about")} />}>
+          <DropdownMenuItem
+            render={<Link href={href("/about")} prefetch={false} />}
+          >
             <InfoIcon weight="duotone" className="size-4" />
             {t("about")}
           </DropdownMenuItem>
-          <DropdownMenuItem render={<Link href={href("/legal/takedown")} />}>
+          <DropdownMenuItem
+            render={<Link href={href("/legal/takedown")} prefetch={false} />}
+          >
             <ShieldWarningIcon weight="duotone" className="size-4" />
             {t("takedown")}
           </DropdownMenuItem>

--- a/src/components/install-command-compact.tsx
+++ b/src/components/install-command-compact.tsx
@@ -63,6 +63,7 @@ export function InstallCommandCompact({
       </div>
       <Link
         href={`/${locale}/docs#install`}
+        prefetch={false}
         className="group inline-flex items-center gap-1 self-start text-muted-3 text-xs transition hover:text-foreground"
       >
         {t("seeGuide")}

--- a/src/components/pet-action-menu.tsx
+++ b/src/components/pet-action-menu.tsx
@@ -551,7 +551,7 @@ export function PetActionMenu({ pet, variant = "card", ownerActions }: Props) {
               <>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
-                  render={<Link href="/submit" />}
+                  render={<Link href="/submit" prefetch={false} />}
                   className="flex items-center gap-2.5 px-3 py-2.5 text-sm text-foreground"
                 >
                   <Plus className="size-4" />
@@ -564,7 +564,9 @@ export function PetActionMenu({ pet, variant = "card", ownerActions }: Props) {
               <>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
-                  render={<Link href={`/pets/${pet.slug}#edit`} />}
+                  render={
+                    <Link href={`/pets/${pet.slug}#edit`} prefetch={false} />
+                  }
                   className="flex items-center gap-2.5 px-3 py-2.5 text-sm text-foreground"
                 >
                   <Pencil className="size-4" />


### PR DESCRIPTION
## Summary
- disable prefetches for auth dropdown internal links
- disable prefetches for pet action menu submit/edit links
- disable prefetch on the compact install docs link

## Cost rationale
Recent route-cost samples included one-off routes such as `/legal/takedown` after the broader nav/footer prefetch work. Dropdown/menu links are not primary navigation and do not need speculative route requests before user intent.

## Validation
- `bun x biome check src/components/auth-badge.tsx src/components/pet-action-menu.tsx src/components/install-command-compact.tsx`
- `git diff --check`
- `bun run i18n:check`
- `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build`