### PR TITLE
Add route cost source attribution

### DIFF
--- a/drizzle/0017_route_cost_sources.sql
+++ b/drizzle/0017_route_cost_sources.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "route_cost_source_buckets" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "bucket_start" timestamp with time zone NOT NULL,
+  "route" text NOT NULL,
+  "route_kind" text NOT NULL,
+  "method" text NOT NULL,
+  "traffic_source" text DEFAULT 'unknown' NOT NULL,
+  "referrer_source" text DEFAULT 'unknown' NOT NULL,
+  "sample_count" integer DEFAULT 0 NOT NULL,
+  "estimated_requests" integer DEFAULT 0 NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "route_cost_source_buckets_bucket_idx" ON "route_cost_source_buckets" USING btree ("bucket_start");
+--> statement-breakpoint
+CREATE INDEX "route_cost_source_buckets_route_idx" ON "route_cost_source_buckets" USING btree ("route","bucket_start");
+--> statement-breakpoint
+CREATE INDEX "route_cost_source_buckets_source_idx" ON "route_cost_source_buckets" USING btree ("route","traffic_source","referrer_source","bucket_start");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "route_cost_source_buckets_unique" ON "route_cost_source_buckets" USING btree ("bucket_start","method","route_kind","route","traffic_source","referrer_source");

