### PR TITLE
Make collection detail pages cacheable

### DIFF
--- a/src/app/[locale]/collections/[slug]/page.tsx
+++ b/src/app/[locale]/collections/[slug]/page.tsx
@@ -1,26 +1,26 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
-import { auth } from "@clerk/nextjs/server";
 import { ExternalLink, Heart, TerminalSquare } from "lucide-react";
-import { getTranslations } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 
-import { getCaughtSlugSet } from "@/lib/catch-status";
 import { getCollection } from "@/lib/collections";
 import { getDexNumberMap } from "@/lib/dex";
 import { formatLocalizedNumber } from "@/lib/format-number";
 import { buildLocaleAlternates } from "@/lib/locale-routing";
-import { resolveOwnerCredits } from "@/lib/owner-credit";
+import { getStoredPublicProfileForUser } from "@/lib/owner-credit";
 
+import { CollectionCaughtProgress } from "@/components/collection-caught-progress";
 import { CollectionPetGrid } from "@/components/collection-pet-grid";
 import { JsonLd } from "@/components/json-ld";
 import { PetSprite } from "@/components/pet-sprite";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 
-import { hasLocale } from "@/i18n/config";
+import { defaultLocale, hasLocale } from "@/i18n/config";
 
-export const dynamic = "force-dynamic";
+export const dynamic = "force-static";
+export const revalidate = 86400;
 
 const SITE_URL = "https://petdex.crafter.run";
 
