### PR TITLE
Inline profile handle in header state

### DIFF
--- a/src/app/api/me/header-state/route.ts
+++ b/src/app/api/me/header-state/route.ts
@@ -15,13 +15,14 @@ export const runtime = "nodejs";
 type HeaderStateRow = {
   notification_count: number | string;
   feedback_count: number | string;
+  profile_handle: string | null;
   caught_slugs: unknown;
 };
 
 // GET /api/me/header-state -> single aggregate the SiteHeader needs on
-// every page-view. Combines what used to be three separate endpoints
-// (notifications unread, feedback unread, caught slugs) so we ship
-// one Edge Request per page-view instead of three.
+// every page-view. Combines notifications unread, feedback unread,
+// caught slugs, and the canonical profile handle so signed-in headers
+// do not fan out into separate reads.
 //
 // Returns lightweight counts + the caught slug set. The full
 // notifications list (`items[]`) still lives at /api/notifications and
@@ -85,7 +86,13 @@ export async function GET(req: Request): Promise<Response> {
     SELECT
       notification_state.notification_count,
       caught_state.caught_slugs,
-      feedback_state.feedback_count
+      feedback_state.feedback_count,
+      (
+        SELECT handle
+        FROM user_profiles
+        WHERE user_id = ${userId}
+        LIMIT 1
+      ) AS profile_handle
     FROM notification_state, caught_state, feedback_state
   `)) as unknown as { rows: HeaderStateRow[] };
   const row = result.rows[0];
@@ -96,6 +103,9 @@ export async function GET(req: Request): Promise<Response> {
       notifications: { unreadCount: toNumber(row?.notification_count) },
       feedback: {
         count: toNumber(row?.feedback_count),
+      },
+      profile: {
+        handle: row?.profile_handle ?? null,
       },
       caught: toStringArray(row?.caught_slugs),
     },

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -240,12 +240,11 @@ export async function PATCH(req: Request): Promise<Response> {
     invalidatePublicHandleCaches(previousHandle, patch.handle),
   ]);
 
-  // Sync Clerk username with the DB handle so the AuthBadge dropdown,
-  // which reads from useUser() in the browser, also lands on the right
-  // /u/<handle>. Clerk username has stricter rules (uniqueness across
-  // the whole instance, format constraints) — if the call fails, log
-  // and move on. The DB stays source-of-truth and AuthBadge already
-  // reads /api/profile/me as its primary source.
+  // Sync Clerk username with the DB handle so Clerk's fallback browser
+  // user object also lands on the right /u/<handle>. Clerk username has
+  // stricter rules (uniqueness across the whole instance, format
+  // constraints) — if the call fails, log and move on. The DB stays
+  // source-of-truth and /api/me/header-state is the primary source.
   if (patch.handle !== undefined && patch.handle) {
     try {
       const cc = await clerkClient();

--- a/src/components/auth-badge.tsx
+++ b/src/components/auth-badge.tsx
@@ -2,7 +2,6 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useEffect, useState } from "react";
 
 import { SignInButton, useAuth, useClerk, useUser } from "@clerk/nextjs";
 import {
@@ -91,7 +90,9 @@ function UserDropdown({ compact = false }: { compact?: boolean }) {
   const { user, isLoaded } = useUser();
   const { signOut, openUserProfile } = useClerk();
   const showAdmin = isAdminClientSafe(user?.id);
-  const unread = useHeaderState().state.feedback.count;
+  const headerState = useHeaderState().state;
+  const unread = headerState.feedback.count;
+  const dbHandle = headerState.profile?.handle ?? null;
   const t = useTranslations("header");
   const locale = useLocale();
   const currentLocale: Locale = hasLocale(locale) ? locale : "en";
@@ -99,32 +100,6 @@ function UserDropdown({ compact = false }: { compact?: boolean }) {
   const adminHref =
     process.env.NEXT_PUBLIC_PETDEX_ADMIN_URL?.replace(/\/$/, "") ||
     "https://admin.petdex.dev";
-
-  // Source of truth for the public profile handle is our DB
-  // (user_profiles.handle), not Clerk's username field. Clerk username
-  // is allowed to drift — Thib's was null while his DB handle was
-  // "thibgl", so the avatar dropdown was deep-linking to /u/<id-slice>
-  // and 404ing. Fetch the real handle once on mount, fall back to the
-  // old slice-of-id while the request is in flight so the dropdown is
-  // never empty.
-  const [dbHandle, setDbHandle] = useState<string | null>(null);
-  useEffect(() => {
-    if (!user) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await fetch("/api/profile/me");
-        if (!res.ok) return;
-        const j = (await res.json()) as { handle?: string | null };
-        if (!cancelled && j.handle) setDbHandle(j.handle);
-      } catch {
-        /* swallow — fallback handle still works */
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [user]);
 
   if (!isLoaded || !user) {
     return <AvatarSkeleton compact={compact} />;

--- a/src/components/header-state-provider.tsx
+++ b/src/components/header-state-provider.tsx
@@ -21,6 +21,7 @@ import {
   headerStateResponseSavedAt,
   INITIAL_HEADER_STATE,
   nextHeaderStatePollDelay,
+  normalizeHeaderState,
   parseCachedHeaderState,
   readCachedHeaderStateFromBrowser,
   releaseHeaderStateRefreshClaim,
@@ -102,7 +103,7 @@ export function HeaderStateProvider({
           cache: headerStateFetchCacheMode(options?.force),
         });
         if (!res.ok) return;
-        const json = (await res.json()) as HeaderState;
+        const json = normalizeHeaderState(await res.json());
         if (
           !mounted.current ||
           generation !== requestGeneration.current ||
@@ -202,7 +203,7 @@ export function HeaderStateProvider({
         nextHeaderStatePollDelay(lastRefreshAt.current, Date.now()),
       );
     };
-    void refresh().finally(schedulePoll);
+    void refresh({ force: !hasCachedState }).finally(schedulePoll);
     const onFocus = () => refreshIfVisible();
     const onVisibilityChange = () => refreshIfVisible();
     const onStorage = (ev: StorageEvent) => {

--- a/src/components/profile-card.tsx
+++ b/src/components/profile-card.tsx
@@ -8,6 +8,8 @@ import { ExternalLink, Loader2, Pencil, Pin, Star, X } from "lucide-react";
 
 import { MAX_PINNED_PETS } from "@/lib/profiles";
 
+import { useHeaderState } from "@/components/header-state-provider";
+
 type ApprovedPet = {
   slug: string;
   displayName: string;
@@ -32,6 +34,7 @@ export function ProfileCard({ profile }: { profile: ProfileData }) {
   const [pinned, setPinned] = useState<string[]>(profile.featuredPetSlugs);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { refresh: refreshHeaderState } = useHeaderState();
   const [, startTransition] = useTransition();
 
   useEffect(() => {
@@ -85,6 +88,7 @@ export function ProfileCard({ profile }: { profile: ProfileData }) {
         return;
       }
       setOpen(false);
+      await refreshHeaderState({ force: true });
       startTransition(() => router.refresh());
     } finally {
       setBusy(false);

--- a/src/components/profile-inline-editor.tsx
+++ b/src/components/profile-inline-editor.tsx
@@ -8,6 +8,8 @@ import { useTranslations } from "next-intl";
 
 import { MAX_PINNED_PETS } from "@/lib/profiles";
 
+import { useHeaderState } from "@/components/header-state-provider";
+
 type ApprovedPet = {
   slug: string;
   displayName: string;
@@ -39,6 +41,7 @@ export function ProfileInlineEditor({
   const [pinned, setPinned] = useState<string[]>(initialFeaturedSlugs);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { refresh: refreshHeaderState } = useHeaderState();
   const [, startTransition] = useTransition();
 
   function togglePin(slug: string) {
@@ -72,6 +75,7 @@ export function ProfileInlineEditor({
         return;
       }
       setOpen(false);
+      await refreshHeaderState({ force: true });
       if (j?.handle && j.handle !== handle) {
         startTransition(() => router.replace(`/u/${j.handle}`));
       } else {

--- a/src/lib/header-state.test.ts
+++ b/src/lib/header-state.test.ts
@@ -8,6 +8,7 @@ import {
   headerStateResponseSavedAt,
   INITIAL_HEADER_STATE,
   nextHeaderStatePollDelay,
+  normalizeHeaderState,
   parseCachedHeaderState,
   readCachedHeaderStateFromBrowser,
   releaseHeaderStateRefreshClaim,
@@ -87,6 +88,7 @@ describe("header state helpers", () => {
       signedIn: true,
       notifications: { unreadCount: 2 },
       feedback: { count: 1 },
+      profile: { handle: "byte-owner" },
       caught: ["byte"],
     };
     const raw = serializeHeaderState(state, 1_000);
@@ -94,6 +96,24 @@ describe("header state helpers", () => {
     expect(parseCachedHeaderState(raw, 30_000)?.state).toEqual(state);
     expect(parseCachedHeaderState(raw, 1_801_001)).toBeNull();
     expect(parseCachedHeaderState(raw, 500)).toBeNull();
+  });
+
+  it("normalizes legacy payloads without profile state", () => {
+    expect(
+      normalizeHeaderState({
+        signedIn: true,
+        notifications: { unreadCount: 1 },
+        feedback: { count: 2 },
+        caught: ["byte"],
+      }),
+    ).toEqual({
+      ...INITIAL_HEADER_STATE,
+      signedIn: true,
+      notifications: { unreadCount: 1 },
+      feedback: { count: 2 },
+      profile: { handle: null },
+      caught: ["byte"],
+    });
   });
 
   it("reads shared browser cache before tab-local fallback cache", () => {
@@ -337,7 +357,7 @@ describe("header state helpers", () => {
   it("scopes cache keys by signed-in user", () => {
     expect(headerStateCacheKey(null)).toBeNull();
     expect(headerStateCacheKey("user_123")).toBe(
-      "petdex:header-state:user_123",
+      "petdex:header-state:v2:user_123",
     );
   });
 

--- a/src/lib/header-state.ts
+++ b/src/lib/header-state.ts
@@ -2,6 +2,7 @@ export type HeaderState = {
   signedIn: boolean;
   notifications: { unreadCount: number };
   feedback: { count: number };
+  profile: { handle: string | null };
   caught: string[];
 };
 
@@ -9,6 +10,7 @@ export const INITIAL_HEADER_STATE: HeaderState = {
   signedIn: false,
   notifications: { unreadCount: 0 },
   feedback: { count: 0 },
+  profile: { handle: null },
   caught: [],
 };
 
@@ -30,7 +32,7 @@ export type HeaderStateRefreshClaim = {
 };
 
 export function headerStateCacheKey(userId: string | null | undefined) {
-  return userId ? `petdex:header-state:${userId}` : null;
+  return userId ? `petdex:header-state:v2:${userId}` : null;
 }
 
 export function shouldRequestHeaderState(input: {
@@ -198,12 +200,13 @@ export function withHeaderUnreadCount(
   };
 }
 
-function normalizeHeaderState(value: unknown): HeaderState {
+export function normalizeHeaderState(value: unknown): HeaderState {
   const input = isRecord(value) ? value : {};
   const notifications = isRecord(input.notifications)
     ? input.notifications
     : {};
   const feedback = isRecord(input.feedback) ? input.feedback : {};
+  const profile = isRecord(input.profile) ? input.profile : {};
   return {
     signedIn: input.signedIn === true,
     notifications: {
@@ -211,6 +214,9 @@ function normalizeHeaderState(value: unknown): HeaderState {
     },
     feedback: {
       count: toNumber(feedback.count),
+    },
+    profile: {
+      handle: typeof profile.handle === "string" ? profile.handle : null,
     },
     caught: Array.isArray(input.caught) ? input.caught.filter(isString) : [],
   };


### PR DESCRIPTION
## Summary
- include the DB-backed profile handle in `/api/me/header-state`
- use that aggregate in `AuthBadge` instead of fetching `/api/profile/me` on each signed-in header mount
- keep `/api/profile/me` available for now, but remove it from the hot header path

## Tests
- `bun test src/lib/header-state.test.ts`
- `./node_modules/.bin/biome check src/lib/header-state.ts src/lib/header-state.test.ts src/app/api/me/header-state/route.ts src/components/auth-badge.tsx`
- `git diff --check`

## Notes
- `bun run check` currently fails on pre-existing formatting/import issues in `src/components/pet-gallery.tsx` and `src/lib/ads/queries.ts`, both outside this diff.