### PR TITLE
Remove card analytics no-ops

### DIFF
--- a/src/components/collection-action-menu.tsx
+++ b/src/components/collection-action-menu.tsx
@@ -21,7 +21,6 @@ import {
   isMacDesktop,
   openPetdexDeepLink,
 } from "@/lib/petdex-desktop-link";
-import { track } from "@/lib/vercel-analytics";
 
 import { CodexLogo } from "@/components/codex-logo";
 
@@ -177,10 +176,6 @@ export function CollectionActionMenu({ collection }: Props) {
                     ) {
                       return;
                     }
-                    track("open_in_petdex_click", {
-                      source: "collection",
-                      count: installSlugs.length,
-                    });
                     e.preventDefault();
                     setOpen(false);
                     openPetdexDeepLink(petdexInstallUrl, downloadHref);

--- a/src/components/like-button.tsx
+++ b/src/components/like-button.tsx
@@ -8,7 +8,6 @@ import { useLocale } from "next-intl";
 
 import { formatLocalizedNumber } from "@/lib/format-number";
 import { loadPetMetrics } from "@/lib/pet-metrics-client";
-import { track } from "@/lib/vercel-analytics";
 
 import { useHeaderState } from "@/components/header-state-provider";
 import { Button } from "@/components/ui/button";
@@ -122,9 +121,6 @@ export function LikeButton({ slug }: LikeButtonProps) {
         setLiked(data.liked);
         setCount(data.count);
         void refresh({ force: true });
-        if (data.liked) {
-          track("pet_liked", { slug });
-        }
       } catch {
         if (mutationVersionRef.current !== mutationVersion) return;
         setLiked(!nextLiked);

--- a/src/components/pet-card-footer.tsx
+++ b/src/components/pet-card-footer.tsx
@@ -9,7 +9,6 @@ import { useLocale } from "next-intl";
 
 import { formatLocalizedNumber } from "@/lib/format-number";
 import { cn } from "@/lib/utils";
-import { track } from "@/lib/vercel-analytics";
 
 import { useHeaderState } from "@/components/header-state-provider";
 import { PetSoundButton } from "@/components/pet-sound-button";
@@ -71,7 +70,6 @@ function PetCardFooterImpl({
       const next = !liked;
       setLiked(next);
       setCount((c) => Math.max(0, c + (next ? 1 : -1)));
-      track("pet_like_toggled", { slug, liked: next, source: "card-footer" });
       try {
         const res = await fetch(`/api/pets/${slug}/like`, {
           method: "POST",
@@ -114,7 +112,6 @@ function PetCardFooterImpl({
       try {
         await navigator.clipboard.writeText(cmd);
         setCopied(true);
-        track("pet_install_copied", { slug, source: "card-footer" });
         setTimeout(() => setCopied(false), 1400);
       } catch {
         /* swallow */
@@ -128,7 +125,6 @@ function PetCardFooterImpl({
       e.preventDefault();
       e.stopPropagation();
       if (!zipUrl) return;
-      track("pet_zip_downloaded", { slug, source: "card-footer" });
       const a = document.createElement("a");
       a.href = zipUrl;
       a.download = `${slug}.zip`;
@@ -145,7 +141,6 @@ function PetCardFooterImpl({
       e.preventDefault();
       e.stopPropagation();
       const url = `${typeof window !== "undefined" ? window.location.origin : ""}/pets/${slug}`;
-      track("pet_shared", { slug, source: "card-footer" });
       if (navigator.share) {
         navigator.share({ title: displayName, url }).catch(() => {});
         return;

--- a/src/components/wechat-community-dialog.tsx
+++ b/src/components/wechat-community-dialog.tsx
@@ -6,7 +6,6 @@ import { useState } from "react";
 import { Loader2 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
-import { track } from "@/lib/vercel-analytics";
 
 import { WeChatIcon } from "@/components/icons/wechat-icon";
 import {
@@ -63,15 +62,10 @@ type WechatCommunityDialogProps = {
 
 export function WechatCommunityDialog({
   className,
-  source = "community_page_hero",
   children = "加入微信群",
 }: WechatCommunityDialogProps) {
   return (
-    <Dialog
-      onOpenChange={(open) => {
-        if (open) track("wechat_qr_open", { source });
-      }}
-    >
+    <Dialog>
       <DialogTrigger
         render={
           <button
@@ -80,9 +74,6 @@ export function WechatCommunityDialog({
               "inline-flex h-11 items-center gap-2 rounded-full border border-[#07C160]/25 bg-[#07C160]/12 px-5 text-sm font-semibold text-[#07C160] backdrop-blur transition hover:bg-[#07C160]/18",
               className,
             )}
-            onClick={() => {
-              track("wechat_click", { source });
-            }}
           >
             <WeChatIcon className="size-4" />
             {children}


### PR DESCRIPTION
## Summary
- remove no-op Vercel analytics calls from card footer, like button, collection menu, and WeChat dialog
- keep public props and user interactions unchanged

## Test plan
- bun run check
- git diff --check
