### PR TITLE
Slim collections listing payload

### DIFF
--- a/src/app/[locale]/collections/page.tsx
+++ b/src/app/[locale]/collections/page.tsx
@@ -1,6 +1,10 @@
 import { getTranslations } from "next-intl/server";
 
-import { getCollectionsForListing } from "@/lib/collections";
+import { sortCollectionListingItems } from "@/lib/collection-listing-order";
+import {
+  getCollectionListingMetadata,
+  getCollectionListingPreviewsBySlugs,
+} from "@/lib/collections";
 import { buildLocaleAlternates } from "@/lib/locale-routing";
 import { resolveOwnerCredits } from "@/lib/owner-credit";
 
@@ -19,6 +23,7 @@ export const revalidate = 86400;
 
 const SITE_URL = "https://petdex.crafter.run";
 const MIN_PETS = 4;
+const INITIAL_PREVIEW_COUNT = 24;
 
 export async function generateMetadata({
   params,
@@ -50,7 +55,16 @@ export default async function CollectionsPage({
     locale: hasLocale(locale) ? locale : "en",
     namespace: "collectionsPage",
   });
-  const collections = await getCollectionsForListing(MIN_PETS, 6);
+  const collections = await getCollectionListingMetadata(MIN_PETS);
+  const defaultVisibleOrder = sortCollectionListingItems(collections, "size");
+  const initialPreviewCollections = await getCollectionListingPreviewsBySlugs(
+    defaultVisibleOrder.slice(0, INITIAL_PREVIEW_COUNT).map((c) => c.slug),
+    MIN_PETS,
+    6,
+  );
+  const previewPetsBySlug = new Map(
+    initialPreviewCollections.map((c) => [c.slug, c.pets]),
+  );
 
   const ownerIds = collections
     .map((c) => c.ownerId)
@@ -89,7 +103,7 @@ export default async function CollectionsPage({
     externalUrl: c.externalUrl,
     coverPetSlug: c.coverPetSlug,
     petCount: c.petCount,
-    pets: c.pets.map((pet) => ({
+    pets: (previewPetsBySlug.get(c.slug) ?? []).map((pet) => ({
       slug: pet.slug,
       displayName: pet.displayName,
       spritesheetPath: pet.spritesheetPath,

--- a/src/app/api/collections/previews/route.ts
+++ b/src/app/api/collections/previews/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+
+import { getCollectionListingPreviewsBySlugs } from "@/lib/collections";
+
+export const runtime = "nodejs";
+
+const MIN_PETS = 4;
+const PETS_PER_PREVIEW = 6;
+const MAX_SLUGS = 24;
+const CACHE_CONTROL =
+  "public, max-age=60, s-maxage=86400, stale-while-revalidate=604800";
+const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,127}$/;
+
+export async function GET(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+  const slugs = parsePreviewSlugs(url.searchParams.get("slugs"));
+  if (slugs.length === 0) {
+    return NextResponse.json(
+      { collections: [] },
+      { headers: { "Cache-Control": CACHE_CONTROL } },
+    );
+  }
+
+  const collections = await getCollectionListingPreviewsBySlugs(
+    slugs,
+    MIN_PETS,
+    PETS_PER_PREVIEW,
+  );
+
+  return NextResponse.json(
+    {
+      collections: collections.map((collection) => ({
+        slug: collection.slug,
+        pets: collection.pets.map((pet) => ({
+          slug: pet.slug,
+          displayName: pet.displayName,
+          spritesheetPath: pet.spritesheetPath,
+        })),
+      })),
+    },
+    { headers: { "Cache-Control": CACHE_CONTROL } },
+  );
+}
+
+function parsePreviewSlugs(raw: string | null): string[] {
+  if (!raw) return [];
+  const seen = new Set<string>();
+  const slugs: string[] = [];
+  for (const value of raw.split(",")) {
+    const slug = value.trim().toLowerCase();
+    if (!SLUG_RE.test(slug) || seen.has(slug)) continue;
+    seen.add(slug);
+    slugs.push(slug);
+    if (slugs.length >= MAX_SLUGS) break;
+  }
+  return slugs;
+}

--- a/src/components/collections-browser.tsx
+++ b/src/components/collections-browser.tsx
@@ -11,6 +11,10 @@ import {
   collectionKind,
   KIND_SLUG,
 } from "@/lib/collection-kind";
+import {
+  type CollectionListingSortKey,
+  sortCollectionListingItems,
+} from "@/lib/collection-listing-order";
 import type { OwnerCredit } from "@/lib/owner-credit";
 
 import { CollectionActionMenu } from "@/components/collection-action-menu";
@@ -44,7 +48,14 @@ type CollectionItem = {
   pets: CollectionCoverPet[];
 };
 
-type SortKey = "size" | "title";
+type CollectionPreviewResponse = {
+  collections?: Array<{
+    slug: string;
+    pets: CollectionCoverPet[];
+  }>;
+};
+
+type SortKey = CollectionListingSortKey;
 
 type KindFilterValue = "all" | CollectionKind;
 
@@ -65,6 +76,7 @@ const SORT_KEYS: SortKey[] = ["size", "title"];
 // which racked up ~500 mounts in idle and dropped FPS to 3-30 during
 // scroll). 24 covers the common viewport without needing a tick.
 const PAGE_SIZE = 24;
+const PREVIEW_FETCH_LIMIT = PAGE_SIZE;
 
 export function CollectionsBrowser({
   collections,
@@ -78,6 +90,23 @@ export function CollectionsBrowser({
   const [kind, setKind] = useState<KindFilterValue>("all");
   const [sort, setSort] = useState<SortKey>("size");
   const [pageCount, setPageCount] = useState(1);
+  const initialPreviewPets = useMemo(
+    () =>
+      new Map(
+        collections
+          .filter((collection) => collection.pets.length > 0)
+          .map((collection) => [collection.slug, collection.pets]),
+      ),
+    [collections],
+  );
+  const [previewPetsBySlug, setPreviewPetsBySlug] =
+    useState<Map<string, CollectionCoverPet[]>>(initialPreviewPets);
+  const requestedPreviewSlugsRef = useRef(new Set(initialPreviewPets.keys()));
+
+  useEffect(() => {
+    requestedPreviewSlugsRef.current = new Set(initialPreviewPets.keys());
+    setPreviewPetsBySlug(initialPreviewPets);
+  }, [initialPreviewPets]);
 
   const counts = useMemo(() => {
     const map: Record<string, number> = { all: collections.length };
@@ -90,7 +119,7 @@ export function CollectionsBrowser({
 
   const visible = useMemo(() => {
     const q = query.trim().toLowerCase();
-    let list = collections.filter((c) => {
+    const list = collections.filter((c) => {
       if (kind !== "all" && collectionKind(c.slug) !== kind) return false;
       if (!q) return true;
       return (
@@ -99,29 +128,7 @@ export function CollectionsBrowser({
         c.slug.toLowerCase().includes(q)
       );
     });
-    list = [...list];
-
-    // Hand-picked slugs that should always lead the list, mirroring
-    // the home page Featured Collections strip. Anything in this set
-    // outranks the user-selected sort; collections outside this set
-    // fall through to the requested sort.
-    const PRIORITY_SLUGS = [
-      "franchise-pokemon",
-      "franchise-league-of-legends",
-      "franchise-jojos-bizarre-adventure",
-    ];
-    const priorityIndex = new Map(PRIORITY_SLUGS.map((s, i) => [s, i]));
-
-    list.sort((a, b) => {
-      const ai = priorityIndex.get(a.slug);
-      const bi = priorityIndex.get(b.slug);
-      if (ai !== undefined && bi !== undefined) return ai - bi;
-      if (ai !== undefined) return -1;
-      if (bi !== undefined) return 1;
-      if (sort === "size") return b.petCount - a.petCount;
-      return a.title.localeCompare(b.title);
-    });
-    return list;
+    return sortCollectionListingItems(list, sort);
   }, [collections, query, kind, sort]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional reset on filter/query/sort change
@@ -134,6 +141,63 @@ export function CollectionsBrowser({
     [visible, pageCount],
   );
   const hasMore = visibleSlice.length < visible.length;
+
+  useEffect(() => {
+    const missing = visibleSlice
+      .filter(
+        (collection) =>
+          !previewPetsBySlug.has(collection.slug) &&
+          !requestedPreviewSlugsRef.current.has(collection.slug),
+      )
+      .slice(0, PREVIEW_FETCH_LIMIT)
+      .map((collection) => collection.slug);
+    if (missing.length === 0) return;
+
+    for (const slug of missing) requestedPreviewSlugsRef.current.add(slug);
+    const controller = new AbortController();
+    const params = new URLSearchParams({ slugs: missing.join(",") });
+    const releaseMissing = (except = new Set<string>()) => {
+      for (const slug of missing) {
+        if (!except.has(slug)) requestedPreviewSlugsRef.current.delete(slug);
+      }
+    };
+
+    fetch(`/api/collections/previews?${params.toString()}`, {
+      signal: controller.signal,
+    })
+      .then(async (res) => {
+        if (!res.ok) {
+          releaseMissing();
+          return null;
+        }
+        return (await res.json()) as CollectionPreviewResponse;
+      })
+      .then((data) => {
+        if (!data?.collections?.length) {
+          releaseMissing();
+          return;
+        }
+        const returned = new Set(data.collections.map((item) => item.slug));
+        releaseMissing(returned);
+        setPreviewPetsBySlug((current) => {
+          const next = new Map(current);
+          for (const collection of data.collections ?? []) {
+            if (!collection.slug || !Array.isArray(collection.pets)) continue;
+            next.set(collection.slug, collection.pets);
+          }
+          return next;
+        });
+      })
+      .catch((error: unknown) => {
+        releaseMissing();
+        if ((error as { name?: string }).name === "AbortError") return;
+      });
+
+    return () => {
+      releaseMissing();
+      controller.abort();
+    };
+  }, [visibleSlice, previewPetsBySlug]);
 
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
@@ -255,7 +319,16 @@ export function CollectionsBrowser({
         <div className="grid auto-rows-fr gap-5 md:grid-cols-2 lg:grid-cols-3">
           {visibleSlice.map((c) => {
             const owner = c.ownerId ? credits[c.ownerId] : null;
-            return <CollectionCard key={c.slug} collection={c} owner={owner} />;
+            return (
+              <CollectionCard
+                key={c.slug}
+                collection={{
+                  ...c,
+                  pets: previewPetsBySlug.get(c.slug) ?? c.pets,
+                }}
+                owner={owner}
+              />
+            );
           })}
         </div>
       )}

--- a/src/lib/collection-listing-order.test.ts
+++ b/src/lib/collection-listing-order.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+
+import { sortCollectionListingItems } from "@/lib/collection-listing-order";
+
+describe("collection listing order", () => {
+  it("keeps priority collections first before size order", () => {
+    const sorted = sortCollectionListingItems(
+      [
+        item("category-small", "Small", 2),
+        item("franchise-league-of-legends", "League", 1),
+        item("category-large", "Large", 100),
+        item("franchise-pokemon", "Pokemon", 5),
+      ],
+      "size",
+    );
+
+    expect(sorted.map((collection) => collection.slug)).toEqual([
+      "franchise-pokemon",
+      "franchise-league-of-legends",
+      "category-large",
+      "category-small",
+    ]);
+  });
+
+  it("keeps priority collections first before title order", () => {
+    const sorted = sortCollectionListingItems(
+      [
+        item("zeta", "Zeta", 50),
+        item("franchise-jojos-bizarre-adventure", "Jojo", 1),
+        item("alpha", "Alpha", 1),
+      ],
+      "title",
+    );
+
+    expect(sorted.map((collection) => collection.slug)).toEqual([
+      "franchise-jojos-bizarre-adventure",
+      "alpha",
+      "zeta",
+    ]);
+  });
+});
+
+function item(slug: string, title: string, petCount: number) {
+  return { slug, title, petCount };
+}

--- a/src/lib/collection-listing-order.ts
+++ b/src/lib/collection-listing-order.ts
@@ -1,0 +1,25 @@
+export type CollectionListingSortKey = "size" | "title";
+
+const PRIORITY_COLLECTION_SLUGS = [
+  "franchise-pokemon",
+  "franchise-league-of-legends",
+  "franchise-jojos-bizarre-adventure",
+];
+
+const priorityIndex = new Map(
+  PRIORITY_COLLECTION_SLUGS.map((slug, index) => [slug, index]),
+);
+
+export function sortCollectionListingItems<
+  T extends { slug: string; title: string; petCount: number },
+>(items: T[], sort: CollectionListingSortKey): T[] {
+  return [...items].sort((a, b) => {
+    const ai = priorityIndex.get(a.slug);
+    const bi = priorityIndex.get(b.slug);
+    if (ai !== undefined && bi !== undefined) return ai - bi;
+    if (ai !== undefined) return -1;
+    if (bi !== undefined) return 1;
+    if (sort === "size") return b.petCount - a.petCount;
+    return a.title.localeCompare(b.title);
+  });
+}

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -31,6 +31,14 @@ export type PetCollectionWithPets = PetCollection & {
   pets: PetWithMetrics[];
 };
 
+export type CollectionListingMetadata = PetCollection & {
+  petCount: number;
+};
+
+export type CollectionListingPreview = CollectionListingMetadata & {
+  pets: PetWithMetrics[];
+};
+
 export type CollectionSitemapEntry = {
   slug: string;
   updatedAt: Date;
@@ -133,17 +141,11 @@ export async function getCollectionSitemapEntries(): Promise<
   )();
 }
 
-// Returns featured collections that have at least `minPets` approved
-// pets, with a small sample for the cover preview. Used by the public
-// /collections listing — keeps the page fast even with hundreds of
-// collections by filtering at the SQL level.
-export async function getCollectionsForListing(
+export async function getCollectionListingMetadata(
   minPets = 4,
-  petsPerPreview = 6,
-): Promise<(PetCollectionWithPets & { petCount: number })[]> {
+): Promise<CollectionListingMetadata[]> {
   return withNextDataCache(
     async () => {
-      let rows: (PetCollection & { petCount: number })[];
       try {
         const result = await db
           .select({
@@ -173,7 +175,7 @@ export async function getCollectionsForListing(
             desc(dsql`count(${schema.petCollectionItems.petSlug})`),
             asc(schema.petCollections.title),
           );
-        rows = result.map((r) => ({
+        return result.map((r) => ({
           ...r,
           petCount: Number(r.petCount),
         }));
@@ -181,18 +183,32 @@ export async function getCollectionsForListing(
         if (isMissingCollectionTableError(error)) return [];
         throw error;
       }
-
-      const hydrated = await hydrateCollections(rows, petsPerPreview);
-      // Re-attach the pet count we computed (hydrate doesn't carry it).
-      const countBySlug = new Map(rows.map((r) => [r.slug, r.petCount]));
-      return hydrated.map((c) => ({
-        ...c,
-        petCount: countBySlug.get(c.slug) ?? c.pets.length,
-      }));
     },
-    ["petdex-collections-for-listing", String(minPets), String(petsPerPreview)],
+    ["petdex-collection-listing-metadata", String(minPets)],
     { tags: ["collection:list"], revalidate: 86400 },
   )();
+}
+
+export async function getCollectionsForListing(
+  minPets = 4,
+  petsPerPreview = 6,
+): Promise<CollectionListingPreview[]> {
+  const rows = await getCollectionListingMetadata(minPets);
+  return hydrateCollectionListingRows(rows, petsPerPreview);
+}
+
+export async function getCollectionListingPreviewsBySlugs(
+  slugs: string[],
+  minPets = 4,
+  petsPerPreview = 6,
+): Promise<CollectionListingPreview[]> {
+  if (slugs.length === 0) return [];
+  const allowed = new Set(slugs);
+  const order = new Map(slugs.map((slug, index) => [slug, index]));
+  const rows = (await getCollectionListingMetadata(minPets))
+    .filter((row) => allowed.has(row.slug))
+    .sort((a, b) => (order.get(a.slug) ?? 0) - (order.get(b.slug) ?? 0));
+  return hydrateCollectionListingRows(rows, petsPerPreview);
 }
 
 export async function getCollection(
@@ -242,6 +258,18 @@ export async function getOwnerCollection(
 
   const [collection] = await hydrateCollections(rows);
   return collection ?? null;
+}
+
+async function hydrateCollectionListingRows(
+  rows: CollectionListingMetadata[],
+  petsPerPreview: number,
+): Promise<CollectionListingPreview[]> {
+  const hydrated = await hydrateCollections(rows, petsPerPreview);
+  const countBySlug = new Map(rows.map((r) => [r.slug, r.petCount]));
+  return hydrated.map((c) => ({
+    ...c,
+    petCount: countBySlug.get(c.slug) ?? c.pets.length,
+  }));
 }
 
 // Personal collections owned by a creator. NOT filtered by featured —

--- a/src/lib/route-cost.test.ts
+++ b/src/lib/route-cost.test.ts
@@ -56,6 +56,9 @@ describe("route cost helpers", () => {
       "/api/ads/checkout",
     );
     expect(normalizeRouteCostPath("/api/ads/event")).toBe("/api/ads/event");
+    expect(normalizeRouteCostPath("/api/collections/previews")).toBe(
+      "/api/collections/previews",
+    );
   });
 
   it("buckets unmatched paths without preserving random segments", () => {

--- a/src/lib/route-cost.ts
+++ b/src/lib/route-cost.ts
@@ -106,6 +106,7 @@ const STATIC_ROUTE_SET = new Set([
   "api/cli/submit",
   "api/cli/submit/check",
   "api/cli/submit/register",
+  "api/collections/previews",
   "api/desktop/latest-release",
   "api/feedback",
   "api/feedback/unread",


### PR DESCRIPTION
## Summary
- keep full /collections metadata in SSR but include preview pets only for the first visible window
- add a public cached /api/collections/previews endpoint for later visible collection covers
- teach route-cost attribution to keep /api/collections/previews distinct

## Validation
- bun run format -- src/lib/route-cost.ts src/lib/route-cost.test.ts src/lib/collections.ts 'src/app/[locale]/collections/page.tsx' src/components/collections-browser.tsx src/app/api/collections/previews/route.ts
- bun test --env-file=.env.mock src/lib/route-cost.test.ts
- bun run check
- bun run i18n:check
- git diff --check
- bun test --env-file=.env.mock
- TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build