### PR TITLE
Throttle build version polling

### DIFF
--- a/src/components/build-version-watcher.tsx
+++ b/src/components/build-version-watcher.tsx
@@ -6,7 +6,8 @@ import { RefreshCw, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import {
-  fetchBuildVersion,
+  buildVersionBrowserCacheKey,
+  fetchBuildVersionWithBrowserCache,
   isChunkLoadFailure,
 } from "@/lib/build-version-check";
 import { createBuildVersionMonitor } from "@/lib/build-version-monitor";
@@ -14,7 +15,7 @@ import { CURRENT_BUILD_KEY } from "@/lib/current-build";
 
 import { Button } from "@/components/ui/button";
 
-const CHECK_INTERVAL_MS = 60_000;
+const CHECK_INTERVAL_MS = 10 * 60_000;
 
 type UpdateReason = "version" | "asset-load";
 
@@ -35,7 +36,10 @@ export function BuildVersionWatcher() {
         window.addEventListener(type, listener),
       clearInterval: (id) => window.clearInterval(id),
       currentVersion: CURRENT_BUILD_KEY,
-      fetchVersion: fetchBuildVersion,
+      fetchVersion: () =>
+        fetchBuildVersionWithBrowserCache(fetch, {
+          cacheKey: buildVersionBrowserCacheKey(CURRENT_BUILD_KEY),
+        }),
       intervalMs: CHECK_INTERVAL_MS,
       isChunkLoadFailure,
       isVisible: () => document.visibilityState === "visible",

--- a/src/lib/build-version-check.test.ts
+++ b/src/lib/build-version-check.test.ts
@@ -1,10 +1,43 @@
 import { describe, expect, it } from "bun:test";
 
 import {
+  buildVersionBrowserCacheKey,
   fetchBuildVersion,
+  fetchBuildVersionWithBrowserCache,
   getBuildVersionTokenFromPayload,
   isChunkLoadFailure,
+  readCachedBuildVersion,
+  writeCachedBuildVersion,
 } from "./build-version-check";
+
+class MemoryStorage implements Storage {
+  [name: string]: unknown;
+  #items = new Map<string, string>();
+
+  get length() {
+    return this.#items.size;
+  }
+
+  clear() {
+    this.#items.clear();
+  }
+
+  getItem(key: string) {
+    return this.#items.get(key) ?? null;
+  }
+
+  key(index: number) {
+    return [...this.#items.keys()][index] ?? null;
+  }
+
+  removeItem(key: string) {
+    this.#items.delete(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.#items.set(key, value);
+  }
+}
 
 describe("build version check helpers", () => {
   it("reads a non-empty version from version payloads", () => {
@@ -66,5 +99,115 @@ describe("build version check helpers", () => {
 
     expect(version).toBeNull();
     expect(signal?.aborted).toBe(true);
+  });
+
+  it("fetches the stable version path without a cache-busting query", async () => {
+    let requestedUrl: RequestInfo | URL | undefined;
+    let requestedInit: RequestInit | undefined;
+    const fetcher = ((url: RequestInfo | URL, init?: RequestInit) => {
+      requestedUrl = url;
+      requestedInit = init;
+      return Promise.resolve(
+        Response.json({
+          version: "abc123",
+          builtAt: "2026-05-17T00:00:00.000Z",
+        }),
+      );
+    }) as typeof fetch;
+
+    const version = await fetchBuildVersion(fetcher);
+
+    expect(version).toBe("abc123|2026-05-17T00:00:00.000Z");
+    expect(requestedUrl).toBe("/version.json");
+    expect(requestedInit?.cache).toBe("no-store");
+  });
+
+  it("coalesces build version checks through local storage", async () => {
+    const storage = new MemoryStorage();
+    let calls = 0;
+    const fetcher = (() => {
+      calls += 1;
+      return Promise.resolve(
+        Response.json({
+          version: "abc123",
+          builtAt: "2026-05-17T00:00:00.000Z",
+        }),
+      );
+    }) as typeof fetch;
+
+    const first = await fetchBuildVersionWithBrowserCache(fetcher, {
+      nowMs: 1_000,
+      storage,
+    });
+    const second = await fetchBuildVersionWithBrowserCache(fetcher, {
+      nowMs: 1_500,
+      storage,
+    });
+
+    expect(first).toBe("abc123|2026-05-17T00:00:00.000Z");
+    expect(second).toBe(first);
+    expect(calls).toBe(1);
+  });
+
+  it("expires cached build versions after the configured TTL", async () => {
+    const storage = new MemoryStorage();
+    writeCachedBuildVersion(storage, "old", 1_000);
+
+    expect(readCachedBuildVersion(storage, 1_500, 1_000)).toBe("old");
+    expect(readCachedBuildVersion(storage, 2_500, 1_000)).toBeNull();
+  });
+
+  it("scopes cached build versions by the running build", async () => {
+    const storage = new MemoryStorage();
+    writeCachedBuildVersion(
+      storage,
+      "old-build",
+      1_000,
+      buildVersionBrowserCacheKey("old-build"),
+    );
+
+    expect(
+      readCachedBuildVersion(
+        storage,
+        1_500,
+        10_000,
+        buildVersionBrowserCacheKey("new-build"),
+      ),
+    ).toBeNull();
+  });
+
+  it("falls back to network when browser storage is blocked", async () => {
+    const originalWindow = globalThis.window;
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: Object.defineProperty({}, "localStorage", {
+        get() {
+          throw new DOMException("Blocked", "SecurityError");
+        },
+      }),
+    });
+
+    let calls = 0;
+    const fetcher = (() => {
+      calls += 1;
+      return Promise.resolve(
+        Response.json({
+          version: "abc123",
+          builtAt: "2026-05-17T00:00:00.000Z",
+        }),
+      );
+    }) as typeof fetch;
+
+    try {
+      const version = await fetchBuildVersionWithBrowserCache(fetcher);
+
+      expect(version).toBe("abc123|2026-05-17T00:00:00.000Z");
+      expect(calls).toBe(1);
+    } finally {
+      Object.defineProperty(globalThis, "window", {
+        configurable: true,
+        value: originalWindow,
+      });
+    }
   });
 });

--- a/src/lib/build-version-check.ts
+++ b/src/lib/build-version-check.ts
@@ -2,6 +2,8 @@ import { createBuildVersionToken } from "@/lib/build-version-token";
 
 export const BUILD_VERSION_PATH = "/version.json";
 export const BUILD_VERSION_FETCH_TIMEOUT_MS = 5_000;
+export const BUILD_VERSION_BROWSER_CACHE_TTL_MS = 10 * 60_000;
+export const BUILD_VERSION_BROWSER_CACHE_KEY = "petdex:build-version";
 
 const CHUNK_LOAD_FAILURE_PATTERNS = [
   "chunkloaderror",
@@ -42,10 +44,10 @@ export async function fetchBuildVersion(
   );
 
   try {
-    const response = await fetcher(
-      `${BUILD_VERSION_PATH}?t=${Date.now().toString()}`,
-      { cache: "no-store", signal: controller.signal },
-    );
+    const response = await fetcher(BUILD_VERSION_PATH, {
+      cache: "no-store",
+      signal: controller.signal,
+    });
 
     if (!response.ok) {
       return null;
@@ -57,6 +59,83 @@ export async function fetchBuildVersion(
   } finally {
     clearTimeout(timeoutId);
   }
+}
+
+export async function fetchBuildVersionWithBrowserCache(
+  fetcher: typeof fetch = fetch,
+  options: {
+    maxAgeMs?: number;
+    nowMs?: number;
+    storage?: Storage | null;
+    timeoutMs?: number;
+    cacheKey?: string;
+  } = {},
+): Promise<string | null> {
+  const nowMs = options.nowMs ?? Date.now();
+  const maxAgeMs = options.maxAgeMs ?? BUILD_VERSION_BROWSER_CACHE_TTL_MS;
+  const storage = options.storage ?? browserStorage();
+  const cacheKey = options.cacheKey ?? BUILD_VERSION_BROWSER_CACHE_KEY;
+  const cached = readCachedBuildVersion(storage, nowMs, maxAgeMs, cacheKey);
+
+  if (cached) {
+    return cached;
+  }
+
+  const version = await fetchBuildVersion(fetcher, {
+    timeoutMs: options.timeoutMs,
+  });
+
+  if (version) {
+    writeCachedBuildVersion(storage, version, nowMs, cacheKey);
+  }
+
+  return version;
+}
+
+export function readCachedBuildVersion(
+  storage: Storage | null,
+  nowMs: number,
+  maxAgeMs = BUILD_VERSION_BROWSER_CACHE_TTL_MS,
+  cacheKey = BUILD_VERSION_BROWSER_CACHE_KEY,
+): string | null {
+  if (!storage) return null;
+
+  try {
+    const raw = storage.getItem(cacheKey);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { savedAt?: unknown; version?: unknown };
+
+    if (typeof parsed.version !== "string") return null;
+    if (typeof parsed.savedAt !== "number") return null;
+    if (!Number.isFinite(parsed.savedAt)) return null;
+    if (nowMs - parsed.savedAt < 0) return null;
+    if (nowMs - parsed.savedAt > maxAgeMs) return null;
+
+    return parsed.version;
+  } catch {
+    return null;
+  }
+}
+
+export function writeCachedBuildVersion(
+  storage: Storage | null,
+  version: string,
+  savedAt: number,
+  cacheKey = BUILD_VERSION_BROWSER_CACHE_KEY,
+): void {
+  if (!storage) return;
+
+  try {
+    storage.setItem(cacheKey, JSON.stringify({ savedAt, version }));
+  } catch {
+    return;
+  }
+}
+
+export function buildVersionBrowserCacheKey(currentVersion: string | null) {
+  return currentVersion
+    ? `${BUILD_VERSION_BROWSER_CACHE_KEY}:${currentVersion}`
+    : BUILD_VERSION_BROWSER_CACHE_KEY;
 }
 
 export function isChunkLoadFailure(errorLike: unknown): boolean {
@@ -96,4 +175,13 @@ function getErrorLikeMessage(errorLike: unknown): string {
   }
 
   return "";
+}
+
+function browserStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary
- reduce visible-tab build version polling from every 60 seconds to every 10 minutes
- cache `/version.json` results in localStorage per running build to coalesce reload, focus, and multi-tab checks
- keep stale chunk failure detection immediate

## Evidence
- production `/version.json` is `x-vercel-cache: HIT`, but every visible tab currently fetches `/version.json?t=...` immediately and every minute with `cache: no-store`
- this static route does not show up as a function hot route, but it still contributes to Edge Requests
- the change removes the timestamp query and limits network checks to one per browser/build TTL in normal browsing

## Validation
- `bunx biome check --write src/components/build-version-watcher.tsx src/lib/build-version-check.ts src/lib/build-version-check.test.ts`
- `bun test src/lib/build-version-check.test.ts src/components/build-version-watcher.test.ts`
- `bun run check`
- `bun run i18n:check`
- `git diff --check`
- `bun test --env-file=.env.mock`
- `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build`