### PR TITLE
Delete analytics shim

### DIFF
--- a/src/lib/vercel-analytics.ts
+++ b/src/lib/vercel-analytics.ts
@@ -1,5 +1,0 @@
-type TrackPayload = Record<string, unknown>;
-
-export function track(_event: string, _payload?: TrackPayload): void {
-  return;
-}


### PR DESCRIPTION
## Summary
- delete the now-unused Vercel analytics shim
- verify there are no remaining `vercel-analytics` or `track(...)` references

## Test plan
- bun run check
- git diff --check
- rg -n 'vercel-analytics|track\\(' src package.json bun.lock\n