### PR TITLE
Drop admin count from header state

### DIFF
--- a/src/app/api/me/header-state/route.ts
+++ b/src/app/api/me/header-state/route.ts
@@ -3,7 +3,6 @@ import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { sql as dsql } from "drizzle-orm";
 
-import { isAdmin } from "@/lib/admin";
 import { hasClerkSessionCookie } from "@/lib/clerk-session-cookie";
 import { db } from "@/lib/db/client";
 import {
@@ -16,7 +15,6 @@ export const runtime = "nodejs";
 type HeaderStateRow = {
   notification_count: number | string;
   feedback_count: number | string;
-  admin_count: number | string;
   caught_slugs: unknown;
 };
 
@@ -57,7 +55,6 @@ export async function GET(req: Request): Promise<Response> {
     "Cache-Control": `private, max-age=${HEADER_STATE_BROWSER_CACHE_SECONDS}, must-revalidate`,
     Vary: "Cookie",
   };
-  const admin = isAdmin(userId);
   const result = (await db.execute(dsql`
     WITH notification_state AS (
       SELECT count(*)::int AS notification_count
@@ -84,32 +81,12 @@ export async function GET(req: Request): Promise<Response> {
               OR fr.created_at > f.user_last_read_at
             )
         )
-    ),
-    admin_feedback_state AS (
-      SELECT
-        CASE
-          WHEN ${admin}::boolean THEN count(*)::int
-          ELSE 0
-        END AS admin_count
-      FROM feedback f
-      WHERE ${admin}::boolean
-        AND EXISTS (
-          SELECT 1
-          FROM feedback_replies fr
-          WHERE fr.feedback_id = f.id
-            AND fr.author_kind = 'user'
-            AND (
-              f.admin_last_read_at IS NULL
-              OR fr.created_at > f.admin_last_read_at
-            )
-        )
     )
     SELECT
       notification_state.notification_count,
       caught_state.caught_slugs,
-      feedback_state.feedback_count,
-      admin_feedback_state.admin_count
-    FROM notification_state, caught_state, feedback_state, admin_feedback_state
+      feedback_state.feedback_count
+    FROM notification_state, caught_state, feedback_state
   `)) as unknown as { rows: HeaderStateRow[] };
   const row = result.rows[0];
 
@@ -119,7 +96,6 @@ export async function GET(req: Request): Promise<Response> {
       notifications: { unreadCount: toNumber(row?.notification_count) },
       feedback: {
         count: toNumber(row?.feedback_count),
-        adminCount: toNumber(row?.admin_count),
       },
       caught: toStringArray(row?.caught_slugs),
     },

--- a/src/lib/header-state.test.ts
+++ b/src/lib/header-state.test.ts
@@ -86,7 +86,7 @@ describe("header state helpers", () => {
       ...INITIAL_HEADER_STATE,
       signedIn: true,
       notifications: { unreadCount: 2 },
-      feedback: { count: 1, adminCount: 0 },
+      feedback: { count: 1 },
       caught: ["byte"],
     };
     const raw = serializeHeaderState(state, 1_000);

--- a/src/lib/header-state.ts
+++ b/src/lib/header-state.ts
@@ -1,14 +1,14 @@
 export type HeaderState = {
   signedIn: boolean;
   notifications: { unreadCount: number };
-  feedback: { count: number; adminCount: number };
+  feedback: { count: number };
   caught: string[];
 };
 
 export const INITIAL_HEADER_STATE: HeaderState = {
   signedIn: false,
   notifications: { unreadCount: 0 },
-  feedback: { count: 0, adminCount: 0 },
+  feedback: { count: 0 },
   caught: [],
 };
 
@@ -211,7 +211,6 @@ function normalizeHeaderState(value: unknown): HeaderState {
     },
     feedback: {
       count: toNumber(feedback.count),
-      adminCount: toNumber(feedback.adminCount),
     },
     caught: Array.isArray(input.caught) ? input.caught.filter(isString) : [],
   };


### PR DESCRIPTION
## Summary
- remove the admin feedback count from /api/me/header-state now that admin UI lives outside the public app
- drop the extra feedback admin-count CTE from the hot header-state query
- simplify the HeaderState feedback shape and cached-state normalization

## Tests
- bun test src/lib/header-state.test.ts
- bunx biome check src/app/api/me/header-state/route.ts src/lib/header-state.ts src/lib/header-state.test.ts
- rg -n "adminCount|admin_count|admin_feedback_state|isAdmin" src/app/api/me/header-state/route.ts src/lib/header-state.ts src/lib/header-state.test.ts
- git diff --check