### PR TITLE
Remove simple no-op analytics calls

### DIFF
--- a/src/components/claim-cta.tsx
+++ b/src/components/claim-cta.tsx
@@ -4,8 +4,6 @@ import { SignInButton, useUser } from "@clerk/nextjs";
 import { ArrowRight } from "lucide-react";
 import { useTranslations } from "next-intl";
 
-import { track } from "@/lib/vercel-analytics";
-
 // Inline "Is this you?" prompt shown on /pets/[slug] for discovered
 // pets when the viewer is either signed-out or signed in as someone
 // other than the listed author. Pushes them to sign in with the
@@ -62,20 +60,12 @@ export function ClaimCTA({
       {isSignedIn ? (
         // Already signed in — send them to their own profile where the
         // claim banner inside ProfileTabs does the actual transfer.
-        <a
-          href={profileHrefForUser(user)}
-          onClick={() => track("claim_cta_clicked", { signed_in: true })}
-          className="inline-flex"
-        >
+        <a href={profileHrefForUser(user)} className="inline-flex">
           {inner}
         </a>
       ) : (
         <SignInButton mode="modal" forceRedirectUrl="/" fallbackRedirectUrl="/">
-          <button
-            type="button"
-            onClick={() => track("claim_cta_clicked", { signed_in: false })}
-            className="inline-flex"
-          >
+          <button type="button" className="inline-flex">
             {inner}
           </button>
         </SignInButton>

--- a/src/components/command-line.tsx
+++ b/src/components/command-line.tsx
@@ -5,15 +5,12 @@ import { Fragment, useState } from "react";
 import { Check, CircleAlert, Copy } from "lucide-react";
 import { useTranslations } from "next-intl";
 
-import { track } from "@/lib/vercel-analytics";
-
 import { CodexLogo } from "@/components/codex-logo";
 
 type CommandLineProps = {
   command: string;
   /** Lighter prefix prepended without being copied (eg. "$ "). Visual only. */
   prefix?: string;
-  /** Tracking event payload key. */
   source?: string;
   className?: string;
   /**
@@ -131,7 +128,6 @@ function tokenize(command: string): React.ReactNode {
 export function CommandLine({
   command,
   prefix = "$ ",
-  source,
   className = "",
   codexPrompt,
   wrap = false,
@@ -156,10 +152,6 @@ export function CommandLine({
     try {
       await writeClipboard(toCopy);
       setCopyState("copied");
-      track("command_line_copied", {
-        command: command.slice(0, 80),
-        source: source ?? "unknown",
-      });
       window.setTimeout(() => setCopyState("idle"), 1500);
     } catch {
       setCopyState("failed");
@@ -201,12 +193,6 @@ export function CommandLine({
         <a
           href={`codex://new?prompt=${encodeURIComponent(`Install this Petdex pet by running: ${pinToLatest(command)}`)}`}
           aria-label={t("openInCodexAria")}
-          onClick={() =>
-            track("command_line_codex_clicked", {
-              command: command.slice(0, 80),
-              source: source ?? "unknown",
-            })
-          }
           className="grid size-6 shrink-0 place-items-center rounded-md text-muted-3 transition hover:bg-brand-tint"
         >
           <CodexLogo className="size-3.5" />

--- a/src/components/command-line.tsx
+++ b/src/components/command-line.tsx
@@ -146,8 +146,7 @@ export function CommandLine({
   async function handleCopy() {
     // Display the natural `npx petdex` form, but copy the
     // version-pinned `petdex@latest` so every paste resolves to
-    // the most recent release. Tracking still uses the visual
-    // form so dashboards stay readable.
+    // the most recent release.
     const toCopy = pinToLatest(command);
     try {
       await writeClipboard(toCopy);

--- a/src/components/discord-link.tsx
+++ b/src/components/discord-link.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-// Client wrapper around the Discord invite anchor so we can attribute
-// clicks per surface (footer vs /community vs anywhere else we add it
-// later). Vercel Analytics will roll up `discord_click` events with
-// the surface as a custom property.
-
 import type { ReactNode } from "react";
-
-import { track } from "@/lib/vercel-analytics";
 
 type DiscordLinkProps = {
   href: string;
@@ -19,7 +12,6 @@ type DiscordLinkProps = {
 
 export function DiscordLink({
   href,
-  source,
   children,
   className,
   ariaLabel,
@@ -31,9 +23,6 @@ export function DiscordLink({
       rel="noreferrer"
       aria-label={ariaLabel}
       className={className}
-      onClick={() => {
-        track("discord_click", { source });
-      }}
     >
       {children}
     </a>

--- a/src/components/download-desktop-cta.tsx
+++ b/src/components/download-desktop-cta.tsx
@@ -1,14 +1,7 @@
 "use client";
 
-// Client wrapper around the /download CTA so we can attribute clicks
-// per surface (hero vs /pets/<slug> vs site-header etc). Vercel
-// Analytics rolls up `download_desktop_click` with the surface as a
-// custom property.
-
 import Link from "next/link";
 import type { ReactNode } from "react";
-
-import { track } from "@/lib/vercel-analytics";
 
 type DownloadDesktopCTAProps = {
   href: string;
@@ -20,7 +13,6 @@ type DownloadDesktopCTAProps = {
 
 export function DownloadDesktopCTA({
   href,
-  source,
   children,
   className,
   ariaLabel,
@@ -31,9 +23,6 @@ export function DownloadDesktopCTA({
       prefetch={false}
       aria-label={ariaLabel}
       className={className}
-      onClick={() => {
-        track("download_desktop_click", { source });
-      }}
     >
       {children}
     </Link>

--- a/src/components/open-in-petdex-button.tsx
+++ b/src/components/open-in-petdex-button.tsx
@@ -12,7 +12,6 @@ import {
   isMacDesktop,
   openPetdexDeepLink,
 } from "@/lib/petdex-desktop-link";
-import { track } from "@/lib/vercel-analytics";
 
 type OpenInPetdexButtonProps = {
   slug: string;
@@ -55,7 +54,6 @@ export function OpenInPetdexButton({ slug }: OpenInPetdexButtonProps) {
 
   function handleClick(e: React.MouseEvent<HTMLAnchorElement>) {
     if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
-    track("open_in_petdex_click", { slug, source: "pet_page" });
     e.preventDefault();
     openPetdexDeepLink(deepLink, downloadHref);
   }

--- a/src/components/profile-external-link.tsx
+++ b/src/components/profile-external-link.tsx
@@ -2,10 +2,7 @@
 
 import { ExternalLink } from "lucide-react";
 
-import { track } from "@/lib/vercel-analytics";
-
 export function ProfileExternalLink({
-  handle,
   url,
   label,
 }: {
@@ -18,21 +15,10 @@ export function ProfileExternalLink({
       href={url}
       target="_blank"
       rel="noreferrer"
-      onClick={() => {
-        track("profile_external_clicked", { handle, host: hostFor(url) });
-      }}
       className="inline-flex h-8 items-center gap-1.5 rounded-full border border-border-base bg-surface/80 px-3 font-mono text-[11px] tracking-[0.06em] text-muted-2 transition hover:border-border-strong hover:bg-white dark:hover:bg-stone-800"
     >
       <ExternalLink className="size-3" />
       {label}
     </a>
   );
-}
-
-function hostFor(url: string): string {
-  try {
-    return new URL(url).host;
-  } catch {
-    return "unknown";
-  }
 }

--- a/src/components/profile-share-button.tsx
+++ b/src/components/profile-share-button.tsx
@@ -12,8 +12,6 @@ import { Check, X as CloseIcon, Link2, Share2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { createPortal } from "react-dom";
 
-import { track } from "@/lib/vercel-analytics";
-
 const SITE_URL = "https://petdex.dev";
 
 type Props = {
@@ -102,30 +100,27 @@ export function ProfileShareButton({ handle, displayName }: Props) {
     try {
       await navigator.clipboard.writeText(profileUrl);
       setCopied(true);
-      track("profile_share", { handle, target: "copy" });
       window.setTimeout(() => setCopied(false), 1400);
     } catch {
       /* ignore clipboard failures */
     }
-  }, [handle, profileUrl]);
+  }, [profileUrl]);
 
   const onShareX = useCallback(() => {
     const url = `https://x.com/intent/tweet?text=${encodeURIComponent(
       shareText,
     )}&url=${encodeURIComponent(profileUrl)}`;
-    track("profile_share", { handle, target: "x" });
     window.open(url, "_blank", "noopener,noreferrer,width=560,height=540");
     setOpen(false);
-  }, [handle, profileUrl, shareText]);
+  }, [profileUrl, shareText]);
 
   const onShareLinkedIn = useCallback(() => {
     const url = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(
       profileUrl,
     )}`;
-    track("profile_share", { handle, target: "linkedin" });
     window.open(url, "_blank", "noopener,noreferrer,width=620,height=600");
     setOpen(false);
-  }, [handle, profileUrl]);
+  }, [profileUrl]);
 
   const onShareNative = useCallback(async () => {
     if (typeof navigator === "undefined" || !("share" in navigator)) return;
@@ -139,12 +134,11 @@ export function ProfileShareButton({ handle, displayName }: Props) {
         text: shareText,
         url: profileUrl,
       });
-      track("profile_share", { handle, target: "native" });
       setOpen(false);
     } catch {
       /* user cancelled */
     }
-  }, [handle, profileUrl, shareLabel, shareText]);
+  }, [profileUrl, shareLabel, shareText]);
 
   const supportsNative =
     typeof navigator !== "undefined" && "share" in navigator;


### PR DESCRIPTION
## Summary
- remove no-op `track(...)` imports/calls from simple CTA/link components
- keep existing public props like `source` intact so callers do not need to change
- preserve click, copy, share, sign-in, and desktop deep-link behavior

## Tests
- `bun run check`
- `rg -n "from \"@/lib/vercel-analytics\"|track\\(" src/components/{claim-cta.tsx,discord-link.tsx,download-desktop-cta.tsx,open-in-petdex-button.tsx,profile-external-link.tsx,profile-share-button.tsx,command-line.tsx}`
- `git diff --check`