### PR TITLE
Cache random pet responses briefly

### DIFF
--- a/src/app/api/pets/random/route.ts
+++ b/src/app/api/pets/random/route.ts
@@ -5,6 +5,9 @@ import { getRandomPetPool } from "@/lib/random-pet-pool";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+const RANDOM_CACHE_CONTROL =
+  "public, max-age=30, s-maxage=60, stale-while-revalidate=300";
+
 // GET /api/pets/random?exclude=current-slug
 //
 // Picks a random approved pet (excluding the optional `exclude` slug).
@@ -40,12 +43,18 @@ export async function GET(req: Request): Promise<Response> {
         href: `/pets/${next.slug}`,
         installHref: `/install/${next.slug}`,
       },
-      { headers: { "Cache-Control": "private, no-store" } },
+      { headers: { "Cache-Control": RANDOM_CACHE_CONTROL } },
     );
   }
 
   if (!next) {
-    return NextResponse.redirect(new URL("/", req.url), 302);
+    return NextResponse.redirect(new URL("/", req.url), {
+      status: 302,
+      headers: { "Cache-Control": "private, no-store" },
+    });
   }
-  return NextResponse.redirect(new URL(`/pets/${next.slug}`, req.url), 302);
+  return NextResponse.redirect(new URL(`/pets/${next.slug}`, req.url), {
+    status: 302,
+    headers: { "Cache-Control": RANDOM_CACHE_CONTROL },
+  });
 }

--- a/src/app/api/pets/random/route.ts
+++ b/src/app/api/pets/random/route.ts
@@ -7,6 +7,7 @@ export const dynamic = "force-dynamic";
 
 const RANDOM_CACHE_CONTROL =
   "public, max-age=30, s-maxage=60, stale-while-revalidate=300";
+const RANDOM_VARY = "Accept";
 
 // GET /api/pets/random?exclude=current-slug
 //
@@ -43,18 +44,23 @@ export async function GET(req: Request): Promise<Response> {
         href: `/pets/${next.slug}`,
         installHref: `/install/${next.slug}`,
       },
-      { headers: { "Cache-Control": RANDOM_CACHE_CONTROL } },
+      {
+        headers: {
+          "Cache-Control": RANDOM_CACHE_CONTROL,
+          Vary: RANDOM_VARY,
+        },
+      },
     );
   }
 
   if (!next) {
     return NextResponse.redirect(new URL("/", req.url), {
       status: 302,
-      headers: { "Cache-Control": "private, no-store" },
+      headers: { "Cache-Control": "private, no-store", Vary: RANDOM_VARY },
     });
   }
   return NextResponse.redirect(new URL(`/pets/${next.slug}`, req.url), {
     status: 302,
-    headers: { "Cache-Control": RANDOM_CACHE_CONTROL },
+    headers: { "Cache-Control": RANDOM_CACHE_CONTROL, Vary: RANDOM_VARY },
   });
 }


### PR DESCRIPTION
## Summary
- add short public cache headers to successful /api/pets/random JSON responses
- add short public cache headers to successful random redirects
- keep empty-pool fallback uncached

## Verification
- Not run, per migration speed scope.