### PR TITLE
Add signed-out header state fast path

### DIFF
--- a/src/app/api/me/header-state/route.ts
+++ b/src/app/api/me/header-state/route.ts
@@ -4,8 +4,12 @@ import { auth } from "@clerk/nextjs/server";
 import { sql as dsql } from "drizzle-orm";
 
 import { isAdmin } from "@/lib/admin";
+import { hasClerkSessionCookie } from "@/lib/clerk-session-cookie";
 import { db } from "@/lib/db/client";
-import { HEADER_STATE_BROWSER_CACHE_SECONDS } from "@/lib/header-state";
+import {
+  HEADER_STATE_BROWSER_CACHE_SECONDS,
+  INITIAL_HEADER_STATE,
+} from "@/lib/header-state";
 
 export const runtime = "nodejs";
 
@@ -24,26 +28,29 @@ type HeaderStateRow = {
 // Returns lightweight counts + the caught slug set. The full
 // notifications list (`items[]`) still lives at /api/notifications and
 // is only fetched when the bell dropdown opens.
-export async function GET(): Promise<Response> {
+export async function GET(req: Request): Promise<Response> {
+  if (!hasClerkSessionCookie(req.headers.get("cookie"))) {
+    return NextResponse.json(INITIAL_HEADER_STATE, {
+      headers: {
+        "Cache-Control":
+          "public, max-age=60, s-maxage=300, stale-while-revalidate=3600",
+        Vary: "Cookie",
+      },
+    });
+  }
+
   const { userId } = await auth();
 
   if (!userId) {
     // Anonymous viewers always get the same empty payload, so let the
     // edge cache absorb most of the load. 5min CDN cache + 1h SWR keeps
     // the header snappy for visitors without hitting the function.
-    return NextResponse.json(
-      {
-        signedIn: false,
-        notifications: { unreadCount: 0 },
-        feedback: { count: 0, adminCount: 0 },
-        caught: [] as string[],
+    return NextResponse.json(INITIAL_HEADER_STATE, {
+      headers: {
+        "Cache-Control": "public, s-maxage=300, stale-while-revalidate=3600",
+        Vary: "Cookie",
       },
-      {
-        headers: {
-          "Cache-Control": "public, s-maxage=300, stale-while-revalidate=3600",
-        },
-      },
-    );
+    });
   }
 
   const headers = {

--- a/src/lib/clerk-session-cookie.test.ts
+++ b/src/lib/clerk-session-cookie.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "bun:test";
+
+import { hasClerkSessionCookie } from "@/lib/clerk-session-cookie";
+
+describe("hasClerkSessionCookie", () => {
+  it("detects Clerk session cookies", () => {
+    expect(hasClerkSessionCookie("__session=abc")).toBe(true);
+    expect(hasClerkSessionCookie("theme=dark; __session=abc")).toBe(true);
+    expect(hasClerkSessionCookie("__session_legacy=abc")).toBe(true);
+  });
+
+  it("ignores non-session cookies", () => {
+    expect(hasClerkSessionCookie(null)).toBe(false);
+    expect(hasClerkSessionCookie("theme=dark")).toBe(false);
+    expect(hasClerkSessionCookie("__client_uat=1780770000")).toBe(false);
+  });
+});

--- a/src/lib/clerk-session-cookie.ts
+++ b/src/lib/clerk-session-cookie.ts
@@ -1,0 +1,7 @@
+export function hasClerkSessionCookie(cookieHeader: string | null): boolean {
+  if (!cookieHeader) return false;
+  return cookieHeader.split(";").some((part) => {
+    const name = part.trim().split("=", 1)[0];
+    return name === "__session" || name.startsWith("__session_");
+  });
+}


### PR DESCRIPTION
## Summary
- Short-circuit /api/me/header-state for requests without a Clerk session cookie.
- Reuse INITIAL_HEADER_STATE for anonymous payloads.
- Add focused coverage for Clerk session cookie detection.

## Why
/api/me/header-state was one of the hottest abused paths. Signed-out callers do not need Clerk auth or DB work; this keeps that path cheap while preserving the authenticated flow when __session is present.

## Verification
- bunx biome check src/lib/clerk-session-cookie.ts src/lib/clerk-session-cookie.test.ts src/app/api/me/header-state/route.ts
- bun test src/lib/clerk-session-cookie.test.ts src/lib/public-traffic-guard.test.ts src/lib/header-state.test.ts
- bun --env-file=/Users/raillyhugo/Programming/crafter-station/petdex/.env.local --env-file=/Users/raillyhugo/Programming/crafter-station/petdex/.env.production.local run build
