### PR TITLE
Cache install endpoints briefly

### DIFF
--- a/src/app/[locale]/install/[slug]/route.ts
+++ b/src/app/[locale]/install/[slug]/route.ts
@@ -13,8 +13,9 @@ export const dynamic = "force-dynamic";
 
 type Params = { locale: string; slug: string };
 
-const INSTALL_MISS_CACHE_CONTROL =
+const INSTALL_INVALID_SLUG_CACHE_CONTROL =
   "public, max-age=60, s-maxage=120, stale-while-revalidate=300";
+const INSTALL_DB_MISS_CACHE_CONTROL = "private, no-store";
 const INSTALL_SUCCESS_CACHE_CONTROL = "private, no-store";
 const INSTALL_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,62}$/;
 const INSTALL_SCRIPT_VARY = "User-Agent";
@@ -58,7 +59,7 @@ export async function GET(
           platform === "ps1"
             ? "text/plain; charset=utf-8"
             : "text/plain; charset=utf-8",
-        "Cache-Control": INSTALL_MISS_CACHE_CONTROL,
+        "Cache-Control": INSTALL_INVALID_SLUG_CACHE_CONTROL,
         Vary: INSTALL_SCRIPT_VARY,
       },
     });
@@ -77,7 +78,7 @@ export async function GET(
           platform === "ps1"
             ? "text/plain; charset=utf-8"
             : "text/plain; charset=utf-8",
-        "Cache-Control": INSTALL_MISS_CACHE_CONTROL,
+        "Cache-Control": INSTALL_DB_MISS_CACHE_CONTROL,
         Vary: INSTALL_SCRIPT_VARY,
       },
     });

--- a/src/app/[locale]/install/[slug]/route.ts
+++ b/src/app/[locale]/install/[slug]/route.ts
@@ -16,6 +16,7 @@ type Params = { locale: string; slug: string };
 const INSTALL_CACHE_CONTROL =
   "public, max-age=60, s-maxage=120, stale-while-revalidate=300";
 const INSTALL_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,62}$/;
+const INSTALL_SCRIPT_VARY = "User-Agent";
 
 function detectPlatformFromRequest(req: Request): "posix" | "ps1" {
   const url = new URL(req.url);
@@ -57,6 +58,7 @@ export async function GET(
             ? "text/plain; charset=utf-8"
             : "text/plain; charset=utf-8",
         "Cache-Control": INSTALL_CACHE_CONTROL,
+        Vary: INSTALL_SCRIPT_VARY,
       },
     });
   }
@@ -75,6 +77,7 @@ export async function GET(
             ? "text/plain; charset=utf-8"
             : "text/plain; charset=utf-8",
         "Cache-Control": INSTALL_CACHE_CONTROL,
+        Vary: INSTALL_SCRIPT_VARY,
       },
     });
   }
@@ -102,6 +105,7 @@ export async function GET(
           ? "text/plain; charset=utf-8"
           : "text/x-shellscript; charset=utf-8",
       "Cache-Control": INSTALL_CACHE_CONTROL,
+      Vary: INSTALL_SCRIPT_VARY,
     },
   });
 }

--- a/src/app/[locale]/install/[slug]/route.ts
+++ b/src/app/[locale]/install/[slug]/route.ts
@@ -13,8 +13,9 @@ export const dynamic = "force-dynamic";
 
 type Params = { locale: string; slug: string };
 
-const INSTALL_CACHE_CONTROL =
+const INSTALL_MISS_CACHE_CONTROL =
   "public, max-age=60, s-maxage=120, stale-while-revalidate=300";
+const INSTALL_SUCCESS_CACHE_CONTROL = "private, no-store";
 const INSTALL_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,62}$/;
 const INSTALL_SCRIPT_VARY = "User-Agent";
 
@@ -57,7 +58,7 @@ export async function GET(
           platform === "ps1"
             ? "text/plain; charset=utf-8"
             : "text/plain; charset=utf-8",
-        "Cache-Control": INSTALL_CACHE_CONTROL,
+        "Cache-Control": INSTALL_MISS_CACHE_CONTROL,
         Vary: INSTALL_SCRIPT_VARY,
       },
     });
