### PR TITLE
Reduce surprise pet auto fetches

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -13,6 +13,8 @@ import { formatLocalizedNumber } from "@/lib/format-number";
 import { buildLocaleAlternates } from "@/lib/locale-routing";
 import { searchPets } from "@/lib/pet-search";
 import { getFeaturedPetsWithMetrics, type PetWithMetrics } from "@/lib/pets";
+import { getRandomPet } from "@/lib/random-pet-pool";
+import { toSurprisePet } from "@/lib/surprise-pets";
 import { cn } from "@/lib/utils";
 
 import { CollectionActionMenu } from "@/components/collection-action-menu";
@@ -38,10 +40,10 @@ import { WechatCommunityDialog } from "@/components/wechat-community-dialog";
 
 import { hasLocale, locales } from "@/i18n/config";
 
-// ISR. The home page renders an alpha-ordered, anon shell — the
+// ISR. The home page renders an alpha-ordered, anon shell.
 // visitor's shuffle seed and caught-slug set are pulled client-side
-// (PetGallery re-fetches /api/pets/search; /api/me/caught-slugs feeds
-// the "caught" highlight). With a 24h ceiling and tag-based
+// after interaction; /api/me/header-state feeds the "caught" highlight.
+// With a 24h ceiling and tag-based
 // invalidation on submit/feature/withdraw, the page stays fresh for
 // editorial changes without burning a function on every visit.
 export const dynamic = "force-static";
