### PR TITLE
Cache manifest redirects longer in browsers

### DIFF
--- a/src/app/api/manifest/route.ts
+++ b/src/app/api/manifest/route.ts
@@ -5,7 +5,7 @@ import { R2_PUBLIC_BASE } from "@/lib/r2-public-url";
 export const runtime = "nodejs";
 export const revalidate = 300;
 
-const BROWSER_CACHE_CONTROL = "public, max-age=60";
+const BROWSER_CACHE_CONTROL = "public, max-age=300";
 const CDN_CACHE_CONTROL = "public, s-maxage=300, stale-while-revalidate=3600";
 const LEGACY_MANIFEST_URL =
   process.env.PETDEX_MANIFEST_V1_URL ??

--- a/src/app/api/manifest/v2/route.ts
+++ b/src/app/api/manifest/v2/route.ts
@@ -5,7 +5,7 @@ import { R2_PUBLIC_BASE } from "@/lib/r2-public-url";
 export const runtime = "nodejs";
 export const revalidate = 300;
 
-const BROWSER_CACHE_CONTROL = "public, max-age=60";
+const BROWSER_CACHE_CONTROL = "public, max-age=300";
 const CDN_CACHE_CONTROL = "public, s-maxage=300, stale-while-revalidate=3600";
 const COMPACT_MANIFEST_URL =
   process.env.PETDEX_MANIFEST_V2_URL ??


### PR DESCRIPTION
## Summary
- align /api/manifest browser cache with its 5 minute revalidate window
- apply the same cache window to /api/manifest/v2
- leave authenticated full manifest uncached/shared behavior unchanged

## Verification
- Not run, per migration speed scope.