### PR TITLE
Reduce client i18n payload

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -19,6 +19,7 @@ import { VercelObservability } from "@/components/vercel-observability";
 import { TopPromoStrip } from "@/components/zh/top-promo-strip";
 import { ZhLayoutSpacer } from "@/components/zh/zh-layout-spacer";
 
+import { pickClientMessages } from "@/i18n/client-messages";
 import { hasLocale, locales } from "@/i18n/config";
 
 const geistSans = Geist({
@@ -100,6 +101,7 @@ export default async function LocaleLayout({ children, params }: Props) {
 
   setRequestLocale(locale);
   const messages = await getMessages();
+  const clientMessages = pickClientMessages(messages);
 
   const isZh = locale === "zh";
 
@@ -110,7 +112,7 @@ export default async function LocaleLayout({ children, params }: Props) {
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col bg-background text-foreground">
-        <NextIntlClientProvider messages={messages}>
+        <NextIntlClientProvider messages={clientMessages}>
           <AppProviders>
             {isZh && <TopPromoStrip />}
             <HeaderStateProvider>

--- a/src/i18n/client-messages.test.ts
+++ b/src/i18n/client-messages.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  CLIENT_MESSAGE_PATHS,
+  pickClientMessages,
+} from "@/i18n/client-messages";
+import en from "@/i18n/messages/en.json";
+import es from "@/i18n/messages/es.json";
+import zh from "@/i18n/messages/zh.json";
+
+const messagesByLocale = { en, es, zh };
+
+describe("client messages", () => {
+  it("covers every literal client translation namespace", () => {
+    const paths = new Set(CLIENT_MESSAGE_PATHS);
+    for (const namespace of clientTranslationNamespaces()) {
+      expect(paths.has(namespace)).toBe(true);
+    }
+  });
+
+  it("keeps every picked namespace available in every locale", () => {
+    for (const messages of Object.values(messagesByLocale)) {
+      const picked = pickClientMessages(messages);
+      for (const path of CLIENT_MESSAGE_PATHS) {
+        expect(readPath(picked, path)).toBeDefined();
+      }
+    }
+  });
+
+  it("keeps server-only copy out of the client provider", () => {
+    const fullBytes = Buffer.byteLength(JSON.stringify(en));
+    const pickedBytes = Buffer.byteLength(
+      JSON.stringify(pickClientMessages(en)),
+    );
+
+    expect(pickedBytes).toBeLessThan(fullBytes * 0.5);
+  });
+});
+
+function clientTranslationNamespaces(): string[] {
+  const namespaces = new Set<string>();
+  for (const file of sourceFiles(join(process.cwd(), "src"))) {
+    if (file.endsWith(".test.ts") || file.endsWith(".test.tsx")) continue;
+    const source = readFileSync(file, "utf8");
+    for (const match of source.matchAll(/useTranslations\("([^"]+)"\)/g)) {
+      namespaces.add(match[1]);
+    }
+  }
+  return [...namespaces].sort();
+}
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      out.push(...sourceFiles(path));
+    } else if (/\.(ts|tsx)$/.test(path)) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+function readPath(value: unknown, path: string): unknown {
+  let cursor = value;
+  for (const part of path.split(".")) {
+    if (typeof cursor !== "object" || cursor === null || !(part in cursor)) {
+      return undefined;
+    }
+    cursor = (cursor as Record<string, unknown>)[part];
+  }
+  return cursor;
+}

--- a/src/i18n/client-messages.ts
+++ b/src/i18n/client-messages.ts
@@ -1,0 +1,97 @@
+type MessageNode = Record<string, unknown>;
+
+export const CLIENT_MESSAGE_PATHS = [
+  "admin.editActions",
+  "admin.feedback.filters",
+  "admin.feedbackActions",
+  "admin.kinds",
+  "admin.requestActions",
+  "admin.status",
+  "admin.tabs",
+  "adminReview",
+  "advertise.card",
+  "advertise.dashboard.edit",
+  "advertise.form",
+  "buildUpdate",
+  "claim",
+  "collaborator.tabs",
+  "collaboratorWechatQr",
+  "collectionActionMenu",
+  "collectionEditor",
+  "collectionsBrowser",
+  "commandLine",
+  "common",
+  "desktopAnnouncement",
+  "feedback",
+  "footer",
+  "gallery",
+  "galleryReorder",
+  "githubStar",
+  "header",
+  "home.surprise",
+  "installCommand",
+  "installCompact",
+  "leaderboard",
+  "myFeedback.filters",
+  "myPets",
+  "myPets.edit",
+  "onboarding",
+  "openInPetdex",
+  "ownerCollections",
+  "petActions",
+  "petStateViewer",
+  "pinnedReorder",
+  "profile",
+  "profileAnnouncement",
+  "profileShare",
+  "requests.view",
+  "sticker",
+  "submit.form",
+  "submit.form.copy",
+  "submit.form.preview",
+  "submit.form.submitButton",
+  "submit.form.success",
+  "submittedBy",
+  "suggestCollection",
+  "theme",
+  "unsubscribePage.form",
+] as const;
+
+export function pickClientMessages<T extends MessageNode>(
+  messages: T,
+): Partial<T> {
+  const picked: MessageNode = {};
+
+  for (const path of CLIENT_MESSAGE_PATHS) {
+    copyPath(messages as MessageNode, picked, path.split("."));
+  }
+
+  return picked as Partial<T>;
+}
+
+function copyPath(source: MessageNode, target: MessageNode, parts: string[]) {
+  let sourceCursor: unknown = source;
+  let targetCursor = target;
+
+  for (const [index, part] of parts.entries()) {
+    if (!isMessageNode(sourceCursor) || !(part in sourceCursor)) return;
+    const sourceValue = sourceCursor[part];
+
+    if (index === parts.length - 1) {
+      targetCursor[part] = sourceValue;
+      return;
+    }
+
+    const targetValue = targetCursor[part];
+    if (!isMessageNode(targetValue)) {
+      targetCursor[part] = {};
+    }
+
+    targetCursor = targetCursor[part] as MessageNode;
+    sourceCursor = sourceValue;
+  }
+}
+
+function isMessageNode(value: unknown): value is MessageNode {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary

- pass only client-used next-intl namespaces to `NextIntlClientProvider`
- add a guard test that fails when a client component introduces a new `useTranslations("...")` namespace without adding it to the client bundle
- keep full server-side messages available through `getTranslations` and metadata/rendering paths

## Cost impact

Local production build, `/pets/boba` after #368 baseline:

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| EN messages JSON sent to client provider | 80,335 | 28,414 | -51,921 |
| Local `/pets/boba` raw HTML bytes | 177,963 | 119,566 | -58,397 |
| Local `/pets/boba` compressed transfer bytes | 45,405 | 27,290 | -18,115 |
| Local `/pets/boba` `self.__next_f.push` bytes | 132,103 | 73,705 | -58,398 |

This targets Fast Origin Transfer and Edge Requests payload weight for every localized route, not just pet detail pages.

## Validation

- `bun run format -- src/i18n/client-messages.ts src/i18n/client-messages.test.ts 'src/app/[locale]/layout.tsx'`
- `bun run check`
- `bun run i18n:check`
- `bun test --env-file=.env.mock`
- `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build`
- local `next start -p 3017` smoke:
  - `/`: 200
  - `/pets/boba`: 200
  - `/leaderboard`: 200
  - `/submit`: 200
  - `/advertise`: 200
