### PR TITLE
Use slim sitemap data queries

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,11 +1,11 @@
 import type { MetadataRoute } from "next";
 
-import { getAllCollections } from "@/lib/collections";
+import { getCollectionSitemapEntries } from "@/lib/collections";
 import {
   buildAbsoluteLocaleAlternates,
   buildAbsoluteUrl,
 } from "@/lib/locale-routing";
-import { getAllApprovedPets } from "@/lib/pets";
+import { getPetSitemapEntries } from "@/lib/pets";
 import { PET_KINDS, PET_VIBES } from "@/lib/types";
 
 export const revalidate = 86400;
@@ -47,8 +47,8 @@ function expandLocalizedEntry(entry: EntryInput): MetadataRoute.Sitemap {
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const [pets, collections] = await Promise.all([
-    getAllApprovedPets(),
-    getAllCollections(),
+    getPetSitemapEntries(),
+    getCollectionSitemapEntries(),
   ]);
   const now = new Date();
 

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -31,6 +31,12 @@ export type PetCollectionWithPets = PetCollection & {
   pets: PetWithMetrics[];
 };
 
+export type CollectionSitemapEntry = {
+  slug: string;
+  updatedAt: Date;
+  featured: boolean;
+};
+
 export async function getFeaturedCollections(
   limit = 3,
 ): Promise<PetCollectionWithPets[]> {
@@ -99,6 +105,30 @@ export async function getAllCollections(): Promise<PetCollectionWithPets[]> {
       return hydrateCollections(rows);
     },
     ["petdex-all-collections"],
+    { tags: ["collection:list"], revalidate: 86400 },
+  )();
+}
+
+export async function getCollectionSitemapEntries(): Promise<
+  CollectionSitemapEntry[]
+> {
+  return withNextDataCache(
+    async () => {
+      try {
+        return await db
+          .select({
+            slug: schema.petCollections.slug,
+            updatedAt: schema.petCollections.updatedAt,
+            featured: schema.petCollections.featured,
+          })
+          .from(schema.petCollections)
+          .orderBy(asc(schema.petCollections.slug));
+      } catch (error) {
+        if (isMissingCollectionTableError(error)) return [];
+        throw error;
+      }
+    },
+    ["petdex-collection-sitemap-entries"],
     { tags: ["collection:list"], revalidate: 86400 },
   )();
 }

--- a/src/lib/pets.ts
+++ b/src/lib/pets.ts
@@ -23,6 +23,12 @@ import type { PetdexPet, PetKind, PetVibe } from "@/lib/types";
 
 export type PetWithMetrics = PetdexPet & { metrics: Metrics };
 
+export type PetSitemapEntry = {
+  slug: string;
+  importedAt: string;
+  featured: boolean;
+};
+
 const EMPTY_METRICS: Metrics = {
   installCount: 0,
   zipDownloadCount: 0,
@@ -191,6 +197,32 @@ export async function getAllApprovedPets(): Promise<PetdexPet[]> {
         },
       ),
     ["petdex-all-approved-pets"],
+    { tags: ["pet:list"], revalidate: 86400 },
+  )();
+}
+
+export async function getPetSitemapEntries(): Promise<PetSitemapEntry[]> {
+  return withNextDataCache(
+    async () => {
+      const rows = await db
+        .select({
+          slug: schema.submittedPets.slug,
+          featured: schema.submittedPets.featured,
+          approvedAt: schema.submittedPets.approvedAt,
+          createdAt: schema.submittedPets.createdAt,
+        })
+        .from(schema.submittedPets)
+        .where(eq(schema.submittedPets.status, "approved"))
+        .orderBy(schema.submittedPets.slug);
+
+      return rows.map((row) => ({
+        slug: row.slug,
+        featured: row.featured,
+        importedAt:
+          row.approvedAt?.toISOString() ?? row.createdAt.toISOString(),
+      }));
+    },
+    ["petdex-pet-sitemap-entries"],
     { tags: ["pet:list"], revalidate: 86400 },
   )();
 }


### PR DESCRIPTION
## Summary
- fetch sitemap pets with only `slug`, `featured`, and the imported date source
- fetch sitemap collections with only `slug`, `updatedAt`, and `featured`
- keep sitemap URLs, alternates, priorities, and revalidation unchanged

## Evidence
- production `/sitemap.xml` is cache HIT but large: `5,301,334` bytes plain and `163,941` bytes gzip
- production-env build before this change logged `items over 2MB can not be cached (3362327 bytes)` while generating sitemap data
- after this change, production-env build no longer logs the sitemap data-cache size warning

## Validation
- `bunx biome check --write src/app/sitemap.ts src/lib/collections.ts src/lib/pets.ts`
- `bun run check`
- `bun run i18n:check`
- `git diff --check`
- `bun test --env-file=.env.mock`
- `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build`
- `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.local run build`