### PR TITLE
fix(assets): make assets.petdex.dev the only trusted asset host

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -47,13 +47,12 @@ function r2PublicSource(): string {
 }
 
 const r2PublicHostValue = r2PublicHost();
+// assets.petdex.dev is the only asset host we serve from. The legacy
+// pub-*.r2.dev and *.workers.dev hosts are dead; stored URLs pointing at
+// them are rewritten to the canonical host at runtime via
+// toCurrentR2PublicUrl, so they never need to be allowed here.
 const r2PublicSources = Array.from(
-  new Set([
-    `https://${CANONICAL_R2_PUBLIC_HOST}`,
-    `https://${WORKERS_DEV_R2_PUBLIC_HOST}`,
-    `https://${LEGACY_R2_PUBLIC_HOST}`,
-    r2PublicSource(),
-  ]),
+  new Set([`https://${CANONICAL_R2_PUBLIC_HOST}`, r2PublicSource()]),
 ).join(" ");
 
 // Content-Security-Policy. Blocks inline <script> sources we didn't ship,
@@ -130,8 +129,6 @@ const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
       { protocol: "https", hostname: CANONICAL_R2_PUBLIC_HOST },
-      { protocol: "https", hostname: WORKERS_DEV_R2_PUBLIC_HOST },
-      { protocol: "https", hostname: LEGACY_R2_PUBLIC_HOST },
       { protocol: "https", hostname: r2PublicHostValue },
       { protocol: "https", hostname: "img.clerk.com" },
       { protocol: "https", hostname: "images.clerk.dev" },

