### PR TITLE
Cache pet metrics in browser

### DIFF
--- a/src/lib/pet-metrics-client.test.ts
+++ b/src/lib/pet-metrics-client.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  loadPetMetrics,
+  type PetMetricsResponse,
+  parseCachedPetMetrics,
+  petMetricsCacheKey,
+  petMetricsResponseSavedAt,
+  readCachedPetMetricsFromBrowser,
+  serializePetMetrics,
+  writeCachedPetMetricsToBrowser,
+} from "@/lib/pet-metrics-client";
+
+const METRICS: PetMetricsResponse = {
+  installCount: 10,
+  zipDownloadCount: 2,
+  likeCount: 4,
+  summary: { maxInstallCount: 20, maxLikeCount: 8 },
+};
+
+describe("pet metrics client cache", () => {
+  it("parses only fresh cached metrics", () => {
+    const raw = serializePetMetrics(METRICS, 1_000);
+
+    expect(parseCachedPetMetrics(raw, 30_000)?.data).toEqual(METRICS);
+    expect(parseCachedPetMetrics(raw, 301_001)).toBeNull();
+    expect(parseCachedPetMetrics(raw, 500)).toBeNull();
+    expect(parseCachedPetMetrics("{}", 30_000)).toBeNull();
+    expect(
+      parseCachedPetMetrics(
+        JSON.stringify({
+          savedAt: 1_000,
+          data: { ...METRICS, likeCount: "4" },
+        }),
+        30_000,
+      ),
+    ).toBeNull();
+  });
+
+  it("scopes cache keys by valid slug", () => {
+    expect(petMetricsCacheKey("boba")).toBe("petdex:pet-metrics:boba");
+    expect(petMetricsCacheKey("../boba")).toBeNull();
+    expect(petMetricsCacheKey("A")).toBeNull();
+  });
+
+  it("uses the freshest browser cache across shared and tab-local storage", () => {
+    const restore = installWindowStorage(
+      new MemoryStorage(),
+      new MemoryStorage(),
+    );
+
+    try {
+      window.localStorage.setItem(
+        "petdex:pet-metrics:boba",
+        serializePetMetrics({ ...METRICS, likeCount: 1 }, 1_000),
+      );
+      window.sessionStorage.setItem(
+        "petdex:pet-metrics:boba",
+        serializePetMetrics({ ...METRICS, likeCount: 7 }, 2_000),
+      );
+
+      expect(readCachedPetMetricsFromBrowser("boba", 3_000)?.data).toEqual({
+        ...METRICS,
+        likeCount: 7,
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it("falls back to tab-local cache when shared browser cache is blocked", () => {
+    const sessionStorage = new MemoryStorage();
+    const restore = installWindowStorage(blockedStorage(), sessionStorage);
+
+    try {
+      writeCachedPetMetricsToBrowser("boba", METRICS, 1_000);
+
+      expect(sessionStorage.getItem("petdex:pet-metrics:boba")).not.toBeNull();
+      expect(readCachedPetMetricsFromBrowser("boba", 2_000)?.data).toEqual(
+        METRICS,
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  it("serves browser-cached metrics without fetching", async () => {
+    const restoreStorage = installWindowStorage(
+      new MemoryStorage(),
+      new MemoryStorage(),
+    );
+    const restoreFetch = installFetch(async () => {
+      throw new Error("unexpected fetch");
+    });
+
+    try {
+      writeCachedPetMetricsToBrowser("cached-pet", METRICS, Date.now());
+
+      await expect(loadPetMetrics("cached-pet")).resolves.toEqual(METRICS);
+    } finally {
+      restoreFetch();
+      restoreStorage();
+    }
+  });
+
+  it("preserves CDN response age for browser cache freshness", () => {
+    const now = Date.parse("2026-06-04T16:10:00.000Z");
+    const date = new Headers({
+      date: "Thu, 04 Jun 2026 16:05:00 GMT",
+    });
+    const age = new Headers({ age: "120" });
+    const futureDate = new Headers({
+      date: "Thu, 04 Jun 2026 16:11:00 GMT",
+      age: "30",
+    });
+    const dateAndAge = new Headers({
+      date: "Thu, 04 Jun 2026 16:09:30 GMT",
+      age: "120",
+    });
+
+    expect(petMetricsResponseSavedAt(date, now)).toBe(
+      Date.parse("2026-06-04T16:05:00.000Z"),
+    );
+    expect(petMetricsResponseSavedAt(age, now)).toBe(now - 120_000);
+    expect(petMetricsResponseSavedAt(futureDate, now)).toBe(now - 30_000);
+    expect(petMetricsResponseSavedAt(dateAndAge, now)).toBe(now - 120_000);
+    expect(petMetricsResponseSavedAt(new Headers(), now)).toBe(now);
+  });
+
+  it("expires in-memory metrics from the original CDN freshness window", async () => {
+    const restoreStorage = installWindowStorage(
+      new MemoryStorage(),
+      new MemoryStorage(),
+    );
+    const firstNow = Date.parse("2026-06-04T16:20:00.000Z");
+    const restoreDateNow = installDateNow(() => firstNow);
+    let fetchCount = 0;
+    const restoreFetch = installFetch(async () => {
+      fetchCount += 1;
+      return Response.json(
+        { ...METRICS, likeCount: fetchCount },
+        { headers: { age: "299" } },
+      );
+    });
+
+    try {
+      await expect(loadPetMetrics("aged-pet")).resolves.toMatchObject({
+        likeCount: 1,
+      });
+      await Promise.resolve();
+      restoreDateNow();
+      const restoreLaterDateNow = installDateNow(() => firstNow + 2_000);
+
+      try {
+        await expect(loadPetMetrics("aged-pet")).resolves.toMatchObject({
+          likeCount: 2,
+        });
+      } finally {
+        restoreLaterDateNow();
+      }
+
+      expect(fetchCount).toBe(2);
+    } finally {
+      restoreFetch();
+      restoreDateNow();
+      restoreStorage();
+    }
+  });
+
+  it("expires browser-cached metrics from the same in-memory freshness window", async () => {
+    const restoreStorage = installWindowStorage(
+      new MemoryStorage(),
+      new MemoryStorage(),
+    );
+    const firstNow = Date.parse("2026-06-04T16:30:00.000Z");
+    const restoreDateNow = installDateNow(() => firstNow);
+    let fetchCount = 0;
+    const restoreFetch = installFetch(async () => {
+      fetchCount += 1;
+      return Response.json({ ...METRICS, likeCount: 9 });
+    });
+
+    try {
+      writeCachedPetMetricsToBrowser(
+        "browser-aged-pet",
+        { ...METRICS, likeCount: 3 },
+        firstNow - 299_000,
+      );
+
+      await expect(loadPetMetrics("browser-aged-pet")).resolves.toMatchObject({
+        likeCount: 3,
+      });
+      await Promise.resolve();
+      restoreDateNow();
+      const restoreLaterDateNow = installDateNow(() => firstNow + 2_000);
+
+      try {
+        await expect(loadPetMetrics("browser-aged-pet")).resolves.toMatchObject(
+          { likeCount: 9 },
+        );
+      } finally {
+        restoreLaterDateNow();
+      }
+
+      expect(fetchCount).toBe(1);
+    } finally {
+      restoreFetch();
+      restoreDateNow();
+      restoreStorage();
+    }
+  });
+});
+
+class MemoryStorage implements Storage {
+  private values = new Map<string, string>();
+
+  get length() {
+    return this.values.size;
+  }
+
+  clear() {
+    this.values.clear();
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number) {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
+function blockedStorage(): Storage {
+  return {
+    get length() {
+      throw new DOMException("Blocked", "SecurityError");
+    },
+    clear() {
+      throw new DOMException("Blocked", "SecurityError");
+    },
+    getItem() {
+      throw new DOMException("Blocked", "SecurityError");
+    },
+    key() {
+      throw new DOMException("Blocked", "SecurityError");
+    },
+    removeItem() {
+      throw new DOMException("Blocked", "SecurityError");
+    },
+    setItem() {
+      throw new DOMException("Blocked", "SecurityError");
+    },
+  };
+}
+
+function installWindowStorage(
+  localStorage: Storage,
+  sessionStorage: Storage,
+): () => void {
+  const originalWindow = globalThis.window;
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      localStorage,
+      sessionStorage,
+    },
+  });
+  return () => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+  };
+}
+
+function installFetch(fetch: typeof globalThis.fetch): () => void {
+  const originalFetch = globalThis.fetch;
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: fetch,
+  });
+  return () => {
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: originalFetch,
+    });
+  };
+}
+
+function installDateNow(now: () => number): () => void {
+  const originalNow = Date.now;
+  Object.defineProperty(Date, "now", {
+    configurable: true,
+    value: now,
+  });
+  return () => {
+    Object.defineProperty(Date, "now", {
+      configurable: true,
+      value: originalNow,
+    });
+  };
+}

--- a/src/lib/pet-metrics-client.ts
+++ b/src/lib/pet-metrics-client.ts
@@ -5,7 +5,13 @@ export type PetMetricsResponse = {
   summary: { maxInstallCount: number; maxLikeCount: number };
 };
 
-const PET_METRICS_CACHE_TTL_MS = 60_000;
+export const PET_METRICS_CACHE_TTL_MS = 300_000;
+
+export type CachedPetMetrics = {
+  savedAt: number;
+  data: PetMetricsResponse;
+};
+
 const petMetricsCache = new Map<
   string,
   { promise: Promise<PetMetricsResponse | null>; savedAt: number }
@@ -18,21 +24,192 @@ export function loadPetMetrics(slug: string) {
     return cached.promise;
   }
 
+  const cachedBrowserMetrics = readCachedPetMetricsFromBrowser(slug, now);
+  if (cachedBrowserMetrics) {
+    const promise = Promise.resolve(cachedBrowserMetrics.data);
+    rememberPetMetricsPromise(slug, promise, cachedBrowserMetrics.savedAt);
+    return promise;
+  }
+
+  let responseSavedAt = now;
   const promise = fetch(`/api/pets/${slug}/metrics`, {
     headers: { accept: "application/json" },
   })
-    .then((res) =>
-      res.ok ? (res.json() as Promise<PetMetricsResponse>) : null,
-    )
+    .then(async (res) => {
+      if (!res.ok) return null;
+      responseSavedAt = petMetricsResponseSavedAt(res.headers, Date.now());
+      return normalizePetMetricsResponse(await res.json());
+    })
     .catch(() => null);
 
-  petMetricsCache.set(slug, { promise, savedAt: now });
-  setTimeout(() => {
-    const cached = petMetricsCache.get(slug);
-    if (cached?.promise === promise) petMetricsCache.delete(slug);
-  }, PET_METRICS_CACHE_TTL_MS);
+  rememberPetMetricsPromise(slug, promise, now);
   void promise.then((data) => {
     if (!data) petMetricsCache.delete(slug);
+    if (data) {
+      rememberPetMetricsPromise(slug, promise, responseSavedAt);
+      writeCachedPetMetricsToBrowser(slug, data, responseSavedAt);
+    }
   });
   return promise;
+}
+
+export function petMetricsCacheKey(slug: string) {
+  return /^[a-z0-9-]{1,60}$/.test(slug) ? `petdex:pet-metrics:${slug}` : null;
+}
+
+export function parseCachedPetMetrics(
+  raw: string | null,
+  now: number,
+  ttlMs = PET_METRICS_CACHE_TTL_MS,
+): CachedPetMetrics | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<CachedPetMetrics>;
+    const data = normalizePetMetricsResponse(parsed.data);
+    if (
+      typeof parsed.savedAt !== "number" ||
+      !data ||
+      parsed.savedAt > now ||
+      now - parsed.savedAt > ttlMs
+    ) {
+      return null;
+    }
+    return { savedAt: parsed.savedAt, data };
+  } catch {
+    return null;
+  }
+}
+
+export function serializePetMetrics(data: PetMetricsResponse, savedAt: number) {
+  return JSON.stringify({ savedAt, data });
+}
+
+export function readCachedPetMetricsFromBrowser(
+  slug: string,
+  now = Date.now(),
+): CachedPetMetrics | null {
+  const cacheKey = petMetricsCacheKey(slug);
+  if (!cacheKey) return null;
+  const local = parseCachedPetMetrics(
+    readStorageValue(browserStorage("localStorage"), cacheKey),
+    now,
+  );
+  const session = parseCachedPetMetrics(
+    readStorageValue(browserStorage("sessionStorage"), cacheKey),
+    now,
+  );
+  if (!local) return session;
+  if (!session) return local;
+  return local.savedAt >= session.savedAt ? local : session;
+}
+
+export function writeCachedPetMetricsToBrowser(
+  slug: string,
+  data: PetMetricsResponse,
+  savedAt: number,
+) {
+  const cacheKey = petMetricsCacheKey(slug);
+  if (!cacheKey) return;
+  const raw = serializePetMetrics(data, savedAt);
+  if (writeStorageValue(browserStorage("localStorage"), cacheKey, raw)) return;
+  writeStorageValue(browserStorage("sessionStorage"), cacheKey, raw);
+}
+
+export function petMetricsResponseSavedAt(
+  headers: Pick<Headers, "get">,
+  now: number,
+) {
+  const dateMs = Date.parse(headers.get("date") ?? "");
+  const validDateMs = Number.isFinite(dateMs) && dateMs <= now ? dateMs : null;
+  const ageSeconds = Number(headers.get("age") ?? NaN);
+  if (Number.isFinite(ageSeconds) && ageSeconds >= 0) {
+    const agedSavedAt = Math.max(0, now - ageSeconds * 1000);
+    return validDateMs === null
+      ? agedSavedAt
+      : Math.min(validDateMs, agedSavedAt);
+  }
+  return validDateMs ?? now;
+}
+
+function normalizePetMetricsResponse(
+  value: unknown,
+): PetMetricsResponse | null {
+  if (!isRecord(value) || !isRecord(value.summary)) return null;
+  const installCount = toFiniteNumber(value.installCount);
+  const zipDownloadCount = toFiniteNumber(value.zipDownloadCount);
+  const likeCount = toFiniteNumber(value.likeCount);
+  const maxInstallCount = toFiniteNumber(value.summary.maxInstallCount);
+  const maxLikeCount = toFiniteNumber(value.summary.maxLikeCount);
+  if (
+    installCount === null ||
+    zipDownloadCount === null ||
+    likeCount === null ||
+    maxInstallCount === null ||
+    maxLikeCount === null
+  ) {
+    return null;
+  }
+  return {
+    installCount,
+    zipDownloadCount,
+    likeCount,
+    summary: { maxInstallCount, maxLikeCount },
+  };
+}
+
+function rememberPetMetricsPromise(
+  slug: string,
+  promise: Promise<PetMetricsResponse | null>,
+  savedAt: number,
+) {
+  petMetricsCache.set(slug, { promise, savedAt });
+  setTimeout(
+    () => {
+      const cached = petMetricsCache.get(slug);
+      if (cached?.promise === promise) petMetricsCache.delete(slug);
+    },
+    Math.max(0, PET_METRICS_CACHE_TTL_MS - Math.max(0, Date.now() - savedAt)),
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toFiniteNumber(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function browserStorage(
+  name: "localStorage" | "sessionStorage",
+): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window[name];
+  } catch {
+    return null;
+  }
+}
+
+function readStorageValue(storage: Storage | null, key: string): string | null {
+  if (!storage) return null;
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writeStorageValue(
+  storage: Storage | null,
+  key: string,
+  value: string,
+): boolean {
+  if (!storage) return false;
+  try {
+    storage.setItem(key, value);
+    return true;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary
- cache public pet metrics responses in browser storage for 5 minutes
- reuse the same shared/local fallback pattern as header state for reloads and cross-tab navigation
- add regression coverage for stale, malformed, blocked-storage, and no-fetch cached reads

## Cost impact
- reduces repeated /api/pets/[slug]/metrics edge/function pressure during repeated pet-detail views without embedding stale counters into 24h ISR HTML
- keeps the existing metrics endpoint freshness model intact after the browser cache expires

## Validation
- bun run format -- src/lib/pet-metrics-client.ts src/lib/pet-metrics-client.test.ts
- bun test src/lib/pet-metrics-client.test.ts
- bun run check
- bun run i18n:check
- bun test --env-file=.env.mock
- TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build