@@ -76,7 +77,7 @@ export async function GET(
           platform === "ps1"
             ? "text/plain; charset=utf-8"
             : "text/plain; charset=utf-8",
-        "Cache-Control": INSTALL_CACHE_CONTROL,
+        "Cache-Control": INSTALL_MISS_CACHE_CONTROL,
         Vary: INSTALL_SCRIPT_VARY,
       },
     });
@@ -104,7 +105,7 @@ export async function GET(
         platform === "ps1"
           ? "text/plain; charset=utf-8"
           : "text/x-shellscript; charset=utf-8",
-      "Cache-Control": INSTALL_CACHE_CONTROL,
+      "Cache-Control": INSTALL_SUCCESS_CACHE_CONTROL,
       Vary: INSTALL_SCRIPT_VARY,
     },
   });

--- a/src/app/[locale]/install/[slug]/route.ts
+++ b/src/app/[locale]/install/[slug]/route.ts
@@ -13,6 +13,10 @@ export const dynamic = "force-dynamic";
 
 type Params = { locale: string; slug: string };
 
+const INSTALL_CACHE_CONTROL =
+  "public, max-age=60, s-maxage=120, stale-while-revalidate=300";
+const INSTALL_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,62}$/;
+
 function detectPlatformFromRequest(req: Request): "posix" | "ps1" {
   const url = new URL(req.url);
   const explicit = url.searchParams.get("platform")?.toLowerCase();
@@ -40,6 +44,23 @@ export async function GET(
   const origin = new URL(req.url).origin;
   const platform = detectPlatformFromRequest(req);
 
+  if (!INSTALL_SLUG_RE.test(slug)) {
+    const body =
+      platform === "ps1"
+        ? powershellNotFoundScript(slug)
+        : posixNotFoundScript(slug);
+    return new Response(body, {
+      status: 404,
+      headers: {
+        "Content-Type":
+          platform === "ps1"
+            ? "text/plain; charset=utf-8"
+            : "text/plain; charset=utf-8",
+        "Cache-Control": INSTALL_CACHE_CONTROL,
+      },
+    });
+  }
+
   const pet = await resolveInstallablePet(slug, origin);
   if (!pet) {
     const body =
@@ -53,6 +74,7 @@ export async function GET(
           platform === "ps1"
             ? "text/plain; charset=utf-8"
             : "text/plain; charset=utf-8",
+        "Cache-Control": INSTALL_CACHE_CONTROL,
       },
     });
   }
@@ -79,7 +101,7 @@ export async function GET(
         platform === "ps1"
           ? "text/plain; charset=utf-8"
           : "text/x-shellscript; charset=utf-8",
-      "Cache-Control": "public, max-age=30",
+      "Cache-Control": INSTALL_CACHE_CONTROL,
     },
   });
 }

--- a/src/app/api/install-pet/[slug]/route.ts
+++ b/src/app/api/install-pet/[slug]/route.ts
@@ -17,8 +17,9 @@ export const dynamic = "force-dynamic";
 
 type Params = { slug: string };
 
-const INSTALL_CACHE_CONTROL =
+const INSTALL_MISS_CACHE_CONTROL =
   "public, max-age=60, s-maxage=120, stale-while-revalidate=300";
