### PR TITLE
Reduce home gallery initial payload

### DIFF
--- a/src/app/[locale]/page.test.ts
+++ b/src/app/[locale]/page.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("home gallery payload", () => {
+  it("keeps the server-rendered gallery page smaller than the client page size", () => {
+    const source = readFileSync(join(__dirname, "page.tsx"), "utf8");
+
+    expect(source).toContain("const HOME_INITIAL_GALLERY_LIMIT = 10;");
+    expect(source).toContain(
+      'searchPets({ sort: "alpha", limit: HOME_INITIAL_GALLERY_LIMIT })',
+    );
+  });
+});

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -63,6 +63,8 @@ export async function generateMetadata({
   };
 }
 const SITE_URL = "https://petdex.crafter.run";
+const HOME_INITIAL_GALLERY_LIMIT = 10;
+
 export function generateStaticParams() {
   return locales.map((locale) => ({ locale }));
 }
@@ -91,7 +93,7 @@ export default async function Home({
   const [heroPets, initialSearch, dexEntries, collections, feedAds, randomPet] =
     await Promise.all([
       getFeaturedPetsWithMetrics(6),
-      searchPets({ sort: "alpha" }),
+      searchPets({ sort: "alpha", limit: HOME_INITIAL_GALLERY_LIMIT }),
       getDexNumberMap(),
       getCollectionsBySlugs(LANDING_COLLECTION_ORDER, 6),
       getActiveFeedAds(6),

--- a/src/app/api/pets/search/route.test.ts
+++ b/src/app/api/pets/search/route.test.ts
@@ -9,14 +9,26 @@ const testMock = (
 
 const TEST_SEED = "0123456789abcdef";
 const calls: Array<{
-  input: { cursor?: number; q?: string; shuffleSeed?: string; sort?: string };
+  input: {
+    cursor?: number;
+    limit?: number;
+    q?: string;
+    shuffleSeed?: string;
+    sort?: string;
+  };
   options: { includeTotal?: boolean; includeFacets?: boolean };
 }> = [];
 
 testMock.module("@/lib/pet-search", () => ({
   SEARCH_LIMITS: { DEFAULT_LIMIT: 24, MAX_LIMIT: 60 },
   searchPets: async (
-    input: { cursor?: number; q?: string; shuffleSeed?: string; sort?: string },
+    input: {
+      cursor?: number;
+      limit?: number;
+      q?: string;
+      shuffleSeed?: string;
+      sort?: string;
+    },
     options: { includeTotal?: boolean; includeFacets?: boolean },
   ) => {
     calls.push({ input, options });
@@ -108,6 +120,22 @@ describe("GET /api/pets/search", () => {
     expect(secondCall?.input.cursor).toBe(24);
     expect(secondCall?.input.shuffleSeed).toBe(TEST_SEED);
     expect(secondCall?.options).toEqual({
+      includeTotal: false,
+      includeFacets: false,
+    });
+  });
+
+  it("accepts a smaller static-home cursor before loading the normal page size", async () => {
+    const response = await search(
+      "https://petdex.local/api/pets/search?sort=alpha&cursor=10&limit=24&includeMeta=0",
+    );
+    const call = calls[0];
+
+    expect(response.headers.get("Cache-Control")).toContain("public");
+    expect(call?.input.cursor).toBe(10);
+    expect(call?.input.limit).toBe(24);
+    expect(call?.input.sort).toBe("alpha");
+    expect(call?.options).toEqual({
       includeTotal: false,
       includeFacets: false,
     });


### PR DESCRIPTION
## Summary

- render 10 gallery pets in the static home payload instead of the full 24-item search page
- keep existing infinite scroll page size unchanged, so the next client fetch continues from cursor 10 and loads 24 more
- add a source guard test so the home page does not accidentally regress to the full initial page size
- add an API route test for the cursor 10 + limit 24 follow-up fetch used after the smaller static home payload

## Cost impact

Baseline production `/` after #369:

| Metric | Before | After local prod-data build | Delta |
|---|---:|---:|---:|
| Raw HTML bytes | 534,009 | 310,028 | -223,981 |
| Compressed transfer bytes | 73,925 | 58,337 | -15,588 |
| R2 URL refs in HTML | 138 | 41 | -97 |
| `self.__next_f.push` bytes | 180,135 | 132,772 | -47,363 |

The local prod-data build used production DB data, Vercel production env, the public Clerk publishable key from current production HTML, and mock auth only to avoid local Clerk middleware calls. The preview/prod deploy measurement should be treated as final.

## Validation

- `bun run format -- 'src/app/[locale]/page.tsx' 'src/app/[locale]/page.test.ts'`
- `bun test 'src/app/api/pets/search/route.test.ts' 'src/app/[locale]/page.test.ts'`
- `bun run check`
- `bun run i18n:check`
- `bun test --env-file=.env.mock`
- `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build`
- prod-data parity build with Vercel production env and public Clerk key: `bun run build`
- local prod-data smoke:
  - `/`: 200
  - `/es`: 200
  - `/zh`: 200
  - `/#gallery`: 200
  - `/api/pets/search?sort=alpha&cursor=10&limit=24&includeMeta=0`: 200
