### PR TITLE
Reduce header state polling cadence

### DIFF
--- a/src/lib/header-state.test.ts
+++ b/src/lib/header-state.test.ts
@@ -82,10 +82,10 @@ describe("header state helpers", () => {
   });
 
   it("schedules cached polls by remaining freshness window", () => {
-    expect(nextHeaderStatePollDelay(0, 1_000)).toBe(300_000);
-    expect(nextHeaderStatePollDelay(1_000, 61_000)).toBe(240_000);
-    expect(nextHeaderStatePollDelay(1_000, 301_000)).toBe(0);
-    expect(nextHeaderStatePollDelay(10_000, 1_000)).toBe(300_000);
+    expect(nextHeaderStatePollDelay(0, 1_000)).toBe(900_000);
+    expect(nextHeaderStatePollDelay(1_000, 61_000)).toBe(840_000);
+    expect(nextHeaderStatePollDelay(1_000, 901_000)).toBe(0);
+    expect(nextHeaderStatePollDelay(10_000, 1_000)).toBe(900_000);
   });
 
   it("scopes cache keys by signed-in user", () => {

--- a/src/lib/header-state.ts
+++ b/src/lib/header-state.ts
@@ -12,7 +12,7 @@ export const INITIAL_HEADER_STATE: HeaderState = {
   caught: [],
 };
 
-export const HEADER_STATE_POLL_MS = 300_000;
+export const HEADER_STATE_POLL_MS = 900_000;
 export const HEADER_STATE_MIN_REFRESH_MS = 300_000;
 export const HEADER_STATE_CACHE_TTL_MS = HEADER_STATE_MIN_REFRESH_MS;
 


### PR DESCRIPTION
## Summary
- reduce visible-tab header-state polling from 5 minutes to 15 minutes
- keep the 5-minute refresh throttle/cache window for reload and focus refreshes
- update header-state helper coverage for the new polling cadence

## Cost rationale
After the prefetch reductions and cache-window change, `/api/me/header-state` is still the top route in the current 15-minute route-cost bucket. Header badges do not need near-realtime polling while the user is just sitting on a visible tab. Focus and initial-load refresh behavior stays intact.

## Validation
- `bun test src/lib/header-state.test.ts`
- `bun x biome check src/lib/header-state.ts src/lib/header-state.test.ts`
- `git diff --check`
- `bun run i18n:check`
- `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build`