### PR TITLE
Make favorite and profile pin actions optimistic

### DIFF
--- a/src/app/[locale]/u/[handle]/page.tsx
+++ b/src/app/[locale]/u/[handle]/page.tsx
@@ -19,21 +19,15 @@ import { formatLocalizedNumber } from "@/lib/format-number";
 import { userIdForHandle } from "@/lib/handles";
 import { getOwnerRank } from "@/lib/leaderboard";
 import { buildLocaleAlternates } from "@/lib/locale-routing";
-import { petStates } from "@/lib/pet-states";
 import { type PetWithMetrics, rowToPet } from "@/lib/pets";
-import { MAX_PINNED_PETS } from "@/lib/profiles";
 
 import { JsonLd } from "@/components/json-ld";
 import type { Submission } from "@/components/my-pets-view";
-import { PetCard } from "@/components/pet-gallery";
-import { PetSprite } from "@/components/pet-sprite";
-import { PinnedReorderGrid } from "@/components/pinned-reorder-grid";
 import { ProfileAnalytics } from "@/components/profile-analytics";
 import { ProfileExternalLink } from "@/components/profile-external-link";
 import { ProfileInlineEditor } from "@/components/profile-inline-editor";
-import { ProfilePinButton } from "@/components/profile-pin-button";
+import { ProfilePinningSurface } from "@/components/profile-pinning-surface";
 import { ProfileShareButton } from "@/components/profile-share-button";
