### PR TITLE
fix(build-version): stop the update banner from getting stuck

### DIFF
--- a/src/components/build-version-watcher.tsx
+++ b/src/components/build-version-watcher.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl";
 
 import {
   buildVersionBrowserCacheKey,
+  clearCachedBuildVersion,
   fetchBuildVersionWithBrowserCache,
   isChunkLoadFailure,
 } from "@/lib/build-version-check";
@@ -26,6 +27,18 @@ export function BuildVersionWatcher() {
 
   const showUpdatePrompt = useCallback((reason: UpdateReason) => {
     setUpdateReason((currentReason) => currentReason ?? reason);
+  }, []);
+
+  const handleRefresh = useCallback(() => {
+    // Drop the cached version token first. Without this, a stale entry can
+    // outlive the reload (bfcache / cached document) and immediately
+    // re-trigger the prompt, leaving the user stuck refreshing forever.
+    try {
+      clearCachedBuildVersion(window.localStorage);
+    } catch {
+      // localStorage may be unavailable (private mode); reload anyway.
+    }
+    window.location.reload();
   }, []);
 
   useEffect(() => {
@@ -105,7 +118,7 @@ export function BuildVersionWatcher() {
               variant="petdex-cta"
               size="sm"
               className="h-9 rounded-full px-4 text-xs shadow-sm shadow-blue-950/10"
-              onClick={() => window.location.reload()}
+              onClick={handleRefresh}
             >
               <RefreshCw className="size-3.5" />
               {t("refresh")}

--- a/src/lib/build-version-check.test.ts
+++ b/src/lib/build-version-check.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import {
   buildVersionBrowserCacheKey,
+  clearCachedBuildVersion,
   fetchBuildVersion,
   fetchBuildVersionWithBrowserCache,
   getBuildVersionTokenFromPayload,
@@ -209,5 +210,22 @@ describe("build version check helpers", () => {
         value: originalWindow,
       });
     }
+  });
+
+  it("clears every build-version cache entry, leaving others intact", () => {
+    const storage = new MemoryStorage();
+    storage.setItem("petdex:build-version", "base");
+    storage.setItem("petdex:build-version:abc123", "keyed");
+    storage.setItem("unrelated", "keep");
+
+    clearCachedBuildVersion(storage);
+
+    expect(storage.getItem("petdex:build-version")).toBeNull();
+    expect(storage.getItem("petdex:build-version:abc123")).toBeNull();
+    expect(storage.getItem("unrelated")).toBe("keep");
+  });
+
+  it("is a no-op when storage is null", () => {
+    expect(() => clearCachedBuildVersion(null)).not.toThrow();
   });
 });

--- a/src/lib/build-version-check.test.ts
+++ b/src/lib/build-version-check.test.ts
@@ -216,12 +216,15 @@ describe("build version check helpers", () => {
     const storage = new MemoryStorage();
     storage.setItem("petdex:build-version", "base");
     storage.setItem("petdex:build-version:abc123", "keyed");
+    storage.setItem("petdex:build-version-settings", "keep");
     storage.setItem("unrelated", "keep");
 
     clearCachedBuildVersion(storage);
 
     expect(storage.getItem("petdex:build-version")).toBeNull();
     expect(storage.getItem("petdex:build-version:abc123")).toBeNull();
+    // Shares the prefix but is not a cache variant, so it must survive.
+    expect(storage.getItem("petdex:build-version-settings")).toBe("keep");
     expect(storage.getItem("unrelated")).toBe("keep");
   });
 

--- a/src/lib/build-version-check.ts
+++ b/src/lib/build-version-check.ts
@@ -144,11 +144,19 @@ export function buildVersionBrowserCacheKey(currentVersion: string | null) {
 export function clearCachedBuildVersion(storage: Storage | null): void {
   if (!storage) return;
 
+  // Match only the base key and per-build variants (`<base>:<token>`),
+  // never an unrelated key that merely shares the prefix such as
+  // `petdex:build-version-settings`.
+  const variantPrefix = `${BUILD_VERSION_BROWSER_CACHE_KEY}:`;
+
   try {
     const keys: string[] = [];
     for (let i = 0; i < storage.length; i += 1) {
       const key = storage.key(i);
-      if (key?.startsWith(BUILD_VERSION_BROWSER_CACHE_KEY)) {
+      if (
+        key === BUILD_VERSION_BROWSER_CACHE_KEY ||
+        key?.startsWith(variantPrefix)
+      ) {
         keys.push(key);
       }
     }

--- a/src/lib/build-version-check.ts
+++ b/src/lib/build-version-check.ts
@@ -138,6 +138,28 @@ export function buildVersionBrowserCacheKey(currentVersion: string | null) {
     : BUILD_VERSION_BROWSER_CACHE_KEY;
 }
 
+// Drop every cached build-version entry (the base key plus any
+// per-build-keyed variants). Called when the user accepts the update so a
+// stale cached token can't keep re-triggering the prompt after reload.
+export function clearCachedBuildVersion(storage: Storage | null): void {
+  if (!storage) return;
+
+  try {
+    const keys: string[] = [];
+    for (let i = 0; i < storage.length; i += 1) {
+      const key = storage.key(i);
+      if (key?.startsWith(BUILD_VERSION_BROWSER_CACHE_KEY)) {
+        keys.push(key);
+      }
+    }
+    for (const key of keys) {
+      storage.removeItem(key);
+    }
+  } catch {
+    return;
+  }
+}
+
 export function isChunkLoadFailure(errorLike: unknown): boolean {
   const message = getErrorLikeMessage(errorLike).toLowerCase();
 


### PR DESCRIPTION
## Problem

The "New version available" prompt reappears after every refresh and never goes away.

**Root cause:** the Refresh button only ran `window.location.reload()`. That does **not** clear the cached version token in `localStorage`, and a reload can be served from bfcache / the cached document. The stale `petdex:build-version*` entry then immediately re-triggers the prompt → infinite refresh loop.

(The server side is consistent — bundle `CURRENT_BUILD_KEY` and `/version.json` match — so this is purely a client cache-busting bug.)

## Fix

`handleRefresh` now clears **all** `petdex:build-version*` entries from `localStorage` before reloading, so the next load re-fetches `version.json` clean and the token comparison resolves.

- Adds `clearCachedBuildVersion(storage)` to `build-version-check.ts` (removes the base key + any per-build-keyed variants, leaves unrelated keys intact)
- Wires it into the watcher's Refresh button
- Tests for both the clear helper and the null-storage no-op

## Verify

- `biome check`: clean
- `bun test build-version-check + build-version-watcher`: 18 pass

## Workaround for already-stuck sessions (pre-deploy)

In the console on petdex.dev:
```js
Object.keys(localStorage).filter(k => k.startsWith("petdex:build-version")).forEach(k => localStorage.removeItem(k));
location.reload();
```
Or a hard reload (Cmd+Shift+R) / incognito.