### PR TITLE
Trim gallery search payload

### DIFF
--- a/src/components/facet-page.tsx
+++ b/src/components/facet-page.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 
 import { getLocale } from "next-intl/server";
 
-import type { PetWithMetrics } from "@/lib/pets";
+import type { SearchPet } from "@/lib/pet-search";
 import { cn } from "@/lib/utils";
 
 import { CommandLine } from "@/components/command-line";
@@ -19,7 +19,7 @@ type FacetPageProps = {
   title: string;
   intro: string;
   countLabel: string;
-  pets: PetWithMetrics[];
+  pets: SearchPet[];
   exampleSlug?: string;
   relatedLabel: string;
   related: { href: string; label: string; count: number }[];

--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -19,7 +19,7 @@ import { COLOR_FAMILIES, type ColorFamily } from "@/lib/color-families";
 import { formatBatchLabel, getBatchKey } from "@/lib/dex-batch";
 import { formatLocalizedNumber } from "@/lib/format-number";
 import { petStates } from "@/lib/pet-states";
-import type { PetWithMetrics } from "@/lib/pets";
+import type { SearchPet } from "@/lib/pet-search";
 import { PET_KINDS, PET_VIBES, type PetKind, type PetVibe } from "@/lib/types";
 import { isAllowedAvatarUrl } from "@/lib/url-allowlist";
 import { cn } from "@/lib/utils";
@@ -66,7 +66,7 @@ type Facets = {
 type SearchMode = "vibe" | "keyword" | "all";
 
 type SearchPayload = {
-  pets: PetWithMetrics[];
+  pets: SearchPet[];
   total?: number;
   nextCursor: number | null;
   searchMode?: SearchMode;
@@ -133,7 +133,7 @@ export function PetGallery({
   const headerCaught = useHeaderState().state.caught;
   const caughtSet = new Set(caughtSlugs ?? headerCaught);
 
-  const [pets, setPets] = useState<PetWithMetrics[]>(initial.pets);
+  const [pets, setPets] = useState<SearchPet[]>(initial.pets);
   const [total, setTotal] = useState<number>(initial.total);
   const [nextCursor, setNextCursor] = useState<number | null>(
     initial.nextCursor,
@@ -776,7 +776,7 @@ export type PetCardPinState = {
 };
 
 type PetCardProps = {
-  pet: PetWithMetrics;
+  pet: SearchPet;
   index: number;
   /** User has already favorited/caught this pet; shown by the heart button. */
   caught?: boolean;

--- a/src/lib/pet-search.ts
+++ b/src/lib/pet-search.ts
@@ -23,10 +23,16 @@ import { db, schema } from "@/lib/db/client";
 import { getAvailableBatches } from "@/lib/dex-batch.server";
 import { PETDEX_EMBEDDING_MODEL } from "@/lib/embeddings";
 import { withNextDataCache } from "@/lib/next-data-cache";
-import type { PetWithMetrics } from "@/lib/pets";
 import { rowToPet } from "@/lib/pets";
 import { embedQuery, looksLikeVibeQuery } from "@/lib/query-embed";
-import { PET_KINDS, PET_VIBES, type PetKind, type PetVibe } from "@/lib/types";
+import { toCurrentR2PublicUrl } from "@/lib/r2-public-url";
+import {
+  PET_KINDS,
+  PET_VIBES,
+  type PetdexPet,
+  type PetKind,
+  type PetVibe,
+} from "@/lib/types";
 
 const rawSql = neon(process.env.DATABASE_URL ?? "");
 
@@ -58,8 +64,33 @@ export type SearchFacets = {
   batches: Array<{ key: string; label: string; count: number }>;
 };
 
+export type SearchPet = Pick<
+  PetdexPet,
+  | "slug"
+  | "displayName"
+  | "description"
+  | "spritesheetPath"
+  | "zipUrl"
+  | "soundUrl"
+  | "featured"
+  | "kind"
+  | "vibes"
+  | "tags"
+  | "dominantColor"
+  | "submittedBy"
+  | "source"
+  | "approvedAt"
+> & {
+  dexNumber?: number | null;
+  metrics: {
+    installCount: number;
+    likeCount: number;
+    zipDownloadCount: number;
+  };
+};
+
 export type SearchOutput = {
-  pets: PetWithMetrics[];
+  pets: SearchPet[];
   total: number;
   nextCursor: number | null;
   /** Which path produced the results. 'vibe' = embedding cosine match,
@@ -195,7 +226,21 @@ export async function searchPets(
   const pageRows = await db
     .with(dexNumbers)
     .select({
-      pet: schema.submittedPets,
+      slug: schema.submittedPets.slug,
+      displayName: schema.submittedPets.displayName,
+      description: schema.submittedPets.description,
+      spritesheetUrl: schema.submittedPets.spritesheetUrl,
+      zipUrl: schema.submittedPets.zipUrl,
+      soundUrl: schema.submittedPets.soundUrl,
+      featured: schema.submittedPets.featured,
+      kind: schema.submittedPets.kind,
+      vibes: schema.submittedPets.vibes,
+      tags: schema.submittedPets.tags,
+      dominantColor: schema.submittedPets.dominantColor,
+      creditName: schema.submittedPets.creditName,
+      creditImage: schema.submittedPets.creditImage,
+      source: schema.submittedPets.source,
+      approvedAt: schema.submittedPets.approvedAt,
       installCount: installCountSql,
       likeCount: likeCountSql,
       zipDownloadCount: zipDownloadCountSql,
@@ -215,15 +260,7 @@ export async function searchPets(
   const hasNext = pageRows.length > limit;
   const slice = hasNext ? pageRows.slice(0, limit) : pageRows;
 
-  const pets: PetWithMetrics[] = slice.map((row) => ({
-    ...rowToPet(row.pet),
-    dexNumber: row.dexNumber,
-    metrics: {
-      installCount: row.installCount ?? 0,
-      likeCount: row.likeCount ?? 0,
-      zipDownloadCount: row.zipDownloadCount ?? 0,
-    },
-  }));
+  const pets = slice.map(toSearchPetFromRow);
 
   const out: SearchPageOutput = {
     pets,
@@ -307,15 +344,14 @@ async function vibeSearch(args: {
   const slice = ranked.slice(args.cursor, args.cursor + args.limit);
   const hasNext = ranked.length > args.cursor + args.limit;
 
-  const pets: PetWithMetrics[] = slice.map((row) => ({
-    ...rowToPet(rowToSchema(row)),
-    dexNumber: row.dex_number == null ? null : Number(row.dex_number),
-    metrics: {
+  const pets = slice.map((row) =>
+    toSearchPet(rowToPet(rowToSchema(row)), {
+      dexNumber: row.dex_number == null ? null : Number(row.dex_number),
       installCount: Number(row.install_count) || 0,
       likeCount: Number(row.like_count) || 0,
       zipDownloadCount: Number(row.zip_download_count) || 0,
-    },
-  }));
+    }),
+  );
 
   const out: SearchPageOutput = {
     pets,
@@ -325,6 +361,81 @@ async function vibeSearch(args: {
   if (args.includeTotal) out.total = ranked.length;
   if (args.includeFacets) out.facets = await loadFacets();
   return out;
+}
+
+function toSearchPet(
+  pet: PetdexPet,
+  metrics: SearchPet["metrics"] & { dexNumber?: number | null },
+): SearchPet {
+  return {
+    slug: pet.slug,
+    displayName: pet.displayName,
+    description: pet.description,
+    spritesheetPath: pet.spritesheetPath,
+    zipUrl: pet.zipUrl,
+    soundUrl: pet.soundUrl,
+    featured: pet.featured,
+    kind: pet.kind,
+    vibes: pet.vibes,
+    tags: pet.tags,
+    dominantColor: pet.dominantColor,
+    submittedBy: pet.submittedBy,
+    source: pet.source,
+    approvedAt: pet.approvedAt,
+    dexNumber: metrics.dexNumber,
+    metrics: {
+      installCount: metrics.installCount,
+      likeCount: metrics.likeCount,
+      zipDownloadCount: metrics.zipDownloadCount,
+    },
+  };
+}
+
+function toSearchPetFromRow(row: {
+  slug: string;
+  displayName: string;
+  description: string;
+  spritesheetUrl: string;
+  zipUrl: string | null;
+  soundUrl: string | null;
+  featured: boolean;
+  kind: string;
+  vibes: unknown;
+  tags: unknown;
+  dominantColor: string | null;
+  creditName: string | null;
+  creditImage: string | null;
+  source: PetdexPet["source"];
+  approvedAt: Date | null;
+  dexNumber: number | null;
+  installCount: number | null;
+  likeCount: number | null;
+  zipDownloadCount: number | null;
+}): SearchPet {
+  return {
+    slug: row.slug,
+    displayName: row.displayName,
+    description: row.description,
+    spritesheetPath: toCurrentR2PublicUrl(row.spritesheetUrl),
+    zipUrl: toCurrentR2PublicUrl(row.zipUrl) ?? undefined,
+    soundUrl: toCurrentR2PublicUrl(row.soundUrl),
+    featured: row.featured,
+    kind: row.kind as PetKind,
+    vibes: Array.isArray(row.vibes) ? (row.vibes as PetVibe[]) : [],
+    tags: Array.isArray(row.tags) ? (row.tags as string[]) : [],
+    dominantColor: row.dominantColor,
+    submittedBy: row.creditName
+      ? { name: row.creditName, imageUrl: row.creditImage ?? undefined }
+      : undefined,
+    source: row.source,
+    approvedAt: row.approvedAt?.toISOString() ?? null,
+    dexNumber: row.dexNumber,
+    metrics: {
+      installCount: row.installCount ?? 0,
+      likeCount: row.likeCount ?? 0,
+      zipDownloadCount: row.zipDownloadCount ?? 0,
+    },
+  };
 }
 
 // Map a snake_case row out of the raw query into the camelCase shape


### PR DESCRIPTION
## Summary
- introduce a slim SearchPet DTO for gallery/search/facet cards
- stop serializing full PetWithMetrics rows into public search payloads
- select explicit submitted_pets columns for deterministic search instead of the full row

## Verification
- Not run, per migration speed scope. CI should validate types for this one.