--- a/scripts/apply-route-cost-buckets.ts
+++ b/scripts/apply-route-cost-buckets.ts
@@ -63,4 +63,67 @@ await tryRun(
   `,
 );
 
+await tryRun(
+  "route_cost_source_buckets table",
+  () => sql`
+    CREATE TABLE route_cost_source_buckets (
+      id serial PRIMARY KEY,
+      bucket_start timestamp with time zone NOT NULL,
+      route text NOT NULL,
+      route_kind text NOT NULL,
+      method text NOT NULL,
+      traffic_source text NOT NULL DEFAULT 'unknown',
+      referrer_source text NOT NULL DEFAULT 'unknown',
+      sample_count integer NOT NULL DEFAULT 0,
+      estimated_requests integer NOT NULL DEFAULT 0,
+      created_at timestamp with time zone NOT NULL DEFAULT now(),
+      updated_at timestamp with time zone NOT NULL DEFAULT now()
+    )
+  `,
+);
+
+await tryRun(
+  "route_cost_source_buckets_bucket_idx",
+  () => sql`
+    CREATE INDEX route_cost_source_buckets_bucket_idx
+    ON route_cost_source_buckets (bucket_start)
+  `,
+);
+
+await tryRun(
+  "route_cost_source_buckets_route_idx",
+  () => sql`
+    CREATE INDEX route_cost_source_buckets_route_idx
+    ON route_cost_source_buckets (route, bucket_start)
+  `,
+);
+
+await tryRun(
+  "route_cost_source_buckets_source_idx",
+  () => sql`
+    CREATE INDEX route_cost_source_buckets_source_idx
+    ON route_cost_source_buckets (
+      route,
+      traffic_source,
+      referrer_source,
+      bucket_start
+    )
+  `,
+);
+
+await tryRun(
+  "route_cost_source_buckets_unique",
+  () => sql`
+    CREATE UNIQUE INDEX route_cost_source_buckets_unique
+    ON route_cost_source_buckets (
+      bucket_start,
+      method,
+      route_kind,
+      route,
+      traffic_source,
+      referrer_source
+    )
+  `,
+);
+
 console.log("done");

--- a/src/app/[locale]/admin/telemetry/page.tsx
+++ b/src/app/[locale]/admin/telemetry/page.tsx
@@ -303,9 +303,11 @@ function RouteCostList({
   items: {
     estimatedRequests: number;
     method: string;
+    referrerSource: string;
     route: string;
     routeKind: string;
     samples: number;
+    trafficSource: string;
   }[];
   emptyLabel: string;
 }) {
@@ -323,7 +325,7 @@ function RouteCostList({
             : 0;
         return (
           <li
-            key={`${item.method}:${item.routeKind}:${item.route}`}
+            key={`${item.method}:${item.routeKind}:${item.route}:${item.trafficSource}:${item.referrerSource}`}
             className="grid gap-2 rounded-md border border-border-base px-3 py-2 text-sm md:grid-cols-[minmax(0,1fr)_160px]"
           >
             <div className="min-w-0">
@@ -334,7 +336,8 @@ function RouteCostList({
                 </span>
               </div>
               <p className="mt-1 font-mono text-[10px] tracking-[0.14em] text-muted-4 uppercase">
-                {item.routeKind} - {item.samples.toLocaleString()} samples
+                {item.routeKind} - {item.trafficSource} / {item.referrerSource}{" "}
+                - {item.samples.toLocaleString()} samples
               </p>
             </div>
             <div className="flex items-center gap-2">

--- a/src/app/api/internal/route-cost/route.ts
+++ b/src/app/api/internal/route-cost/route.ts
@@ -3,7 +3,12 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import { sql } from "drizzle-orm";
 
 import { db, schema } from "@/lib/db/client";
-import { type RouteCostKind, routeCostSecret } from "@/lib/route-cost";
+import {
+  type RouteCostKind,
+  type RouteCostReferrerSource,
+  type RouteCostTrafficSource,
+  routeCostSecret,
+} from "@/lib/route-cost";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -24,13 +29,31 @@ const METHOD_SET = new Set([
   "DELETE",
   "OPTIONS",
 ]);
+const REFERRER_SOURCE_SET = new Set<RouteCostReferrerSource>([
+  "direct",
+  "external",
+  "internal",
+  "search",
+  "social",
+  "unknown",
+]);
+const TRAFFIC_SOURCE_SET = new Set<RouteCostTrafficSource>([
+  "bot",
+  "browser",
+  "monitor",
+  "prefetch",
+  "preview",
+  "unknown",
+]);
 
 type Body = {
   at?: unknown;
   method?: unknown;
+  referrerSource?: unknown;
   route?: unknown;
   routeKind?: unknown;
   sampleWeight?: unknown;
+  trafficSource?: unknown;
 };
 
 class PayloadTooLargeError extends Error {
@@ -105,6 +128,41 @@ export async function POST(req: Request): Promise<Response> {
     );
   }
 
+  try {
+    await db
+      .insert(schema.routeCostSourceBuckets)
+      .values({
+        bucketStart: parsed.data.bucketStart,
+        method: parsed.data.method,
+        referrerSource: parsed.data.referrerSource,
+        route: parsed.data.route,
+        routeKind: parsed.data.routeKind,
+        trafficSource: parsed.data.trafficSource,
+        sampleCount: 1,
+        estimatedRequests: parsed.data.sampleWeight,
+      })
+      .onConflictDoUpdate({
+        target: [
+          schema.routeCostSourceBuckets.bucketStart,
+          schema.routeCostSourceBuckets.method,
+          schema.routeCostSourceBuckets.routeKind,
+          schema.routeCostSourceBuckets.route,
+          schema.routeCostSourceBuckets.trafficSource,
+          schema.routeCostSourceBuckets.referrerSource,
+        ],
+        set: {
+          sampleCount: sql`${schema.routeCostSourceBuckets.sampleCount} + 1`,
+          estimatedRequests: sql`${schema.routeCostSourceBuckets.estimatedRequests} + ${parsed.data.sampleWeight}`,
+          updatedAt: new Date(),
+        },
+      });
+  } catch (err) {
+    console.error(
+      "[route-cost-source] upsert failed:",
+      err instanceof Error ? err.message : "unknown error",
+    );
+  }
+
   return new Response(null, { status: 204 });
 }
 
@@ -141,9 +199,11 @@ function parseBody(body: Body):
       data: {
         bucketStart: Date;
         method: string;
+        referrerSource: RouteCostReferrerSource;
         route: string;
         routeKind: RouteCostKind;
         sampleWeight: number;
+        trafficSource: RouteCostTrafficSource;
       };
     }
   | { ok: false; error: string } {
@@ -158,6 +218,16 @@ function parseBody(body: Body):
     KIND_SET.has(body.routeKind as RouteCostKind)
       ? (body.routeKind as RouteCostKind)
       : null;
+  const referrerSource =
+    typeof body.referrerSource === "string" &&
+    REFERRER_SOURCE_SET.has(body.referrerSource as RouteCostReferrerSource)
+      ? (body.referrerSource as RouteCostReferrerSource)
+      : "unknown";
+  const trafficSource =
+    typeof body.trafficSource === "string" &&
+    TRAFFIC_SOURCE_SET.has(body.trafficSource as RouteCostTrafficSource)
+      ? (body.trafficSource as RouteCostTrafficSource)
+      : "unknown";
   const at = typeof body.at === "string" ? new Date(body.at) : new Date();
   const sampleWeight =
     typeof body.sampleWeight === "number" &&
@@ -179,9 +249,11 @@ function parseBody(body: Body):
     data: {
       bucketStart: bucketStart(at),
       method,
+      referrerSource,
       route,
       routeKind,
       sampleWeight,
+      trafficSource,
     },
   };
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -862,6 +862,54 @@ export const routeCostBuckets = pgTable(
 export type RouteCostBucket = typeof routeCostBuckets.$inferSelect;
 export type NewRouteCostBucket = typeof routeCostBuckets.$inferInsert;
 
+export const routeCostSourceBuckets = pgTable(
+  "route_cost_source_buckets",
+  {
+    id: serial("id").primaryKey(),
+    bucketStart: timestamp("bucket_start", { withTimezone: true }).notNull(),
+    route: text("route").notNull(),
+    routeKind: text("route_kind").notNull(),
+    method: text("method").notNull(),
+    trafficSource: text("traffic_source").notNull().default("unknown"),
+    referrerSource: text("referrer_source").notNull().default("unknown"),
+    sampleCount: integer("sample_count").notNull().default(0),
+    estimatedRequests: integer("estimated_requests").notNull().default(0),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => ({
+    bucketIdx: index("route_cost_source_buckets_bucket_idx").on(
+      table.bucketStart,
+    ),
+    routeIdx: index("route_cost_source_buckets_route_idx").on(
+      table.route,
+      table.bucketStart,
+    ),
+    sourceIdx: index("route_cost_source_buckets_source_idx").on(
+      table.route,
+      table.trafficSource,
+      table.referrerSource,
+      table.bucketStart,
+    ),
+    uniqueBucket: uniqueIndex("route_cost_source_buckets_unique").on(
+      table.bucketStart,
+      table.method,
+      table.routeKind,
+      table.route,
+      table.trafficSource,
+      table.referrerSource,
+    ),
+  }),
+);
+
+export type RouteCostSourceBucket = typeof routeCostSourceBuckets.$inferSelect;
+export type NewRouteCostSourceBucket =
+  typeof routeCostSourceBuckets.$inferInsert;
+
 export const wechatQrUploads = pgTable(
   "wechat_qr_uploads",
   {

--- a/src/lib/route-cost.test.ts
+++ b/src/lib/route-cost.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "bun:test";
 
 import {
   buildRouteCostSample,
+  classifyRouteCostReferrerSource,
+  classifyRouteCostTrafficSource,
   normalizeRouteCostPath,
   routeCostKind,
   routeCostSampleRate,
@@ -85,10 +87,63 @@ describe("route cost helpers", () => {
       }),
     ).toMatchObject({
       method: "GET",
+      referrerSource: "direct",
       route: "/api/pets/[slug]/thumb",
       routeKind: "asset-api",
       sampleWeight: 1000,
+      trafficSource: "unknown",
     });
+  });
+
+  it("classifies sampled browser and prefetch requests without storing raw headers", () => {
+    expect(
+      classifyRouteCostTrafficSource({
+        "next-router-prefetch": "1",
+        "user-agent": "Mozilla/5.0",
+      }),
+    ).toBe("prefetch");
+    expect(
+      classifyRouteCostTrafficSource({
+        "sec-fetch-site": "same-origin",
+        "user-agent": "Mozilla/5.0",
+      }),
+    ).toBe("browser");
+    expect(
+      classifyRouteCostReferrerSource(
+        { referer: "https://petdex.crafter.run/pets/nukey" },
+        "https://petdex.crafter.run",
+      ),
+    ).toBe("internal");
+  });
+
+  it("classifies preview, bot, monitor, and external referrers coarsely", () => {
+    expect(
+      classifyRouteCostTrafficSource({
+        "user-agent": "Discordbot/2.0",
+      }),
+    ).toBe("preview");
+    expect(
+      classifyRouteCostTrafficSource({
+        "user-agent": "Googlebot/2.1",
+      }),
+    ).toBe("bot");
+    expect(
+      classifyRouteCostTrafficSource({
+        "user-agent": "curl/8.7.1",
+      }),
+    ).toBe("monitor");
+    expect(
+      classifyRouteCostReferrerSource(
+        { referer: "https://www.google.com/search?q=petdex" },
+        "https://petdex.crafter.run",
+      ),
+    ).toBe("search");
+    expect(
+      classifyRouteCostReferrerSource(
+        { referer: "https://github.com/crafter-station/petdex" },
+        "https://petdex.crafter.run",
+      ),
+    ).toBe("external");
   });
 
   it("requires explicit route cost env values", () => {

--- a/src/lib/route-cost.ts
+++ b/src/lib/route-cost.ts
@@ -1,12 +1,32 @@
 export type RouteCostKind = "api" | "asset-api" | "metadata" | "page";
+export type RouteCostReferrerSource =
+  | "direct"
+  | "external"
+  | "internal"
+  | "search"
+  | "social"
+  | "unknown";
+export type RouteCostTrafficSource =
+  | "bot"
+  | "browser"
+  | "monitor"
+  | "prefetch"
+  | "preview"
+  | "unknown";
 
 export type RouteCostSample = {
   method: string;
   route: string;
   routeKind: RouteCostKind;
+  trafficSource: RouteCostTrafficSource;
+  referrerSource: RouteCostReferrerSource;
   sampleWeight: number;
   at: string;
 };
+
+type HeaderBag =
+  | Pick<Headers, "get">
+  | Record<string, string | null | undefined>;
 
 const LOCALE_SET = new Set(["en", "es", "zh"]);
 const DYNAMIC_ROUTE_PATTERNS = [
@@ -170,6 +190,8 @@ export function shouldSampleRouteCost(rate = routeCostSampleRate()): boolean {
 export function buildRouteCostSample(input: {
   method: string;
   pathname: string;
+  headers?: HeaderBag;
+  origin?: string;
   sampleRate?: number;
 }): RouteCostSample | null {
   if (input.pathname === "/api/internal/route-cost") return null;
@@ -180,9 +202,84 @@ export function buildRouteCostSample(input: {
     method: normalizeMethod(input.method),
     route,
     routeKind: routeCostKind(route),
+    trafficSource: classifyRouteCostTrafficSource(input.headers),
+    referrerSource: classifyRouteCostReferrerSource(
+      input.headers,
+      input.origin,
+    ),
     sampleWeight: Math.max(1, Math.round(1 / sampleRate)),
     at: new Date().toISOString(),
   };
+}
+
+export function classifyRouteCostTrafficSource(
+  headers?: HeaderBag,
+): RouteCostTrafficSource {
+  const purpose = [
+    readHeader(headers, "purpose"),
+    readHeader(headers, "sec-purpose"),
+    readHeader(headers, "x-purpose"),
+  ]
+    .join(" ")
+    .toLowerCase();
+  const nextPrefetch = readHeader(headers, "next-router-prefetch");
+  const middlewarePrefetch = readHeader(headers, "x-middleware-prefetch");
+  if (
+    purpose.includes("prefetch") ||
+    purpose.includes("prerender") ||
+    isTruthyHeader(nextPrefetch) ||
+    isTruthyHeader(middlewarePrefetch)
+  ) {
+    return "prefetch";
+  }
+
+  const userAgent = readHeader(headers, "user-agent").toLowerCase();
+  if (!userAgent) return "unknown";
+
+  if (PREVIEW_USER_AGENT_RE.test(userAgent)) return "preview";
+  if (MONITOR_USER_AGENT_RE.test(userAgent)) return "monitor";
+  if (BOT_USER_AGENT_RE.test(userAgent)) return "bot";
+
+  if (
+    readHeader(headers, "sec-fetch-site") ||
+    readHeader(headers, "sec-ch-ua") ||
+    (userAgent.includes("mozilla") &&
+      readHeader(headers, "accept").toLowerCase().includes("text/html"))
+  ) {
+    return "browser";
+  }
+
+  return "unknown";
+}
+
+export function classifyRouteCostReferrerSource(
+  headers?: HeaderBag,
+  origin?: string,
+): RouteCostReferrerSource {
+  const referrer =
+    readHeader(headers, "referer") || readHeader(headers, "referrer");
+  if (!referrer) return "direct";
+
+  let url: URL;
+  try {
+    url = new URL(referrer, origin);
+  } catch {
+    return "unknown";
+  }
+
+  if (origin) {
+    try {
+      const current = new URL(origin);
+      if (url.origin === current.origin) return "internal";
+    } catch {
+      return "unknown";
+    }
+  }
+
+  const host = url.hostname.toLowerCase().replace(/^www\./, "");
+  if (SEARCH_REFERRER_RE.test(host)) return "search";
+  if (SOCIAL_REFERRER_RE.test(host)) return "social";
+  return "external";
 }
 
 export function normalizeRouteCostPath(pathname: string): string {
@@ -232,6 +329,20 @@ function normalizeMethod(method: string): string {
   return upper.length <= 12 ? upper : "OTHER";
 }
 
+function readHeader(headers: HeaderBag | undefined, name: string): string {
+  if (!headers) return "";
+  if (typeof (headers as Pick<Headers, "get">).get === "function") {
+    return (headers as Pick<Headers, "get">).get(name) ?? "";
+  }
+  const bag = headers as Record<string, string | null | undefined>;
+  return bag[name] ?? bag[name.toLowerCase()] ?? bag[name.toUpperCase()] ?? "";
+}
+
+function isTruthyHeader(value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
 function firstNonEmpty(...values: Array<string | undefined>): string | null {
   for (const value of values) {
     const trimmed = value?.trim();
@@ -254,3 +365,14 @@ function matchDynamicRoutePattern(parts: string[]): string[] | null {
 function isDynamicPart(part: string): boolean {
   return part.startsWith("[") && part.endsWith("]");
 }
+
+const PREVIEW_USER_AGENT_RE =
+  /\b(discordbot|slackbot|twitterbot|facebookexternalhit|linkedinbot|whatsapp|telegrambot|pinterest|skypeuripreview|embedly|quora link preview)\b/;
+const MONITOR_USER_AGENT_RE =
+  /\b(uptimerobot|pingdom|healthcheck|statuscake|checkly|datadog|newrelic|better uptime|vercel|curl|wget)\b/;
+const BOT_USER_AGENT_RE =
+  /\b(bot|crawler|spider|crawling|slurp|ahrefs|semrush|applebot|googlebot|bingbot|duckduckbot|baiduspider|yandexbot|petalbot)\b/;
+const SEARCH_REFERRER_RE =
+  /(^|\.)((google|bing|duckduckgo|baidu|yahoo|yandex|ecosia|brave|perplexity)\.)/;
+const SOCIAL_REFERRER_RE =
+  /(^|\.)((x|twitter|t|facebook|instagram|threads|linkedin|reddit|discord|slack|youtube|telegram|whatsapp|pinterest)\.)/;

--- a/src/lib/telemetry/queries.ts
+++ b/src/lib/telemetry/queries.ts
@@ -3,6 +3,12 @@ import "server-only";
 import { sql } from "drizzle-orm";
 
 import { db } from "@/lib/db/client";
+import {
+  combineRouteCostAttributionRows,
+  type RouteCostAttributionRow,
+  type RouteCostBucketInput,
+  type RouteCostSourceBucketInput,
+} from "@/lib/telemetry/route-cost-attribution";
 
 export type InstallsByDayRow = { date: string; count: number };
 export type OsRow = { os: string; count: number };
@@ -10,13 +16,7 @@ export type ArchRow = { arch: string; count: number };
 export type VersionRow = { binary_version: string; count: number };
 export type AgentRow = { agent: string; count: number };
 export type CountryRow = { country: string; count: number };
-export type RouteCostRow = {
-  estimatedRequests: number;
-  method: string;
-  route: string;
-  routeKind: string;
-  samples: number;
-};
+export type RouteCostRow = RouteCostAttributionRow;
 export type VersionAdoptionRow = {
   day: string;
   version: string;
@@ -201,25 +201,7 @@ export async function getTelemetrySummary(): Promise<TelemetrySummary> {
     ).rows ?? []
   ).map((r) => ({ country: r.country, count: toNum(r.count) }));
 
-  const routeCostTop = (
-    (
-      routeCostResult as unknown as {
-        rows: Array<{
-          estimated_requests: unknown;
-          method: string;
-          route: string;
-          route_kind: string;
-          samples: unknown;
-        }>;
-      }
-    ).rows ?? []
-  ).map((r) => ({
-    estimatedRequests: toNum(r.estimated_requests),
-    method: r.method,
-    route: r.route,
-    routeKind: r.route_kind,
-    samples: toNum(r.samples),
-  }));
+  const routeCostTop = routeCostResult;
 
   const funnelRow = (
     funnelResult as unknown as {
@@ -263,10 +245,12 @@ export async function getTelemetrySummary(): Promise<TelemetrySummary> {
   };
 }
 
-async function getRouteCostTop() {
+async function getRouteCostTop(): Promise<RouteCostRow[]> {
+  let legacyRows: RouteCostBucketInput[];
   try {
-    return await db.execute(sql`
+    const legacyResult = await db.execute(sql`
       SELECT
+        bucket_start,
         method,
         route,
         route_kind,
@@ -274,13 +258,91 @@ async function getRouteCostTop() {
         SUM(estimated_requests) AS estimated_requests
       FROM route_cost_buckets
       WHERE bucket_start >= now() - interval '24 hours'
-      GROUP BY method, route, route_kind
-      ORDER BY estimated_requests DESC
-      LIMIT 20
+      GROUP BY bucket_start, method, route, route_kind
     `);
+    legacyRows = mapLegacyRows(legacyResult);
   } catch {
-    return { rows: [] };
+    return [];
   }
