### PR TITLE
fix(seo): point public SEO outputs at canonical petdex.dev

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -12,7 +12,7 @@ import { SiteHeader } from "@/components/site-header";
 
 import { hasLocale } from "@/i18n/config";
 
-const SITE_URL = "https://petdex.crafter.run";
+const SITE_URL = "https://petdex.dev";
 
 export const revalidate = 3600;
 

--- a/src/app/[locale]/advertise/page.tsx
+++ b/src/app/[locale]/advertise/page.tsx
@@ -19,7 +19,7 @@ import { SiteHeader } from "@/components/site-header";
 import type { Locale } from "@/i18n/config";
 import { hasLocale } from "@/i18n/config";
 
-const SITE_URL = "https://petdex.crafter.run";
+const SITE_URL = "https://petdex.dev";
 const PACKAGE_IDS = Object.keys(AD_PACKAGES) as Array<keyof typeof AD_PACKAGES>;
 
 export async function generateMetadata({

--- a/src/app/[locale]/brand/page.tsx
+++ b/src/app/[locale]/brand/page.tsx
@@ -10,7 +10,7 @@ import { SiteHeader } from "@/components/site-header";
 
 import { hasLocale } from "@/i18n/config";
 
-const SITE_URL = "https://petdex.crafter.run";
+const SITE_URL = "https://petdex.dev";
 const PREVIEW_BACKGROUND = {
   light: "bg-[#f7f8ff]",
   dark: "bg-[#12141f]",

--- a/src/app/[locale]/built-with/page.tsx
+++ b/src/app/[locale]/built-with/page.tsx
@@ -15,7 +15,7 @@ import { SiteHeader } from "@/components/site-header";
 import builtWithData from "@/data/built-with.json";
 import { hasLocale } from "@/i18n/config";
 
-const SITE_URL = "https://petdex.crafter.run";
+const SITE_URL = "https://petdex.dev";
 const SUBMIT_ISSUE_URL =
   "https://github.com/crafter-station/petdex/issues/new?template=built-with.yml";
 const REGISTRY_URL =

--- a/src/app/[locale]/collections/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/collections/[slug]/opengraph-image.tsx
@@ -232,7 +232,7 @@ export default async function Image({
             textTransform: "uppercase",
           }}
         >
-          petdex.crafter.run/collections/{collection.slug}
+          petdex.dev/collections/{collection.slug}
         </div>
       </div>
     </div>,

--- a/src/app/[locale]/collections/[slug]/page.tsx
+++ b/src/app/[locale]/collections/[slug]/page.tsx
@@ -22,7 +22,7 @@ import { defaultLocale, hasLocale } from "@/i18n/config";
 export const dynamic = "force-static";
 export const revalidate = 86400;
 
-const SITE_URL = "https://petdex.crafter.run";
+const SITE_URL = "https://petdex.dev";
 
 type PageProps = { params: Promise<{ slug: string; locale: string }> };
 

--- a/src/app/[locale]/collections/page.tsx
+++ b/src/app/[locale]/collections/page.tsx
@@ -21,7 +21,7 @@ import { hasLocale } from "@/i18n/config";
 // a function on every visit.
 export const revalidate = 86400;
 
-const SITE_URL = "https://petdex.crafter.run";
+const SITE_URL = "https://petdex.dev";
 const MIN_PETS = 4;
 const INITIAL_PREVIEW_COUNT = 24;
 

--- a/src/app/[locale]/community/page.tsx
+++ b/src/app/[locale]/community/page.tsx
@@ -24,7 +24,7 @@ import {
 import { hasLocale } from "@/i18n/config";
 
 export const dynamic = "force-static";
-const SITE_URL = "https://petdex.crafter.run";
+const SITE_URL = "https://petdex.dev";
 const WECHAT_COMMUNITY_ENABLED =
   process.env.NEXT_PUBLIC_WECHAT_COMMUNITY_ENABLED === "1";
 

--- a/src/app/[locale]/download/opengraph-image.tsx
+++ b/src/app/[locale]/download/opengraph-image.tsx
@@ -170,7 +170,7 @@ export default async function Image({
             textTransform: "uppercase",
           }}
         >
-          petdex.crafter.run/download
+          petdex.dev/download
         </div>
       </div>
     </div>,

--- a/src/app/[locale]/download/page.tsx
+++ b/src/app/[locale]/download/page.tsx
@@ -26,7 +26,7 @@ import { StaticPetSprite } from "@/components/static-pet-sprite";
 import { hasLocale } from "@/i18n/config";
 import { buildSetupSteps, parsePendingInstallSlugs } from "./setup-steps";
 
-const SITE_URL = "https://petdex.crafter.run";
+const SITE_URL = "https://petdex.dev";
 const DEFAULT_PREVIEW_PET_SLUG = "boba";
 const DEFAULT_PREVIEW_PET = {
   displayName: "Boba",

--- a/src/app/[locale]/kind/[kind]/page.tsx
+++ b/src/app/[locale]/kind/[kind]/page.tsx
@@ -11,7 +11,7 @@ import { JsonLd } from "@/components/json-ld";
 
 import { hasLocale } from "@/i18n/config";
 
-const SITE_URL = "https://petdex.crafter.run";
+const SITE_URL = "https://petdex.dev";
 
 type Props = { params: Promise<{ kind: string; locale: string }> };
 

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -37,7 +37,7 @@ type Props = {
   params: Promise<{ locale: string }>;
 };
 
-const SITE_URL = "https://petdex.crafter.run";
+const SITE_URL = "https://petdex.dev";
 
 export function generateStaticParams() {
   return locales.map((locale) => ({ locale }));

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -62,7 +62,7 @@ export async function generateMetadata({
     ),
   };
 }
-const SITE_URL = "https://petdex.crafter.run";
+const SITE_URL = "https://petdex.dev";
 const HOME_INITIAL_GALLERY_LIMIT = 10;
 
 export function generateStaticParams() {

--- a/src/app/[locale]/pets/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/pets/[slug]/opengraph-image.tsx
@@ -263,7 +263,7 @@ export default async function Image({
             textTransform: "uppercase",
           }}
         >
-          petdex.crafter.run
+          petdex.dev
         </div>
       </div>
     </div>,

--- a/src/app/[locale]/pets/[slug]/page.tsx
+++ b/src/app/[locale]/pets/[slug]/page.tsx
@@ -38,7 +38,7 @@ import { SubmittedBy } from "@/components/submitted-by";
 
 import { defaultLocale, hasLocale } from "@/i18n/config";
 
-const SITE_URL = "https://petdex.crafter.run";
+const SITE_URL = "https://petdex.dev";
 
 type PageProps = {
   params: Promise<{

--- a/src/app/[locale]/u/[handle]/opengraph-image.tsx
+++ b/src/app/[locale]/u/[handle]/opengraph-image.tsx
@@ -298,7 +298,7 @@ export default async function Image({
               textTransform: "uppercase",
             }}
           >
-            {petCount} {petCount === 1 ? "pet" : "pets"} · petdex.crafter.run
+            {petCount} {petCount === 1 ? "pet" : "pets"} · petdex.dev
           </div>
         </div>
       </div>

--- a/src/app/[locale]/u/[handle]/page.tsx
+++ b/src/app/[locale]/u/[handle]/page.tsx
@@ -36,7 +36,7 @@ import { hasLocale } from "@/i18n/config";
 
 export const dynamic = "force-dynamic";
 
-const SITE_URL = "https://petdex.crafter.run";
+const SITE_URL = "https://petdex.dev";
 
 type PageProps = { params: Promise<{ handle: string; locale: string }> };
 

--- a/src/app/[locale]/vibe/[vibe]/page.tsx
+++ b/src/app/[locale]/vibe/[vibe]/page.tsx
@@ -20,7 +20,7 @@ function curatedSort(pets: PetWithMetrics[]): PetWithMetrics[] {
   });
 }
 
-const SITE_URL = "https://petdex.crafter.run";
+const SITE_URL = "https://petdex.dev";
 
 type Props = { params: Promise<{ locale: string; vibe: string }> };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 
 import "./globals.css";
 
-const SITE_URL = "https://petdex.crafter.run";
+const SITE_URL = "https://petdex.dev";
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from "next";
 
-const SITE = "https://petdex.crafter.run";
+const SITE = "https://petdex.dev";
 
 export default function robots(): MetadataRoute.Robots {
   return {

--- a/src/components/collection-action-menu.tsx
+++ b/src/components/collection-action-menu.tsx
@@ -25,7 +25,7 @@ import { track } from "@/lib/vercel-analytics";
 
 import { CodexLogo } from "@/components/codex-logo";
 
-const SITE_URL = "https://petdex.crafter.run";
+const SITE_URL = "https://petdex.dev";
 // Cap on the install command length. Beyond this we truncate with a
 // hint so the user can paste the rest manually instead of getting a
 // 4 KB clipboard payload that some shells reject.

--- a/src/components/pet-action-menu.tsx
+++ b/src/components/pet-action-menu.tsx
@@ -41,7 +41,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
-const SITE_URL = "https://petdex.crafter.run";
+const SITE_URL = "https://petdex.dev";
 const TAKEDOWN_ISSUE_URL =
   "https://github.com/crafter-station/petdex/issues/new";
 

--- a/src/components/profile-share-button.tsx
+++ b/src/components/profile-share-button.tsx
@@ -14,7 +14,7 @@ import { createPortal } from "react-dom";
 
 import { track } from "@/lib/vercel-analytics";
 
-const SITE_URL = "https://petdex.crafter.run";
+const SITE_URL = "https://petdex.dev";
 
 type Props = {
   /** Public handle without leading @ — used to build the URL. */

--- a/src/lib/locale-routing.ts
+++ b/src/lib/locale-routing.ts
@@ -1,6 +1,6 @@
 import { defaultLocale, type Locale } from "@/i18n/config";
 
-export const SITE_URL = "https://petdex.crafter.run";
+export const SITE_URL = "https://petdex.dev";
 
 const HREFLANG_BY_LOCALE: Record<Locale, string> = {
   en: "en",

--- a/src/lib/seo-canonical.test.ts
+++ b/src/lib/seo-canonical.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  buildAbsoluteLocaleAlternates,
+  buildAbsoluteUrl,
+  SITE_URL,
+} from "@/lib/locale-routing";
+
+// Guard against the legacy domain leaking back into any crawler-facing
+// SEO output during/after the petdex.crafter.run -> petdex.dev migration.
+// The legacy host should survive ONLY in redirect/proxy compatibility
+// config (next.config.ts redirects, proxy.ts), never in canonical URLs,
+// sitemap, robots, hreflang, Open Graph, Twitter cards, or JSON-LD.
+
+const CANONICAL_ORIGIN = "https://petdex.dev";
+const LEGACY_HOST = "petdex.crafter.run";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+
+// Every file that emits a public SEO artifact. If a new SEO surface is
+// added, list it here so the guard keeps covering it.
+const SEO_SOURCE_FILES = [
+  "src/lib/locale-routing.ts",
+  "src/app/sitemap.ts",
+  "src/app/robots.ts",
+  "src/app/layout.tsx",
+  "src/app/[locale]/layout.tsx",
+  "src/components/json-ld.tsx",
+  "src/app/[locale]/page.tsx",
+  "src/app/[locale]/about/page.tsx",
+  "src/app/[locale]/advertise/page.tsx",
+  "src/app/[locale]/brand/page.tsx",
+  "src/app/[locale]/built-with/page.tsx",
+  "src/app/[locale]/collections/page.tsx",
+  "src/app/[locale]/collections/[slug]/page.tsx",
+  "src/app/[locale]/community/page.tsx",
+  "src/app/[locale]/download/page.tsx",
+  "src/app/[locale]/kind/[kind]/page.tsx",
+  "src/app/[locale]/pets/[slug]/page.tsx",
+  "src/app/[locale]/u/[handle]/page.tsx",
+  "src/app/[locale]/vibe/[vibe]/page.tsx",
+  "src/app/[locale]/collections/[slug]/opengraph-image.tsx",
+  "src/app/[locale]/download/opengraph-image.tsx",
+  "src/app/[locale]/pets/[slug]/opengraph-image.tsx",
+  "src/app/[locale]/u/[handle]/opengraph-image.tsx",
+  "src/components/collection-action-menu.tsx",
+  "src/components/pet-action-menu.tsx",
+  "src/components/profile-share-button.tsx",
+];
+
+describe("SEO canonical domain", () => {
+  it("locale-routing SITE_URL is the canonical origin", () => {
+    expect(SITE_URL).toBe(CANONICAL_ORIGIN);
+  });
+
+  it("absolute sitemap URLs resolve to the canonical origin", () => {
+    expect(buildAbsoluteUrl("/", "en")).toBe(`${CANONICAL_ORIGIN}/`);
+    expect(buildAbsoluteUrl("/pets/cai-chao", "zh")).toBe(
+      `${CANONICAL_ORIGIN}/zh/pets/cai-chao`,
+    );
+  });
+
+  it("hreflang alternates are all on the canonical origin", () => {
+    const { languages } = buildAbsoluteLocaleAlternates("/pets/cai-chao");
+    for (const url of Object.values(languages)) {
+      expect(url.startsWith(`${CANONICAL_ORIGIN}/`)).toBe(true);
+      expect(url).not.toContain(LEGACY_HOST);
+    }
+  });
+
+  it("no SEO source file references the legacy domain", () => {
+    const offenders: string[] = [];
+    for (const rel of SEO_SOURCE_FILES) {
+      const source = readFileSync(join(REPO_ROOT, rel), "utf8");
+      if (source.includes(LEGACY_HOST)) offenders.push(rel);
+    }
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Make every crawler-facing SEO output use `https://petdex.dev` as canonical, so we do not lose the legacy domain's SEO equity during the migration. Builds on top of #381 (host-level 308 redirects from `petdex.crafter.run` → `petdex.dev`).

## SEO surfaces audited and fixed

| Surface | Before | After |
|---|---|---|
| `metadataBase` (root layout) | petdex.crafter.run | petdex.dev |
| canonical URLs | resolved off legacy base | petdex.dev |
| hreflang alternates (sitemap) | petdex.crafter.run | petdex.dev |
| sitemap `<loc>` | petdex.crafter.run | petdex.dev |
| robots `Host` / `Sitemap` | petdex.crafter.run | petdex.dev |
| Open Graph `url` / `image` | petdex.crafter.run | petdex.dev |
| Twitter card images | resolved off legacy base | petdex.dev |
| JSON-LD `@id` / breadcrumbs | petdex.crafter.run | petdex.dev |
| OG image visible domain text | petdex.crafter.run | petdex.dev |
| share-link components | petdex.crafter.run | petdex.dev |

24 one-line domain swaps. `sitemap.ts` and `json-ld.tsx` needed no edits — they read the central `SITE_URL` from `locale-routing.ts`.

## Out of scope (intentionally left as-is)

- Redirect/proxy compatibility: `next.config.ts` redirects + `proxy.ts` (owned by #381)
- CLI install commands, email templates, OAuth issuer, wasticker publisher metadata, `built-with.json` third-party quotes, i18n doc strings — none are crawler-facing canonical signals
- No CI workflow changes. No Cloudflare/Astro migration WIP.

## Regression guard

`src/lib/seo-canonical.test.ts`:
- asserts `SITE_URL`, `buildAbsoluteUrl`, `buildAbsoluteLocaleAlternates` resolve to `petdex.dev`
- statically scans every SEO source file and fails if `petdex.crafter.run` reappears

Confirmed the guard fails when a legacy reference is reintroduced and passes after.

## Verification

- `bunx biome check` on all 25 changed files: clean
- `bun test`: 454 pass, 0 fail (incl. new guard)
- mock-mode `bun run build`: green
- Generated `sitemap.xml`: 540 `petdex.dev` URLs, **0** legacy references; hreflang (en/es/zh-Hans/x-default) all on `petdex.dev`
- Generated `robots.txt`: `Host` + `Sitemap` → `petdex.dev`
- Smoke `/`: canonical + og:url = `petdex.dev`
- Smoke `/api/og`: 200; OG image URLs build off `petdex.dev`

## Acceptance

- [x] Crawlers see `petdex.dev` as canonical everywhere
- [x] Backlinks to `petdex.crafter.run/...` land on the same path at `petdex.dev/...` (via #381, path + query preserved, single 308)
- [x] Sitemap contains `petdex.dev` URLs only
- [x] No accidental `noindex` on production public pages (existing noindex limited to private/transactional + not-found branches)
- [x] No CI workflow changes
- [x] Small and focused