-import { ProfileTabs } from "@/components/profile-tabs";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 
@@ -244,11 +238,9 @@ export default async function UserProfilePage({ params }: PageProps) {
   // Resolve pinned slugs to full pet objects, preserving owner-chosen
   // order. Drop any that are no longer approved (would otherwise break
   // the layout with empty cards).
-  const featuredSet = new Set(featuredSlugs);
   const featuredPets = featuredSlugs
     .map((slug) => pets.find((p) => p.slug === slug))
     .filter((p): p is PetWithMetrics => Boolean(p));
-  const restPets = pets.filter((p) => !featuredSet.has(p.slug));
 
   // Aggregate stats.
   const totalLikes = pets.reduce((acc, p) => acc + p.metrics.likeCount, 0);
@@ -438,63 +430,11 @@ export default async function UserProfilePage({ params }: PageProps) {
       </section>
 
       <section className="mx-auto flex w-full max-w-[1440px] flex-col gap-8 px-5 py-12 md:px-8 md:py-16">
-        {featuredPets.length > 0 ? (
-          isOwner && featuredPets.length >= 2 ? (
-            <PinnedReorderGrid
-              pets={featuredPets}
-              petStateCount={petStates.length}
-              hideAuthor
-            />
-          ) : (
-            <div className="space-y-4">
-              <div className="flex items-center justify-between">
-                <p className="font-mono text-[11px] tracking-[0.22em] text-brand uppercase">
-                  ★ Pinned
-                </p>
-                <p className="font-mono text-[10px] tracking-[0.18em] text-muted-4 uppercase">
-                  {featuredPets.length} of {MAX_PINNED_PETS}
-                </p>
-              </div>
-              {featuredPets.length === 1 ? (
-                <div className="relative">
-                  <FeaturedPin
-                    pet={featuredPets[0]}
-                    locale={locale}
-                    installsLabel={(count: string) => t("installs", { count })}
-                  />
-                  {isOwner ? (
-                    <div className="absolute top-4 right-4 z-40">
-                      <ProfilePinButton
-                        slug={featuredPets[0].slug}
-                        isPinned
-                        pinnedCount={featuredPets.length}
-                        maxPins={MAX_PINNED_PETS}
-                      />
-                    </div>
-                  ) : null}
-                </div>
-              ) : (
-                <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-6">
-                  {featuredPets.map((pet, index) => (
-                    <div key={pet.slug} className="relative h-full">
-                      <PetCard
-                        pet={pet}
-                        index={index}
-                        stateCount={petStates.length}
-                        hideAuthor
-                      />
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          )
-        ) : null}
-
-        <ProfileTabs
+        <ProfilePinningSurface
           isOwner={isOwner}
           publicHandle={publicHandle}
-          approvedPets={restPets}
+          pets={pets}
+          initialPinnedSlugs={featuredSlugs}
           ownerSubmissions={ownerSubmissions}
           likedPets={likedPets}
           collection={
@@ -515,11 +455,6 @@ export default async function UserProfilePage({ params }: PageProps) {
             displayName: p.displayName,
             spritesheetUrl: p.spritesheetPath,
           }))}
-          pinning={
-            isOwner
-              ? { pinnedSlugs: featuredSlugs, maxPins: MAX_PINNED_PETS }
-              : null
-          }
           ownerCollections={ownerCollectionsForTabs}
           maxOwnerCollections={MAX_OWNER_COLLECTIONS}
         />
@@ -527,61 +462,5 @@ export default async function UserProfilePage({ params }: PageProps) {
 
       <SiteFooter />
     </main>
-  );
-}
-
-function FeaturedPin({
-  pet,
-  locale,
-  installsLabel,
-}: {
-  pet: PetWithMetrics;
-  locale: string;
-  installsLabel: (count: string) => string;
-}) {
-  return (
-    <Link
-      href={`/pets/${pet.slug}`}
-      prefetch={false}
-      aria-label={`Open ${pet.displayName}`}
-      className="featured-pin-card group relative flex flex-col overflow-hidden rounded-3xl border border-brand-light/45 bg-surface/80 backdrop-blur transition hover:bg-white md:flex-row md:items-stretch dark:hover:bg-stone-800"
-    >
-      <div className="pet-sprite-stage featured-pin-stage flex shrink-0 items-center justify-center px-8 py-10 md:w-[420px] md:py-14">
-        <PetSprite
-          src={pet.spritesheetPath}
-          cycleStates
-          scale={1.1}
-          label={`${pet.displayName} animated`}
-        />
-      </div>
-      <div className="flex flex-1 flex-col justify-center gap-3 border-t border-black/[0.06] p-6 md:border-t-0 md:border-l dark:border-white/[0.06]">
-        <span className="font-mono text-[11px] tracking-[0.22em] text-brand uppercase">
-          ★ Pinned
-        </span>
-        <h2 className="text-3xl font-semibold tracking-tight text-foreground md:text-4xl">
-          {pet.displayName}
-        </h2>
-        <p className="max-w-2xl text-base leading-7 text-muted-2">
-          {pet.description}
-        </p>
-        <div className="mt-1 flex flex-wrap items-center gap-3 font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
-          {pet.metrics.likeCount > 0 ? (
-            <span className="inline-flex items-center gap-1.5">
-              <Heart className="size-3" />
-              {formatLocalizedNumber(pet.metrics.likeCount, locale)}
-            </span>
-          ) : null}
-          {pet.metrics.installCount > 0 ? (
-            <span className="inline-flex items-center gap-1.5">
-              <TerminalSquare className="size-3" />
-              {installsLabel(
-                formatLocalizedNumber(pet.metrics.installCount, locale),
-              )}
-            </span>
-          ) : null}
-          <span>{pet.kind}</span>
-        </div>
-      </div>
-    </Link>
   );
 }

--- a/src/components/optimistic-actions.test.ts
+++ b/src/components/optimistic-actions.test.ts
@@ -26,6 +26,11 @@ const profileTabsSource = readFileSync(
   "utf8",
 );
 
+const pinnedReorderGridSource = readFileSync(
+  new URL("./pinned-reorder-grid.tsx", import.meta.url),
+  "utf8",
+);
+
 describe("optimistic lightweight actions", () => {
   it("keeps card favorites instant without a loading spinner", () => {
     expect(petCardFooterSource).not.toContain("Loader2");
@@ -62,6 +67,15 @@ describe("optimistic lightweight actions", () => {
     expect(profileTabsSource).toContain("onPinChange={pinning?.onPinChange}");
     expect(profileTabsSource).toContain("onPinChange?.(pet.slug, isPinned)");
     expect(profileTabsSource).not.toContain("pinning.onPinChange?.");
+  });
+
+  it("keeps a single owner-pinned pet in the compact pinned grid", () => {
+    expect(profilePinningSurfaceSource).toContain("isOwner ? (");
+    expect(profilePinningSurfaceSource).toContain("<PinnedReorderGrid");
+    expect(profilePinningSurfaceSource).not.toContain(
+      "isOwner && featuredPets.length >= 2",
+    );
+    expect(pinnedReorderGridSource).not.toContain('? "relative"');
   });
 
   it("does not duplicate favorite state with the old caught dot", () => {

--- a/src/components/optimistic-actions.test.ts
+++ b/src/components/optimistic-actions.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const petCardFooterSource = readFileSync(
+  new URL("./pet-card-footer.tsx", import.meta.url),
+  "utf8",
+);
+
+const profilePinButtonSource = readFileSync(
+  new URL("./profile-pin-button.tsx", import.meta.url),
+  "utf8",
+);
+
+describe("optimistic lightweight actions", () => {
+  it("keeps card favorites instant without a loading spinner", () => {
+    expect(petCardFooterSource).not.toContain("Loader2");
+    expect(petCardFooterSource).not.toContain("setBusy");
+    expect(petCardFooterSource).toContain("JSON.stringify({ liked: next })");
+    expect(petCardFooterSource).toContain("likeRequestSeq.current !== seq");
+  });
+
+  it("keeps profile pins instant without a loading spinner", () => {
+    expect(profilePinButtonSource).not.toContain("Loader2");
+    expect(profilePinButtonSource).not.toContain("setBusy");
+    expect(profilePinButtonSource).toContain("useState(isPinned)");
+    expect(profilePinButtonSource).toContain("setOptimisticPinned(nextPinned)");
+    expect(profilePinButtonSource).toContain("pinRequestSeq.current === seq");
+  });
+});

--- a/src/components/optimistic-actions.test.ts
+++ b/src/components/optimistic-actions.test.ts
@@ -35,6 +35,7 @@ describe("optimistic lightweight actions", () => {
   it("does not duplicate favorite state with the old caught dot", () => {
     expect(petGallerySource).not.toContain("CheckCircle2");
     expect(petGallerySource).not.toContain("caughtTitle");
-    expect(petGallerySource).not.toContain("caught={");
+    expect(petGallerySource).toContain("initialLiked={caught}");
+    expect(petCardFooterSource).toContain("setLiked(initialLiked)");
   });
 });

--- a/src/components/optimistic-actions.test.ts
+++ b/src/components/optimistic-actions.test.ts
@@ -21,6 +21,11 @@ const profilePinningSurfaceSource = readFileSync(
   "utf8",
 );
 
+const profileTabsSource = readFileSync(
+  new URL("./profile-tabs.tsx", import.meta.url),
+  "utf8",
+);
+
 describe("optimistic lightweight actions", () => {
   it("keeps card favorites instant without a loading spinner", () => {
     expect(petCardFooterSource).not.toContain("Loader2");
@@ -54,6 +59,9 @@ describe("optimistic lightweight actions", () => {
     expect(profilePinningSurfaceSource).toContain(
       "onPinChange: handlePinChange",
     );
+    expect(profileTabsSource).toContain("onPinChange={pinning?.onPinChange}");
+    expect(profileTabsSource).toContain("onPinChange?.(pet.slug, isPinned)");
+    expect(profileTabsSource).not.toContain("pinning.onPinChange?.");
   });
 
   it("does not duplicate favorite state with the old caught dot", () => {

--- a/src/components/optimistic-actions.test.ts
+++ b/src/components/optimistic-actions.test.ts
@@ -11,6 +11,11 @@ const profilePinButtonSource = readFileSync(
   "utf8",
 );
 
+const petGallerySource = readFileSync(
+  new URL("./pet-gallery.tsx", import.meta.url),
+  "utf8",
+);
+
 describe("optimistic lightweight actions", () => {
   it("keeps card favorites instant without a loading spinner", () => {
     expect(petCardFooterSource).not.toContain("Loader2");
@@ -25,5 +30,11 @@ describe("optimistic lightweight actions", () => {
     expect(profilePinButtonSource).toContain("useState(isPinned)");
     expect(profilePinButtonSource).toContain("setOptimisticPinned(nextPinned)");
     expect(profilePinButtonSource).toContain("pinRequestSeq.current === seq");
+  });
+
+  it("does not duplicate favorite state with the old caught dot", () => {
+    expect(petGallerySource).not.toContain("CheckCircle2");
+    expect(petGallerySource).not.toContain("caughtTitle");
+    expect(petGallerySource).not.toContain("caught={");
   });
 });

--- a/src/components/optimistic-actions.test.ts
+++ b/src/components/optimistic-actions.test.ts
@@ -16,6 +16,11 @@ const petGallerySource = readFileSync(
   "utf8",
 );
 
+const profilePinningSurfaceSource = readFileSync(
+  new URL("./profile-pinning-surface.tsx", import.meta.url),
+  "utf8",
+);
+
 describe("optimistic lightweight actions", () => {
   it("keeps card favorites instant without a loading spinner", () => {
     expect(petCardFooterSource).not.toContain("Loader2");
@@ -29,7 +34,26 @@ describe("optimistic lightweight actions", () => {
     expect(profilePinButtonSource).not.toContain("setBusy");
     expect(profilePinButtonSource).toContain("useState(isPinned)");
     expect(profilePinButtonSource).toContain("setOptimisticPinned(nextPinned)");
+    expect(profilePinButtonSource).toContain(
+      "onOptimisticChange?.(nextPinned)",
+    );
+    expect(profilePinButtonSource).toContain(
+      "onOptimisticChange?.(previousPinned)",
+    );
     expect(profilePinButtonSource).toContain("pinRequestSeq.current === seq");
+  });
+
+  it("moves profile pinned cards optimistically between sections", () => {
+    expect(profilePinningSurfaceSource).toContain(
+      "useState(initialPinnedSlugs)",
+    );
+    expect(profilePinningSurfaceSource).toContain("setOptimisticPinnedSlugs");
+    expect(profilePinningSurfaceSource).toContain(
+      "const restPets = pets.filter((pet) => !pinnedSet.has(pet.slug))",
+    );
+    expect(profilePinningSurfaceSource).toContain(
+      "onPinChange: handlePinChange",
+    );
   });
 
   it("does not duplicate favorite state with the old caught dot", () => {

--- a/src/components/optimistic-actions.test.ts
+++ b/src/components/optimistic-actions.test.ts
@@ -71,11 +71,32 @@ describe("optimistic lightweight actions", () => {
 
   it("keeps a single owner-pinned pet in the compact pinned grid", () => {
     expect(profilePinningSurfaceSource).toContain("isOwner ? (");
-    expect(profilePinningSurfaceSource).toContain("<PinnedReorderGrid");
+    expect(profilePinningSurfaceSource).toContain("<OwnerPinnedReorderGrid");
     expect(profilePinningSurfaceSource).not.toContain(
       "isOwner && featuredPets.length >= 2",
     );
     expect(pinnedReorderGridSource).not.toContain('? "relative"');
+  });
+
+  it("keeps owner reorder code out of the static profile surface import path", () => {
+    expect(profilePinningSurfaceSource).toContain(
+      "dynamic<OwnerPinnedReorderGridProps>",
+    );
+    expect(profilePinningSurfaceSource).toContain(
+      'import("@/components/pinned-reorder-grid")',
+    );
+    expect(profilePinningSurfaceSource).not.toContain(
+      "import { PinnedReorderGrid }",
+    );
+  });
+
+  it("syncs saved pinned reorder back to the parent optimistic list", () => {
+    expect(profilePinningSurfaceSource).toContain("handlePinOrderChange");
+    expect(profilePinningSurfaceSource).toContain(
+      "onOrderChange={handlePinOrderChange}",
+    );
+    expect(pinnedReorderGridSource).toContain("onOrderChange?:");
+    expect(pinnedReorderGridSource).toContain("onOrderChange?.(slugs)");
   });
 
   it("does not duplicate favorite state with the old caught dot", () => {

--- a/src/components/pet-card-footer.tsx
+++ b/src/components/pet-card-footer.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { memo, useCallback, useState } from "react";
+import { memo, useCallback, useRef, useState } from "react";
 
 import { useClerk } from "@clerk/nextjs";
-import { Download, Heart, Loader2, Share2, TerminalSquare } from "lucide-react";
+import { Download, Heart, Share2, TerminalSquare } from "lucide-react";
 import { useLocale } from "next-intl";
 
 import { formatLocalizedNumber } from "@/lib/format-number";
@@ -45,8 +45,8 @@ function PetCardFooterImpl({
 
   const [liked, setLiked] = useState(initialLiked ?? false);
   const [count, setCount] = useState(likeCount);
-  const [busy, setBusy] = useState(false);
   const [copied, setCopied] = useState(false);
+  const likeRequestSeq = useRef(0);
   const formattedLikeCount = formatLocalizedNumber(count, locale);
   const formattedInstallCount = formatLocalizedNumber(installCount, locale);
 
@@ -54,37 +54,52 @@ function PetCardFooterImpl({
     async (e: React.MouseEvent) => {
       e.preventDefault();
       e.stopPropagation();
-      if (busy) return;
       if (!clerk.loaded) return;
       const session = clerk.session;
       if (!session) {
         router.push("/?signin=1");
         return;
       }
+      const seq = likeRequestSeq.current + 1;
+      likeRequestSeq.current = seq;
+      const previousLiked = liked;
+      const previousCount = count;
       const next = !liked;
       setLiked(next);
       setCount((c) => Math.max(0, c + (next ? 1 : -1)));
-      setBusy(true);
       track("pet_like_toggled", { slug, liked: next, source: "card-footer" });
       try {
-        const res = await fetch(`/api/pets/${slug}/like`, { method: "POST" });
+        const res = await fetch(`/api/pets/${slug}/like`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ liked: next }),
+        });
         if (!res.ok) {
-          setLiked(!next);
-          setCount((c) => Math.max(0, c + (next ? -1 : 1)));
+          if (likeRequestSeq.current === seq) {
+            setLiked(previousLiked);
+            setCount(previousCount);
+          }
           return;
         }
         const j = (await res.json().catch(() => null)) as {
+          count?: number;
           likeCount?: number;
           liked?: boolean;
         } | null;
-        if (j && typeof j.likeCount === "number") setCount(j.likeCount);
-        if (j && typeof j.liked === "boolean") setLiked(j.liked);
+        if (likeRequestSeq.current !== seq) return;
+        const serverCount =
+          typeof j?.count === "number" ? j.count : j?.likeCount;
+        if (typeof serverCount === "number") setCount(serverCount);
+        if (typeof j?.liked === "boolean") setLiked(j.liked);
         void refresh({ force: true });
-      } finally {
-        setBusy(false);
+      } catch {
+        if (likeRequestSeq.current === seq) {
+          setLiked(previousLiked);
+          setCount(previousCount);
+        }
       }
     },
-    [busy, clerk, liked, refresh, router, slug],
+    [clerk, count, liked, refresh, router, slug],
   );
 
   const copyInstall = useCallback(
@@ -217,8 +232,6 @@ function PetCardFooterImpl({
           <Share2 className="size-3.5" />
         </Button>
       </div>
-
-      {busy ? <Loader2 className="size-3.5 animate-spin text-muted-4" /> : null}
     </div>
   );
 }

--- a/src/components/pet-card-footer.tsx
+++ b/src/components/pet-card-footer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { memo, useCallback, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 
 import { useClerk } from "@clerk/nextjs";
 import { Download, Heart, Share2, TerminalSquare } from "lucide-react";
@@ -49,6 +49,10 @@ function PetCardFooterImpl({
   const likeRequestSeq = useRef(0);
   const formattedLikeCount = formatLocalizedNumber(count, locale);
   const formattedInstallCount = formatLocalizedNumber(installCount, locale);
+
+  useEffect(() => {
+    if (typeof initialLiked === "boolean") setLiked(initialLiked);
+  }, [initialLiked]);
 
   const toggleLike = useCallback(
     async (e: React.MouseEvent) => {

--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -779,6 +779,9 @@ export type PetCardPinState = {
   maxPins: number;
   /** Mirrors the button's optimistic state into parent-owned layouts. */
   onPinChange?: (isPinned: boolean) => void;
+  /** Temporarily prevents pin writes while another full-list pin save is in flight. */
+  disabled?: boolean;
+  disabledTitle?: string;
 };
 
 type PetCardProps = {
@@ -1076,6 +1079,8 @@ function PetCardImpl({
               maxPins={pinState.maxPins}
               appearance="subtle"
               onOptimisticChange={pinState.onPinChange}
+              disabled={pinState.disabled}
+              disabledTitle={pinState.disabledTitle}
             />
           ) : null}
           <PetActionMenu
@@ -1102,6 +1107,8 @@ function PetCardImpl({
                 pinnedCount={pinState.pinnedCount}
                 maxPins={pinState.maxPins}
                 onOptimisticChange={pinState.onPinChange}
+                disabled={pinState.disabled}
+                disabledTitle={pinState.disabledTitle}
               />
             </div>
           ) : null}

--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -26,6 +26,7 @@ import { cn } from "@/lib/utils";
 import { track } from "@/lib/vercel-analytics";
 
 import { FeedAdSlot } from "@/components/ads/feed-ad-slot";
+import { useHeaderState } from "@/components/header-state-provider";
 import { PetActionMenu } from "@/components/pet-action-menu";
 import { PetCardFooter } from "@/components/pet-card-footer";
 import { PetSprite } from "@/components/pet-sprite";
@@ -138,9 +139,8 @@ export function PetGallery({
   const [activeBatches, setActiveBatches] = useState<Set<string>>(new Set());
   const [sort, setSort] = useState<SortKey>("alpha");
   const [sortTouched, setSortTouched] = useState(false);
-  // Kept for call-site compatibility; card favorite state is already shown by
-  // the heart button, so we no longer duplicate it with a caught dot.
-  void caughtSlugs;
+  const headerCaught = useHeaderState().state.caught;
+  const caughtSet = new Set(caughtSlugs ?? headerCaught);
 
   const [pets, setPets] = useState<PetWithMetrics[]>(initial.pets);
   const [total, setTotal] = useState<number>(initial.total);
@@ -577,6 +577,7 @@ export function PetGallery({
                 index={index}
                 stateCount={stateCount}
                 dexNumber={dexMap?.[pet.slug] ?? null}
+                caught={caughtSet.has(pet.slug)}
               />
               {ad ? <FeedAdSlot ad={ad} /> : null}
             </Fragment>
@@ -781,6 +782,8 @@ export type PetCardPinState = {
 type PetCardProps = {
   pet: PetWithMetrics;
   index: number;
+  /** User has already favorited/caught this pet; shown by the heart button. */
+  caught?: boolean;
   /**
    * Optional. Kept on the type so older call sites that still pass
    * stateCount don't break. The card no longer renders a 'states'
@@ -832,6 +835,7 @@ function PetCardImpl({
   pet,
   index,
   dexNumber,
+  caught,
   ownerActions,
   statusOverlay,
   pinState,
@@ -1041,6 +1045,7 @@ function PetCardImpl({
           soundUrl={pet.soundUrl}
           installCount={installCount}
           likeCount={likeCount}
+          initialLiked={caught}
         />
       </div>
 

--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -777,6 +777,8 @@ export type PetCardPinState = {
   pinnedCount: number;
   /** Hard cap for the owner. Same constant the editor uses. */
   maxPins: number;
+  /** Mirrors the button's optimistic state into parent-owned layouts. */
+  onPinChange?: (isPinned: boolean) => void;
 };
 
 type PetCardProps = {
@@ -1073,6 +1075,7 @@ function PetCardImpl({
               pinnedCount={pinState.pinnedCount}
               maxPins={pinState.maxPins}
               appearance="subtle"
+              onOptimisticChange={pinState.onPinChange}
             />
           ) : null}
           <PetActionMenu
@@ -1098,6 +1101,7 @@ function PetCardImpl({
                 isPinned={pinState.isPinned}
                 pinnedCount={pinState.pinnedCount}
                 maxPins={pinState.maxPins}
+                onOptimisticChange={pinState.onPinChange}
               />
             </div>
           ) : null}

--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -11,15 +11,7 @@ import {
   useState,
 } from "react";
 
-import {
-  Check,
-  CheckCircle2,
-  Loader2,
-  Plus,
-  Search,
-  Sparkles,
-  X,
-} from "lucide-react";
+import { Check, Loader2, Plus, Search, Sparkles, X } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 
 import type { PublicFeedAd } from "@/lib/ads/queries";
@@ -34,7 +26,6 @@ import { cn } from "@/lib/utils";
 import { track } from "@/lib/vercel-analytics";
 
 import { FeedAdSlot } from "@/components/ads/feed-ad-slot";
-import { useHeaderState } from "@/components/header-state-provider";
 import { PetActionMenu } from "@/components/pet-action-menu";
 import { PetCardFooter } from "@/components/pet-card-footer";
 import { PetSprite } from "@/components/pet-sprite";
@@ -147,13 +138,9 @@ export function PetGallery({
   const [activeBatches, setActiveBatches] = useState<Set<string>>(new Set());
   const [sort, setSort] = useState<SortKey>("alpha");
   const [sortTouched, setSortTouched] = useState(false);
-  // The home page no longer ships caughtSlugs server-side — that would
-  // make every SSR render per-visitor and kill ISR. We pull the caught
-  // slug set from the shared HeaderStateProvider (one polled aggregate
-  // instead of per-component fetch) so the "caught" highlight still
-  // works for signed-in users without an extra Edge Request per page.
-  const headerCaught = useHeaderState().state.caught;
-  const caughtSet = new Set(caughtSlugs ?? headerCaught);
+  // Kept for call-site compatibility; card favorite state is already shown by
+  // the heart button, so we no longer duplicate it with a caught dot.
+  void caughtSlugs;
 
   const [pets, setPets] = useState<PetWithMetrics[]>(initial.pets);
   const [total, setTotal] = useState<number>(initial.total);
@@ -590,7 +577,6 @@ export function PetGallery({
                 index={index}
                 stateCount={stateCount}
                 dexNumber={dexMap?.[pet.slug] ?? null}
-                caught={caughtSet.has(pet.slug)}
               />
               {ad ? <FeedAdSlot ad={ad} /> : null}
             </Fragment>
@@ -795,7 +781,6 @@ export type PetCardPinState = {
 type PetCardProps = {
   pet: PetWithMetrics;
   index: number;
-  caught?: boolean;
   /**
    * Optional. Kept on the type so older call sites that still pass
    * stateCount don't break. The card no longer renders a 'states'
@@ -847,7 +832,6 @@ function PetCardImpl({
   pet,
   index,
   dexNumber,
-  caught,
   ownerActions,
   statusOverlay,
   pinState,
@@ -918,11 +902,6 @@ function PetCardImpl({
             <span className="font-mono text-[11px] tracking-[0.22em] text-muted-3 uppercase">
               No. {dexLabel}
             </span>
-            {caught ? (
-              <span title={t("caughtTitle")} className="text-emerald-600">
-                <CheckCircle2 className="size-4 fill-current" />
-              </span>
-            ) : null}
           </div>
         </div>
 

--- a/src/components/pinned-reorder-grid.tsx
+++ b/src/components/pinned-reorder-grid.tsx
@@ -39,6 +39,8 @@ type PinnedReorderGridProps = {
   hideAuthor?: boolean;
   onPinChange?: (slug: string, isPinned: boolean) => void;
   onOrderChange?: (slugs: string[]) => void;
+  pinActionsDisabled?: boolean;
+  onOrderSavePendingChange?: (isPending: boolean) => void;
 };
 
 type SaveState = "idle" | "saving" | "saved" | "error";
@@ -71,6 +73,8 @@ export function PinnedReorderGrid({
   hideAuthor,
   onPinChange,
   onOrderChange,
+  pinActionsDisabled,
+  onOrderSavePendingChange,
 }: PinnedReorderGridProps) {
   const t = useTranslations("pinnedReorder");
   const orderRef = useRef<PetWithMetrics[]>(pets);
@@ -132,6 +136,7 @@ export function PinnedReorderGrid({
 
   async function saveOrder(nextOrder: PetWithMetrics[]) {
     setSaveState("saving");
+    onOrderSavePendingChange?.(true);
     setError(null);
     try {
       const slugs = nextOrder.map((pet) => pet.slug);
@@ -152,6 +157,8 @@ export function PinnedReorderGrid({
     } catch (err) {
       setSaveState("error");
       setError((err as Error).message);
+    } finally {
+      onOrderSavePendingChange?.(false);
     }
   }
 
@@ -287,6 +294,7 @@ export function PinnedReorderGrid({
                 pinnedCount={order.length}
                 hideAuthor={hideAuthor}
                 onPinChange={onPinChange}
+                pinActionsDisabled={pinActionsDisabled || isSaving}
               />
             ))}
           </div>
@@ -327,6 +335,7 @@ type SortablePinnedPetProps = {
   pinnedCount: number;
   hideAuthor?: boolean;
   onPinChange?: (slug: string, isPinned: boolean) => void;
+  pinActionsDisabled?: boolean;
 };
 
 function SortablePinnedPet({
@@ -338,6 +347,7 @@ function SortablePinnedPet({
   pinnedCount,
   hideAuthor,
   onPinChange,
+  pinActionsDisabled,
 }: SortablePinnedPetProps) {
   const {
     attributes,
@@ -377,6 +387,8 @@ function SortablePinnedPet({
             pinnedCount,
             maxPins: MAX_PINNED_PETS,
             onPinChange: (isPinned) => onPinChange?.(pet.slug, isPinned),
+            disabled: pinActionsDisabled,
+            disabledTitle: "Pinned order is saving",
           }}
           actionMode="profilePinHover"
         />

--- a/src/components/pinned-reorder-grid.tsx
+++ b/src/components/pinned-reorder-grid.tsx
@@ -37,6 +37,7 @@ type PinnedReorderGridProps = {
   pets: PetWithMetrics[];
   petStateCount: number;
   hideAuthor?: boolean;
+  onPinChange?: (slug: string, isPinned: boolean) => void;
 };
 
 type SaveState = "idle" | "saving" | "saved" | "error";
@@ -67,6 +68,7 @@ export function PinnedReorderGrid({
   pets,
   petStateCount,
   hideAuthor,
+  onPinChange,
 }: PinnedReorderGridProps) {
   const t = useTranslations("pinnedReorder");
   const orderRef = useRef<PetWithMetrics[]>(pets);
@@ -287,6 +289,7 @@ export function PinnedReorderGrid({
                 petStateCount={petStateCount}
                 pinnedCount={order.length}
                 hideAuthor={hideAuthor}
+                onPinChange={onPinChange}
               />
             ))}
           </div>
@@ -326,6 +329,7 @@ type SortablePinnedPetProps = {
   petStateCount: number;
   pinnedCount: number;
   hideAuthor?: boolean;
+  onPinChange?: (slug: string, isPinned: boolean) => void;
 };
 
 function SortablePinnedPet({
@@ -336,6 +340,7 @@ function SortablePinnedPet({
   petStateCount,
   pinnedCount,
   hideAuthor,
+  onPinChange,
 }: SortablePinnedPetProps) {
   const {
     attributes,
@@ -370,7 +375,12 @@ function SortablePinnedPet({
           index={index}
           stateCount={petStateCount}
           hideAuthor={hideAuthor}
-          pinState={{ isPinned: true, pinnedCount, maxPins: MAX_PINNED_PETS }}
+          pinState={{
+            isPinned: true,
+            pinnedCount,
+            maxPins: MAX_PINNED_PETS,
+            onPinChange: (isPinned) => onPinChange?.(pet.slug, isPinned),
+          }}
           actionMode="profilePinHover"
         />
       </div>

--- a/src/components/pinned-reorder-grid.tsx
+++ b/src/components/pinned-reorder-grid.tsx
@@ -38,6 +38,7 @@ type PinnedReorderGridProps = {
   petStateCount: number;
   hideAuthor?: boolean;
   onPinChange?: (slug: string, isPinned: boolean) => void;
+  onOrderChange?: (slugs: string[]) => void;
 };
 
 type SaveState = "idle" | "saving" | "saved" | "error";
@@ -69,6 +70,7 @@ export function PinnedReorderGrid({
   petStateCount,
   hideAuthor,
   onPinChange,
+  onOrderChange,
 }: PinnedReorderGridProps) {
   const t = useTranslations("pinnedReorder");
   const orderRef = useRef<PetWithMetrics[]>(pets);
@@ -145,6 +147,7 @@ export function PinnedReorderGrid({
         throw new Error(body.error ?? `save failed (${res.status})`);
       }
       setSavedSlugs(slugs);
+      onOrderChange?.(slugs);
       setSaveState("saved");
     } catch (err) {
       setSaveState("error");

--- a/src/components/pinned-reorder-grid.tsx
+++ b/src/components/pinned-reorder-grid.tsx
@@ -32,6 +32,10 @@ import type { PetWithMetrics } from "@/lib/pets";
 import { MAX_PINNED_PETS } from "@/lib/profiles";
 
 import { PetCard } from "@/components/pet-gallery";
+import {
+  hasSamePinnedOrder,
+  shouldResetPinnedOrderFromProps,
+} from "@/components/profile-pinning-state";
 
 type PinnedReorderGridProps = {
   pets: PetWithMetrics[];
@@ -78,6 +82,7 @@ export function PinnedReorderGrid({
 }: PinnedReorderGridProps) {
   const t = useTranslations("pinnedReorder");
   const orderRef = useRef<PetWithMetrics[]>(pets);
+  const propSlugsRef = useRef<string[]>(pets.map((pet) => pet.slug));
   const [order, setOrder] = useState<PetWithMetrics[]>(pets);
   const [savedSlugs, setSavedSlugs] = useState<string[]>(
     pets.map((pet) => pet.slug),
@@ -97,6 +102,20 @@ export function PinnedReorderGrid({
 
   useEffect(() => {
     const slugs = pets.map((pet) => pet.slug);
+    const previousPropSlugs = propSlugsRef.current;
+    const currentOrderSlugs = orderRef.current.map((pet) => pet.slug);
+    const propOrderChanged = !hasSamePinnedOrder(previousPropSlugs, slugs);
+    propSlugsRef.current = slugs;
+    if (
+      !shouldResetPinnedOrderFromProps({
+        previousPropSlugs,
+        nextPropSlugs: slugs,
+        currentOrderSlugs,
+      })
+    ) {
+      if (propOrderChanged) setSavedSlugs(slugs);
+      return;
+    }
     orderRef.current = pets;
     setOrder(pets);
     setSavedSlugs(slugs);

--- a/src/components/pinned-reorder-grid.tsx
+++ b/src/components/pinned-reorder-grid.tsx
@@ -34,6 +34,7 @@ import { MAX_PINNED_PETS } from "@/lib/profiles";
 import { PetCard } from "@/components/pet-gallery";
 import {
   hasSamePinnedOrder,
+  refreshPinnedOrderItems,
   shouldResetPinnedOrderFromProps,
 } from "@/components/profile-pinning-state";
 
@@ -113,6 +114,9 @@ export function PinnedReorderGrid({
         currentOrderSlugs,
       })
     ) {
+      const refreshedOrder = refreshPinnedOrderItems(orderRef.current, pets);
+      orderRef.current = refreshedOrder;
+      setOrder(refreshedOrder);
       if (propOrderChanged) setSavedSlugs(slugs);
       return;
     }

--- a/src/components/pinned-reorder-grid.tsx
+++ b/src/components/pinned-reorder-grid.tsx
@@ -272,13 +272,7 @@ export function PinnedReorderGrid({
         onDragEnd={handleDragEnd}
       >
         <SortableContext items={itemIds} strategy={rectSortingStrategy}>
-          <div
-            className={
-              oneOnly
-                ? "relative"
-                : "grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-6"
-            }
-          >
+          <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-6">
             {order.map((pet, index) => (
               <SortablePinnedPet
                 key={pet.slug}

--- a/src/components/profile-pin-button.tsx
+++ b/src/components/profile-pin-button.tsx
@@ -15,6 +15,8 @@ export function ProfilePinButton({
   maxPins,
   appearance = "default",
   onOptimisticChange,
+  disabled,
+  disabledTitle,
 }: {
   slug: string;
   isPinned: boolean;
@@ -22,6 +24,8 @@ export function ProfilePinButton({
   maxPins: number;
   appearance?: "default" | "subtle";
   onOptimisticChange?: (isPinned: boolean) => void;
+  disabled?: boolean;
+  disabledTitle?: string;
 }) {
   const router = useRouter();
   const [, startTransition] = useTransition();
@@ -40,6 +44,7 @@ export function ProfilePinButton({
   async function toggle(e: React.MouseEvent) {
     e.preventDefault();
     e.stopPropagation();
+    if (disabled) return;
     if (capReached) {
       alert(`You can pin up to ${maxPins} pets. Unpin one first.`);
       return;
@@ -84,17 +89,19 @@ export function ProfilePinButton({
     }
   }
 
-  const title = optimisticPinned
-    ? "Unpin from profile"
-    : capReached
-      ? `Pin cap reached (${maxPins})`
-      : "Pin to profile";
+  const title = disabled
+    ? (disabledTitle ?? "Pin controls are temporarily unavailable")
+    : optimisticPinned
+      ? "Unpin from profile"
+      : capReached
+        ? `Pin cap reached (${maxPins})`
+        : "Pin to profile";
 
   return (
     <button
       type="button"
       onClick={toggle}
-      disabled={capReached}
+      disabled={disabled || capReached}
       title={title}
       aria-label={title}
       style={{ zIndex: 30 }}

--- a/src/components/profile-pin-button.tsx
+++ b/src/components/profile-pin-button.tsx
@@ -14,12 +14,14 @@ export function ProfilePinButton({
   pinnedCount,
   maxPins,
   appearance = "default",
+  onOptimisticChange,
 }: {
   slug: string;
   isPinned: boolean;
   pinnedCount: number;
   maxPins: number;
   appearance?: "default" | "subtle";
+  onOptimisticChange?: (isPinned: boolean) => void;
 }) {
   const router = useRouter();
   const [, startTransition] = useTransition();
@@ -47,6 +49,7 @@ export function ProfilePinButton({
     const seq = pinRequestSeq.current + 1;
     pinRequestSeq.current = seq;
     setOptimisticPinned(nextPinned);
+    onOptimisticChange?.(nextPinned);
     try {
       const body = nextPinned ? { pin: { slug } } : { unpin: { slug } };
       const res = await fetch("/api/profile", {
@@ -55,7 +58,10 @@ export function ProfilePinButton({
         body: JSON.stringify(body),
       });
       if (!res.ok) {
-        if (pinRequestSeq.current === seq) setOptimisticPinned(previousPinned);
+        if (pinRequestSeq.current === seq) {
+          setOptimisticPinned(previousPinned);
+          onOptimisticChange?.(previousPinned);
+        }
         const j = (await res.json().catch(() => null)) as {
           error?: string;
         } | null;
@@ -70,7 +76,10 @@ export function ProfilePinButton({
         startTransition(() => router.refresh());
       }
     } catch {
-      if (pinRequestSeq.current === seq) setOptimisticPinned(previousPinned);
+      if (pinRequestSeq.current === seq) {
+        setOptimisticPinned(previousPinned);
+        onOptimisticChange?.(previousPinned);
+      }
       alert("Failed: network error");
     }
   }

--- a/src/components/profile-pin-button.tsx
+++ b/src/components/profile-pin-button.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 
-import { Loader2, Pin, PinOff } from "lucide-react";
+import { Pin, PinOff } from "lucide-react";
 
 // One-click pin/unpin for an approved pet on the owner's /u/[handle]
 // page. Calls /api/profile with a pin or unpin action so the server
@@ -22,10 +22,18 @@ export function ProfilePinButton({
   appearance?: "default" | "subtle";
 }) {
   const router = useRouter();
-  const [busy, setBusy] = useState(false);
   const [, startTransition] = useTransition();
+  const [optimisticPinned, setOptimisticPinned] = useState(isPinned);
+  const pinRequestSeq = useRef(0);
 
-  const capReached = !isPinned && pinnedCount >= maxPins;
+  useEffect(() => {
+    setOptimisticPinned(isPinned);
+  }, [isPinned]);
+
+  const optimisticPinnedCount =
+    pinnedCount +
+    (optimisticPinned === isPinned ? 0 : optimisticPinned ? 1 : -1);
+  const capReached = !optimisticPinned && optimisticPinnedCount >= maxPins;
 
   async function toggle(e: React.MouseEvent) {
     e.preventDefault();
@@ -34,15 +42,20 @@ export function ProfilePinButton({
       alert(`You can pin up to ${maxPins} pets. Unpin one first.`);
       return;
     }
-    setBusy(true);
+    const previousPinned = optimisticPinned;
+    const nextPinned = !previousPinned;
+    const seq = pinRequestSeq.current + 1;
+    pinRequestSeq.current = seq;
+    setOptimisticPinned(nextPinned);
     try {
-      const body = isPinned ? { unpin: { slug } } : { pin: { slug } };
+      const body = nextPinned ? { pin: { slug } } : { unpin: { slug } };
       const res = await fetch("/api/profile", {
         method: "PATCH",
         headers: { "content-type": "application/json" },
         body: JSON.stringify(body),
       });
       if (!res.ok) {
+        if (pinRequestSeq.current === seq) setOptimisticPinned(previousPinned);
         const j = (await res.json().catch(() => null)) as {
           error?: string;
         } | null;
@@ -53,13 +66,16 @@ export function ProfilePinButton({
         }
         return;
       }
-      startTransition(() => router.refresh());
-    } finally {
-      setBusy(false);
+      if (pinRequestSeq.current === seq) {
+        startTransition(() => router.refresh());
+      }
+    } catch {
+      if (pinRequestSeq.current === seq) setOptimisticPinned(previousPinned);
+      alert("Failed: network error");
     }
   }
 
-  const title = isPinned
+  const title = optimisticPinned
     ? "Unpin from profile"
     : capReached
       ? `Pin cap reached (${maxPins})`
@@ -69,23 +85,21 @@ export function ProfilePinButton({
     <button
       type="button"
       onClick={toggle}
-      disabled={busy || capReached}
+      disabled={capReached}
       title={title}
       aria-label={title}
       style={{ zIndex: 30 }}
       className={`inline-flex size-8 items-center justify-center rounded-full border backdrop-blur transition disabled:cursor-not-allowed disabled:opacity-60 ${
         appearance === "subtle"
-          ? isPinned
+          ? optimisticPinned
             ? "border-border-base bg-surface/90 text-brand hover:border-brand/30 hover:bg-brand-tint"
             : "border-black/10 bg-surface/90 text-muted-2 hover:border-border-strong hover:text-black"
-          : isPinned
+          : optimisticPinned
             ? "border-brand/40 bg-brand text-white hover:bg-brand-deep"
             : "border-black/10 bg-surface/90 text-muted-2 hover:border-border-strong hover:text-black"
       }`}
     >
-      {busy ? (
-        <Loader2 className="size-3.5 animate-spin" />
-      ) : isPinned ? (
+      {optimisticPinned ? (
         <PinOff className="size-3.5" />
       ) : (
         <Pin className="size-3.5" />

--- a/src/components/profile-pinning-state.test.ts
+++ b/src/components/profile-pinning-state.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "bun:test";
 import {
   applyPinChangeToPinnedSlugs,
   applyPinnedOrderChange,
+  refreshPinnedOrderItems,
   shouldResetPinnedOrderFromProps,
 } from "@/components/profile-pinning-state";
 
@@ -54,5 +55,24 @@ describe("profile pinning state", () => {
         currentOrderSlugs: ["corsair", "boba", "quack"],
       }),
     ).toBe(true);
+  });
+
+  it("refreshes pinned item data without resetting the current order", () => {
+    const currentOrder = [
+      { slug: "corsair", name: "Corsair Cat" },
+      { slug: "boba", name: "Boba" },
+      { slug: "quack", name: "Captain Quack" },
+    ];
+    const latestItems = [
+      { slug: "boba", name: "Boba fresh" },
+      { slug: "quack", name: "Captain Quack fresh" },
+      { slug: "corsair", name: "Corsair Cat fresh" },
+    ];
+
+    expect(refreshPinnedOrderItems(currentOrder, latestItems)).toEqual([
+      { slug: "corsair", name: "Corsair Cat fresh" },
+      { slug: "boba", name: "Boba fresh" },
+      { slug: "quack", name: "Captain Quack fresh" },
+    ]);
   });
 });

--- a/src/components/profile-pinning-state.test.ts
+++ b/src/components/profile-pinning-state.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "bun:test";
 import {
   applyPinChangeToPinnedSlugs,
   applyPinnedOrderChange,
+  shouldResetPinnedOrderFromProps,
 } from "@/components/profile-pinning-state";
 
 describe("profile pinning state", () => {
@@ -27,5 +28,31 @@ describe("profile pinning state", () => {
     expect(
       applyPinChangeToPinnedSlugs(["a", "b", "c", "d", "e", "f"], "g", true, 6),
     ).toEqual(["a", "b", "c", "d", "e", "f"]);
+  });
+
+  it("does not reset dragged order for parent renders with unchanged prop order", () => {
+    expect(
+      shouldResetPinnedOrderFromProps({
+        previousPropSlugs: ["boba", "quack", "corsair"],
+        nextPropSlugs: ["boba", "quack", "corsair"],
+        currentOrderSlugs: ["corsair", "boba", "quack"],
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldResetPinnedOrderFromProps({
+        previousPropSlugs: ["boba", "quack", "corsair"],
+        nextPropSlugs: ["corsair", "boba", "quack"],
+        currentOrderSlugs: ["corsair", "boba", "quack"],
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldResetPinnedOrderFromProps({
+        previousPropSlugs: ["boba", "quack", "corsair"],
+        nextPropSlugs: ["boba", "quack", "corsair", "boxcat"],
+        currentOrderSlugs: ["corsair", "boba", "quack"],
+      }),
+    ).toBe(true);
   });
 });

--- a/src/components/profile-pinning-state.test.ts
+++ b/src/components/profile-pinning-state.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  applyPinChangeToPinnedSlugs,
+  applyPinnedOrderChange,
+} from "@/components/profile-pinning-state";
+
+describe("profile pinning state", () => {
+  it("keeps concurrently pinned pets when a saved reorder reports an older full list", () => {
+    const afterPin = applyPinChangeToPinnedSlugs(
+      ["boba", "quack", "corsair"],
+      "boxcat",
+      true,
+      6,
+    );
+
+    expect(
+      applyPinnedOrderChange(afterPin, ["corsair", "boba", "quack"]),
+    ).toEqual(["corsair", "boba", "quack", "boxcat"]);
+  });
+
+  it("does not add duplicate pins or exceed the cap", () => {
+    expect(
+      applyPinChangeToPinnedSlugs(["boba", "quack"], "boba", true, 6),
+    ).toEqual(["quack", "boba"]);
+
+    expect(
+      applyPinChangeToPinnedSlugs(["a", "b", "c", "d", "e", "f"], "g", true, 6),
+    ).toEqual(["a", "b", "c", "d", "e", "f"]);
+  });
+});

--- a/src/components/profile-pinning-state.ts
+++ b/src/components/profile-pinning-state.ts
@@ -30,6 +30,19 @@ export function hasSamePinnedOrder(left: string[], right: string[]): boolean {
   );
 }
 
+export function refreshPinnedOrderItems<T extends { slug: string }>(
+  currentOrder: T[],
+  latestItems: T[],
+): T[] {
+  const latestBySlug = new Map(latestItems.map((item) => [item.slug, item]));
+  const nextOrder = currentOrder
+    .map((item) => latestBySlug.get(item.slug))
+    .filter((item): item is T => Boolean(item));
+  const nextSlugs = new Set(nextOrder.map((item) => item.slug));
+  const appendedItems = latestItems.filter((item) => !nextSlugs.has(item.slug));
+  return [...nextOrder, ...appendedItems];
+}
+
 export function shouldResetPinnedOrderFromProps({
   previousPropSlugs,
   nextPropSlugs,

--- a/src/components/profile-pinning-state.ts
+++ b/src/components/profile-pinning-state.ts
@@ -1,0 +1,25 @@
+export function applyPinChangeToPinnedSlugs(
+  currentSlugs: string[],
+  slug: string,
+  nextPinned: boolean,
+  maxPins: number,
+): string[] {
+  const normalizedSlug = slug.toLowerCase();
+  const withoutSlug = currentSlugs.filter((item) => item !== normalizedSlug);
+  if (!nextPinned) return withoutSlug;
+  if (withoutSlug.length >= maxPins) return currentSlugs;
+  return [...withoutSlug, normalizedSlug];
+}
+
+export function applyPinnedOrderChange(
+  currentSlugs: string[],
+  orderedSlugs: string[],
+): string[] {
+  const currentSet = new Set(currentSlugs);
+  const orderedCurrentSlugs = orderedSlugs.filter((slug) =>
+    currentSet.has(slug),
+  );
+  const orderedSet = new Set(orderedCurrentSlugs);
+  const remainingSlugs = currentSlugs.filter((slug) => !orderedSet.has(slug));
+  return [...orderedCurrentSlugs, ...remainingSlugs];
+}

--- a/src/components/profile-pinning-state.ts
+++ b/src/components/profile-pinning-state.ts
@@ -23,3 +23,22 @@ export function applyPinnedOrderChange(
   const remainingSlugs = currentSlugs.filter((slug) => !orderedSet.has(slug));
   return [...orderedCurrentSlugs, ...remainingSlugs];
 }
+
+export function hasSamePinnedOrder(left: string[], right: string[]): boolean {
+  return (
+    left.length === right.length && left.every((slug, i) => slug === right[i])
+  );
+}
+
+export function shouldResetPinnedOrderFromProps({
+  previousPropSlugs,
+  nextPropSlugs,
+  currentOrderSlugs,
+}: {
+  previousPropSlugs: string[];
+  nextPropSlugs: string[];
+  currentOrderSlugs: string[];
+}): boolean {
+  if (hasSamePinnedOrder(previousPropSlugs, nextPropSlugs)) return false;
+  return !hasSamePinnedOrder(currentOrderSlugs, nextPropSlugs);
+}

--- a/src/components/profile-pinning-surface.tsx
+++ b/src/components/profile-pinning-surface.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { Heart, TerminalSquare } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
+
+import { formatLocalizedNumber } from "@/lib/format-number";
+import { petStates } from "@/lib/pet-states";
+import type { PetWithMetrics } from "@/lib/pets";
+import { MAX_PINNED_PETS } from "@/lib/profiles";
+
+import type { EditableCollection } from "@/components/collection-editor";
+import type { Submission } from "@/components/my-pets-view";
+import type { OwnerCollection } from "@/components/owner-collections-manager";
+import { PetCard } from "@/components/pet-gallery";
+import { PetSprite } from "@/components/pet-sprite";
+import { PinnedReorderGrid } from "@/components/pinned-reorder-grid";
+import { ProfilePinButton } from "@/components/profile-pin-button";
+import { ProfileTabs } from "@/components/profile-tabs";
+
+type ProfilePinningSurfaceProps = {
+  isOwner: boolean;
+  publicHandle: string;
+  pets: PetWithMetrics[];
+  initialPinnedSlugs: string[];
+  ownerSubmissions: Submission[];
+  likedPets: PetWithMetrics[];
+  collection: EditableCollection;
+  canManageCollections: boolean;
+  collectionApprovedPets: {
+    slug: string;
+    displayName: string;
+    spritesheetUrl: string;
+  }[];
+  ownerCollections: OwnerCollection[];
+  maxOwnerCollections: number;
+};
+
+export function ProfilePinningSurface({
+  isOwner,
+  publicHandle,
+  pets,
+  initialPinnedSlugs,
+  ownerSubmissions,
+  likedPets,
+  collection,
+  canManageCollections,
+  collectionApprovedPets,
+  ownerCollections,
+  maxOwnerCollections,
+}: ProfilePinningSurfaceProps) {
+  const locale = useLocale();
+  const t = useTranslations("profile");
+  const [optimisticPinnedSlugs, setOptimisticPinnedSlugs] =
+    useState(initialPinnedSlugs);
+
+  useEffect(() => {
+    setOptimisticPinnedSlugs(initialPinnedSlugs);
+  }, [initialPinnedSlugs]);
+
+  const petBySlug = useMemo(
+    () => new Map(pets.map((pet) => [pet.slug, pet])),
+    [pets],
+  );
+  const pinnedSlugs = isOwner ? optimisticPinnedSlugs : initialPinnedSlugs;
+  const validPinnedSlugs = pinnedSlugs.filter((slug) => petBySlug.has(slug));
+  const pinnedSet = new Set(validPinnedSlugs);
+  const featuredPets = validPinnedSlugs
+    .map((slug) => petBySlug.get(slug))
+    .filter((pet): pet is PetWithMetrics => Boolean(pet));
+  const restPets = pets.filter((pet) => !pinnedSet.has(pet.slug));
+
+  const handlePinChange = useCallback(
+    (slug: string, nextPinned: boolean) => {
+      if (!isOwner) return;
+      setOptimisticPinnedSlugs((current) => {
+        const normalizedSlug = slug.toLowerCase();
+        const withoutSlug = current.filter((item) => item !== normalizedSlug);
+        if (!nextPinned) return withoutSlug;
+        if (withoutSlug.length >= MAX_PINNED_PETS) return current;
+        return [...withoutSlug, normalizedSlug];
+      });
+    },
+    [isOwner],
+  );
+
+  return (
+    <>
+      {featuredPets.length > 0 ? (
+        isOwner && featuredPets.length >= 2 ? (
+          <PinnedReorderGrid
+            pets={featuredPets}
+            petStateCount={petStates.length}
+            hideAuthor
+            onPinChange={handlePinChange}
+          />
+        ) : (
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <p className="font-mono text-[11px] tracking-[0.22em] text-brand uppercase">
+                ★ Pinned
+              </p>
+              <p className="font-mono text-[10px] tracking-[0.18em] text-muted-4 uppercase">
+                {featuredPets.length} of {MAX_PINNED_PETS}
+              </p>
+            </div>
+            {featuredPets.length === 1 ? (
+              <div className="relative">
+                <FeaturedPin
+                  pet={featuredPets[0]}
+                  locale={locale}
+                  installsLabel={(count: string) => t("installs", { count })}
+                />
+                {isOwner ? (
+                  <div className="absolute top-4 right-4 z-40">
+                    <ProfilePinButton
+                      slug={featuredPets[0].slug}
+                      isPinned
+                      pinnedCount={featuredPets.length}
+                      maxPins={MAX_PINNED_PETS}
+                      onOptimisticChange={(nextPinned) =>
+                        handlePinChange(featuredPets[0].slug, nextPinned)
+                      }
+                    />
+                  </div>
+                ) : null}
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-6">
+                {featuredPets.map((pet, index) => (
+                  <div key={pet.slug} className="relative h-full">
+                    <PetCard
+                      pet={pet}
+                      index={index}
+                      stateCount={petStates.length}
+                      hideAuthor
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )
+      ) : null}
+
+      <ProfileTabs
+        isOwner={isOwner}
+        publicHandle={publicHandle}
+        approvedPets={restPets}
+        ownerSubmissions={ownerSubmissions}
+        likedPets={likedPets}
+        collection={collection}
+        canManageCollections={canManageCollections}
+        collectionApprovedPets={collectionApprovedPets}
+        pinning={
+          isOwner
+            ? {
+                pinnedSlugs: validPinnedSlugs,
+                maxPins: MAX_PINNED_PETS,
+                onPinChange: handlePinChange,
+              }
+            : null
+        }
+        ownerCollections={ownerCollections}
+        maxOwnerCollections={maxOwnerCollections}
+      />
+    </>
+  );
+}
+
+function FeaturedPin({
+  pet,
+  locale,
+  installsLabel,
+}: {
+  pet: PetWithMetrics;
+  locale: string;
+  installsLabel: (count: string) => string;
+}) {
+  return (
+    <Link
+      href={`/pets/${pet.slug}`}
+      prefetch={false}
+      aria-label={`Open ${pet.displayName}`}
+      className="featured-pin-card group relative flex flex-col overflow-hidden rounded-3xl border border-brand-light/45 bg-surface/80 backdrop-blur transition hover:bg-white md:flex-row md:items-stretch dark:hover:bg-stone-800"
+    >
+      <div className="pet-sprite-stage featured-pin-stage flex shrink-0 items-center justify-center px-8 py-10 md:w-[420px] md:py-14">
+        <PetSprite
+          src={pet.spritesheetPath}
+          cycleStates
+          scale={1.1}
+          label={`${pet.displayName} animated`}
+        />
+      </div>
+      <div className="flex flex-1 flex-col justify-center gap-3 border-t border-black/[0.06] p-6 md:border-t-0 md:border-l dark:border-white/[0.06]">
+        <span className="font-mono text-[11px] tracking-[0.22em] text-brand uppercase">
+          ★ Pinned
+        </span>
+        <h2 className="text-3xl font-semibold tracking-tight text-foreground md:text-4xl">
+          {pet.displayName}
+        </h2>
+        <p className="max-w-2xl text-base leading-7 text-muted-2">
+          {pet.description}
+        </p>
+        <div className="mt-1 flex flex-wrap items-center gap-3 font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
+          {pet.metrics.likeCount > 0 ? (
+            <span className="inline-flex items-center gap-1.5">
+              <Heart className="size-3" />
+              {formatLocalizedNumber(pet.metrics.likeCount, locale)}
+            </span>
+          ) : null}
+          {pet.metrics.installCount > 0 ? (
+            <span className="inline-flex items-center gap-1.5">
+              <TerminalSquare className="size-3" />
+              {installsLabel(
+                formatLocalizedNumber(pet.metrics.installCount, locale),
+              )}
+            </span>
+          ) : null}
+          <span>{pet.kind}</span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/profile-pinning-surface.tsx
+++ b/src/components/profile-pinning-surface.tsx
@@ -17,6 +17,10 @@ import type { Submission } from "@/components/my-pets-view";
 import type { OwnerCollection } from "@/components/owner-collections-manager";
 import { PetCard } from "@/components/pet-gallery";
 import { PetSprite } from "@/components/pet-sprite";
+import {
+  applyPinChangeToPinnedSlugs,
+  applyPinnedOrderChange,
+} from "@/components/profile-pinning-state";
 import { ProfileTabs } from "@/components/profile-tabs";
 
 type OwnerPinnedReorderGridProps = {
@@ -25,6 +29,8 @@ type OwnerPinnedReorderGridProps = {
   hideAuthor?: boolean;
   onPinChange?: (slug: string, isPinned: boolean) => void;
   onOrderChange?: (slugs: string[]) => void;
+  pinActionsDisabled?: boolean;
+  onOrderSavePendingChange?: (isPending: boolean) => void;
 };
 
 const OwnerPinnedReorderGrid = dynamic<OwnerPinnedReorderGridProps>(
@@ -70,6 +76,7 @@ export function ProfilePinningSurface({
   const t = useTranslations("profile");
   const [optimisticPinnedSlugs, setOptimisticPinnedSlugs] =
     useState(initialPinnedSlugs);
+  const [pinActionsLocked, setPinActionsLocked] = useState(false);
 
   useEffect(() => {
     setOptimisticPinnedSlugs(initialPinnedSlugs);
@@ -90,13 +97,9 @@ export function ProfilePinningSurface({
   const handlePinChange = useCallback(
     (slug: string, nextPinned: boolean) => {
       if (!isOwner) return;
-      setOptimisticPinnedSlugs((current) => {
-        const normalizedSlug = slug.toLowerCase();
-        const withoutSlug = current.filter((item) => item !== normalizedSlug);
-        if (!nextPinned) return withoutSlug;
-        if (withoutSlug.length >= MAX_PINNED_PETS) return current;
-        return [...withoutSlug, normalizedSlug];
-      });
+      setOptimisticPinnedSlugs((current) =>
+        applyPinChangeToPinnedSlugs(current, slug, nextPinned, MAX_PINNED_PETS),
+      );
     },
     [isOwner],
   );
@@ -104,7 +107,17 @@ export function ProfilePinningSurface({
   const handlePinOrderChange = useCallback(
     (slugs: string[]) => {
       if (!isOwner) return;
-      setOptimisticPinnedSlugs(slugs);
+      setOptimisticPinnedSlugs((current) =>
+        applyPinnedOrderChange(current, slugs),
+      );
+    },
+    [isOwner],
+  );
+
+  const handleOrderSavePendingChange = useCallback(
+    (isPending: boolean) => {
+      if (!isOwner) return;
+      setPinActionsLocked(isPending);
     },
     [isOwner],
   );
@@ -119,6 +132,8 @@ export function ProfilePinningSurface({
             hideAuthor
             onPinChange={handlePinChange}
             onOrderChange={handlePinOrderChange}
+            pinActionsDisabled={pinActionsLocked}
+            onOrderSavePendingChange={handleOrderSavePendingChange}
           />
         ) : (
           <div className="space-y-4">
@@ -171,6 +186,7 @@ export function ProfilePinningSurface({
                 pinnedSlugs: validPinnedSlugs,
                 maxPins: MAX_PINNED_PETS,
                 onPinChange: handlePinChange,
+                pinActionsDisabled: pinActionsLocked,
               }
             : null
         }

--- a/src/components/profile-pinning-surface.tsx
+++ b/src/components/profile-pinning-surface.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -16,8 +17,23 @@ import type { Submission } from "@/components/my-pets-view";
 import type { OwnerCollection } from "@/components/owner-collections-manager";
 import { PetCard } from "@/components/pet-gallery";
 import { PetSprite } from "@/components/pet-sprite";
-import { PinnedReorderGrid } from "@/components/pinned-reorder-grid";
 import { ProfileTabs } from "@/components/profile-tabs";
+
+type OwnerPinnedReorderGridProps = {
+  pets: PetWithMetrics[];
+  petStateCount: number;
+  hideAuthor?: boolean;
+  onPinChange?: (slug: string, isPinned: boolean) => void;
+  onOrderChange?: (slugs: string[]) => void;
+};
+
+const OwnerPinnedReorderGrid = dynamic<OwnerPinnedReorderGridProps>(
+  () =>
+    import("@/components/pinned-reorder-grid").then(
+      (mod) => mod.PinnedReorderGrid,
+    ),
+  { ssr: false },
+);
 
 type ProfilePinningSurfaceProps = {
   isOwner: boolean;
@@ -85,15 +101,24 @@ export function ProfilePinningSurface({
     [isOwner],
   );
 
+  const handlePinOrderChange = useCallback(
+    (slugs: string[]) => {
+      if (!isOwner) return;
+      setOptimisticPinnedSlugs(slugs);
+    },
+    [isOwner],
+  );
+
   return (
     <>
       {featuredPets.length > 0 ? (
         isOwner ? (
-          <PinnedReorderGrid
+          <OwnerPinnedReorderGrid
             pets={featuredPets}
             petStateCount={petStates.length}
             hideAuthor
             onPinChange={handlePinChange}
+            onOrderChange={handlePinOrderChange}
           />
         ) : (
           <div className="space-y-4">

--- a/src/components/profile-pinning-surface.tsx
+++ b/src/components/profile-pinning-surface.tsx
@@ -17,7 +17,6 @@ import type { OwnerCollection } from "@/components/owner-collections-manager";
 import { PetCard } from "@/components/pet-gallery";
 import { PetSprite } from "@/components/pet-sprite";
 import { PinnedReorderGrid } from "@/components/pinned-reorder-grid";
-import { ProfilePinButton } from "@/components/profile-pin-button";
 import { ProfileTabs } from "@/components/profile-tabs";
 
 type ProfilePinningSurfaceProps = {
@@ -89,7 +88,7 @@ export function ProfilePinningSurface({
   return (
     <>
       {featuredPets.length > 0 ? (
-        isOwner && featuredPets.length >= 2 ? (
+        isOwner ? (
           <PinnedReorderGrid
             pets={featuredPets}
             petStateCount={petStates.length}
@@ -113,19 +112,6 @@ export function ProfilePinningSurface({
                   locale={locale}
                   installsLabel={(count: string) => t("installs", { count })}
                 />
-                {isOwner ? (
-                  <div className="absolute top-4 right-4 z-40">
-                    <ProfilePinButton
-                      slug={featuredPets[0].slug}
-                      isPinned
-                      pinnedCount={featuredPets.length}
-                      maxPins={MAX_PINNED_PETS}
-                      onOptimisticChange={(nextPinned) =>
-                        handlePinChange(featuredPets[0].slug, nextPinned)
-                      }
-                    />
-                  </div>
-                ) : null}
               </div>
             ) : (
               <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4 lg:grid-cols-6">

--- a/src/components/profile-tabs.tsx
+++ b/src/components/profile-tabs.tsx
@@ -177,6 +177,7 @@ export function ProfileTabs(props: ProfileTabsProps) {
           pinnedSet={pinnedSet}
           pinnedCount={pinnedCount}
           maxPins={pinning?.maxPins ?? null}
+          onPinChange={pinning?.onPinChange}
           isZh={isZh}
           approvedLabel={(count: number) => t("approvedSection", { count })}
         />
@@ -211,6 +212,7 @@ function PetsPanel({
   pinnedSet,
   pinnedCount,
   maxPins,
+  onPinChange,
   isZh,
   approvedLabel,
 }: {
@@ -223,6 +225,7 @@ function PetsPanel({
   pinnedSet: Set<string> | null;
   pinnedCount: number;
   maxPins: number | null;
+  onPinChange?: (slug: string, isPinned: boolean) => void;
   isZh: boolean;
   approvedLabel: (count: number) => string;
 }) {
@@ -294,7 +297,7 @@ function PetsPanel({
                             pinnedCount,
                             maxPins,
                             onPinChange: (isPinned) =>
-                              pinning.onPinChange?.(pet.slug, isPinned),
+                              onPinChange?.(pet.slug, isPinned),
                           }
                         : undefined
                     }

--- a/src/components/profile-tabs.tsx
+++ b/src/components/profile-tabs.tsx
@@ -53,6 +53,7 @@ export type ProfileTabsProps = {
   pinning?: {
     pinnedSlugs: string[];
     maxPins: number;
+    onPinChange?: (slug: string, isPinned: boolean) => void;
   } | null;
   // Owner-only: every collection this user owns (personal + featured).
   // When present and isOwner, the Collections tab swaps to the multi
@@ -292,6 +293,8 @@ function PetsPanel({
                             isPinned: pinnedSet.has(pet.slug),
                             pinnedCount,
                             maxPins,
+                            onPinChange: (isPinned) =>
+                              pinning.onPinChange?.(pet.slug, isPinned),
                           }
                         : undefined
                     }

--- a/src/components/profile-tabs.tsx
+++ b/src/components/profile-tabs.tsx
@@ -54,6 +54,7 @@ export type ProfileTabsProps = {
     pinnedSlugs: string[];
     maxPins: number;
     onPinChange?: (slug: string, isPinned: boolean) => void;
+    pinActionsDisabled?: boolean;
   } | null;
   // Owner-only: every collection this user owns (personal + featured).
   // When present and isOwner, the Collections tab swaps to the multi
@@ -178,6 +179,7 @@ export function ProfileTabs(props: ProfileTabsProps) {
           pinnedCount={pinnedCount}
           maxPins={pinning?.maxPins ?? null}
           onPinChange={pinning?.onPinChange}
+          pinActionsDisabled={pinning?.pinActionsDisabled}
           isZh={isZh}
           approvedLabel={(count: number) => t("approvedSection", { count })}
         />
@@ -213,6 +215,7 @@ function PetsPanel({
   pinnedCount,
   maxPins,
   onPinChange,
+  pinActionsDisabled,
   isZh,
   approvedLabel,
 }: {
@@ -226,6 +229,7 @@ function PetsPanel({
   pinnedCount: number;
   maxPins: number | null;
   onPinChange?: (slug: string, isPinned: boolean) => void;
+  pinActionsDisabled?: boolean;
   isZh: boolean;
   approvedLabel: (count: number) => string;
 }) {
@@ -298,6 +302,8 @@ function PetsPanel({
                             maxPins,
                             onPinChange: (isPinned) =>
                               onPinChange?.(pet.slug, isPinned),
+                            disabled: pinActionsDisabled,
+                            disabledTitle: "Pinned order is saving",
                           }
                         : undefined
                     }


### PR DESCRIPTION
## Summary

- Make card favorite toggles respond immediately without showing a loading spinner.
- Send the desired `liked` state to the API, reconcile with the server response, and ignore stale responses from earlier clicks.
- Hydrate gallery heart state from the user's caught/liked state so a refreshed homepage does not fall back to the seed UI.
- Remove the old green `caught` marker from gallery cards so favorite state is shown only through the heart button.
- Make profile pin/unpin optimistic at both levels: the icon changes immediately, and the card moves immediately between the pinned section and the regular profile grid.
- Keep full-list pinned reorder saves from racing pin/unpin writes by locking pin controls while reorder is saving and merging saved order back into the parent pinned list.
- Keep the reorder grid's internal drag order stable during parent renders that do not change the pinned slug order, while refreshing the cards with the latest pet data.

## Why

Favorites and profile pins are lightweight, reversible interactions. Waiting for a network round trip makes these actions feel heavier than they are: the user has already made a clear choice, but the interface delays the acknowledgement.

This is a good fit for optimistic updates because the experience upside is immediate and the failure cost is low. The UI can reflect the intended state first, keep the interaction moving, and still let the server remain authoritative. If the request fails or the server rejects the change, the latest attempted state rolls back.

The profile pin flow previously only updated the button icon optimistically. The page layout still came from server-split `featuredPets` and `restPets`, so the card itself moved only after `router.refresh()`. This PR lifts the current pinned slug list into a small client-side profile surface so the pinned section and regular pet grid update in the same interaction frame as the icon.

Pinned reorder saves use the full `featuredPetSlugs` list, so they need to be treated as a write that can conflict with pin/unpin toggles. The profile surface now keeps the parent pinned order in sync and prevents pin writes while a full-list reorder save is in flight.

The reorder grid also treats parent renders with the same pinned slug order as no-ops for its local drag state. That keeps a pending save lock render from snapping the card back to the old order. When the parent has fresh pet objects from a refresh or edit, the grid rebuilds the current order with those latest objects so card details do not go stale.

The gallery already shows favorite state through the heart button. Keeping the old green `caught` marker made the same state look like two separate signals, so this PR removes that duplicate marker and keeps the favorite affordance focused.

## Validation

- `bun test src/components/profile-pinning-state.test.ts src/components/optimistic-actions.test.ts`
- `bunx biome check src/components/profile-pinning-state.ts src/components/profile-pinning-state.test.ts src/components/profile-pinning-surface.tsx src/components/pinned-reorder-grid.tsx src/components/profile-pin-button.tsx src/components/pet-gallery.tsx src/components/profile-tabs.tsx src/components/optimistic-actions.test.ts`
- `git diff --check`
- AceLens `lsp_detect_changes` with deep analysis for the changed TS/TSX files; new reset and refresh helpers are referenced by the reorder grid and focused tests.