@@ -65,33 +65,27 @@ export async function generateMetadata({ params }: PageProps) {
 
 export default async function CollectionPage({ params }: PageProps) {
   const { slug, locale } = await params;
+  const localeValue = hasLocale(locale) ? locale : defaultLocale;
+  setRequestLocale(localeValue);
   const collection = await getCollection(slug);
   if (!collection) notFound();
-  const t = await getTranslations("collectionDetail");
+  const t = await getTranslations({
+    locale: localeValue,
+    namespace: "collectionDetail",
+  });
 
-  const { userId } = await auth();
-  const [caughtSlugs, dexEntries, credits] = await Promise.all([
-    getCaughtSlugSet(userId),
+  const [dexEntries, ownerProfile] = await Promise.all([
     getDexNumberMap(),
     collection.ownerId
-      ? resolveOwnerCredits([
-          {
-            ownerId: collection.ownerId,
-            creditName: null,
-            creditUrl: null,
-            creditImage: null,
-          },
-        ])
-      : Promise.resolve(new Map()),
+      ? getStoredPublicProfileForUser(collection.ownerId)
+      : Promise.resolve(null),
   ]);
-  const owner = collection.ownerId ? credits.get(collection.ownerId) : null;
+  const ownerHref = ownerProfile?.handle ? `/u/${ownerProfile.handle}` : null;
+  const petSlugs = collection.pets.map((pet) => pet.slug);
   const leadPet =
     collection.pets.find((pet) => pet.slug === collection.coverPetSlug) ??
     collection.pets[0] ??
     null;
-  const caughtCount = collection.pets.filter((pet) =>
-    caughtSlugs.has(pet.slug),
-  ).length;
   const totalLikes = collection.pets.reduce(
     (acc, pet) => acc + pet.metrics.likeCount,
     0,
@@ -101,7 +95,6 @@ export default async function CollectionPage({ params }: PageProps) {
     0,
   );
   const dexMap = Object.fromEntries(dexEntries.entries());
-
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
@@ -146,9 +139,9 @@ export default async function CollectionPage({ params }: PageProps) {
               </p>
 
               <div className="mt-6 flex flex-wrap items-center gap-3">
-                {owner ? (
+                {ownerHref ? (
                   <Link
-                    href={`/u/${owner.handle}`}
+                    href={ownerHref}
                     prefetch={false}
                     className="inline-flex h-10 items-center rounded-full bg-inverse px-4 text-sm font-medium text-on-inverse transition hover:bg-inverse-hover"
                   >
@@ -170,11 +163,7 @@ export default async function CollectionPage({ params }: PageProps) {
 
               <div className="mt-6 flex flex-wrap items-center gap-x-5 gap-y-2 font-mono text-[11px] tracking-[0.18em] text-muted-3 uppercase">
                 <span>{collection.pets.length} pets</span>
-                {userId ? (
-                  <span>
-                    caught {caughtCount}/{collection.pets.length}
-                  </span>
-                ) : null}
+                <CollectionCaughtProgress petSlugs={petSlugs} />
                 {totalLikes > 0 ? (
                   <span className="inline-flex items-center gap-1.5">
                     <Heart className="size-3" />
@@ -222,11 +211,7 @@ export default async function CollectionPage({ params }: PageProps) {
           </Link>
         </div>
 
-        <CollectionPetGrid
-          pets={collection.pets}
-          dexMap={dexMap}
-          caughtSlugs={[...caughtSlugs]}
-        />
+        <CollectionPetGrid pets={collection.pets} dexMap={dexMap} />
       </section>
 
       <SiteFooter />

--- a/src/components/collection-caught-progress.tsx
+++ b/src/components/collection-caught-progress.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { useHeaderState } from "@/components/header-state-provider";
+
+type Props = {
+  petSlugs: string[];
+};
+
+export function CollectionCaughtProgress({ petSlugs }: Props) {
+  const { state } = useHeaderState();
+  const caughtCount = useMemo(() => {
+    const caught = new Set(state.caught);
+    return petSlugs.filter((slug) => caught.has(slug)).length;
+  }, [petSlugs, state.caught]);
+
+  if (!state.signedIn) return null;
+
+  return (
+    <span>
+      caught {caughtCount}/{petSlugs.length}
+    </span>
+  );
+}

--- a/src/components/collection-pet-grid.tsx
+++ b/src/components/collection-pet-grid.tsx
@@ -7,6 +7,7 @@ import { useLocale } from "next-intl";
 import type { PetWithMetrics } from "@/lib/pets";
 import { cn } from "@/lib/utils";
 
+import { useHeaderState } from "@/components/header-state-provider";
 import { PetCard } from "@/components/pet-gallery";
 
 const PAGE_SIZE = 24;
@@ -14,13 +15,18 @@ const PAGE_SIZE = 24;
 type Props = {
   pets: PetWithMetrics[];
   dexMap: Record<string, number>;
-  caughtSlugs: string[];
+  caughtSlugs?: string[];
 };
 
-export function CollectionPetGrid({ pets, dexMap, caughtSlugs }: Props) {
+export function CollectionPetGrid({ pets, dexMap, caughtSlugs = [] }: Props) {
   const isZh = useLocale() === "zh";
+  const { state } = useHeaderState();
   const [pageCount, setPageCount] = useState(1);
-  const caughtSet = useMemo(() => new Set(caughtSlugs), [caughtSlugs]);
+  const activeCaughtSlugs = state.signedIn ? state.caught : caughtSlugs;
+  const caughtSet = useMemo(
+    () => new Set(activeCaughtSlugs),
+    [activeCaughtSlugs],
+  );
 
   const slice = useMemo(
     () => pets.slice(0, pageCount * PAGE_SIZE),

--- a/src/lib/owner-credit.ts
+++ b/src/lib/owner-credit.ts
@@ -400,3 +400,9 @@ async function getStoredPublicProfile(
     },
   )();
 }
+
+export async function getStoredPublicProfileForUser(
+  userId: string,
+): Promise<StoredPublicProfile | null> {
+  return getStoredPublicProfile(userId);
+}


### PR DESCRIPTION
## Summary
- move `/collections/[slug]` off force-dynamic and onto the static/ISR path
- remove server-side auth and caught-slug reads from the collection shell
- read caught progress from the existing client header-state provider
- render the creator link only when a stored public profile handle exists, avoiding fallback handles that can 404

## Evidence
- production before this PR: `/collections/ebl2eyxu` returned `cache-control: private, no-cache, no-store, max-age=0, must-revalidate` and `x-vercel-cache: MISS`
- local production build after this PR classifies `/[locale]/collections/[slug]` as `○ Static`
- local `next start` after this PR returns `Cache-Control: s-maxage=86400, stale-while-revalidate=31449600` for `/collections/ebl2eyxu` in mock 404, proving the route shell is no longer no-store

## Validation
- `bunx biome check src/app/[locale]/collections/[slug]/page.tsx src/components/collection-caught-progress.tsx src/components/collection-pet-grid.tsx`
- `bunx biome check src/app/[locale]/collections/[slug]/page.tsx src/components/collection-caught-progress.tsx src/components/collection-pet-grid.tsx src/lib/owner-credit.ts`
- `bun run check`
- `bun run i18n:check`
- `git diff --check`
- `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build`