+
+  let sourceRows: RouteCostSourceBucketInput[] = [];
+  try {
+    const sourceResult = await db.execute(sql`
+      SELECT
+        bucket_start,
+        method,
+        referrer_source,
+        route,
+        route_kind,
+        traffic_source,
+        SUM(sample_count) AS samples,
+        SUM(estimated_requests) AS estimated_requests
+      FROM route_cost_source_buckets
+      WHERE bucket_start >= now() - interval '24 hours'
+      GROUP BY
+        bucket_start,
+        method,
+        route,
+        route_kind,
+        traffic_source,
+        referrer_source
+    `);
+    sourceRows = mapSourceRows(sourceResult);
+  } catch {}
+
+  return combineRouteCostAttributionRows(legacyRows, sourceRows, 20);
+}
+
+function mapLegacyRows(result: unknown): RouteCostBucketInput[] {
+  return (
+    (
+      result as {
+        rows?: Array<{
+          bucket_start: unknown;
+          estimated_requests: unknown;
+          method: string;
+          route: string;
+          route_kind: string;
+          samples: unknown;
+        }>;
+      }
+    ).rows ?? []
+  ).map((r) => ({
+    bucketStart: String(r.bucket_start),
+    estimatedRequests: toNum(r.estimated_requests),
+    method: r.method,
+    route: r.route,
+    routeKind: r.route_kind,
+    samples: toNum(r.samples),
+  }));
+}
+
+function mapSourceRows(result: unknown): RouteCostSourceBucketInput[] {
+  return (
+    (
+      result as {
+        rows?: Array<{
+          bucket_start: unknown;
+          estimated_requests: unknown;
+          method: string;
+          referrer_source: string;
+          route: string;
+          route_kind: string;
+          samples: unknown;
+          traffic_source: string;
+        }>;
+      }
+    ).rows ?? []
+  ).map((r) => ({
+    bucketStart: String(r.bucket_start),
+    estimatedRequests: toNum(r.estimated_requests),
+    method: r.method,
+    referrerSource: r.referrer_source,
+    route: r.route,
+    routeKind: r.route_kind,
+    samples: toNum(r.samples),
+    trafficSource: r.traffic_source,
+  }));
 }
 
 export async function versionAdoptionOverTime(): Promise<VersionAdoptionRow[]> {

--- a/src/lib/telemetry/route-cost-attribution.test.ts
+++ b/src/lib/telemetry/route-cost-attribution.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "bun:test";
+
+import { combineRouteCostAttributionRows } from "@/lib/telemetry/route-cost-attribution";
+
+describe("route cost attribution merge", () => {
+  it("keeps legacy residuals when source buckets cover only part of a window", () => {
+    const rows = combineRouteCostAttributionRows(
+      [
+        {
+          bucketStart: "2026-06-04T10:00:00.000Z",
+          estimatedRequests: 10_000,
+          method: "GET",
+          route: "/pets/[slug]",
+          routeKind: "page",
+          samples: 10,
+        },
+      ],
+      [
+        {
+          bucketStart: "2026-06-04T10:00:00.000Z",
+          estimatedRequests: 3_000,
+          method: "GET",
+          referrerSource: "internal",
+          route: "/pets/[slug]",
+          routeKind: "page",
+          samples: 3,
+          trafficSource: "browser",
+        },
+      ],
+    );
+
+    expect(rows).toEqual([
+      {
+        estimatedRequests: 7_000,
+        method: "GET",
+        referrerSource: "unknown",
+        route: "/pets/[slug]",
+        routeKind: "page",
+        samples: 7,
+        trafficSource: "unknown",
+      },
+      {
+        estimatedRequests: 3_000,
+        method: "GET",
+        referrerSource: "internal",
+        route: "/pets/[slug]",
+        routeKind: "page",
+        samples: 3,
+        trafficSource: "browser",
+      },
+    ]);
+  });
+
+  it("does not create negative residuals when source rows meet legacy totals", () => {
+    const rows = combineRouteCostAttributionRows(
+      [
+        {
+          bucketStart: "2026-06-04T10:00:00.000Z",
+          estimatedRequests: 1_000,
+          method: "GET",
+          route: "/api/me/header-state",
+          routeKind: "api",
+          samples: 1,
+        },
+      ],
+      [
+        {
+          bucketStart: "2026-06-04T10:00:00.000Z",
+          estimatedRequests: 1_000,
+          method: "GET",
+          referrerSource: "internal",
+          route: "/api/me/header-state",
+          routeKind: "api",
+          samples: 1,
+          trafficSource: "browser",
+        },
+      ],
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.trafficSource).toBe("browser");
+  });
+
+  it("sums the same route and source across buckets into one returned row", () => {
+    const rows = combineRouteCostAttributionRows(
+      [
+        {
+          bucketStart: "2026-06-04T10:00:00.000Z",
+          estimatedRequests: 1_000,
+          method: "GET",
+          route: "/pets/[slug]",
+          routeKind: "page",
+          samples: 1,
+        },
+        {
+          bucketStart: "2026-06-04T10:15:00.000Z",
+          estimatedRequests: 2_000,
+          method: "GET",
+          route: "/pets/[slug]",
+          routeKind: "page",
+          samples: 2,
+        },
+      ],
+      [
+        {
+          bucketStart: "2026-06-04T10:00:00.000Z",
+          estimatedRequests: 1_000,
+          method: "GET",
+          referrerSource: "internal",
+          route: "/pets/[slug]",
+          routeKind: "page",
+          samples: 1,
+          trafficSource: "browser",
+        },
+        {
+          bucketStart: "2026-06-04T10:15:00.000Z",
+          estimatedRequests: 2_000,
+          method: "GET",
+          referrerSource: "internal",
+          route: "/pets/[slug]",
+          routeKind: "page",
+          samples: 2,
+          trafficSource: "browser",
+        },
+      ],
+    );
+
+    expect(rows).toEqual([
+      {
+        estimatedRequests: 3_000,
+        method: "GET",
+        referrerSource: "internal",
+        route: "/pets/[slug]",
+        routeKind: "page",
+        samples: 3,
+        trafficSource: "browser",
+      },
+    ]);
+  });
+});

--- a/src/lib/telemetry/route-cost-attribution.ts
+++ b/src/lib/telemetry/route-cost-attribution.ts
@@ -1,0 +1,119 @@
+export type RouteCostBucketInput = {
+  bucketStart: string;
+  estimatedRequests: number;
+  method: string;
+  route: string;
+  routeKind: string;
+  samples: number;
+};
+
+export type RouteCostSourceBucketInput = RouteCostBucketInput & {
+  referrerSource: string;
+  trafficSource: string;
+};
+
+export type RouteCostAttributionRow = Omit<
+  RouteCostSourceBucketInput,
+  "bucketStart"
+>;
+
+export function combineRouteCostAttributionRows(
+  legacyRows: RouteCostBucketInput[],
+  sourceRows: RouteCostSourceBucketInput[],
+  limit = 20,
+): RouteCostAttributionRow[] {
+  const sourceTotals = new Map<
+    string,
+    { estimatedRequests: number; samples: number }
+  >();
+  const out = new Map<string, RouteCostAttributionRow>();
+
+  for (const row of sourceRows) {
+    addToTotal(sourceTotals, legacyKey(row), row);
+    addToOutput(out, outputKey(row), row);
+  }
+
+  for (const row of legacyRows) {
+    const sourceTotal = sourceTotals.get(legacyKey(row));
+    const residualEstimated =
+      row.estimatedRequests - (sourceTotal?.estimatedRequests ?? 0);
+    if (residualEstimated <= 0) continue;
+    const residualSamples = Math.max(
+      0,
+      row.samples - (sourceTotal?.samples ?? 0),
+    );
+    addToOutput(out, outputKey(row, "unknown", "unknown"), {
+      ...row,
+      estimatedRequests: residualEstimated,
+      referrerSource: "unknown",
+      samples: residualSamples,
+      trafficSource: "unknown",
+    });
+  }
+
+  return [...out.values()]
+    .filter((row) => row.estimatedRequests > 0)
+    .sort((a, b) => {
+      if (b.estimatedRequests !== a.estimatedRequests) {
+        return b.estimatedRequests - a.estimatedRequests;
+      }
+      return (
+        [
+          a.route.localeCompare(b.route),
+          a.method.localeCompare(b.method),
+          a.trafficSource.localeCompare(b.trafficSource),
+          a.referrerSource.localeCompare(b.referrerSource),
+        ].find((n) => n !== 0) ?? 0
+      );
+    })
+    .slice(0, limit);
+}
+
+function addToTotal(
+  map: Map<string, { estimatedRequests: number; samples: number }>,
+  key: string,
+  row: Pick<RouteCostBucketInput, "estimatedRequests" | "samples">,
+) {
+  const current = map.get(key);
+  map.set(key, {
+    estimatedRequests:
+      (current?.estimatedRequests ?? 0) + row.estimatedRequests,
+    samples: (current?.samples ?? 0) + row.samples,
+  });
+}
+
+function addToOutput(
+  map: Map<string, RouteCostAttributionRow>,
+  key: string,
+  row: RouteCostSourceBucketInput,
+) {
+  const current = map.get(key);
+  map.set(key, {
+    estimatedRequests:
+      (current?.estimatedRequests ?? 0) + row.estimatedRequests,
+    method: row.method,
+    referrerSource: row.referrerSource,
+    route: row.route,
+    routeKind: row.routeKind,
+    samples: (current?.samples ?? 0) + row.samples,
+    trafficSource: row.trafficSource,
+  });
+}
+
+function legacyKey(row: RouteCostBucketInput): string {
+  return [row.bucketStart, row.method, row.routeKind, row.route].join("\x1f");
+}
+
+function outputKey(
+  row: RouteCostBucketInput,
+  trafficSource?: string,
+  referrerSource?: string,
+): string {
+  return [
+    row.method,
+    row.routeKind,
+    row.route,
+    trafficSource ?? (row as RouteCostSourceBucketInput).trafficSource,
+    referrerSource ?? (row as RouteCostSourceBucketInput).referrerSource,
+  ].join("\x1f");
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -89,6 +89,8 @@ function scheduleRouteCostSample(req: NextRequest, event?: NextFetchEvent) {
   const sample = buildRouteCostSample({
     method: req.method,
     pathname: req.nextUrl.pathname,
+    headers: req.headers,
+    origin: req.nextUrl.origin,
     sampleRate,
   });
   if (!sample) return;


### PR DESCRIPTION
## Summary
- add coarse traffic/referrer attribution to route-cost samples
- write attribution into a new route_cost_source_buckets table while preserving the existing route_cost_buckets aggregation
- show traffic/referrer source in the admin telemetry route-cost list, with fallback to legacy buckets when source rows are empty

## Production data
- ran `bun --env-file=/Users/raillyhugo/Programming/crafter-station/petdex/.env.local run cost:apply-route-buckets`
- created `route_cost_source_buckets` and indexes only; existing `route_cost_buckets` was left intact

## Validation
- `bun install --frozen-lockfile`
- `./node_modules/.bin/biome check src/lib/route-cost.ts src/lib/route-cost.test.ts src/proxy.ts src/app/api/internal/route-cost/route.ts src/lib/db/schema.ts src/lib/telemetry/queries.ts "src/app/[locale]/admin/telemetry/page.tsx" scripts/apply-route-cost-buckets.ts drizzle/0017_route_cost_sources.sql`
- `bun test src/lib/route-cost.test.ts`
- `bun run i18n:check`
- `git diff --check`
- `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build`

## Note
- `bun run check` is red on current main from unrelated existing Biome findings in CLI/admin files; this PR keeps validation scoped to touched files plus full Next build.