### PR TITLE
Make pet detail pages cacheable

### DIFF
--- a/src/app/[locale]/pets/[slug]/page.tsx
+++ b/src/app/[locale]/pets/[slug]/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { Layers, Shuffle, Sparkles } from "lucide-react";
-import { getTranslations } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 
 import { getCollectionsContainingPet } from "@/lib/collections";
 import { formatDexNumber, getDexEntryMap } from "@/lib/dex";
@@ -36,7 +36,7 @@ import { SiteHeader } from "@/components/site-header";
 import { StaticPetSprite } from "@/components/static-pet-sprite";
 import { SubmittedBy } from "@/components/submitted-by";
 
-import { hasLocale } from "@/i18n/config";
+import { defaultLocale, hasLocale } from "@/i18n/config";
 
 const SITE_URL = "https://petdex.crafter.run";
 
@@ -48,6 +48,7 @@ type PageProps = {
 };
 
 export const dynamicParams = true;
+export const dynamic = "force-static";
 // Long ISR window — the shell is byte-stable (metrics fetched
 // client-side), so the page only needs to regenerate when its
 // editorial fields change. Write paths call revalidateTag('pet:${slug}')
@@ -123,9 +124,11 @@ export async function generateMetadata({ params }: PageProps) {
 }
 
 export default async function PetPage({ params }: PageProps) {
-  const { slug } = await params;
+  const { slug, locale } = await params;
+  const localeValue = hasLocale(locale) ? locale : defaultLocale;
+  setRequestLocale(localeValue);
   const pet = await getPet(slug);
-  const tPet = await getTranslations("pet");
+  const tPet = await getTranslations({ locale: localeValue, namespace: "pet" });
 
   if (!pet) {
     notFound();

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -389,41 +389,46 @@ export async function getCollectionCandidatesForPet(
 export async function getCollectionsContainingPet(
   petSlug: string,
 ): Promise<Array<Pick<PetCollection, "slug" | "title" | "ownerId">>> {
-  return cachedAggregate(
-    {
-      key: collectionBacklinksCacheKey(petSlug),
-      ttlSeconds: COLLECTION_BACKLINKS_TTL_SECONDS,
-    },
-    async () => {
-      try {
-        const rows = await db
-          .select({
-            slug: schema.petCollections.slug,
-            title: schema.petCollections.title,
-            ownerId: schema.petCollections.ownerId,
-          })
-          .from(schema.petCollectionItems)
-          .innerJoin(
-            schema.petCollections,
-            eq(
-              schema.petCollectionItems.collectionId,
-              schema.petCollections.id,
-            ),
-          )
-          .where(
-            and(
-              eq(schema.petCollectionItems.petSlug, petSlug),
-              eq(schema.petCollections.featured, true),
-            ),
-          )
-          .orderBy(asc(schema.petCollections.title));
-        return rows;
-      } catch (error) {
-        if (isMissingCollectionTableError(error)) return [];
-        throw error;
-      }
-    },
-  );
+  return withNextDataCache(
+    async () =>
+      cachedAggregate(
+        {
+          key: collectionBacklinksCacheKey(petSlug),
+          ttlSeconds: COLLECTION_BACKLINKS_TTL_SECONDS,
+        },
+        async () => {
+          try {
+            const rows = await db
+              .select({
+                slug: schema.petCollections.slug,
+                title: schema.petCollections.title,
+                ownerId: schema.petCollections.ownerId,
+              })
+              .from(schema.petCollectionItems)
+              .innerJoin(
+                schema.petCollections,
+                eq(
+                  schema.petCollectionItems.collectionId,
+                  schema.petCollections.id,
+                ),
+              )
+              .where(
+                and(
+                  eq(schema.petCollectionItems.petSlug, petSlug),
+                  eq(schema.petCollections.featured, true),
+                ),
+              )
+              .orderBy(asc(schema.petCollections.title));
+            return rows;
+          } catch (error) {
+            if (isMissingCollectionTableError(error)) return [];
+            throw error;
+          }
+        },
+      ),
+    ["petdex-collection-backlinks", petSlug],
+    { tags: [`collection:backlinks:${petSlug}`], revalidate: 600 },
+  )();
 }
 
 function isMissingCollectionTableError(error: unknown): boolean {

--- a/src/lib/db/cached-aggregates.ts
+++ b/src/lib/db/cached-aggregates.ts
@@ -144,13 +144,15 @@ export async function invalidateMetricCaches(
 export async function invalidatePublicProfileCaches(
   ...userIds: string[]
 ): Promise<void> {
+  const cleanUserIds = userIds.filter(Boolean);
   await invalidateAggregates(
-    ...userIds
-      .filter(Boolean)
-      .flatMap((userId) => [
-        publicProfileCacheKey(userId),
-        handleForUserCacheKey(userId),
-      ]),
+    ...cleanUserIds.flatMap((userId) => [
+      publicProfileCacheKey(userId),
+      handleForUserCacheKey(userId),
+    ]),
+  );
+  await expireNextCacheTags(
+    ...cleanUserIds.map((userId) => `petdex:profile:${userId}`),
   );
 }
 
@@ -167,8 +169,12 @@ export async function invalidatePublicHandleCaches(
 export async function invalidateCollectionBacklinks(
   ...slugs: string[]
 ): Promise<void> {
+  const cleanSlugs = slugs.filter(Boolean);
   await invalidateAggregates(
-    ...slugs.filter(Boolean).map((slug) => collectionBacklinksCacheKey(slug)),
+    ...cleanSlugs.map((slug) => collectionBacklinksCacheKey(slug)),
+  );
+  await expireNextCacheTags(
+    ...cleanSlugs.map((slug) => `collection:backlinks:${slug}`),
   );
 }
 
@@ -179,6 +185,7 @@ export async function invalidateCollectionBacklinks(
 const NEXT_TAGS_FOR_KEY: Record<string, string[]> = {
   [AGGREGATE_KEYS.facets]: ["petdex:facets"],
   [AGGREGATE_KEYS.dexNumbers]: ["petdex:dex"],
+  [AGGREGATE_KEYS.variantIndex]: ["petdex:variant-index"],
 };
 
 // Invalidate keys after writes that change the aggregate (approve,
@@ -203,16 +210,16 @@ export async function invalidateAggregates(...keys: string[]): Promise<void> {
   }
   if (tags.size === 0) return;
 
+  await expireNextCacheTags(...tags);
+}
+
+async function expireNextCacheTags(...tags: string[]): Promise<void> {
+  const cleanTags = tags.filter(Boolean);
+  if (cleanTags.length === 0) return;
+
   try {
     const { revalidateTag } = await import("next/cache");
-    // Next 16's `revalidateTag(tag, "max")` is stale-while-revalidate —
-    // it marks the entry stale and serves the old value while refreshing
-    // in the background. That's the wrong semantics here: after we've
-    // already deleted the Upstash value, a background refresh from the
-    // inner Next cache would re-seed Upstash with the stale data.
-    // `{ expire: 0 }` forces immediate eviction so the next read is a
-    // real miss that hits the DB.
-    for (const tag of tags) revalidateTag(tag, { expire: 0 });
+    for (const tag of cleanTags) revalidateTag(tag, { expire: 0 });
   } catch {
     /* next/cache unavailable in some runtime contexts (tests, scripts) */
   }

--- a/src/lib/owner-credit.ts
+++ b/src/lib/owner-credit.ts
@@ -23,6 +23,7 @@ import {
   publicProfileCacheKey,
 } from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
+import { withNextDataCache } from "@/lib/next-data-cache";
 
 export type OwnerExternal = {
   provider: "github" | "x";
@@ -324,35 +325,41 @@ export async function resolveStoredOwnerCreditFor(
 export async function resolveStoredOwnerCreditForSlug(
   slug: string,
 ): Promise<StoredOwnerCredit | null> {
-  const row = await cachedAggregate<RowCreditFallback | null>(
-    {
-      key: petOwnerCreditCacheKey(slug),
-      ttlSeconds: PET_OWNER_CREDIT_TTL_SECONDS,
-    },
-    async () => {
-      const stored = await db.query.submittedPets.findFirst({
-        columns: {
-          ownerId: true,
-          creditName: true,
-          creditUrl: true,
-          creditImage: true,
-          source: true,
+  const row = await withNextDataCache(
+    async () =>
+      cachedAggregate<RowCreditFallback | null>(
+        {
+          key: petOwnerCreditCacheKey(slug),
+          ttlSeconds: PET_OWNER_CREDIT_TTL_SECONDS,
         },
-        where: and(
-          eq(schema.submittedPets.slug, slug),
-          eq(schema.submittedPets.status, "approved"),
-        ),
-      });
-      if (!stored) return null;
-      return {
-        ownerId: stored.ownerId,
-        creditName: stored.creditName,
-        creditUrl: stored.creditUrl,
-        creditImage: stored.source === "discover" ? null : stored.creditImage,
-        ownerIsProxy: stored.source === "discover",
-      };
-    },
-  );
+        async () => {
+          const stored = await db.query.submittedPets.findFirst({
+            columns: {
+              ownerId: true,
+              creditName: true,
+              creditUrl: true,
+              creditImage: true,
+              source: true,
+            },
+            where: and(
+              eq(schema.submittedPets.slug, slug),
+              eq(schema.submittedPets.status, "approved"),
+            ),
+          });
+          if (!stored) return null;
+          return {
+            ownerId: stored.ownerId,
+            creditName: stored.creditName,
+            creditUrl: stored.creditUrl,
+            creditImage:
+              stored.source === "discover" ? null : stored.creditImage,
+            ownerIsProxy: stored.source === "discover",
+          };
+        },
+      ),
+    ["petdex-pet-owner-credit", slug],
+    { tags: [`pet:${slug}`], revalidate: PET_OWNER_CREDIT_TTL_SECONDS },
+  )();
 
   if (!row) return null;
   return {
@@ -364,24 +371,32 @@ export async function resolveStoredOwnerCreditForSlug(
 async function getStoredPublicProfile(
   userId: string,
 ): Promise<StoredPublicProfile | null> {
-  return cachedAggregate(
+  return withNextDataCache(
+    async () =>
+      cachedAggregate(
+        {
+          key: publicProfileCacheKey(userId),
+          ttlSeconds: PUBLIC_PROFILE_TTL_SECONDS,
+        },
+        async () => {
+          try {
+            const [storedProfile] = await db
+              .select({
+                displayName: schema.userProfiles.displayName,
+                handle: schema.userProfiles.handle,
+              })
+              .from(schema.userProfiles)
+              .where(inArray(schema.userProfiles.userId, [userId]));
+            return storedProfile ?? { displayName: null, handle: null };
+          } catch {
+            return null;
+          }
+        },
+      ),
+    ["petdex-public-profile", userId],
     {
-      key: publicProfileCacheKey(userId),
-      ttlSeconds: PUBLIC_PROFILE_TTL_SECONDS,
+      tags: [`petdex:profile:${userId}`],
+      revalidate: PUBLIC_PROFILE_TTL_SECONDS,
     },
-    async () => {
-      try {
-        const [storedProfile] = await db
-          .select({
-            displayName: schema.userProfiles.displayName,
-            handle: schema.userProfiles.handle,
-          })
-          .from(schema.userProfiles)
-          .where(inArray(schema.userProfiles.userId, [userId]));
-        return storedProfile ?? { displayName: null, handle: null };
-      } catch {
-        return null;
-      }
-    },
-  );
+  )();
 }

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -5,6 +5,7 @@ import { eq } from "drizzle-orm";
 import { AGGREGATE_KEYS, cachedAggregate } from "@/lib/db/cached-aggregates";
 import { db, schema } from "@/lib/db/client";
 import { getDexNumberMap } from "@/lib/dex";
+import { withNextDataCache } from "@/lib/next-data-cache";
 
 export const VARIANT_DISTANCE_THRESHOLD = 14;
 export const VARIANT_MAX_RESULTS = 6;
@@ -28,29 +29,37 @@ type VariantIndexRow = {
 const VARIANT_INDEX_TTL_SECONDS = 600;
 
 const getVariantIndex = cache(async (): Promise<VariantIndexRow[]> => {
-  return cachedAggregate(
-    { key: AGGREGATE_KEYS.variantIndex, ttlSeconds: VARIANT_INDEX_TTL_SECONDS },
-    async () => {
-      const rows = await db.query.submittedPets.findMany({
-        columns: {
-          slug: true,
-          displayName: true,
-          spritesheetUrl: true,
-          dhash: true,
-          source: true,
+  return withNextDataCache(
+    async () =>
+      cachedAggregate(
+        {
+          key: AGGREGATE_KEYS.variantIndex,
+          ttlSeconds: VARIANT_INDEX_TTL_SECONDS,
         },
-        where: eq(schema.submittedPets.status, "approved"),
-      });
+        async () => {
+          const rows = await db.query.submittedPets.findMany({
+            columns: {
+              slug: true,
+              displayName: true,
+              spritesheetUrl: true,
+              dhash: true,
+              source: true,
+            },
+            where: eq(schema.submittedPets.status, "approved"),
+          });
 
-      return rows.map((row) => ({
-        slug: row.slug,
-        displayName: row.displayName,
-        spritesheetUrl: row.spritesheetUrl,
-        dhash: row.dhash,
-        source: row.source,
-      }));
-    },
-  );
+          return rows.map((row) => ({
+            slug: row.slug,
+            displayName: row.displayName,
+            spritesheetUrl: row.spritesheetUrl,
+            dhash: row.dhash,
+            source: row.source,
+          }));
+        },
+      ),
+    ["petdex-variant-index"],
+    { tags: ["petdex:variant-index"], revalidate: VARIANT_INDEX_TTL_SECONDS },
+  )();
 });
 
 export const getVariantsFor = cache(


### PR DESCRIPTION
## Summary
- force the pet detail route back onto the static/ISR path
- pass the pet page locale explicitly to next-intl
- wrap pet detail auxiliary reads for owner credit, collection backlinks, and variants in Next data cache so Redis-backed aggregate fetches do not make the HTML private/no-store
- wire the new Next cache tags into existing invalidation helpers for variant index, collection backlinks, and public profile data

## Evidence
- production before this PR: `/pets/nickel-file-corner` returned `cache-control: private, no-cache, no-store, max-age=0, must-revalidate` and `x-vercel-cache: MISS`
- local production build after this PR: `/pets/nickel-file-corner` in mock data 404 still returned `Cache-Control: s-maxage=86400, stale-while-revalidate=31449600`, proving the route shell is no longer no-store
- `next build` route output now classifies `/[locale]/pets/[slug]` as static instead of dynamic server-rendered

## Validation
- `bunx biome check --write src/app/[locale]/pets/[slug]/page.tsx src/lib/collections.ts src/lib/owner-credit.ts src/lib/variants.ts`
- `bunx biome check src/lib/db/cached-aggregates.ts src/lib/collections.ts src/lib/owner-credit.ts src/lib/variants.ts src/app/[locale]/pets/[slug]/page.tsx`
- `bun run check`
- `bun run i18n:check`
- `git diff --check`
- `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build`

## Known unrelated local test failures
- `bun test --env-file=.env.mock` currently fails on existing source-text tests that expect literal UI strings already replaced by `useTranslations` on `origin/main`
- the same full run also fails for independent CLI package tests because root install does not install `@clack/prompts`, which matches the repo note that CLI packages install independently
