### PR TITLE
Add explicit type annotation to CURRENT_BUILD_KEY

### DIFF
--- a/src/lib/current-build.ts
+++ b/src/lib/current-build.ts
@@ -1,3 +1,3 @@
 import { CURRENT_BUILD_KEY as GENERATED_CURRENT_BUILD_KEY } from "@/generated/current-build";
 
-export const CURRENT_BUILD_KEY = GENERATED_CURRENT_BUILD_KEY || null;
+export const CURRENT_BUILD_KEY: string | null = GENERATED_CURRENT_BUILD_KEY || null;


### PR DESCRIPTION
## Problem Background
In TypeScript, explicit type annotations improve code clarity and ensure robust type checking. The exported constant `CURRENT_BUILD_KEY` lacked an explicit type, which could lead to less predictable type inference and potentially affect maintainability.

## Changes
Added the explicit type annotation `string | null` to `CURRENT_BUILD_KEY` based on its initialization expression (`GENERATED_CURRENT_BUILD_KEY || null`), enhancing readability and type safety without altering functionality.

## Verification
- Run the TypeScript compiler (e.g., `tsc`) to confirm no type errors are introduced.
- Execute project tests to ensure no behavioral changes occur.