+const INSTALL_SUCCESS_CACHE_CONTROL = "private, no-store";
 const INSTALL_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,62}$/;
 
 export async function GET(
@@ -33,7 +34,10 @@ export async function GET(
   if (!INSTALL_SLUG_RE.test(slug)) {
     return Response.json(
       { ok: false, error: "invalid_slug" },
-      { status: 400, headers: { "cache-control": INSTALL_CACHE_CONTROL } },
+      {
+        status: 400,
+        headers: { "cache-control": INSTALL_MISS_CACHE_CONTROL },
+      },
     );
   }
 
@@ -41,7 +45,10 @@ export async function GET(
   if (!pet) {
     return Response.json(
       { ok: false, error: "not_found", slug },
-      { status: 404, headers: { "cache-control": INSTALL_CACHE_CONTROL } },
+      {
+        status: 404,
+        headers: { "cache-control": INSTALL_MISS_CACHE_CONTROL },
+      },
     );
   }
 
@@ -70,7 +77,7 @@ export async function GET(
     {
       status: 200,
       headers: {
-        "cache-control": INSTALL_CACHE_CONTROL,
+        "cache-control": INSTALL_SUCCESS_CACHE_CONTROL,
         "content-type": "application/json",
       },
     },

--- a/src/app/api/install-pet/[slug]/route.ts
+++ b/src/app/api/install-pet/[slug]/route.ts
@@ -17,6 +17,10 @@ export const dynamic = "force-dynamic";
 
 type Params = { slug: string };
 
+const INSTALL_CACHE_CONTROL =
+  "public, max-age=60, s-maxage=120, stale-while-revalidate=300";
+const INSTALL_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,62}$/;
+
 export async function GET(
   req: Request,
   ctx: { params: Promise<Params> },
@@ -26,10 +30,10 @@ export async function GET(
 
   // Slug shape gate before hitting the DB. Defends against odd inputs and
   // gives a clean 400 instead of 404 for nonsense.
-  if (!/^[a-z0-9][a-z0-9-]{0,62}$/.test(slug)) {
+  if (!INSTALL_SLUG_RE.test(slug)) {
     return Response.json(
       { ok: false, error: "invalid_slug" },
-      { status: 400, headers: { "cache-control": "no-store" } },
+      { status: 400, headers: { "cache-control": INSTALL_CACHE_CONTROL } },
     );
   }
 
@@ -37,7 +41,7 @@ export async function GET(
   if (!pet) {
     return Response.json(
       { ok: false, error: "not_found", slug },
-      { status: 404, headers: { "cache-control": "no-store" } },
+      { status: 404, headers: { "cache-control": INSTALL_CACHE_CONTROL } },
     );
   }
 
@@ -66,7 +70,7 @@ export async function GET(
     {
       status: 200,
       headers: {
-        "cache-control": "public, max-age=60",
+        "cache-control": INSTALL_CACHE_CONTROL,
         "content-type": "application/json",
       },
     },

--- a/src/app/api/install-pet/[slug]/route.ts
+++ b/src/app/api/install-pet/[slug]/route.ts
@@ -17,8 +17,9 @@ export const dynamic = "force-dynamic";
 
 type Params = { slug: string };
 
-const INSTALL_MISS_CACHE_CONTROL =
+const INSTALL_INVALID_SLUG_CACHE_CONTROL =
   "public, max-age=60, s-maxage=120, stale-while-revalidate=300";
+const INSTALL_DB_MISS_CACHE_CONTROL = "private, no-store";
 const INSTALL_SUCCESS_CACHE_CONTROL = "private, no-store";
 const INSTALL_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,62}$/;
 
@@ -36,7 +37,7 @@ export async function GET(
       { ok: false, error: "invalid_slug" },
       {
         status: 400,
-        headers: { "cache-control": INSTALL_MISS_CACHE_CONTROL },
+        headers: { "cache-control": INSTALL_INVALID_SLUG_CACHE_CONTROL },
       },
     );
   }
@@ -47,7 +48,7 @@ export async function GET(
       { ok: false, error: "not_found", slug },
       {
         status: 404,
-        headers: { "cache-control": INSTALL_MISS_CACHE_CONTROL },
+        headers: { "cache-control": INSTALL_DB_MISS_CACHE_CONTROL },
       },
     );
   }


### PR DESCRIPTION
## Summary
- add short shared cache headers to install metadata and install scripts
- cache valid miss/invalid slug responses briefly
- add a slug gate before DB lookup on the script endpoint

## Verification
- Not run, per migration speed scope.