### PR TITLE
Extend header state cache window

### DIFF
--- a/src/components/header-state-provider.tsx
+++ b/src/components/header-state-provider.tsx
@@ -16,6 +16,7 @@ import {
   type HeaderState,
   headerStateCacheKey,
   INITIAL_HEADER_STATE,
+  nextHeaderStatePollDelay,
   parseCachedHeaderState,
   serializeHeaderState,
   shouldRequestHeaderState,
@@ -140,9 +141,14 @@ export function HeaderStateProvider({
       if (document.visibilityState !== "visible") return;
       void refresh(options);
     };
-    const id = window.setInterval(
-      () => refreshIfVisible({ force: true }),
-      HEADER_STATE_POLL_MS,
+    let intervalId: number | null = null;
+    const poll = () => refreshIfVisible({ force: true });
+    const timeoutId = window.setTimeout(
+      () => {
+        poll();
+        intervalId = window.setInterval(poll, HEADER_STATE_POLL_MS);
+      },
+      nextHeaderStatePollDelay(lastRefreshAt.current, Date.now()),
     );
     const onFocus = () => refreshIfVisible();
     const onVisibilityChange = () => refreshIfVisible();
@@ -151,7 +157,8 @@ export function HeaderStateProvider({
     return () => {
       mounted.current = false;
       requestGeneration.current += 1;
-      window.clearInterval(id);
+      window.clearTimeout(timeoutId);
+      if (intervalId !== null) window.clearInterval(intervalId);
       window.removeEventListener("focus", onFocus);
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };

--- a/src/lib/header-state.test.ts
+++ b/src/lib/header-state.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "bun:test";
 import {
   headerStateCacheKey,
   INITIAL_HEADER_STATE,
+  nextHeaderStatePollDelay,
   parseCachedHeaderState,
   serializeHeaderState,
   shouldRequestHeaderState,
@@ -76,8 +77,15 @@ describe("header state helpers", () => {
     const raw = serializeHeaderState(state, 1_000);
 
     expect(parseCachedHeaderState(raw, 30_000)?.state).toEqual(state);
-    expect(parseCachedHeaderState(raw, 90_000)).toBeNull();
+    expect(parseCachedHeaderState(raw, 301_001)).toBeNull();
     expect(parseCachedHeaderState(raw, 500)).toBeNull();
+  });
+
+  it("schedules cached polls by remaining freshness window", () => {
+    expect(nextHeaderStatePollDelay(0, 1_000)).toBe(300_000);
+    expect(nextHeaderStatePollDelay(1_000, 61_000)).toBe(240_000);
+    expect(nextHeaderStatePollDelay(1_000, 301_000)).toBe(0);
+    expect(nextHeaderStatePollDelay(10_000, 1_000)).toBe(300_000);
   });
 
   it("scopes cache keys by signed-in user", () => {

--- a/src/lib/header-state.ts
+++ b/src/lib/header-state.ts
@@ -14,7 +14,7 @@ export const INITIAL_HEADER_STATE: HeaderState = {
 
 export const HEADER_STATE_POLL_MS = 300_000;
 export const HEADER_STATE_MIN_REFRESH_MS = 300_000;
-export const HEADER_STATE_CACHE_TTL_MS = 60_000;
+export const HEADER_STATE_CACHE_TTL_MS = HEADER_STATE_MIN_REFRESH_MS;
 
 type CachedHeaderState = {
   savedAt: number;
@@ -40,6 +40,15 @@ export function shouldRequestHeaderState(input: {
     input.now - input.lastRefreshAt >=
       (input.minRefreshMs ?? HEADER_STATE_MIN_REFRESH_MS)
   );
+}
+
+export function nextHeaderStatePollDelay(
+  lastRefreshAt: number,
+  now: number,
+  pollMs = HEADER_STATE_POLL_MS,
+) {
+  if (lastRefreshAt <= 0 || lastRefreshAt > now) return pollMs;
+  return Math.max(0, pollMs - (now - lastRefreshAt));
 }
 
 export function parseCachedHeaderState(


### PR DESCRIPTION
## Summary
- extend header-state session cache from 60s to the 5m refresh window
- schedule the first forced poll from cached state based on cache age
- add helper coverage for stale cache parsing and remaining poll delay

## Cost rationale
`/api/me/header-state` remains the top recent route-cost bucket after prefetch reductions. A 60s cache still refetches on many reloads/new navigations. Extending the cache to 5m cuts repeat calls, while age-based polling avoids turning a 4-minute cached payload into another full 5-minute wait.

## Validation
- `bun test src/lib/header-state.test.ts`
- `bun x biome check src/lib/header-state.ts src/lib/header-state.test.ts src/components/header-state-provider.tsx`
- `git diff --check`
- `bun run i18n:check`
- `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build`