### PR TITLE
Clean up public artifacts on moderation changes

### DIFF
--- a/scripts/takedown-by-keyword.ts
+++ b/scripts/takedown-by-keyword.ts
@@ -28,6 +28,7 @@ import {
   findBlockedKeyword,
 } from "@/lib/keyword-blocklist";
 import { createNotification } from "@/lib/notifications";
+import { petPublicArtifactKeys } from "@/lib/pet-public-artifact-keys";
 import { deleteR2Objects, keyFromR2Url } from "@/lib/r2";
 import { getPreferredLocaleForUser } from "@/lib/user-locale";
 
@@ -158,6 +159,7 @@ async function takedownOne(pet: Pet, reason: string) {
     keyFromR2Url(pet.petJsonUrl),
     keyFromR2Url(pet.zipUrl),
     keyFromR2Url(pet.soundUrl),
+    ...petPublicArtifactKeys(slug),
   ].filter((k): k is string => Boolean(k));
   try {
     await deleteR2Objects(keys);

--- a/scripts/takedown-pet.ts
+++ b/scripts/takedown-pet.ts
@@ -16,6 +16,7 @@ import { Resend } from "resend";
 import { db, schema } from "@/lib/db/client";
 import { renderSubmissionTakedownEmail } from "@/lib/email-templates/submission-takedown";
 import { createNotification } from "@/lib/notifications";
+import { petPublicArtifactKeys } from "@/lib/pet-public-artifact-keys";
 import { deleteR2Objects, keyFromR2Url } from "@/lib/r2";
 import { getPreferredLocaleForUser } from "@/lib/user-locale";
 
@@ -64,6 +65,7 @@ async function main() {
     keyFromR2Url(pet.petJsonUrl),
     keyFromR2Url(pet.zipUrl),
     keyFromR2Url(pet.soundUrl),
+    ...petPublicArtifactKeys(pet.slug),
   ].filter((k): k is string => Boolean(k));
 
   console.log("\nTakedown plan");

--- a/src/app/api/pets/[slug]/sticker/route.ts
+++ b/src/app/api/pets/[slug]/sticker/route.ts
@@ -6,6 +6,7 @@ import {
   petStickerFilename,
   petStickerUrl,
 } from "@/lib/pet-sticker-artifacts";
+import { getPet } from "@/lib/pets";
 
 export const runtime = "nodejs";
 
@@ -17,14 +18,21 @@ export async function GET(
   if (!isValidPetSlug(slug)) {
     return new NextResponse("invalid_slug", { status: 400 });
   }
+  const pet = await getPet(slug);
+  if (!pet) {
+    return new NextResponse("not_found", {
+      status: 404,
+      headers: { "cache-control": "no-store" },
+    });
+  }
 
-  const response = NextResponse.redirect(petStickerUrl(slug), {
+  const response = NextResponse.redirect(petStickerUrl(pet.slug), {
     status: 308,
   });
   response.headers.set("cache-control", PET_STICKER_REDIRECT_CACHE_HEADER);
   response.headers.set(
     "content-disposition",
-    `attachment; filename="${petStickerFilename(slug)}"`,
+    `attachment; filename="${petStickerFilename(pet.slug)}"`,
   );
   return response;
 }

--- a/src/app/api/pets/[slug]/thumb/route.ts
+++ b/src/app/api/pets/[slug]/thumb/route.ts
@@ -5,6 +5,7 @@ import {
   PET_THUMBNAIL_REDIRECT_CACHE_HEADER,
   petThumbnailUrl,
 } from "@/lib/pet-thumbnail";
+import { getPet } from "@/lib/pets";
 
 export const runtime = "nodejs";
 
@@ -16,8 +17,15 @@ export async function GET(
   if (!isValidPetSlug(slug)) {
     return new NextResponse("invalid_slug", { status: 400 });
   }
+  const pet = await getPet(slug);
+  if (!pet) {
+    return new NextResponse("not_found", {
+      status: 404,
+      headers: { "cache-control": "no-store" },
+    });
+  }
 
-  const response = NextResponse.redirect(petThumbnailUrl(slug), {
+  const response = NextResponse.redirect(petThumbnailUrl(pet.slug), {
     status: 308,
   });
   response.headers.set("cache-control", PET_THUMBNAIL_REDIRECT_CACHE_HEADER);

--- a/src/app/api/pets/[slug]/wastickers/route.ts
+++ b/src/app/api/pets/[slug]/wastickers/route.ts
@@ -4,6 +4,7 @@ import {
   isValidPetSlug,
   PET_STICKER_UNAVAILABLE_CACHE_HEADER,
 } from "@/lib/pet-sticker-artifacts";
+import { getPet } from "@/lib/pets";
 
 export const runtime = "nodejs";
 
@@ -14,6 +15,13 @@ export async function GET(
   const { slug } = await ctx.params;
   if (!isValidPetSlug(slug)) {
     return new NextResponse("invalid_slug", { status: 400 });
+  }
+  const pet = await getPet(slug);
+  if (!pet) {
+    return new NextResponse("not_found", {
+      status: 404,
+      headers: { "cache-control": "no-store" },
+    });
   }
 
   return new NextResponse("pack_unavailable", {

--- a/src/lib/pet-public-artifact-keys.test.ts
+++ b/src/lib/pet-public-artifact-keys.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+
+import { petPublicArtifactKeys } from "@/lib/pet-public-artifact-keys";
+import {
+  PET_STICKER_FORMATS,
+  PET_STICKER_STATES,
+} from "@/lib/pet-sticker-artifacts";
+import { petThumbnailKey } from "@/lib/pet-thumbnail";
+
+describe("pet public artifact keys", () => {
+  it("covers thumbnails, every sticker derivative, and packs", () => {
+    const keys = petPublicArtifactKeys("cai-chao");
+
+    expect(keys).toContain(petThumbnailKey("cai-chao"));
+    expect(keys).toContain("pets/cai-chao/wastickers.zip");
+
+    for (const state of PET_STICKER_STATES) {
+      for (const format of PET_STICKER_FORMATS) {
+        expect(keys).toContain(`pets/cai-chao/stickers/${state}.${format}`);
+      }
+    }
+
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});

--- a/src/lib/pet-public-artifact-keys.ts
+++ b/src/lib/pet-public-artifact-keys.ts
@@ -1,0 +1,17 @@
+import {
+  PET_STICKER_FORMATS,
+  PET_STICKER_STATES,
+  petStickerKey,
+  petStickerPackKey,
+} from "@/lib/pet-sticker-artifacts";
+import { petThumbnailKey } from "@/lib/pet-thumbnail";
+
+export function petPublicArtifactKeys(slug: string): string[] {
+  return [
+    petThumbnailKey(slug),
+    ...PET_STICKER_STATES.flatMap((state) =>
+      PET_STICKER_FORMATS.map((format) => petStickerKey(slug, state, format)),
+    ),
+    petStickerPackKey(slug),
+  ];
+}

--- a/src/lib/public-traffic-guard.test.ts
+++ b/src/lib/public-traffic-guard.test.ts
@@ -11,6 +11,12 @@ describe("public traffic guard", () => {
     expect(
       publicTrafficGuardRule({
         method: "GET",
+        pathname: "/api/pets/nukey/thumb",
+      }),
+    ).toBe("sticker");
+    expect(
+      publicTrafficGuardRule({
+        method: "GET",
         pathname: "/api/pets/nukey/sticker",
       }),
     ).toBe("sticker");
@@ -118,13 +124,7 @@ describe("public traffic guard", () => {
     ).toBe("page");
   });
 
-  it("does not target cheap reads or non-read methods", () => {
-    expect(
-      publicTrafficGuardRule({
-        method: "GET",
-        pathname: "/api/pets/nukey/thumb",
-      }),
-    ).toBeNull();
+  it("does not target non-read methods or private surfaces", () => {
     expect(
       publicTrafficGuardRule({
         method: "POST",

--- a/src/lib/public-traffic-guard.ts
+++ b/src/lib/public-traffic-guard.ts
@@ -19,7 +19,9 @@ export function publicTrafficGuardRule(input: {
 }): PublicTrafficGuardRule | null {
   if (input.method !== "GET" && input.method !== "HEAD") return null;
   const pathname = input.pathname;
-  if (/^\/api\/pets\/[^/]+\/sticker\/?$/.test(pathname)) return "sticker";
+  if (/^\/api\/pets\/[^/]+\/(?:thumb|sticker)\/?$/.test(pathname)) {
+    return "sticker";
+  }
   if (/^\/api\/pets\/[^/]+\/wastickers\/?$/.test(pathname)) return "pack";
   if (pathname === "/api/manifest") return "catalog";
   if (pathname === "/api/collections/previews") return "catalog";

--- a/src/lib/submission-decisions.ts
+++ b/src/lib/submission-decisions.ts
@@ -128,6 +128,22 @@ export async function applySubmissionAction(
   if (body.action === "approve" && !options.skipSideEffects) {
     row = await runPostApprovalEffects(row, actor, db);
   }
+  if (
+    body.action === "edit" &&
+    current.status === "approved" &&
+    row.status === "approved" &&
+    current.slug !== row.slug &&
+    !options.skipSideEffects
+  ) {
+    await publishApprovedPublicArtifacts(row, actor);
+  }
+  if (
+    current.status === "approved" &&
+    (row.status !== "approved" || current.slug !== row.slug) &&
+    !options.skipSideEffects
+  ) {
+    await deletePetPublicArtifacts(current.slug, actor);
+  }
 
   const skipNotifications =
     options.skipNotifications ?? options.skipSideEffects ?? false;
@@ -186,23 +202,7 @@ async function runPostApprovalEffects(
     }
   }
 
-  try {
-    const { publishPetPublicArtifacts } = await import(
-      "@/lib/pet-public-artifacts"
-    );
-    const artifacts = await publishPetPublicArtifacts({
-      slug: row.slug,
-      spritesheetUrl: row.spritesheetUrl,
-    });
-    if (!artifacts.ok) {
-      console.error(`[${actor}] public artifact publish failed`, {
-        slug: row.slug,
-        failed: artifacts.failed,
-      });
-    }
-  } catch (e) {
-    console.error(`[${actor}] public artifact publish failed`, e);
-  }
+  await publishApprovedPublicArtifacts(row, actor);
 
   const { refreshSimilarityFor } = await import("@/lib/similarity");
   void refreshSimilarityFor(row.id).catch((err) => {
@@ -267,6 +267,44 @@ async function runPostApprovalEffects(
   })();
 
   return row;
+}
+
+async function publishApprovedPublicArtifacts(
+  row: SubmittedPet,
+  actor: SubmissionActionActor,
+): Promise<void> {
+  try {
+    const { publishPetPublicArtifacts } = await import(
+      "@/lib/pet-public-artifacts"
+    );
+    const artifacts = await publishPetPublicArtifacts({
+      slug: row.slug,
+      spritesheetUrl: row.spritesheetUrl,
+    });
+    if (!artifacts.ok) {
+      console.error(`[${actor}] public artifact publish failed`, {
+        slug: row.slug,
+        failed: artifacts.failed,
+      });
+    }
+  } catch (e) {
+    console.error(`[${actor}] public artifact publish failed`, e);
+  }
+}
+
+async function deletePetPublicArtifacts(
+  slug: string,
+  actor: SubmissionActionActor,
+): Promise<void> {
+  try {
+    const [{ petPublicArtifactKeys }, { deleteR2Objects }] = await Promise.all([
+      import("@/lib/pet-public-artifact-keys"),
+      import("@/lib/r2"),
+    ]);
+    await deleteR2Objects(petPublicArtifactKeys(slug));
+  } catch (e) {
+    console.error(`[${actor}] public artifact cleanup failed`, { slug, e });
+  }
 }
 
 async function notifySubmissionOwner(row: SubmittedPet): Promise<void> {

--- a/src/lib/takedown.ts
+++ b/src/lib/takedown.ts
@@ -13,6 +13,7 @@ import {
 import { db, schema } from "@/lib/db/client";
 import { renderSubmissionTakedownEmail } from "@/lib/email-templates/submission-takedown";
 import { createNotification } from "@/lib/notifications";
+import { petPublicArtifactKeys } from "@/lib/pet-public-artifact-keys";
 import { deleteR2Objects, keyFromR2Url } from "@/lib/r2";
 import { getPreferredLocaleForUser } from "@/lib/user-locale";
 
@@ -117,15 +118,15 @@ export async function takedownPet(
   await invalidateAggregates(AGGREGATE_KEYS.metricsIndex);
   await invalidateMetricCaches(pet.slug);
 
-  // 6. Best-effort R2 cleanup. We derive keys from the URLs the
-  //    submission stored; anything off-host (legacy or external credit
-  //    image) is skipped. R2 errors are logged but don't fail the
-  //    takedown — the DB is already gone.
+  // 6. Best-effort R2 cleanup. Stored source URLs and deterministic
+  //    public derivatives are removed together. Anything off-host is
+  //    skipped. R2 errors are logged but don't fail the takedown.
   const keys = [
     keyFromR2Url(pet.spritesheetUrl),
     keyFromR2Url(pet.petJsonUrl),
     keyFromR2Url(pet.zipUrl),
     keyFromR2Url(pet.soundUrl),
+    ...petPublicArtifactKeys(slug),
   ].filter((k): k is string => Boolean(k));
   try {
     await deleteR2Objects(keys);


### PR DESCRIPTION
## Summary
- Require an approved pet lookup before thumb, sticker, and wastickers endpoints return public cacheable responses.
- Return 404 no-store for valid slugs that are not currently approved.
- Delete deterministic public derivatives on takedown: thumb, every sticker state/format, and pack zip key.
- Delete old derivatives when an approved submission becomes rejected/pending or changes slug.
- Republish derivatives for approved slug edits.

## Note
The build still emits the existing kind/vibe >2MB data-cache warnings on main. Those are addressed by the follow-up facet-page optimization branch, not by this moderation hotfix.