### PR TITLE
Disable profile link prefetches

### DIFF
--- a/src/app/[locale]/admin/collection-requests/page.tsx
+++ b/src/app/[locale]/admin/collection-requests/page.tsx
@@ -216,6 +216,7 @@ function RequestRow({
             {requester ? (
               <Link
                 href={`/u/${requester.handle}`}
+                prefetch={false}
                 className="text-foreground hover:underline"
               >
                 {requester.name}

--- a/src/app/[locale]/admin/feedback/page.tsx
+++ b/src/app/[locale]/admin/feedback/page.tsx
@@ -365,6 +365,7 @@ export default async function AdminFeedbackPage({
                     {info?.handle ? (
                       <Link
                         href={`/u/${info.handle}`}
+                        prefetch={false}
                         target="_blank"
                         rel="noreferrer"
                         title={`View @${info.handle}'s profile`}

--- a/src/app/[locale]/collections/[slug]/page.tsx
+++ b/src/app/[locale]/collections/[slug]/page.tsx
@@ -149,6 +149,7 @@ export default async function CollectionPage({ params }: PageProps) {
                 {owner ? (
                   <Link
                     href={`/u/${owner.handle}`}
+                    prefetch={false}
                     className="inline-flex h-10 items-center rounded-full bg-inverse px-4 text-sm font-medium text-on-inverse transition hover:bg-inverse-hover"
                   >
                     View creator

--- a/src/components/admin-review-row.tsx
+++ b/src/components/admin-review-row.tsx
@@ -376,6 +376,7 @@ export function AdminReviewRow({
           {ownerHandle ? (
             <Link
               href={`/u/${ownerHandle}`}
+              prefetch={false}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-1 underline-offset-4 transition hover:text-foreground hover:underline"

--- a/src/components/collections-browser.tsx
+++ b/src/components/collections-browser.tsx
@@ -381,6 +381,7 @@ const CollectionCard = memo(function CollectionCard({
           <div className="mt-auto border-t border-black/[0.05] pt-2 dark:border-white/[0.05]">
             <Link
               href={`/u/${owner.handle}`}
+              prefetch={false}
               className="font-mono text-[10px] tracking-[0.12em] text-muted-3 uppercase hover:text-foreground"
             >
               {t("card.byOwner", { name: owner.name })}

--- a/src/components/leaderboard-view.tsx
+++ b/src/components/leaderboard-view.tsx
@@ -218,6 +218,7 @@ function LeaderboardRowItem({
     >
       <Link
         href={`/u/${handle}`}
+        prefetch={false}
         className="group flex items-center gap-4 rounded-2xl border border-border-base bg-surface/80 px-4 py-3 transition hover:border-border-strong"
       >
         <RankBadge rank={rank} />

--- a/src/components/pet-requests-review-page.tsx
+++ b/src/components/pet-requests-review-page.tsx
@@ -304,6 +304,7 @@ function RequestRow({
             {requester ? (
               <Link
                 href={`/u/${requester.handle}`}
+                prefetch={false}
                 target="_blank"
                 rel="noreferrer"
                 className="inline-flex items-center gap-1.5 rounded-full bg-surface-muted px-2 py-1 transition hover:bg-surface-muted hover:text-stone-900 dark:hover:text-stone-100"

--- a/src/components/profile-announcement-modal.tsx
+++ b/src/components/profile-announcement-modal.tsx
@@ -139,6 +139,7 @@ export function ProfileAnnouncementModal() {
           <div className="flex items-center gap-2 pt-1">
             <Link
               href={`/u/${handle}`}
+              prefetch={false}
               onClick={() => close("cta_view")}
               className="inline-flex h-10 flex-1 items-center justify-center gap-1.5 rounded-full bg-inverse px-5 text-sm font-medium text-on-inverse transition hover:bg-inverse-hover"
             >

--- a/src/components/profile-card.tsx
+++ b/src/components/profile-card.tsx
@@ -139,6 +139,7 @@ export function ProfileCard({ profile }: { profile: ProfileData }) {
         <div className="flex shrink-0 items-center gap-2">
           <Link
             href={`/u/${profile.handle}`}
+            prefetch={false}
             target="_blank"
             rel="noreferrer"
             className="inline-flex h-9 items-center gap-1.5 rounded-full border border-border-base bg-surface px-3 text-xs font-medium text-muted-2 transition hover:border-border-strong"

--- a/src/components/requests-view.tsx
+++ b/src/components/requests-view.tsx
@@ -708,6 +708,7 @@ function RequestCard({
             {request.requester ? (
               <Link
                 href={`/u/${request.requester.handle}`}
+                prefetch={false}
                 className="inline-flex items-center gap-1.5 rounded-full bg-surface-muted px-2 py-0.5 text-muted-2 transition hover:bg-surface-muted hover:text-stone-900 dark:hover:text-stone-100"
               >
                 {request.requester.imageUrl ? (

--- a/src/components/submitted-by.tsx
+++ b/src/components/submitted-by.tsx
@@ -62,6 +62,7 @@ export function SubmittedBy({ credit }: SubmittedByProps) {
     <div className="group rounded-2xl border border-border-base bg-surface/76 p-4 backdrop-blur transition hover:border-border-strong hover:bg-surface">
       <Link
         href={profileHref}
+        prefetch={false}
         aria-label={t("viewProfile", { name: displayCredit.name })}
         className="flex items-center gap-3 rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
       >


### PR DESCRIPTION
## Summary
- disable Next prefetch for internal `/u/[handle]` profile links across public and admin surfaces
- keep navigation, targets, and click handlers unchanged

## Why
- post-attribution route-cost buckets show `/u/[handle]` as `browser/internal`
- profile pages are dynamic and should only be requested when the user intentionally opens them

## Validation
- biome check on touched files
- bun run i18n:check
- git diff --check
- TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build