--- a/packages/petdex-cli/src/desktop/install.test.ts
+++ b/packages/petdex-cli/src/desktop/install.test.ts
@@ -433,7 +433,7 @@ describe("resolveDesktopInstallPlan", () => {
 //   - happy path → files land in both ~/.petdex/pets and ~/.codex/pets
 //   - partial download failure → rollback removes orphan directories
 
-const TRUSTED_HOST = "https://petdex-assets.raillyhugo.workers.dev";
+const TRUSTED_HOST = "https://assets.petdex.dev";
 
 describe("installStarterPet", () => {
   const realHome = process.env.HOME;
@@ -889,33 +889,31 @@ describe("installStarterPet", () => {
 // could either reject legit installs or accept attacker bytes.
 
 describe("isTrustedAssetUrl", () => {
-  test("accepts the protected R2 worker", () => {
-    expect(
-      isTrustedAssetUrl(
-        "https://petdex-assets.raillyhugo.workers.dev/pets/boba/spritesheet.webp",
-      ),
-    ).toBe(true);
-  });
-
-  test("accepts the R2 public bucket", () => {
-    expect(
-      isTrustedAssetUrl(
-        "https://pub-94495283df974cfea5e98d6a9e3fa462.r2.dev/pets/boba/spritesheet.webp",
-      ),
-    ).toBe(true);
-  });
-
-  test("accepts the R2 custom domain", () => {
+  test("accepts the canonical asset host", () => {
     expect(
       isTrustedAssetUrl("https://assets.petdex.dev/pets/boba/spritesheet.webp"),
     ).toBe(true);
   });
 
-  test("rejects http (must be https)", () => {
+  test("rejects the retired R2 worker host", () => {
     expect(
       isTrustedAssetUrl(
-        "http://pub-94495283df974cfea5e98d6a9e3fa462.r2.dev/pets/boba/spritesheet.webp",
+        "https://petdex-assets.raillyhugo.workers.dev/pets/boba/spritesheet.webp",
       ),
+    ).toBe(false);
+  });
+
+  test("rejects the retired R2 public bucket host", () => {
+    expect(
+      isTrustedAssetUrl(
+        "https://pub-94495283df974cfea5e98d6a9e3fa462.r2.dev/pets/boba/spritesheet.webp",
+      ),
+    ).toBe(false);
+  });
+
+  test("rejects http (must be https)", () => {
+    expect(
+      isTrustedAssetUrl("http://assets.petdex.dev/pets/boba/spritesheet.webp"),
     ).toBe(false);
   });
 

--- a/packages/petdex-cli/src/desktop/install.ts
+++ b/packages/petdex-cli/src/desktop/install.ts
@@ -697,11 +697,7 @@ const PETDEX_URL = process.env.PETDEX_URL ?? "https://petdex.dev";
 // malicious origin in CI/dev, an unrestricted fetch would write
 // attacker-controlled bytes to ~/.petdex/pets and ~/.codex/pets.
 // Keep this list in sync with the server-side allowlist.
-const TRUSTED_ASSET_HOSTS = new Set<string>([
-  "assets.petdex.dev",
-  "petdex-assets.raillyhugo.workers.dev",
-  "pub-94495283df974cfea5e98d6a9e3fa462.r2.dev",
-]);
+const TRUSTED_ASSET_HOSTS = new Set<string>(["assets.petdex.dev"]);
 
 export function isTrustedAssetUrl(url: string): boolean {
   try {

--- a/src/app/[locale]/download/page.tsx
+++ b/src/app/[locale]/download/page.tsx
@@ -30,8 +30,7 @@ const SITE_URL = "https://petdex.dev";
 const DEFAULT_PREVIEW_PET_SLUG = "boba";
 const DEFAULT_PREVIEW_PET = {
   displayName: "Boba",
-  spritesheetPath:
-    "https://pub-94495283df974cfea5e98d6a9e3fa462.r2.dev/curated/boba/spritesheet.webp",
+  spritesheetPath: "https://assets.petdex.dev/curated/boba/spritesheet.webp",
 };
 
 // Auto-detected /download/opengraph-image is locale-prefixed

--- a/src/lib/r2-public-url.ts
+++ b/src/lib/r2-public-url.ts
@@ -4,7 +4,7 @@ export const WORKERS_DEV_R2_PUBLIC_BASE =
 export const LEGACY_R2_PUBLIC_BASE =
   "https://pub-94495283df974cfea5e98d6a9e3fa462.r2.dev";
 
-function normalizeBase(raw: string | undefined): string {
+export function normalizeBase(raw: string | undefined): string {
   if (!raw) return DEFAULT_R2_PUBLIC_BASE;
   try {
     const parsed = new URL(raw);

--- a/src/lib/r2-public-url.ts
+++ b/src/lib/r2-public-url.ts
@@ -27,10 +27,22 @@ function normalizeBase(raw: string | undefined): string {
 
 export const R2_PUBLIC_BASE = normalizeBase(process.env.R2_PUBLIC_BASE);
 
+// Hosts we recognize ONLY to rewrite stray stored URLs to the canonical host
+// at runtime (toCurrentR2PublicUrl). Includes the dead legacy hosts on purpose
+// — recognizing them is how we auto-correct old DB rows. This is NOT a trust
+// list: never use it to validate new user input.
 export const R2_PUBLIC_HOSTS = new Set<string>([
   new URL(DEFAULT_R2_PUBLIC_BASE).host,
   new URL(LEGACY_R2_PUBLIC_BASE).host,
   new URL(WORKERS_DEV_R2_PUBLIC_BASE).host,
+  new URL(R2_PUBLIC_BASE).host,
+]);
+
+// Hosts we trust for NEW input: submissions, edits, OG fetches, render.
+// Only the live canonical host (+ configured override). The dead legacy hosts
+// are deliberately excluded so we never accept or persist URLs that 401/404.
+export const R2_TRUSTED_HOSTS = new Set<string>([
+  new URL(DEFAULT_R2_PUBLIC_BASE).host,
   new URL(R2_PUBLIC_BASE).host,
 ]);
 

--- a/src/lib/security.test.ts
+++ b/src/lib/security.test.ts
@@ -28,12 +28,9 @@ import {
 } from "@/lib/url-allowlist";
 
 const BASE_INPUT = {
-  zipUrl:
-    "https://pub-94495283df974cfea5e98d6a9e3fa462.r2.dev/community/x/x.zip",
-  spritesheetUrl:
-    "https://pub-94495283df974cfea5e98d6a9e3fa462.r2.dev/community/x/spritesheet.webp",
-  petJsonUrl:
-    "https://pub-94495283df974cfea5e98d6a9e3fa462.r2.dev/community/x/pet.json",
+  zipUrl: "https://assets.petdex.dev/community/x/x.zip",
+  spritesheetUrl: "https://assets.petdex.dev/community/x/spritesheet.webp",
+  petJsonUrl: "https://assets.petdex.dev/community/x/pet.json",
   displayName: "Test Pet",
   description: "A test pet.",
   petId: "test-pet",
@@ -42,20 +39,28 @@ const BASE_INPUT = {
 };
 
 describe("isAllowedAssetUrl", () => {
-  it("allows R2 https", () => {
+  it("allows canonical asset host https", () => {
+    expect(isAllowedAssetUrl("https://assets.petdex.dev/x/y.webp")).toBe(true);
+  });
+
+  it("blocks retired legacy r2.dev host", () => {
     expect(
       isAllowedAssetUrl(
         "https://pub-94495283df974cfea5e98d6a9e3fa462.r2.dev/x/y.webp",
       ),
-    ).toBe(true);
+    ).toBe(false);
+  });
+
+  it("blocks retired workers.dev host", () => {
+    expect(
+      isAllowedAssetUrl(
+        "https://petdex-assets.raillyhugo.workers.dev/x/y.webp",
+      ),
+    ).toBe(false);
   });
 
   it("blocks http", () => {
-    expect(
-      isAllowedAssetUrl(
-        "http://pub-94495283df974cfea5e98d6a9e3fa462.r2.dev/x/y.webp",
-      ),
-    ).toBe(false);
+    expect(isAllowedAssetUrl("http://assets.petdex.dev/x/y.webp")).toBe(false);
   });
 
   it("blocks javascript:", () => {

--- a/src/lib/security.test.ts
+++ b/src/lib/security.test.ts
@@ -20,6 +20,12 @@ import {
   posixNotFoundScript,
   powershellInstallScript,
 } from "@/lib/install-script-render";
+import {
+  DEFAULT_R2_PUBLIC_BASE,
+  LEGACY_R2_PUBLIC_BASE,
+  normalizeBase,
+  WORKERS_DEV_R2_PUBLIC_BASE,
+} from "@/lib/r2-public-url";
 import { validateSubmission } from "@/lib/submissions-validation";
 import {
   isAllowedAssetUrl,
@@ -90,6 +96,35 @@ describe("isAllowedAssetUrl", () => {
     expect(isAllowedAssetUrl("")).toBe(false);
     expect(isAllowedAssetUrl(null)).toBe(false);
     expect(isAllowedAssetUrl(undefined)).toBe(false);
+  });
+});
+
+// R2_PUBLIC_BASE feeds the trusted host set. If a deployment sets it to a
+// retired host, normalizeBase must rewrite it to the canonical host so the
+// dead host never re-enters the allowlist via the env override.
+describe("normalizeBase (env override safety)", () => {
+  it("rewrites the legacy r2.dev base to canonical", () => {
+    expect(normalizeBase(LEGACY_R2_PUBLIC_BASE)).toBe(DEFAULT_R2_PUBLIC_BASE);
+  });
+
+  it("rewrites the workers.dev base to canonical", () => {
+    expect(normalizeBase(WORKERS_DEV_R2_PUBLIC_BASE)).toBe(
+      DEFAULT_R2_PUBLIC_BASE,
+    );
+  });
+
+  it("falls back to canonical for non-https / malformed bases", () => {
+    expect(normalizeBase("http://assets.petdex.dev")).toBe(
+      DEFAULT_R2_PUBLIC_BASE,
+    );
+    expect(normalizeBase("not a url")).toBe(DEFAULT_R2_PUBLIC_BASE);
+    expect(normalizeBase(undefined)).toBe(DEFAULT_R2_PUBLIC_BASE);
+  });
+
+  it("preserves a valid custom https base", () => {
+    expect(normalizeBase("https://cdn.example.com")).toBe(
+      "https://cdn.example.com",
+    );
   });
 });
 

--- a/src/lib/url-allowlist.ts
+++ b/src/lib/url-allowlist.ts
@@ -3,15 +3,17 @@
 // rejected at the validateSubmission boundary and skipped at the OG
 // fetch boundary so we never SSRF or echo attacker-controlled URLs.
 //
-// We allow the configured R2 public bucket and known R2 legacy hosts.
+// We allow only the live canonical R2 public bucket (+ configured override).
+// The dead legacy hosts are deliberately NOT trusted here — recognizing them
+// for rewrite is r2-public-url's job, not a reason to accept new input.
 //
 // Block everything else, including http://, file://, data:, javascript:,
 // and lan IPs.
 
-import { R2_PUBLIC_HOSTS } from "@/lib/r2-public-url";
+import { R2_TRUSTED_HOSTS } from "@/lib/r2-public-url";
 
 const ALLOWED_HOSTS = (() => {
-  const hosts = new Set<string>(R2_PUBLIC_HOSTS);
+  const hosts = new Set<string>(R2_TRUSTED_HOSTS);
   const base = process.env.R2_PUBLIC_BASE;
   if (base) {
     try {

--- a/src/lib/url-allowlist.ts
+++ b/src/lib/url-allowlist.ts
@@ -12,18 +12,12 @@
 
 import { R2_TRUSTED_HOSTS } from "@/lib/r2-public-url";
 
-const ALLOWED_HOSTS = (() => {
-  const hosts = new Set<string>(R2_TRUSTED_HOSTS);
-  const base = process.env.R2_PUBLIC_BASE;
-  if (base) {
-    try {
-      hosts.add(new URL(base).host);
-    } catch {
-      /* ignore malformed env */
-    }
-  }
-  return hosts;
-})();
+// R2_TRUSTED_HOSTS already includes the normalized R2_PUBLIC_BASE host, where
+// normalizeBase() has rewritten any legacy/workers override back to the
+// canonical host. We intentionally do NOT re-add the raw env host here: a
+// deployment with R2_PUBLIC_BASE pointing at a retired host must not re-enter
+// the trust set and start accepting new submissions/edits for a dead host.
+const ALLOWED_HOSTS = new Set<string>(R2_TRUSTED_HOSTS);
 
 export function isAllowedAssetUrl(raw: string | null | undefined): boolean {
   if (!raw) return false;


### PR DESCRIPTION
## Why

The legacy asset hosts are dead:
- `pub-94495283…r2.dev` (R2 public bucket) → **401**
- `petdex-assets.raillyhugo.workers.dev` → **404**

Stored DB URLs were already rewritten to `assets.petdex.dev`. This PR stops the codebase from advertising or trusting the dead hosts, making `assets.petdex.dev` the single source of truth.

## Changes

- **CSP** (`img-src` / `media-src` / `connect-src`): only `assets.petdex.dev`
- **next/image `remotePatterns`**: drop `r2.dev` + `workers.dev`
- **CLI desktop `TRUSTED_ASSET_HOSTS`** (anti-SSRF allowlist): only `assets.petdex.dev`
- **download page** Boba default → `assets.petdex.dev`
- Updated `install.test.ts` for the single-host allowlist (legacy hosts now assert `false`)

## Kept as a safety net

`toCurrentR2PublicUrl` / `R2_PUBLIC_HOSTS` still **recognize** the legacy hosts, but only to **rewrite** any stray stored URL to the canonical host at runtime, not to trust them. So if an old URL ever slips into the DB again, it auto-corrects instead of 404ing.

## Verify

- `bun run check`: clean (549 files)
- `bun test`: 458 pass
- mock-mode `bun run build`: green; CSP has 0 legacy hosts

## Follow-up (not in this PR)

- 17 pets still on UploadThing (`ufs.sh`) need real migration to R2
- Optionally retire the `petdex-assets` worker in Cloudflare (needs `wrangler login`)