@@ -86,17 +88,19 @@ export default async function Home({
     "franchise-jojos-bizarre-adventure",
   ];
 
-  const [heroPets, initialSearch, dexEntries, collections, feedAds] =
+  const [heroPets, initialSearch, dexEntries, collections, feedAds, randomPet] =
     await Promise.all([
       getFeaturedPetsWithMetrics(6),
       searchPets({ sort: "alpha" }),
       getDexNumberMap(),
       getCollectionsBySlugs(LANDING_COLLECTION_ORDER, 6),
       getActiveFeedAds(6),
+      getRandomPet(),
     ]);
   const totalPets = initialSearch.total;
   const formattedTotalPets = formatLocalizedNumber(totalPets, locale);
   const showWechatCommunity = isZh;
+  const surprisePet = randomPet ? toSurprisePet(randomPet) : null;
 
   // Plain-object so the server -> client serializer doesn't choke on a
   // Map. Same source of truth either way.
@@ -141,7 +145,7 @@ export default async function Home({
   return (
     <main className="min-h-dvh bg-background text-foreground">
       <JsonLd data={jsonLd} />
-      <SurprisePetCard />
+      <SurprisePetCard initialPet={surprisePet} />
       <SiteHeader />
       <section className="petdex-cloud relative -mt-[84px] overflow-clip pt-[84px]">
         <div className="relative mx-auto flex w-full max-w-[1440px] flex-col px-5 pb-10 md:px-8">

--- a/src/app/api/pets/random/route.ts
+++ b/src/app/api/pets/random/route.ts
@@ -1,21 +1,9 @@
 import { NextResponse } from "next/server";
 
-import { and, eq, ne } from "drizzle-orm";
-
-import { AGGREGATE_KEYS, cachedAggregate } from "@/lib/db/cached-aggregates";
-import { db, schema } from "@/lib/db/client";
+import { getRandomPetPool } from "@/lib/random-pet-pool";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-
-const RANDOM_POOL_TTL_SECONDS = 300;
-
-type RandomPet = {
-  slug: string;
-  displayName: string;
-  description: string;
-  spritesheetPath: string;
-};
 
 // GET /api/pets/random?exclude=current-slug
 //
@@ -60,28 +48,4 @@ export async function GET(req: Request): Promise<Response> {
     return NextResponse.redirect(new URL("/", req.url), 302);
   }
   return NextResponse.redirect(new URL(`/pets/${next.slug}`, req.url), 302);
-}
-
-async function getRandomPetPool(): Promise<RandomPet[]> {
-  return cachedAggregate(
-    {
-      key: AGGREGATE_KEYS.randomPetPool,
-      ttlSeconds: RANDOM_POOL_TTL_SECONDS,
-    },
-    async () =>
-      db
-        .select({
-          slug: schema.submittedPets.slug,
-          displayName: schema.submittedPets.displayName,
-          description: schema.submittedPets.description,
-          spritesheetPath: schema.submittedPets.spritesheetUrl,
-        })
-        .from(schema.submittedPets)
-        .where(
-          and(
-            eq(schema.submittedPets.status, "approved"),
-            ne(schema.submittedPets.source, "discover"),
-          ),
-        ),
-  );
 }

--- a/src/components/surprise-pet-card.tsx
+++ b/src/components/surprise-pet-card.tsx
@@ -7,31 +7,32 @@ import { Dice5, ExternalLink, PackageOpen, X } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 
 import { withLocale } from "@/lib/locale-routing";
+import type { SurprisePet } from "@/lib/surprise-pets";
 import { safeGetItem, safeSetItem } from "@/lib/utils";
 
 import { PetSprite } from "@/components/pet-sprite";
 
 import { hasLocale, type Locale } from "@/i18n/config";
 
-type SurprisePet = {
-  slug: string;
-  displayName: string;
-  description: string;
-  spritesheetPath: string;
-  href: string;
-  installHref: string;
-};
-
 const BASE_KEY = "petdex_surprise_pet_seen";
 const THUMBNAIL_SPRITE_SCALE = 0.45;
 
-export function SurprisePetCard() {
+type SurprisePetCardProps = {
+  initialPet?: SurprisePet | null;
+};
+
+export function SurprisePetCard({ initialPet = null }: SurprisePetCardProps) {
   const locale = useLocale();
   const currentLocale: Locale = hasLocale(locale) ? locale : "en";
   const t = useTranslations("home.surprise");
   const [pet, setPet] = useState<SurprisePet | null>(null);
   const [visible, setVisible] = useState(false);
   const [loading, setLoading] = useState(false);
+
+  const showPet = useCallback((next: SurprisePet) => {
+    setPet(next);
+    setVisible(true);
+  }, []);
 
   const loadPet = useCallback(async () => {
     setLoading(true);
@@ -42,12 +43,11 @@ export function SurprisePetCard() {
       });
       if (!response.ok) return;
       const next = (await response.json()) as SurprisePet;
-      setPet(next);
-      setVisible(true);
+      showPet(next);
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [showPet]);
 
   useEffect(() => {
     const today = new Date().toISOString().slice(0, 10);
@@ -55,10 +55,14 @@ export function SurprisePetCard() {
     if (safeGetItem(key) === "1") return;
     const timeout = window.setTimeout(() => {
       safeSetItem(key, "1");
-      void loadPet();
+      if (initialPet) {
+        showPet(initialPet);
+      } else {
+        void loadPet();
+      }
     }, 2200);
     return () => window.clearTimeout(timeout);
-  }, [loadPet]);
+  }, [initialPet, loadPet, showPet]);
 
   if (!visible || pet === null) return null;
 

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -116,7 +116,7 @@
     "petAnimated": "{name} animated",
     "petParadeAria": "Featured pets",
     "surprise": {
-      "eyebrow": "Surprise drop",
+      "eyebrow": "Featured surprise",
       "title": "A pet found you",
       "dismiss": "Dismiss surprise pet",
       "view": "View",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -116,7 +116,7 @@
     "petAnimated": "{name} animado",
     "petParadeAria": "Mascotas destacadas",
     "surprise": {
-      "eyebrow": "Sorpresa diaria",
+      "eyebrow": "Sorpresa destacada",
       "title": "Una mascota te encontró",
       "dismiss": "Cerrar mascota sorpresa",
       "view": "Ver",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -126,7 +126,7 @@
     "petAnimated__fixme": true,
     "petParadeAria": "精选宠物",
     "surprise": {
-      "eyebrow": "惊喜掉落",
+      "eyebrow": "精选惊喜",
       "title": "有只宠物找到了你",
       "title__fixme": true,
       "dismiss": "关闭惊喜宠物",

--- a/src/lib/random-pet-pool.ts
+++ b/src/lib/random-pet-pool.ts
@@ -1,0 +1,43 @@
+import "server-only";
+
+import { and, eq, ne } from "drizzle-orm";
+
+import { AGGREGATE_KEYS, cachedAggregate } from "@/lib/db/cached-aggregates";
+import { db, schema } from "@/lib/db/client";
+import {
+  pickRandomPet,
+  type RandomPetCandidate,
+} from "@/lib/random-pet-selection";
+
+const RANDOM_POOL_TTL_SECONDS = 300;
+
+export type RandomPet = RandomPetCandidate;
+
+export async function getRandomPetPool(): Promise<RandomPet[]> {
+  return cachedAggregate(
+    {
+      key: AGGREGATE_KEYS.randomPetPool,
+      ttlSeconds: RANDOM_POOL_TTL_SECONDS,
+    },
+    async () =>
+      db
+        .select({
+          slug: schema.submittedPets.slug,
+          displayName: schema.submittedPets.displayName,
+          description: schema.submittedPets.description,
+          spritesheetPath: schema.submittedPets.spritesheetUrl,
+        })
+        .from(schema.submittedPets)
+        .where(
+          and(
+            eq(schema.submittedPets.status, "approved"),
+            ne(schema.submittedPets.source, "discover"),
+          ),
+        ),
+  );
+}
+
+export async function getRandomPet(): Promise<RandomPet | null> {
+  const pool = await getRandomPetPool();
+  return pickRandomPet(pool);
+}

--- a/src/lib/random-pet-selection.test.ts
+++ b/src/lib/random-pet-selection.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+
+import { pickRandomPet } from "@/lib/random-pet-selection";
+
+const pool = [
+  {
+    slug: "alpha",
+    displayName: "Alpha",
+    description: "First",
+    spritesheetPath: "https://assets.test/alpha.png",
+  },
+  {
+    slug: "beta",
+    displayName: "Beta",
+    description: "Second",
+    spritesheetPath: "https://assets.test/beta.png",
+  },
+  {
+    slug: "gamma",
+    displayName: "Gamma",
+    description: "Third",
+    spritesheetPath: "https://assets.test/gamma.png",
+  },
+];
+
+describe("pickRandomPet", () => {
+  test("returns null for an empty pool", () => {
+    expect(pickRandomPet([], () => 0)).toBeNull();
+  });
+
+  test("selects from the full eligible pool", () => {
+    expect(pickRandomPet(pool, () => 0)?.slug).toBe("alpha");
+    expect(pickRandomPet(pool, () => 0.67)?.slug).toBe("gamma");
+  });
+
+  test("clamps out-of-range random sources", () => {
+    expect(pickRandomPet(pool, () => 1)?.slug).toBe("gamma");
+    expect(pickRandomPet(pool, () => -1)?.slug).toBe("alpha");
+  });
+});

--- a/src/lib/random-pet-selection.ts
+++ b/src/lib/random-pet-selection.ts
@@ -1,0 +1,18 @@
+export type RandomPetCandidate = {
+  slug: string;
+  displayName: string;
+  description: string;
+  spritesheetPath: string;
+};
+
+export function pickRandomPet(
+  pool: readonly RandomPetCandidate[],
+  random = Math.random,
+) {
+  if (pool.length === 0) return null;
+  const index = Math.min(
+    pool.length - 1,
+    Math.max(0, Math.floor(random() * pool.length)),
+  );
+  return pool[index] ?? null;
+}

--- a/src/lib/surprise-pets.test.ts
+++ b/src/lib/surprise-pets.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+
+import { toSurprisePet } from "@/lib/surprise-pets";
+
+describe("toSurprisePet", () => {
+  test("builds card and install links from a pet", () => {
+    expect(
+      toSurprisePet({
+        slug: "alpha",
+        displayName: "Alpha",
+        description: "First",
+        spritesheetPath: "https://assets.test/alpha.png",
+      }),
+    ).toEqual({
+      slug: "alpha",
+      displayName: "Alpha",
+      description: "First",
+      spritesheetPath: "https://assets.test/alpha.png",
+      href: "/pets/alpha",
+      installHref: "/install/alpha",
+    });
+  });
+});

--- a/src/lib/surprise-pets.ts
+++ b/src/lib/surprise-pets.ts
@@ -1,0 +1,26 @@
+export type SurprisePet = {
+  slug: string;
+  displayName: string;
+  description: string;
+  spritesheetPath: string;
+  href: string;
+  installHref: string;
+};
+
+type SurprisePetSource = {
+  slug: string;
+  displayName: string;
+  description: string;
+  spritesheetPath: string;
+};
+
+export function toSurprisePet(pet: SurprisePetSource): SurprisePet {
+  return {
+    slug: pet.slug,
+    displayName: pet.displayName,
+    description: pet.description,
+    spritesheetPath: pet.spritesheetPath,
+    href: `/pets/${pet.slug}`,
+    installHref: `/install/${pet.slug}`,
+  };
+}


### PR DESCRIPTION
## Summary
- seed the home surprise card from the same approved, non-discover pool used by `/api/pets/random`
- make the automatic card a featured surprise served from the cached home shell
- keep `/api/pets/random` for explicit shuffle clicks
- add deterministic tests for surprise pet shaping and random pool selection

## Why
- recent route-cost attribution showed browser/internal samples for `/api/pets/random`
- the auto card was invoking that endpoint per visitor even though the first card can be served from the cached home shell
- shipping the full eligible pool would add roughly 589k raw chars before JSON to every home response, so this keeps payload small and avoids a per-visitor function call

## Validation
- bun test src/lib/surprise-pets.test.ts src/lib/random-pet-selection.test.ts
- bun run check
- bun run i18n:check
- git diff --check
- TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build
