### PR TITLE
Align header state cache with polling cadence

### DIFF
--- a/src/lib/header-state.test.ts
+++ b/src/lib/header-state.test.ts
@@ -52,7 +52,7 @@ describe("header state helpers", () => {
         isLoaded: true,
         isSignedIn: true,
         lastRefreshAt: 1_000,
-        now: 302_000,
+        now: 902_000,
       }),
     ).toBe(true);
     expect(
@@ -77,7 +77,7 @@ describe("header state helpers", () => {
     const raw = serializeHeaderState(state, 1_000);
 
     expect(parseCachedHeaderState(raw, 30_000)?.state).toEqual(state);
-    expect(parseCachedHeaderState(raw, 301_001)).toBeNull();
+    expect(parseCachedHeaderState(raw, 901_001)).toBeNull();
     expect(parseCachedHeaderState(raw, 500)).toBeNull();
   });
 

--- a/src/lib/header-state.ts
+++ b/src/lib/header-state.ts
@@ -13,7 +13,7 @@ export const INITIAL_HEADER_STATE: HeaderState = {
 };
 
 export const HEADER_STATE_POLL_MS = 900_000;
-export const HEADER_STATE_MIN_REFRESH_MS = 300_000;
+export const HEADER_STATE_MIN_REFRESH_MS = HEADER_STATE_POLL_MS;
 export const HEADER_STATE_CACHE_TTL_MS = HEADER_STATE_MIN_REFRESH_MS;
 
 type CachedHeaderState = {


### PR DESCRIPTION
Reduces repeat /api/me/header-state calls by aligning the focus/visibility refresh throttle and session cache TTL with the existing 15-minute polling cadence.\n\nValidation:\n- bun test src/lib/header-state.test.ts\n- bun x biome check src/lib/header-state.ts src/lib/header-state.test.ts\n- bun run i18n:check\n- git diff --check\n- TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build