### PR TITLE
Reduce build version polling

### DIFF
--- a/src/components/build-version-watcher.tsx
+++ b/src/components/build-version-watcher.tsx
@@ -16,7 +16,7 @@ import { CURRENT_BUILD_KEY } from "@/lib/current-build";
 
 import { Button } from "@/components/ui/button";
 
-const CHECK_INTERVAL_MS = 10 * 60_000;
+const CHECK_INTERVAL_MS = 60 * 60_000;
 
 type UpdateReason = "version" | "asset-load";
 

--- a/src/lib/build-version-check.ts
+++ b/src/lib/build-version-check.ts
@@ -2,7 +2,7 @@ import { createBuildVersionToken } from "@/lib/build-version-token";
 
 export const BUILD_VERSION_PATH = "/version.json";
 export const BUILD_VERSION_FETCH_TIMEOUT_MS = 5_000;
-export const BUILD_VERSION_BROWSER_CACHE_TTL_MS = 10 * 60_000;
+export const BUILD_VERSION_BROWSER_CACHE_TTL_MS = 60 * 60_000;
 export const BUILD_VERSION_BROWSER_CACHE_KEY = "petdex:build-version";
 
 const CHUNK_LOAD_FAILURE_PATTERNS = [


### PR DESCRIPTION
## Summary
- Increase build-version browser cache TTL from 10 minutes to 60 minutes.
- Increase foreground polling interval from 10 minutes to 60 minutes.

## Why
/version.json is static, but every active browser session was still polling it frequently. Chunk-load failures still trigger the update prompt immediately through error events, so the important stale-asset protection remains.

## Verification
- bun test src/lib/build-version-check.test.ts src/components/build-version-watcher.test.ts
- bunx biome check src/lib/build-version-check.ts src/components/build-version-watcher.tsx
