### PR TITLE
Reduce header state polling across tabs

### DIFF
--- a/src/components/header-state-provider.tsx
+++ b/src/components/header-state-provider.tsx
@@ -12,6 +12,8 @@ import {
 import { useAuth } from "@clerk/nextjs";
 
 import {
+  claimHeaderStateRefresh,
+  clearCachedHeaderStateFromBrowser,
   HEADER_STATE_POLL_MS,
   type HeaderState,
   headerStateCacheKey,
@@ -20,9 +22,11 @@ import {
   INITIAL_HEADER_STATE,
   nextHeaderStatePollDelay,
   parseCachedHeaderState,
-  serializeHeaderState,
+  readCachedHeaderStateFromBrowser,
+  releaseHeaderStateRefreshClaim,
   shouldRequestHeaderState,
   withHeaderUnreadCount,
+  writeCachedHeaderStateToBrowser,
 } from "@/lib/header-state";
 
 type Ctx = {
@@ -51,6 +55,19 @@ export function HeaderStateProvider({
   const requestGeneration = useRef(0);
   const userScope = useRef<string | null>(null);
   const inFlightUser = useRef<string | null>(null);
+  const previousCacheKey = useRef<string | null>(null);
+
+  const applyCachedState = useCallback(
+    (now = Date.now()) => {
+      if (!cacheKey) return false;
+      const cached = readCachedHeaderStateFromBrowser(cacheKey, now);
+      if (!cached) return false;
+      setState(cached.state);
+      lastRefreshAt.current = cached.savedAt;
+      return true;
+    },
+    [cacheKey],
+  );
 
   const setUnreadCount = useCallback(
     (next: number | ((current: number) => number)) => {
@@ -63,6 +80,9 @@ export function HeaderStateProvider({
     async (options?: { force?: boolean }) => {
       const now = Date.now();
       const requestUserId = userId ?? null;
+      if (!options?.force) {
+        applyCachedState(now);
+      }
       if (
         !shouldRequestHeaderState({
           force: options?.force,
@@ -94,7 +114,7 @@ export function HeaderStateProvider({
         setState(json);
         lastRefreshAt.current = savedAt;
         if (cacheKey) {
-          writeCachedHeaderState(cacheKey, json, savedAt);
+          writeCachedHeaderStateToBrowser(cacheKey, json, savedAt);
         }
       } catch {
         return;
@@ -104,7 +124,7 @@ export function HeaderStateProvider({
         }
       }
     },
-    [cacheKey, isLoaded, isSignedIn, userId],
+    [applyCachedState, cacheKey, isLoaded, isSignedIn, userId],
   );
 
   useEffect(() => {
@@ -118,6 +138,10 @@ export function HeaderStateProvider({
       };
     }
     if (!isSignedIn) {
+      if (previousCacheKey.current) {
+        clearCachedHeaderStateFromBrowser(previousCacheKey.current);
+        previousCacheKey.current = null;
+      }
       setState(INITIAL_HEADER_STATE);
       lastRefreshAt.current = 0;
       return () => {
@@ -125,18 +149,13 @@ export function HeaderStateProvider({
         requestGeneration.current += 1;
       };
     }
-    let hasCachedState = false;
-    if (cacheKey) {
-      const cached = parseCachedHeaderState(
-        readCachedHeaderState(cacheKey),
-        Date.now(),
-      );
-      if (cached) {
-        setState(cached.state);
-        lastRefreshAt.current = cached.savedAt;
-        hasCachedState = true;
+    if (cacheKey && previousCacheKey.current !== cacheKey) {
+      if (previousCacheKey.current) {
+        clearCachedHeaderStateFromBrowser(previousCacheKey.current);
       }
+      previousCacheKey.current = cacheKey;
     }
+    const hasCachedState = applyCachedState();
     if (!hasCachedState) {
       setState(INITIAL_HEADER_STATE);
       lastRefreshAt.current = 0;
@@ -148,7 +167,30 @@ export function HeaderStateProvider({
     let cancelled = false;
     let intervalId: number | null = null;
     let timeoutId: number | null = null;
-    const poll = () => refreshIfVisible({ force: true });
+    const poll = () => {
+      if (document.visibilityState !== "visible") return;
+      const now = Date.now();
+      applyCachedState(now);
+      if (
+        !shouldRequestHeaderState({
+          isLoaded,
+          isSignedIn,
+          lastRefreshAt: lastRefreshAt.current,
+          now,
+        })
+      ) {
+        return;
+      }
+      const claim = cacheKey
+        ? claimHeaderStateRefresh(cacheKey, now)
+        : { shouldRefresh: true, token: null };
+      if (!claim.shouldRefresh) return;
+      void refresh({ force: true }).finally(() => {
+        if (cacheKey && claim.token) {
+          releaseHeaderStateRefreshClaim(cacheKey, claim.token);
+        }
+      });
+    };
     const schedulePoll = () => {
       if (cancelled) return;
       timeoutId = window.setTimeout(
@@ -163,7 +205,15 @@ export function HeaderStateProvider({
     void refresh().finally(schedulePoll);
     const onFocus = () => refreshIfVisible();
     const onVisibilityChange = () => refreshIfVisible();
+    const onStorage = (ev: StorageEvent) => {
+      if (ev.key !== cacheKey || !ev.newValue) return;
+      const cached = parseCachedHeaderState(ev.newValue, Date.now());
+      if (!cached || userScope.current !== (userId ?? null)) return;
+      setState(cached.state);
+      lastRefreshAt.current = cached.savedAt;
+    };
     window.addEventListener("focus", onFocus);
+    window.addEventListener("storage", onStorage);
     document.addEventListener("visibilitychange", onVisibilityChange);
     return () => {
       cancelled = true;
@@ -172,9 +222,10 @@ export function HeaderStateProvider({
       if (timeoutId !== null) window.clearTimeout(timeoutId);
       if (intervalId !== null) window.clearInterval(intervalId);
       window.removeEventListener("focus", onFocus);
+      window.removeEventListener("storage", onStorage);
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };
-  }, [cacheKey, isLoaded, isSignedIn, refresh, userId]);
+  }, [applyCachedState, cacheKey, isLoaded, isSignedIn, refresh, userId]);
 
   return (
     <HeaderStateContext.Provider value={{ refresh, setUnreadCount, state }}>
@@ -191,27 +242,4 @@ export function useHeaderState(): Ctx {
     setUnreadCount: () => {},
     state: INITIAL_HEADER_STATE,
   };
-}
-
-function readCachedHeaderState(cacheKey: string) {
-  try {
-    return window.sessionStorage.getItem(cacheKey);
-  } catch {
-    return null;
-  }
-}
-
-function writeCachedHeaderState(
-  cacheKey: string,
-  state: HeaderState,
-  savedAt: number,
-) {
-  try {
-    window.sessionStorage.setItem(
-      cacheKey,
-      serializeHeaderState(state, savedAt),
-    );
-  } catch {
-    return;
-  }
 }

--- a/src/lib/header-state.test.ts
+++ b/src/lib/header-state.test.ts
@@ -1,15 +1,20 @@
 import { describe, expect, it } from "bun:test";
 
 import {
+  claimHeaderStateRefresh,
+  clearCachedHeaderStateFromBrowser,
   headerStateCacheKey,
   headerStateFetchCacheMode,
   headerStateResponseSavedAt,
   INITIAL_HEADER_STATE,
   nextHeaderStatePollDelay,
   parseCachedHeaderState,
+  readCachedHeaderStateFromBrowser,
+  releaseHeaderStateRefreshClaim,
   serializeHeaderState,
   shouldRequestHeaderState,
   withHeaderUnreadCount,
+  writeCachedHeaderStateToBrowser,
 } from "@/lib/header-state";
 
 describe("header state helpers", () => {
@@ -83,6 +88,237 @@ describe("header state helpers", () => {
     expect(parseCachedHeaderState(raw, 500)).toBeNull();
   });
 
+  it("reads shared browser cache before tab-local fallback cache", () => {
+    const restore = installWindowStorage(
+      new MemoryStorage(),
+      new MemoryStorage(),
+    );
+    const cacheKey = signedInCacheKey();
+    const localState = {
+      ...INITIAL_HEADER_STATE,
+      signedIn: true,
+      notifications: { unreadCount: 2 },
+    };
+    const sessionState = {
+      ...INITIAL_HEADER_STATE,
+      signedIn: true,
+      notifications: { unreadCount: 1 },
+    };
+
+    try {
+      window.localStorage.setItem(
+        cacheKey,
+        serializeHeaderState(localState, 2_000),
+      );
+      window.sessionStorage.setItem(
+        cacheKey,
+        serializeHeaderState(sessionState, 1_000),
+      );
+
+      expect(readCachedHeaderStateFromBrowser(cacheKey, 3_000)?.state).toEqual(
+        localState,
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  it("falls back to tab-local cache when shared browser cache is blocked", () => {
+    const sessionStorage = new MemoryStorage();
+    const restore = installWindowStorage(blockedStorage(), sessionStorage);
+    const cacheKey = signedInCacheKey();
+    const state = {
+      ...INITIAL_HEADER_STATE,
+      signedIn: true,
+      caught: ["byte-bunny"],
+    };
+
+    try {
+      writeCachedHeaderStateToBrowser(cacheKey, state, 1_000);
+
+      expect(sessionStorage.getItem(cacheKey)).not.toBeNull();
+      expect(readCachedHeaderStateFromBrowser(cacheKey, 2_000)?.state).toEqual(
+        state,
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  it("falls back to fresh tab-local cache when shared cache is stale", () => {
+    const restore = installWindowStorage(
+      new MemoryStorage(),
+      new MemoryStorage(),
+    );
+    const cacheKey = signedInCacheKey();
+    const localState = {
+      ...INITIAL_HEADER_STATE,
+      signedIn: true,
+      notifications: { unreadCount: 9 },
+    };
+    const sessionState = {
+      ...INITIAL_HEADER_STATE,
+      signedIn: true,
+      notifications: { unreadCount: 3 },
+    };
+
+    try {
+      window.localStorage.setItem(
+        cacheKey,
+        serializeHeaderState(localState, 1_000),
+      );
+      window.sessionStorage.setItem(
+        cacheKey,
+        serializeHeaderState(sessionState, 900_000),
+      );
+
+      expect(
+        readCachedHeaderStateFromBrowser(cacheKey, 901_001)?.state,
+      ).toEqual(sessionState);
+    } finally {
+      restore();
+    }
+  });
+
+  it("uses the freshest browser cache across shared and tab-local storage", () => {
+    const restore = installWindowStorage(
+      new MemoryStorage(),
+      new MemoryStorage(),
+    );
+    const cacheKey = signedInCacheKey();
+    const localState = {
+      ...INITIAL_HEADER_STATE,
+      signedIn: true,
+      notifications: { unreadCount: 2 },
+    };
+    const sessionState = {
+      ...INITIAL_HEADER_STATE,
+      signedIn: true,
+      notifications: { unreadCount: 7 },
+    };
+
+    try {
+      window.localStorage.setItem(
+        cacheKey,
+        serializeHeaderState(localState, 1_000),
+      );
+      window.sessionStorage.setItem(
+        cacheKey,
+        serializeHeaderState(sessionState, 2_000),
+      );
+
+      expect(readCachedHeaderStateFromBrowser(cacheKey, 3_000)?.state).toEqual(
+        sessionState,
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  it("clears shared and tab-local browser cache for the signed-in user", () => {
+    const restore = installWindowStorage(
+      new MemoryStorage(),
+      new MemoryStorage(),
+    );
+    const cacheKey = signedInCacheKey();
+    const state = {
+      ...INITIAL_HEADER_STATE,
+      signedIn: true,
+      caught: ["byte-bunny"],
+    };
+
+    try {
+      window.localStorage.setItem(cacheKey, serializeHeaderState(state, 1_000));
+      window.sessionStorage.setItem(
+        cacheKey,
+        serializeHeaderState(state, 1_000),
+      );
+      expect(claimHeaderStateRefresh(cacheKey, 1_000, 15_000, "tab-a")).toEqual(
+        {
+          shouldRefresh: true,
+          token: "tab-a",
+        },
+      );
+
+      clearCachedHeaderStateFromBrowser(cacheKey);
+
+      expect(window.localStorage.getItem(cacheKey)).toBeNull();
+      expect(window.sessionStorage.getItem(cacheKey)).toBeNull();
+      expect(claimHeaderStateRefresh(cacheKey, 2_000, 15_000, "tab-b")).toEqual(
+        {
+          shouldRefresh: true,
+          token: "tab-b",
+        },
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  it("claims automatic refreshes with a short shared browser lock", () => {
+    const restore = installWindowStorage(
+      new MemoryStorage(),
+      new MemoryStorage(),
+    );
+    const cacheKey = signedInCacheKey();
+
+    try {
+      expect(claimHeaderStateRefresh(cacheKey, 1_000, 15_000, "tab-a")).toEqual(
+        {
+          shouldRefresh: true,
+          token: "tab-a",
+        },
+      );
+      expect(claimHeaderStateRefresh(cacheKey, 2_000, 15_000, "tab-b")).toEqual(
+        {
+          shouldRefresh: false,
+          token: null,
+        },
+      );
+      expect(
+        claimHeaderStateRefresh(cacheKey, 16_001, 15_000, "tab-b"),
+      ).toEqual({
+        shouldRefresh: true,
+        token: "tab-b",
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it("releases only the matching automatic refresh claim", () => {
+    const restore = installWindowStorage(
+      new MemoryStorage(),
+      new MemoryStorage(),
+    );
+    const cacheKey = signedInCacheKey();
+
+    try {
+      expect(claimHeaderStateRefresh(cacheKey, 1_000, 15_000, "tab-a")).toEqual(
+        {
+          shouldRefresh: true,
+          token: "tab-a",
+        },
+      );
+      releaseHeaderStateRefreshClaim(cacheKey, "tab-b");
+      expect(claimHeaderStateRefresh(cacheKey, 2_000, 15_000, "tab-c")).toEqual(
+        {
+          shouldRefresh: false,
+          token: null,
+        },
+      );
+      releaseHeaderStateRefreshClaim(cacheKey, "tab-a");
+      expect(claimHeaderStateRefresh(cacheKey, 3_000, 15_000, "tab-c")).toEqual(
+        {
+          shouldRefresh: true,
+          token: "tab-c",
+        },
+      );
+    } finally {
+      restore();
+    }
+  });
+
   it("schedules cached polls by remaining freshness window", () => {
     expect(nextHeaderStatePollDelay(0, 1_000)).toBe(900_000);
     expect(nextHeaderStatePollDelay(1_000, 61_000)).toBe(840_000);
@@ -137,3 +373,80 @@ describe("header state helpers", () => {
     expect(current.notifications.unreadCount).toBe(3);
   });
 });
+
+class MemoryStorage implements Storage {
+  private values = new Map<string, string>();
+
+  get length() {
+    return this.values.size;
+  }
+
+  clear() {
+    this.values.clear();
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number) {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
+function blockedStorage(): Storage {
+  return {
+    get length() {
+      throw new DOMException("Blocked", "SecurityError");
+    },
+    clear() {
+      throw new DOMException("Blocked", "SecurityError");
+    },
+    getItem() {
+      throw new DOMException("Blocked", "SecurityError");
+    },
+    key() {
+      throw new DOMException("Blocked", "SecurityError");
+    },
+    removeItem() {
+      throw new DOMException("Blocked", "SecurityError");
+    },
+    setItem() {
+      throw new DOMException("Blocked", "SecurityError");
+    },
+  };
+}
+
+function installWindowStorage(
+  localStorage: Storage,
+  sessionStorage: Storage,
+): () => void {
+  const originalWindow = globalThis.window;
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      localStorage,
+      sessionStorage,
+    },
+  });
+  return () => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+  };
+}
+
+function signedInCacheKey() {
+  const cacheKey = headerStateCacheKey("user_123");
+  if (!cacheKey) throw new Error("missing signed-in cache key");
+  return cacheKey;
+}

--- a/src/lib/header-state.ts
+++ b/src/lib/header-state.ts
@@ -16,10 +16,16 @@ export const HEADER_STATE_POLL_MS = 900_000;
 export const HEADER_STATE_MIN_REFRESH_MS = HEADER_STATE_POLL_MS;
 export const HEADER_STATE_CACHE_TTL_MS = HEADER_STATE_MIN_REFRESH_MS;
 export const HEADER_STATE_BROWSER_CACHE_SECONDS = 300;
+export const HEADER_STATE_REFRESH_LOCK_MS = 15_000;
 
-type CachedHeaderState = {
+export type CachedHeaderState = {
   savedAt: number;
   state: HeaderState;
+};
+
+export type HeaderStateRefreshClaim = {
+  shouldRefresh: boolean;
+  token: string | null;
 };
 
 export function headerStateCacheKey(userId: string | null | undefined) {
@@ -79,6 +85,81 @@ export function parseCachedHeaderState(
 
 export function serializeHeaderState(state: HeaderState, savedAt: number) {
   return JSON.stringify({ savedAt, state });
+}
+
+export function readCachedHeaderStateFromBrowser(
+  cacheKey: string,
+  now = Date.now(),
+): CachedHeaderState | null {
+  const local = parseCachedHeaderState(
+    readStorageValue(browserStorage("localStorage"), cacheKey),
+    now,
+  );
+  const session = parseCachedHeaderState(
+    readStorageValue(browserStorage("sessionStorage"), cacheKey),
+    now,
+  );
+  if (!local) return session;
+  if (!session) return local;
+  return local.savedAt >= session.savedAt ? local : session;
+}
+
+export function writeCachedHeaderStateToBrowser(
+  cacheKey: string,
+  state: HeaderState,
+  savedAt: number,
+) {
+  const raw = serializeHeaderState(state, savedAt);
+  if (writeStorageValue(browserStorage("localStorage"), cacheKey, raw)) return;
+  writeStorageValue(browserStorage("sessionStorage"), cacheKey, raw);
+}
+
+export function clearCachedHeaderStateFromBrowser(cacheKey: string) {
+  removeStorageValue(browserStorage("localStorage"), cacheKey);
+  removeStorageValue(browserStorage("sessionStorage"), cacheKey);
+  removeStorageValue(
+    browserStorage("localStorage"),
+    headerStateRefreshLockKey(cacheKey),
+  );
+}
+
+export function claimHeaderStateRefresh(
+  cacheKey: string,
+  now = Date.now(),
+  lockMs = HEADER_STATE_REFRESH_LOCK_MS,
+  token = `${now}:${Math.random()}`,
+): HeaderStateRefreshClaim {
+  const storage = browserStorage("localStorage");
+  if (!storage) return { shouldRefresh: true, token: null };
+  const lockKey = headerStateRefreshLockKey(cacheKey);
+  const current = parseRefreshLock(readStorageValue(storage, lockKey));
+  if (current && current.expiresAt > now) {
+    return { shouldRefresh: false, token: null };
+  }
+  const next = JSON.stringify({ expiresAt: now + lockMs, token });
+  if (!writeStorageValue(storage, lockKey, next)) {
+    return { shouldRefresh: true, token: null };
+  }
+  const saved = parseRefreshLock(readStorageValue(storage, lockKey));
+  return saved?.token === token
+    ? { shouldRefresh: true, token }
+    : { shouldRefresh: false, token: null };
+}
+
+export function releaseHeaderStateRefreshClaim(
+  cacheKey: string,
+  token: string,
+) {
+  const storage = browserStorage("localStorage");
+  if (!storage) return;
+  const lockKey = headerStateRefreshLockKey(cacheKey);
+  const current = parseRefreshLock(readStorageValue(storage, lockKey));
+  if (current?.token !== token) return;
+  try {
+    storage.removeItem(lockKey);
+  } catch {
+    return;
+  }
 }
 
 export function headerStateFetchCacheMode(force?: boolean): RequestCache {
@@ -142,4 +223,69 @@ function isString(value: unknown): value is string {
 
 function toNumber(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function headerStateRefreshLockKey(cacheKey: string) {
+  return `${cacheKey}:refresh-lock`;
+}
+
+function parseRefreshLock(raw: string | null): {
+  expiresAt: number;
+  token: string;
+} | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as { expiresAt?: unknown; token?: unknown };
+    if (
+      typeof parsed.expiresAt === "number" &&
+      Number.isFinite(parsed.expiresAt) &&
+      typeof parsed.token === "string"
+    ) {
+      return { expiresAt: parsed.expiresAt, token: parsed.token };
+    }
+  } catch {}
+  return null;
+}
+
+function browserStorage(
+  name: "localStorage" | "sessionStorage",
+): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window[name];
+  } catch {
+    return null;
+  }
+}
+
+function readStorageValue(storage: Storage | null, key: string): string | null {
+  if (!storage) return null;
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writeStorageValue(
+  storage: Storage | null,
+  key: string,
+  value: string,
+): boolean {
+  if (!storage) return false;
+  try {
+    storage.setItem(key, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function removeStorageValue(storage: Storage | null, key: string) {
+  if (!storage) return;
+  try {
+    storage.removeItem(key);
+  } catch {
+    return;
+  }
 }


### PR DESCRIPTION
## Summary
- share signed-in header-state cache across tabs via localStorage with sessionStorage fallback
- add a short localStorage claim for automatic polls so concurrent tabs do not all force-refresh /api/me/header-state
- keep manual forced refreshes for mutations unchanged

## Cost context
- latest 14:15Z route-cost bucket showed only GET /api/me/header-state with 4 samples / 4,000 estimated requests
- this targets duplicated signed-in tab polling without changing the API payload contract

## Verification
- bun run check
- bun run i18n:check
- bun test src/lib/header-state.test.ts
- bun test --env-file=.env.mock
- TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build