### PR TITLE
Slim collections page payload

### DIFF
--- a/src/app/[locale]/collections/page.tsx
+++ b/src/app/[locale]/collections/page.tsx
@@ -89,7 +89,11 @@ export default async function CollectionsPage({
     externalUrl: c.externalUrl,
     coverPetSlug: c.coverPetSlug,
     petCount: c.petCount,
-    pets: c.pets,
+    pets: c.pets.map((pet) => ({
+      slug: pet.slug,
+      displayName: pet.displayName,
+      spritesheetPath: pet.spritesheetPath,
+    })),
   }));
 
   return (

--- a/src/components/collection-cover.tsx
+++ b/src/components/collection-cover.tsx
@@ -9,12 +9,16 @@
 // server picks one offset and the client picks another; a slug-derived
 // pseudo-hash gives both sides the same answer without coordination.
 
-import type { PetWithMetrics } from "@/lib/pets";
-
 import { PetSprite } from "@/components/pet-sprite";
 
+export type CollectionCoverPet = {
+  slug: string;
+  displayName: string;
+  spritesheetPath: string;
+};
+
 type CollectionCoverProps = {
-  pets: PetWithMetrics[];
+  pets: CollectionCoverPet[];
   /** Slug to render largest and most prominent. Falls back to first pet. */
   coverSlug: string | null;
   /** Max sprites rendered. Defaults to 5 (works on mobile). */

--- a/src/components/collections-browser.tsx
+++ b/src/components/collections-browser.tsx
@@ -12,10 +12,12 @@ import {
   KIND_SLUG,
 } from "@/lib/collection-kind";
 import type { OwnerCredit } from "@/lib/owner-credit";
-import type { PetWithMetrics } from "@/lib/pets";
 
 import { CollectionActionMenu } from "@/components/collection-action-menu";
-import { CollectionCover } from "@/components/collection-cover";
+import {
+  CollectionCover,
+  type CollectionCoverPet,
+} from "@/components/collection-cover";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -39,7 +41,7 @@ type CollectionItem = {
   externalUrl: string | null;
   coverPetSlug: string | null;
   petCount: number;
-  pets: PetWithMetrics[];
+  pets: CollectionCoverPet[];
 };
 
 type SortKey = "size" | "title";


### PR DESCRIPTION
## Summary
- pass only the cover pet fields needed by the collections browser client component
- keep the existing collection listing UI and cache behavior unchanged
- reduce serialized `/collections` payload pressure behind Fast Origin Transfer

## Evidence
- production `/collections` is already cache HIT, but transfers about 1.04 MB uncompressed and 180 KB gzip
- the previous client boundary received full `PetWithMetrics` objects for each preview pet, while the cover only reads `slug`, `displayName`, and `spritesheetPath`

## Validation
- `bunx biome check --write src/app/[locale]/collections/page.tsx src/components/collection-cover.tsx src/components/collections-browser.tsx`
- `bun run check`
- `bun run i18n:check`
- `git diff --check`
- `bun test --env-file=.env.mock`
- `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build`