### PR TITLE
Cache build version asset at the edge

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -122,6 +122,13 @@ const securityHeaders = [
   { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
 ];
 
+const versionJsonHeaders = [
+  {
+    key: "Cache-Control",
+    value: "public, max-age=300, s-maxage=600, stale-while-revalidate=3600",
+  },
+];
+
 const mockRoot = path.resolve(__dirname, "src/lib/mock");
 
 const nextConfig: NextConfig = {
@@ -152,6 +159,10 @@ const nextConfig: NextConfig = {
   ],
   async headers() {
     return [
+      {
+        source: "/version.json",
+        headers: versionJsonHeaders,
+      },
       {
         source: "/:path*",
         headers: securityHeaders,

--- a/next.config.ts
+++ b/next.config.ts
@@ -125,7 +125,7 @@ const securityHeaders = [
 const versionJsonHeaders = [
   {
     key: "Cache-Control",
-    value: "public, max-age=300, s-maxage=600, stale-while-revalidate=3600",
+    value: "public, max-age=300, s-maxage=600, must-revalidate",
   },
 ];
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -125,7 +125,7 @@ const securityHeaders = [
 const versionJsonHeaders = [
   {
     key: "Cache-Control",
-    value: "public, max-age=300, s-maxage=600, must-revalidate",
+    value: "public, max-age=0, s-maxage=600, must-revalidate",
   },
 ];
 

--- a/src/lib/build-version-check.test.ts
+++ b/src/lib/build-version-check.test.ts
@@ -120,7 +120,7 @@ describe("build version check helpers", () => {
 
     expect(version).toBe("abc123|2026-05-17T00:00:00.000Z");
     expect(requestedUrl).toBe("/version.json");
-    expect(requestedInit?.cache).toBe("no-store");
+    expect(requestedInit?.cache).toBe("default");
   });
 
   it("coalesces build version checks through local storage", async () => {

--- a/src/lib/build-version-check.ts
+++ b/src/lib/build-version-check.ts
@@ -45,7 +45,7 @@ export async function fetchBuildVersion(
 
   try {
     const response = await fetcher(BUILD_VERSION_PATH, {
-      cache: "no-store",
+      cache: "default",
       signal: controller.signal,
     });
 


### PR DESCRIPTION
## Summary
- add a specific cache policy for /version.json
- keep security headers applied globally
- reduce origin hits from direct version polling and bot traffic

## Verification
- Not run, per migration speed scope.