### PR TITLE
Reduce pet detail page payload

### DIFF
--- a/src/app/[locale]/pets/[slug]/page.tsx
+++ b/src/app/[locale]/pets/[slug]/page.tsx
@@ -28,7 +28,7 @@ import { PetKeyboardNav } from "@/components/pet-keyboard-nav";
 import { PetRadarClient } from "@/components/pet-radar-client";
 import { PetSoundButton } from "@/components/pet-sound-button";
 import { PetSprite } from "@/components/pet-sprite";
-import { PetStateViewer } from "@/components/pet-state-viewer";
+import { PetStateViewerLazy } from "@/components/pet-state-viewer-lazy";
 import { ReducedMotionHint } from "@/components/reduced-motion-hint";
 import { SaveAsSticker } from "@/components/save-as-sticker";
 import { SiteFooter } from "@/components/site-footer";
@@ -449,7 +449,10 @@ export default async function PetPage({ params }: PageProps) {
             the hero so its internal 2-column layout has the full content
             width to breathe. The hero idle preview keeps users grounded
             while they scroll into the state grid. */}
-        <PetStateViewer src={pet.spritesheetPath} petName={pet.displayName} />
+        <PetStateViewerLazy
+          src={pet.spritesheetPath}
+          petName={pet.displayName}
+        />
 
         {/* Full install guide. CLI + Curl tabs, platform-specific
             terminal instructions, "Activate in Codex" steps. Lives

--- a/src/components/pet-state-viewer-lazy.tsx
+++ b/src/components/pet-state-viewer-lazy.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+type PetStateViewerLazyProps = {
+  src: string;
+  petName: string;
+};
+
+const STATE_SKELETON_KEYS = [
+  "idle",
+  "walk",
+  "run",
+  "jump",
+  "sleep",
+  "happy",
+  "sad",
+  "attack",
+  "special",
+];
+
+const PetStateViewerClient = dynamic(
+  () =>
+    import("@/components/pet-state-viewer").then((mod) => mod.PetStateViewer),
+  {
+    ssr: false,
+    loading: PetStateViewerFallback,
+  },
+);
+
+export function PetStateViewerLazy(props: PetStateViewerLazyProps) {
+  return <PetStateViewerClient {...props} />;
+}
+
+function PetStateViewerFallback() {
+  return (
+    <div
+      className="grid gap-6 lg:grid-cols-[minmax(280px,420px)_1fr]"
+      aria-hidden="true"
+    >
+      <section className="rounded-lg border border-border-base bg-surface p-5">
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-3">
+            <div className="h-3 w-24 rounded bg-surface-muted" />
+            <div className="h-7 w-36 rounded bg-surface-muted" />
+          </div>
+          <div className="h-9 w-24 rounded-md bg-surface-muted" />
+        </div>
+        <div className="pet-checkerboard mt-6 flex min-h-80 items-center justify-center rounded-lg border border-border-base">
+          <div className="h-48 w-44 rounded-lg bg-surface-muted/70" />
+        </div>
+        <div className="mt-4 h-5 w-3/4 rounded bg-surface-muted" />
+      </section>
+      <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        {STATE_SKELETON_KEYS.map((key) => (
+          <div
+            key={key}
+            className="h-[104px] rounded-lg border border-border-base bg-surface p-4"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="space-y-2">
+                <div className="h-4 w-20 rounded bg-surface-muted" />
+                <div className="h-3 w-24 rounded bg-surface-muted" />
+              </div>
+              <div className="size-14 rounded-md bg-surface-muted" />
+            </div>
+          </div>
+        ))}
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Lazy-load the below-fold pet state viewer on pet detail pages.
- Keep the hero, metadata, install CTA, and SEO-rendered content server-rendered.
- Render a stable skeleton while the state viewer hydrates client-side.

## Cost evidence
- Route-cost first post-#365 bucket moved visible traffic to `GET /pets/[slug]`.
- Production baseline `/pets/boba`: 232,245 raw bytes, 54,166 transferred bytes.
- Local branch `/pets/boba` with mock data: 190,830 raw bytes, 49,469 transferred bytes.
- `self.__next_f.push` bytes dropped from 160,110 to 132,099 in the measured boba snapshots.
- R2 URL refs in HTML dropped from 30 to 7 in the measured boba snapshots.

## Validation
- `bun run format -- src/components/pet-state-viewer-lazy.tsx 'src/app/[locale]/pets/[slug]/page.tsx'`
- `bun run check`
- `bun run i18n:check`
- `bun test --env-file=.env.mock` (418 pass)
- `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build`
- local `next start -p 3015` smoke for `/pets/boba`

## Notes
- Playwright browser smoke was skipped because this worktree does not have Playwright installed.
- The production/local byte comparison is directional because production uses real data and local uses mock data.
