### PR TITLE
Fix root test suite drift

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -49,6 +49,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.14",
+        "@clack/prompts": "^1.3.0",
         "@tailwindcss/postcss": "^4.2.4",
         "@types/ali-oss": "^6.23.3",
         "@types/node": "^25.6.0",
@@ -56,6 +57,7 @@
         "@types/react-dom": "^19.2.3",
         "bun-types": "^1.3.13",
         "drizzle-kit": "^0.31.10",
+        "picocolors": "^1.1.1",
         "postgres": "^3.4.9",
         "tailwindcss": "^4.2.4",
         "typescript": "^6.0.3",
@@ -237,6 +239,10 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.14", "", { "os": "win32", "cpu": "x64" }, "sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA=="],
+
+    "@clack/core": ["@clack/core@1.4.1", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-FILJa1gGKEFTGZAJE9RpVhrjKz3c3h4ar60dSv6cGuDqufQ84YEIS3GAGvZiN+H6yaLbbvTFNejjCC4tXpZEuw=="],
+
+    "@clack/prompts": ["@clack/prompts@1.5.1", "", { "dependencies": { "@clack/core": "1.4.1", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw=="],
 
     "@clerk/backend": ["@clerk/backend@3.4.4", "", { "dependencies": { "@clerk/shared": "^4.9.0", "standardwebhooks": "^1.0.0", "tslib": "2.8.1" } }, "sha512-EGdpxBG1joIYzRBtpzTq2FGyM2ErSSF2UB7FZXrHiSb6V/uRUcvVcX7IWvYeEyg1AG100gJWr0KpbutajVCLMA=="],
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.14",
+    "@clack/prompts": "^1.3.0",
     "@tailwindcss/postcss": "^4.2.4",
     "@types/ali-oss": "^6.23.3",
     "@types/node": "^25.6.0",
@@ -74,6 +75,7 @@
     "@types/react-dom": "^19.2.3",
     "bun-types": "^1.3.13",
     "drizzle-kit": "^0.31.10",
+    "picocolors": "^1.1.1",
     "postgres": "^3.4.9",
     "tailwindcss": "^4.2.4",
     "typescript": "^6.0.3"

--- a/src/components/desktop-announcement-modal.test.ts
+++ b/src/components/desktop-announcement-modal.test.ts
@@ -16,8 +16,9 @@ describe("DesktopAnnouncementModal theme classes", () => {
     expect(source).not.toContain("vibe-search");
   });
 
-  it("announces the Desktop App feature", () => {
-    expect(source).toContain("Desktop App");
-    expect(source).toContain("cta_download");
+  it("announces through the desktop announcement message namespace", () => {
+    expect(source).toContain('useTranslations("desktopAnnouncement")');
+    expect(source).toContain('t("title")');
+    expect(source).toContain('t("downloadCta")');
   });
 });

--- a/src/components/pinned-reorder-grid.test.ts
+++ b/src/components/pinned-reorder-grid.test.ts
@@ -30,7 +30,8 @@ describe("PinnedReorderGrid behavior contract", () => {
   });
 
   it("keeps failure recovery visible", () => {
-    expect(source).toContain("Could not save order");
+    expect(source).toContain('useTranslations("pinnedReorder")');
+    expect(source).toContain('t("saveError", { error })');
     expect(source).toContain("Retry");
     expect(source).toContain("Restore saved order");
   });


### PR DESCRIPTION
## Summary
- update source-string tests to assert the current i18n wiring instead of removed literal copy
- add root dev deps needed by CLI package tests discovered by the root Bun test runner
- keep package-local CLI dependencies unchanged

## Validation
- bun test --env-file=.env.mock src/components/desktop-announcement-modal.test.ts src/components/pinned-reorder-grid.test.ts packages/petdex-cli/src/desktop/select.test.ts packages/petdex-cli/src/desktop/install.test.ts packages/petdex-cli/src/desktop/update.test.ts packages/petdex-cli/src/hooks/install.test.ts packages/petdex-cli/src/hooks/uninstall.test.ts
- bun run check
- bun run i18n:check
- git diff --check
- bun test --env-file=.env.mock
- TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build