### PR TITLE
Disable download CTA prefetches

### DIFF
--- a/src/app/[locale]/docs/page.tsx
+++ b/src/app/[locale]/docs/page.tsx
@@ -274,6 +274,7 @@ export default async function DocsPage({
                 download: (chunks) => (
                   <Link
                     href={withLocale("/download", localeValue)}
+                    prefetch={false}
                     className="font-medium underline underline-offset-4"
                   >
                     {chunks}

--- a/src/components/desktop-announcement-modal.tsx
+++ b/src/components/desktop-announcement-modal.tsx
@@ -84,6 +84,7 @@ export function DesktopAnnouncementModal({
           <div className="flex items-center gap-2 pt-1">
             <Link
               href="/download"
+              prefetch={false}
               onClick={() => close("cta_download")}
               className="inline-flex h-10 flex-1 items-center justify-center gap-1.5 rounded-full bg-inverse px-5 text-sm font-medium text-on-inverse transition hover:bg-inverse-hover"
             >
@@ -92,6 +93,7 @@ export function DesktopAnnouncementModal({
             </Link>
             <Link
               href="/download#how-it-works"
+              prefetch={false}
               onClick={() => close("cta_docs")}
               className="inline-flex h-10 items-center justify-center rounded-full border border-border-base bg-surface px-4 text-sm font-medium text-muted-2 transition hover:border-border-strong"
             >

--- a/src/components/download-desktop-cta.tsx
+++ b/src/components/download-desktop-cta.tsx
@@ -28,6 +28,7 @@ export function DownloadDesktopCTA({
   return (
     <Link
       href={href}
+      prefetch={false}
       aria-label={ariaLabel}
       className={className}
       onClick={() => {

--- a/src/components/open-in-petdex-button.tsx
+++ b/src/components/open-in-petdex-button.tsx
@@ -63,6 +63,7 @@ export function OpenInPetdexButton({ slug }: OpenInPetdexButtonProps) {
   return (
     <Link
       href={downloadHref}
+      prefetch={false}
       onClick={handleClick}
       aria-label={t("ariaLabel", { slug })}
       className="group relative isolate inline-flex w-full items-center gap-3 overflow-hidden rounded-2xl border border-brand/30 bg-gradient-to-br from-brand/15 via-brand-light/10 to-brand-deep/15 p-3 text-left shadow-[0_8px_32px_-8px_oklch(from_var(--brand)_l_c_h/0.35)] transition-all hover:border-brand/50 hover:shadow-[0_12px_40px_-8px_oklch(from_var(--brand)_l_c_h/0.45)] active:scale-[0.99]"


### PR DESCRIPTION
## Summary
- disable Next prefetching on `/download` CTAs
- cover the shared desktop download CTA, docs inline link, desktop announcement modal, and pet-page fallback link

## Cost rationale
Recent route-cost buckets surfaced `/download` as a fresh one-off page request after broader nav/menu prefetch reductions. Download CTAs should navigate normally on click without speculative page requests.

## Validation
- `bun x biome check src/components/download-desktop-cta.tsx src/components/open-in-petdex-button.tsx src/app/[locale]/docs/page.tsx src/components/desktop-announcement-modal.tsx`
- `git diff --check`
- `bun run i18n:check`
- `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build`