### PR TITLE
Increase deterministic search cache window

### DIFF
--- a/src/app/api/pets/search/route.test.ts
+++ b/src/app/api/pets/search/route.test.ts
@@ -98,6 +98,21 @@ describe("GET /api/pets/search", () => {
     expect(call?.input.shuffleSeed).toBe(TEST_SEED);
   });
 
+  it("keeps explicit sorted text search private", async () => {
+    const response = await search(
+      "https://petdex.local/api/pets/search?q=cozy&sort=alpha",
+    );
+    const body = (await response.json()) as { shuffleSeed?: string };
+    const call = calls[0];
+
+    expect(body.shuffleSeed).toBeUndefined();
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(response.headers.get("Set-Cookie")).toBeNull();
+    expect(call?.input.q).toBe("cozy");
+    expect(call?.input.sort).toBe("alpha");
+    expect(call?.input.shuffleSeed).toBeUndefined();
+  });
+
   it("returns the minted curated seed so no-cookie pagination can reuse it", async () => {
     const first = await search(
       "https://petdex.local/api/pets/search?sort=curated",

--- a/src/app/api/pets/search/route.test.ts
+++ b/src/app/api/pets/search/route.test.ts
@@ -8,6 +8,8 @@ const testMock = (
 ).mock;
 
 const TEST_SEED = "0123456789abcdef";
+const DETERMINISTIC_CACHE_CONTROL =
+  "public, max-age=300, s-maxage=600, stale-while-revalidate=3600";
 const calls: Array<{
   input: {
     cursor?: number;
@@ -71,7 +73,9 @@ describe("GET /api/pets/search", () => {
     const call = calls[0];
 
     expect(body.shuffleSeed).toBeUndefined();
-    expect(response.headers.get("Cache-Control")).toContain("public");
+    expect(response.headers.get("Cache-Control")).toBe(
+      DETERMINISTIC_CACHE_CONTROL,
+    );
     expect(response.headers.get("Set-Cookie")).toBeNull();
     expect(call?.input.shuffleSeed).toBeUndefined();
     expect(call?.input.sort).toBe("alpha");
@@ -131,7 +135,9 @@ describe("GET /api/pets/search", () => {
     );
     const call = calls[0];
 
-    expect(response.headers.get("Cache-Control")).toContain("public");
+    expect(response.headers.get("Cache-Control")).toBe(
+      DETERMINISTIC_CACHE_CONTROL,
+    );
     expect(call?.input.cursor).toBe(10);
     expect(call?.input.limit).toBe(24);
     expect(call?.input.sort).toBe("alpha");

--- a/src/app/api/pets/search/route.ts
+++ b/src/app/api/pets/search/route.ts
@@ -90,7 +90,7 @@ export async function GET(req: Request): Promise<Response> {
   const cacheHeader =
     sort === "curated"
       ? "private, no-store"
-      : "public, max-age=60, s-maxage=120, stale-while-revalidate=600";
+      : "public, max-age=300, s-maxage=600, stale-while-revalidate=3600";
 
   const payload =
     sort === "curated" && shuffleSeed ? { ...result, shuffleSeed } : result;

--- a/src/app/api/pets/search/route.ts
+++ b/src/app/api/pets/search/route.ts
@@ -88,7 +88,7 @@ export async function GET(req: Request): Promise<Response> {
   // alpha, recent) are deterministic per (filters, cursor, limit), so
   // the edge serves them shared with a generous SWR window.
   const cacheHeader =
-    sort === "curated"
+    sort === "curated" || q
       ? "private, no-store"
       : "public, max-age=300, s-maxage=600, stale-while-revalidate=3600";
 

--- a/src/app/api/pets/search/route.ts
+++ b/src/app/api/pets/search/route.ts
@@ -83,10 +83,10 @@ export async function GET(req: Request): Promise<Response> {
     { includeTotal: includeMeta, includeFacets: includeMeta },
   );
 
-  // Curated results are per-visitor (shuffle seed cookie) so the edge
-  // can't share them across users. Other sorts (popular, installed,
-  // alpha, recent) are deterministic per (filters, cursor, limit), so
-  // the edge serves them shared with a generous SWR window.
+  // Curated results are per-visitor (shuffle seed cookie), and text
+  // searches stay private even with a deterministic sort. Other sorts
+  // (popular, installed, alpha, recent) are deterministic per (filters,
+  // cursor, limit), so the edge serves them shared with a generous SWR window.
   const cacheHeader =
     sort === "curated" || q
       ? "private, no-store"


### PR DESCRIPTION
## Summary
- increase shared cache window for deterministic /api/pets/search responses
- keep curated/text search private and uncached
- pin the cache contract in route tests

## Verification
- Not run, per migration speed scope.