### PR TITLE
Trim public requests payload

### DIFF
--- a/src/app/[locale]/requests/page.tsx
+++ b/src/app/[locale]/requests/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-import { clerkClient } from "@clerk/nextjs/server";
+import { auth, clerkClient } from "@clerk/nextjs/server";
 import { desc, inArray, sql } from "drizzle-orm";
 import { getTranslations } from "next-intl/server";
 
@@ -14,6 +14,8 @@ import { SiteHeader } from "@/components/site-header";
 import { hasLocale } from "@/i18n/config";
 
 export const dynamic = "force-dynamic";
+
+const VISIBLE_VOTER_LIMIT = 3;
 
 export async function generateMetadata({
   params,
@@ -35,12 +37,23 @@ export async function generateMetadata({
 
 export default async function RequestsPage() {
   const t = await getTranslations("requests");
+  const { userId } = await auth();
 
   // Pull everything (open + fulfilled + dismissed) so the sort tabs in
   // RequestsView can switch instantly without a refetch. The list is
   // small enough that 80 rows is fine.
   const rows = await db
-    .select()
+    .select({
+      id: schema.petRequests.id,
+      query: schema.petRequests.query,
+      requestedBy: schema.petRequests.requestedBy,
+      upvoteCount: schema.petRequests.upvoteCount,
+      status: schema.petRequests.status,
+      fulfilledPetSlug: schema.petRequests.fulfilledPetSlug,
+      imageUrl: schema.petRequests.imageUrl,
+      imageReviewStatus: schema.petRequests.imageReviewStatus,
+      createdAt: schema.petRequests.createdAt,
+    })
     .from(schema.petRequests)
     .orderBy(
       sql`${schema.petRequests.upvoteCount} DESC, ${schema.petRequests.createdAt} DESC`,
@@ -63,15 +76,23 @@ export default async function RequestsPage() {
 
   const userIdSet = new Set<string>();
   for (const r of rows) if (r.requestedBy) userIdSet.add(r.requestedBy);
-  for (const v of votes) userIdSet.add(v.userId);
 
   type ClerkInfo = {
     handle: string;
     displayName: string | null;
-    username: string | null;
     imageUrl: string | null;
   };
   const clerkInfo = new Map<string, ClerkInfo>();
+  const votersByRequestId = new Map<string, string[]>();
+  const requesterByRequestId = new Map(rows.map((r) => [r.id, r.requestedBy]));
+  for (const v of votes) {
+    if (v.userId === requesterByRequestId.get(v.requestId)) continue;
+    const current = votersByRequestId.get(v.requestId) ?? [];
+    if (current.length >= VISIBLE_VOTER_LIMIT) continue;
+    current.push(v.userId);
+    votersByRequestId.set(v.requestId, current);
+    userIdSet.add(v.userId);
+  }
   if (userIdSet.size > 0) {
     try {
       const client = await clerkClient();
@@ -91,7 +112,6 @@ export default async function RequestsPage() {
               ? u.username.toLowerCase()
               : u.id.slice(-8).toLowerCase(),
             displayName: displayName || null,
-            username: u.username ?? null,
             imageUrl: u.imageUrl ?? null,
           });
         }
@@ -116,7 +136,6 @@ export default async function RequestsPage() {
         .select({
           slug: schema.submittedPets.slug,
           displayName: schema.submittedPets.displayName,
-          spritesheetUrl: schema.submittedPets.spritesheetUrl,
         })
         .from(schema.submittedPets)
         .where(inArray(schema.submittedPets.slug, fulfilledSlugs))
@@ -127,11 +146,10 @@ export default async function RequestsPage() {
     const requester = r.requestedBy
       ? (clerkInfo.get(r.requestedBy) ?? null)
       : null;
-    const voters = votes
-      .filter((v) => v.requestId === r.id && v.userId !== r.requestedBy)
-      .map((v) => clerkInfo.get(v.userId))
+    const voters = (votersByRequestId.get(r.id) ?? [])
+      .map((id) => clerkInfo.get(id))
       .filter((v): v is ClerkInfo => Boolean(v))
-      .slice(0, 6);
+      .slice(0, VISIBLE_VOTER_LIMIT);
     const fulfilledPet = r.fulfilledPetSlug
       ? (petBySlug.get(r.fulfilledPetSlug) ?? null)
       : null;
@@ -174,7 +192,7 @@ export default async function RequestsPage() {
           </Link>
         </header>
 
-        <RequestsView initial={initial} />
+        <RequestsView initial={initial} refreshOnMount={Boolean(userId)} />
       </section>
       <SiteFooter />
     </main>

--- a/src/app/api/pet-requests/route.ts
+++ b/src/app/api/pet-requests/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import { neon } from "@neondatabase/serverless";
-import { desc, eq, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
 
 import { db, schema } from "@/lib/db/client";
 import {
@@ -23,6 +23,7 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const rawSql = neon(process.env.DATABASE_URL ?? "");
+const VISIBLE_VOTER_LIMIT = 3;
 
 function normalize(q: string): string {
   return q
@@ -46,14 +47,34 @@ export async function GET(req: Request): Promise<Response> {
 
   const rows = includeAll
     ? await db
-        .select()
+        .select({
+          id: schema.petRequests.id,
+          query: schema.petRequests.query,
+          requestedBy: schema.petRequests.requestedBy,
+          upvoteCount: schema.petRequests.upvoteCount,
+          status: schema.petRequests.status,
+          fulfilledPetSlug: schema.petRequests.fulfilledPetSlug,
+          imageUrl: schema.petRequests.imageUrl,
+          imageReviewStatus: schema.petRequests.imageReviewStatus,
+          createdAt: schema.petRequests.createdAt,
+        })
         .from(schema.petRequests)
         .orderBy(
           sql`${schema.petRequests.upvoteCount} DESC, ${schema.petRequests.createdAt} DESC`,
         )
         .limit(limit)
     : await db
-        .select()
+        .select({
+          id: schema.petRequests.id,
+          query: schema.petRequests.query,
+          requestedBy: schema.petRequests.requestedBy,
+          upvoteCount: schema.petRequests.upvoteCount,
+          status: schema.petRequests.status,
+          fulfilledPetSlug: schema.petRequests.fulfilledPetSlug,
+          imageUrl: schema.petRequests.imageUrl,
+          imageReviewStatus: schema.petRequests.imageReviewStatus,
+          createdAt: schema.petRequests.createdAt,
+        })
         .from(schema.petRequests)
         .where(eq(schema.petRequests.status, statusParam))
         .orderBy(
@@ -70,12 +91,16 @@ export async function GET(req: Request): Promise<Response> {
     const v = await db
       .select({ requestId: schema.petRequestVotes.requestId })
       .from(schema.petRequestVotes)
-      .where(eq(schema.petRequestVotes.userId, userId));
+      .where(
+        and(
+          eq(schema.petRequestVotes.userId, userId),
+          inArray(schema.petRequestVotes.requestId, requestIds),
+        ),
+      );
     myVotes = new Set(v.map((r) => r.requestId));
   }
 
-  // Top voters per request (most-recent first; cap is enforced client-
-  // side as we render up to 3).
+  // Top voters per request, most-recent first.
   type VoteRow = { requestId: string; userId: string };
   const votes: VoteRow[] = requestIds.length
     ? ((await db
@@ -91,15 +116,23 @@ export async function GET(req: Request): Promise<Response> {
   // Batch one Clerk lookup for all relevant userIds (requesters + voters).
   const userIdSet = new Set<string>();
   for (const r of rows) if (r.requestedBy) userIdSet.add(r.requestedBy);
-  for (const v of votes) userIdSet.add(v.userId);
 
   type ClerkInfo = {
     handle: string;
     displayName: string | null;
-    username: string | null;
     imageUrl: string | null;
   };
   const clerkInfo = new Map<string, ClerkInfo>();
+  const votersByRequestId = new Map<string, string[]>();
+  const requesterByRequestId = new Map(rows.map((r) => [r.id, r.requestedBy]));
+  for (const v of votes) {
+    if (v.userId === requesterByRequestId.get(v.requestId)) continue;
+    const current = votersByRequestId.get(v.requestId) ?? [];
+    if (current.length >= VISIBLE_VOTER_LIMIT) continue;
+    current.push(v.userId);
+    votersByRequestId.set(v.requestId, current);
+    userIdSet.add(v.userId);
+  }
   if (userIdSet.size > 0) {
     try {
       const client = await clerkClient();
@@ -119,7 +152,6 @@ export async function GET(req: Request): Promise<Response> {
               ? u.username.toLowerCase()
               : u.id.slice(-8).toLowerCase(),
             displayName: displayName || null,
-            username: u.username ?? null,
             imageUrl: u.imageUrl ?? null,
           });
         }
@@ -141,7 +173,6 @@ export async function GET(req: Request): Promise<Response> {
         .select({
           slug: schema.submittedPets.slug,
           displayName: schema.submittedPets.displayName,
-          spritesheetUrl: schema.submittedPets.spritesheetUrl,
         })
         .from(schema.submittedPets)
         .where(inArray(schema.submittedPets.slug, fulfilledSlugs))
@@ -153,16 +184,10 @@ export async function GET(req: Request): Promise<Response> {
       const requester = r.requestedBy
         ? (clerkInfo.get(r.requestedBy) ?? null)
         : null;
-      // Exclude the requester from the voter stack — they auto-vote
-      // for their own request, but rendering them twice in the UI
-      // (chip + duplicate avatar) feels broken.
-      const voterUserIds = votes
-        .filter((v) => v.requestId === r.id && v.userId !== r.requestedBy)
-        .map((v) => v.userId);
-      const voters = voterUserIds
+      const voters = (votersByRequestId.get(r.id) ?? [])
         .map((id) => clerkInfo.get(id))
         .filter((v): v is ClerkInfo => Boolean(v))
-        .slice(0, 6);
+        .slice(0, VISIBLE_VOTER_LIMIT);
       const fulfilledPet = r.fulfilledPetSlug
         ? (petBySlug.get(r.fulfilledPetSlug) ?? null)
         : null;

--- a/src/components/requests-view.tsx
+++ b/src/components/requests-view.tsx
@@ -30,14 +30,12 @@ import { ClaimRequestButton } from "@/components/claim-request-button";
 type ClerkInfo = {
   handle: string;
   displayName: string | null;
-  username: string | null;
   imageUrl: string | null;
 };
 
 type FulfilledPet = {
   slug: string;
   displayName: string;
-  spritesheetUrl: string;
 };
 
 export type RequestRow = {
@@ -63,7 +61,13 @@ const COLLECTION_PREFIX = "Collection:";
 type Sort = "top" | "new" | "fulfilled";
 type RequestKind = "pet" | "collection";
 
-export function RequestsView({ initial }: { initial: RequestRow[] }) {
+export function RequestsView({
+  initial,
+  refreshOnMount,
+}: {
+  initial: RequestRow[];
+  refreshOnMount: boolean;
+}) {
   const t = useTranslations("requests.view");
   const [requests, setRequests] = useState<RequestRow[]>(initial);
   const [pending, setPending] = useState<Set<string>>(new Set());
@@ -90,6 +94,7 @@ export function RequestsView({ initial }: { initial: RequestRow[] }) {
   // We always pull status=all so all three sort tabs work without
   // another roundtrip when the user toggles them.
   useEffect(() => {
+    if (!refreshOnMount) return;
     let cancelled = false;
     void (async () => {
       try {
@@ -105,7 +110,7 @@ export function RequestsView({ initial }: { initial: RequestRow[] }) {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [refreshOnMount]);
 
   const counts = useMemo(() => {
     return {


### PR DESCRIPTION
## Summary
- select only public request columns needed by `/requests` and `/api/pet-requests`
- send only the visible voter avatars instead of every voter profile
- remove unused fulfilled-pet `spritesheetUrl` and Clerk `username` fields from the hydrated shape
- skip the anonymous `/api/pet-requests?status=all&limit=80` refetch; signed-in users still refresh to light up their own votes

## Validation
- `bun run format -- src/app/[locale]/requests/page.tsx src/app/api/pet-requests/route.ts src/components/requests-view.tsx`
- `bun test --env-file=.env.mock src/app/api/pets/search/route.test.ts src/lib/route-cost.test.ts`
- `git diff --check`
- `bun run check`
- `bun run i18n:check`
- `bun test --env-file=.env.mock`
- `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build`