### PR TITLE
Lazy-load pet install guide

### DIFF
--- a/src/app/[locale]/pets/[slug]/page.tsx
+++ b/src/app/[locale]/pets/[slug]/page.tsx
@@ -12,8 +12,8 @@ import { getPet, getStaticPetSlugs } from "@/lib/pets";
 import { getVariantsFor } from "@/lib/variants";
 
 import { ClaimCTA } from "@/components/claim-cta";
-import { InstallCommand } from "@/components/install-command";
 import { InstallCommandCompact } from "@/components/install-command-compact";
+import { InstallCommandLazy } from "@/components/install-command-lazy";
 import { JsonLd } from "@/components/json-ld";
 import { LikeButton } from "@/components/like-button";
 import { OpenInPetdexButton } from "@/components/open-in-petdex-button";
@@ -460,7 +460,7 @@ export default async function PetPage({ params }: PageProps) {
             the primary CTA (Open in Petdex Desktop) plus a compact
             one-line npx command already cover the common path. */}
         <div id="install" className="scroll-mt-24">
-          <InstallCommand slug={pet.slug} displayName={pet.displayName} />
+          <InstallCommandLazy slug={pet.slug} displayName={pet.displayName} />
         </div>
 
         {/* Owner credit + claim CTA. Compact row that wraps cleanly on

--- a/src/components/install-command-lazy.tsx
+++ b/src/components/install-command-lazy.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+type InstallCommandLazyProps = {
+  slug: string;
+  displayName: string;
+};
+
+const InstallCommandClient = dynamic(
+  () =>
+    import("@/components/install-command").then((mod) => mod.InstallCommand),
+  {
+    ssr: false,
+    loading: InstallCommandFallback,
+  },
+);
+
+export function InstallCommandLazy(props: InstallCommandLazyProps) {
+  return <InstallCommandClient {...props} />;
+}
+
+function InstallCommandFallback() {
+  return (
+    <div className="rounded-2xl border border-border-base bg-surface/80 p-5 shadow-sm shadow-blue-950/5 backdrop-blur">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="h-5 w-32 rounded bg-surface-muted" />
+        <div className="h-8 w-28 rounded-full bg-surface-muted" />
+      </div>
+      <div className="mt-3 h-4 w-3/4 rounded bg-surface-muted" />
+      <div className="mt-3 h-8 w-36 rounded-full bg-surface-muted" />
+      <div className="mt-2 h-12 w-full rounded-2xl bg-surface-muted" />
+      <div className="mt-3 rounded-2xl border border-border-base bg-surface-muted/70 px-4 py-3">
+        <div className="h-4 w-28 rounded bg-surface" />
+        <div className="mt-3 space-y-2">
+          <div className="h-3 w-full rounded bg-surface" />
+          <div className="h-3 w-5/6 rounded bg-surface" />
+          <div className="h-3 w-2/3 rounded bg-surface" />
+        </div>
+      </div>
+      <div className="mt-5 h-5 w-36 rounded bg-surface-muted" />
+      <div className="mt-3 space-y-2">
+        <div className="h-3 w-full rounded bg-surface-muted" />
+        <div className="h-3 w-11/12 rounded bg-surface-muted" />
+        <div className="h-3 w-3/4 rounded bg-surface-muted" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Lazy-load the below-fold full install guide on pet detail pages.
- Keep the compact hero install CTA server-rendered.
- Render a stable skeleton while the full install guide hydrates client-side.

## Cost evidence
- Production `/pets/boba` after #367: 228,735 raw bytes, 53,996 transferred bytes.
- Local branch `/pets/boba` with mock data: 177,963 raw bytes, 45,405 transferred bytes.
- Local branch `self.__next_f.push` bytes: 132,103.
- Local branch R2 URL refs in HTML: 7.
- The expected production reduction should come from removing verbose platform instructions and large platform SVG paths from the initial HTML.

## Validation
- `bun run format -- src/components/install-command-lazy.tsx 'src/app/[locale]/pets/[slug]/page.tsx'`
- `bun run check`
- `bun run i18n:check`
- `bun test --env-file=.env.mock` (418 pass)
- `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build`
- local `next start -p 3016` smoke for `/pets/boba`

## Notes
- The hero still includes the one-line install command and desktop CTA.
- The production/local byte comparison is directional because production uses real data and local uses mock data.
