### PR TITLE
Remove header state background polling

### DIFF
--- a/src/components/header-state-provider.tsx
+++ b/src/components/header-state-provider.tsx
@@ -12,27 +12,27 @@ import {
 import { useAuth } from "@clerk/nextjs";
 
 import {
-  claimHeaderStateRefresh,
   clearCachedHeaderStateFromBrowser,
-  HEADER_STATE_POLL_MS,
+  HEADER_STATE_EVENTUAL_REFRESH_MS,
+  HEADER_STATE_MIN_REFRESH_MS,
   type HeaderState,
   headerStateCacheKey,
   headerStateFetchCacheMode,
   headerStateResponseSavedAt,
   INITIAL_HEADER_STATE,
-  nextHeaderStatePollDelay,
   normalizeHeaderState,
   parseCachedHeaderState,
   readCachedHeaderStateFromBrowser,
-  releaseHeaderStateRefreshClaim,
   shouldRequestHeaderState,
   withHeaderUnreadCount,
   writeCachedHeaderStateToBrowser,
 } from "@/lib/header-state";
 
+type HeaderRefreshResult = "failed" | "fetched" | "skipped";
+
 type Ctx = {
   state: HeaderState;
-  refresh: (options?: { force?: boolean }) => Promise<void>;
+  refresh: (options?: { force?: boolean }) => Promise<HeaderRefreshResult>;
   setUnreadCount: (next: number | ((current: number) => number)) => void;
 };
 
@@ -93,23 +93,25 @@ export function HeaderStateProvider({
           now,
         })
       ) {
-        return;
+        return "skipped";
       }
-      if (!options?.force && inFlightUser.current === requestUserId) return;
+      if (!options?.force && inFlightUser.current === requestUserId) {
+        return "skipped";
+      }
       const generation = ++requestGeneration.current;
       inFlightUser.current = requestUserId;
       try {
         const res = await fetch("/api/me/header-state", {
           cache: headerStateFetchCacheMode(options?.force),
         });
-        if (!res.ok) return;
+        if (!res.ok) return "failed";
         const json = normalizeHeaderState(await res.json());
         if (
           !mounted.current ||
           generation !== requestGeneration.current ||
           userScope.current !== requestUserId
         ) {
-          return;
+          return "skipped";
         }
         const savedAt = headerStateResponseSavedAt(res.headers, now);
         setState(json);
@@ -117,8 +119,9 @@ export function HeaderStateProvider({
         if (cacheKey) {
           writeCachedHeaderStateToBrowser(cacheKey, json, savedAt);
         }
+        return "fetched";
       } catch {
-        return;
+        return "failed";
       } finally {
         if (inFlightUser.current === requestUserId) {
           inFlightUser.current = null;
@@ -161,51 +164,42 @@ export function HeaderStateProvider({
       setState(INITIAL_HEADER_STATE);
       lastRefreshAt.current = 0;
     }
-    const refreshIfVisible = (options?: { force?: boolean }) => {
-      if (document.visibilityState !== "visible") return;
-      void refresh(options);
+    const nextRefreshDelay = (result: HeaderRefreshResult | "hidden") => {
+      if (result === "fetched" || result === "hidden") {
+        return HEADER_STATE_EVENTUAL_REFRESH_MS;
+      }
+      if (result === "failed") return HEADER_STATE_MIN_REFRESH_MS;
+      const elapsed = Date.now() - lastRefreshAt.current;
+      return Math.max(1_000, HEADER_STATE_MIN_REFRESH_MS - elapsed);
+    };
+    const refreshIfVisible = async (options?: { force?: boolean }) => {
+      if (document.visibilityState !== "visible") return "hidden" as const;
+      return refresh(options);
     };
     let cancelled = false;
-    let intervalId: number | null = null;
-    let timeoutId: number | null = null;
-    const poll = () => {
-      if (document.visibilityState !== "visible") return;
-      const now = Date.now();
-      applyCachedState(now);
-      if (
-        !shouldRequestHeaderState({
-          isLoaded,
-          isSignedIn,
-          lastRefreshAt: lastRefreshAt.current,
-          now,
-        })
-      ) {
-        return;
+    let eventualRefreshId: number | null = null;
+    const scheduleEventualRefresh = (delay: number) => {
+      eventualRefreshId = window.setTimeout(() => {
+        void (async () => {
+          const refreshed = await refreshIfVisible();
+          if (!cancelled) {
+            scheduleEventualRefresh(nextRefreshDelay(refreshed));
+          }
+        })();
+      }, delay);
+    };
+    void (async () => {
+      const refreshed = await refresh({ force: !hasCachedState });
+      if (!cancelled) {
+        scheduleEventualRefresh(nextRefreshDelay(refreshed));
       }
-      const claim = cacheKey
-        ? claimHeaderStateRefresh(cacheKey, now)
-        : { shouldRefresh: true, token: null };
-      if (!claim.shouldRefresh) return;
-      void refresh({ force: true }).finally(() => {
-        if (cacheKey && claim.token) {
-          releaseHeaderStateRefreshClaim(cacheKey, claim.token);
-        }
-      });
+    })();
+    const onFocus = () => {
+      void refreshIfVisible();
     };
-    const schedulePoll = () => {
-      if (cancelled) return;
-      timeoutId = window.setTimeout(
-        () => {
-          if (cancelled) return;
-          poll();
-          intervalId = window.setInterval(poll, HEADER_STATE_POLL_MS);
-        },
-        nextHeaderStatePollDelay(lastRefreshAt.current, Date.now()),
-      );
+    const onVisibilityChange = () => {
+      void refreshIfVisible();
     };
-    void refresh({ force: !hasCachedState }).finally(schedulePoll);
-    const onFocus = () => refreshIfVisible();
-    const onVisibilityChange = () => refreshIfVisible();
     const onStorage = (ev: StorageEvent) => {
       if (ev.key !== cacheKey || !ev.newValue) return;
       const cached = parseCachedHeaderState(ev.newValue, Date.now());
@@ -217,11 +211,12 @@ export function HeaderStateProvider({
     window.addEventListener("storage", onStorage);
     document.addEventListener("visibilitychange", onVisibilityChange);
     return () => {
-      cancelled = true;
       mounted.current = false;
+      cancelled = true;
       requestGeneration.current += 1;
-      if (timeoutId !== null) window.clearTimeout(timeoutId);
-      if (intervalId !== null) window.clearInterval(intervalId);
+      if (eventualRefreshId !== null) {
+        window.clearTimeout(eventualRefreshId);
+      }
       window.removeEventListener("focus", onFocus);
       window.removeEventListener("storage", onStorage);
       document.removeEventListener("visibilitychange", onVisibilityChange);
@@ -239,7 +234,7 @@ export function useHeaderState(): Ctx {
   const ctx = useContext(HeaderStateContext);
   if (ctx) return ctx;
   return {
-    refresh: async () => {},
+    refresh: async () => "skipped",
     setUnreadCount: () => {},
     state: INITIAL_HEADER_STATE,
   };

--- a/src/lib/header-state.test.ts
+++ b/src/lib/header-state.test.ts
@@ -1,17 +1,14 @@
 import { describe, expect, it } from "bun:test";
 
 import {
-  claimHeaderStateRefresh,
   clearCachedHeaderStateFromBrowser,
   headerStateCacheKey,
   headerStateFetchCacheMode,
   headerStateResponseSavedAt,
   INITIAL_HEADER_STATE,
-  nextHeaderStatePollDelay,
   normalizeHeaderState,
   parseCachedHeaderState,
   readCachedHeaderStateFromBrowser,
-  releaseHeaderStateRefreshClaim,
   serializeHeaderState,
   shouldRequestHeaderState,
   withHeaderUnreadCount,
@@ -261,97 +258,14 @@ describe("header state helpers", () => {
         cacheKey,
         serializeHeaderState(state, 1_000),
       );
-      expect(claimHeaderStateRefresh(cacheKey, 1_000, 15_000, "tab-a")).toEqual(
-        {
-          shouldRefresh: true,
-          token: "tab-a",
-        },
-      );
 
       clearCachedHeaderStateFromBrowser(cacheKey);
 
       expect(window.localStorage.getItem(cacheKey)).toBeNull();
       expect(window.sessionStorage.getItem(cacheKey)).toBeNull();
-      expect(claimHeaderStateRefresh(cacheKey, 2_000, 15_000, "tab-b")).toEqual(
-        {
-          shouldRefresh: true,
-          token: "tab-b",
-        },
-      );
     } finally {
       restore();
     }
-  });
-
-  it("claims automatic refreshes with a short shared browser lock", () => {
-    const restore = installWindowStorage(
-      new MemoryStorage(),
-      new MemoryStorage(),
-    );
-    const cacheKey = signedInCacheKey();
-
-    try {
-      expect(claimHeaderStateRefresh(cacheKey, 1_000, 15_000, "tab-a")).toEqual(
-        {
-          shouldRefresh: true,
-          token: "tab-a",
-        },
-      );
-      expect(claimHeaderStateRefresh(cacheKey, 2_000, 15_000, "tab-b")).toEqual(
-        {
-          shouldRefresh: false,
-          token: null,
-        },
-      );
-      expect(
-        claimHeaderStateRefresh(cacheKey, 16_001, 15_000, "tab-b"),
-      ).toEqual({
-        shouldRefresh: true,
-        token: "tab-b",
-      });
-    } finally {
-      restore();
-    }
-  });
-
-  it("releases only the matching automatic refresh claim", () => {
-    const restore = installWindowStorage(
-      new MemoryStorage(),
-      new MemoryStorage(),
-    );
-    const cacheKey = signedInCacheKey();
-
-    try {
-      expect(claimHeaderStateRefresh(cacheKey, 1_000, 15_000, "tab-a")).toEqual(
-        {
-          shouldRefresh: true,
-          token: "tab-a",
-        },
-      );
-      releaseHeaderStateRefreshClaim(cacheKey, "tab-b");
-      expect(claimHeaderStateRefresh(cacheKey, 2_000, 15_000, "tab-c")).toEqual(
-        {
-          shouldRefresh: false,
-          token: null,
-        },
-      );
-      releaseHeaderStateRefreshClaim(cacheKey, "tab-a");
-      expect(claimHeaderStateRefresh(cacheKey, 3_000, 15_000, "tab-c")).toEqual(
-        {
-          shouldRefresh: true,
-          token: "tab-c",
-        },
-      );
-    } finally {
-      restore();
-    }
-  });
-
-  it("schedules cached polls by remaining freshness window", () => {
-    expect(nextHeaderStatePollDelay(0, 1_000)).toBe(1_800_000);
-    expect(nextHeaderStatePollDelay(1_000, 61_000)).toBe(1_740_000);
-    expect(nextHeaderStatePollDelay(1_000, 1_801_000)).toBe(0);
-    expect(nextHeaderStatePollDelay(10_000, 1_000)).toBe(1_800_000);
   });
 
   it("scopes cache keys by signed-in user", () => {

--- a/src/lib/header-state.ts
+++ b/src/lib/header-state.ts
@@ -14,21 +14,15 @@ export const INITIAL_HEADER_STATE: HeaderState = {
   caught: [],
 };
 
-export const HEADER_STATE_POLL_MS = 1_800_000;
-export const HEADER_STATE_MIN_REFRESH_MS = HEADER_STATE_POLL_MS;
+export const HEADER_STATE_MIN_REFRESH_MS = 1_800_000;
 export const HEADER_STATE_CACHE_TTL_MS = HEADER_STATE_MIN_REFRESH_MS;
 export const HEADER_STATE_BROWSER_CACHE_SECONDS =
   HEADER_STATE_CACHE_TTL_MS / 1000;
-export const HEADER_STATE_REFRESH_LOCK_MS = 15_000;
+export const HEADER_STATE_EVENTUAL_REFRESH_MS = 6 * 60 * 60_000;
 
 export type CachedHeaderState = {
   savedAt: number;
   state: HeaderState;
-};
-
-export type HeaderStateRefreshClaim = {
-  shouldRefresh: boolean;
-  token: string | null;
 };
 
 export function headerStateCacheKey(userId: string | null | undefined) {
@@ -50,15 +44,6 @@ export function shouldRequestHeaderState(input: {
     input.now - input.lastRefreshAt >=
       (input.minRefreshMs ?? HEADER_STATE_MIN_REFRESH_MS)
   );
-}
-
-export function nextHeaderStatePollDelay(
-  lastRefreshAt: number,
-  now: number,
-  pollMs = HEADER_STATE_POLL_MS,
-) {
-  if (lastRefreshAt <= 0 || lastRefreshAt > now) return pollMs;
-  return Math.max(0, pollMs - (now - lastRefreshAt));
 }
 
 export function parseCachedHeaderState(
@@ -120,49 +105,6 @@ export function writeCachedHeaderStateToBrowser(
 export function clearCachedHeaderStateFromBrowser(cacheKey: string) {
   removeStorageValue(browserStorage("localStorage"), cacheKey);
   removeStorageValue(browserStorage("sessionStorage"), cacheKey);
-  removeStorageValue(
-    browserStorage("localStorage"),
-    headerStateRefreshLockKey(cacheKey),
-  );
-}
-
-export function claimHeaderStateRefresh(
-  cacheKey: string,
-  now = Date.now(),
-  lockMs = HEADER_STATE_REFRESH_LOCK_MS,
-  token = `${now}:${Math.random()}`,
-): HeaderStateRefreshClaim {
-  const storage = browserStorage("localStorage");
-  if (!storage) return { shouldRefresh: true, token: null };
-  const lockKey = headerStateRefreshLockKey(cacheKey);
-  const current = parseRefreshLock(readStorageValue(storage, lockKey));
-  if (current && current.expiresAt > now) {
-    return { shouldRefresh: false, token: null };
-  }
-  const next = JSON.stringify({ expiresAt: now + lockMs, token });
-  if (!writeStorageValue(storage, lockKey, next)) {
-    return { shouldRefresh: true, token: null };
-  }
-  const saved = parseRefreshLock(readStorageValue(storage, lockKey));
-  return saved?.token === token
-    ? { shouldRefresh: true, token }
-    : { shouldRefresh: false, token: null };
-}
-
-export function releaseHeaderStateRefreshClaim(
-  cacheKey: string,
-  token: string,
-) {
-  const storage = browserStorage("localStorage");
-  if (!storage) return;
-  const lockKey = headerStateRefreshLockKey(cacheKey);
-  const current = parseRefreshLock(readStorageValue(storage, lockKey));
-  if (current?.token !== token) return;
-  try {
-    storage.removeItem(lockKey);
-  } catch {
-    return;
-  }
 }
 
 export function headerStateFetchCacheMode(force?: boolean): RequestCache {
@@ -232,28 +174,6 @@ function isString(value: unknown): value is string {
 
 function toNumber(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
-}
-
-function headerStateRefreshLockKey(cacheKey: string) {
-  return `${cacheKey}:refresh-lock`;
-}
-
-function parseRefreshLock(raw: string | null): {
-  expiresAt: number;
-  token: string;
-} | null {
-  if (!raw) return null;
-  try {
-    const parsed = JSON.parse(raw) as { expiresAt?: unknown; token?: unknown };
-    if (
-      typeof parsed.expiresAt === "number" &&
-      Number.isFinite(parsed.expiresAt) &&
-      typeof parsed.token === "string"
-    ) {
-      return { expiresAt: parsed.expiresAt, token: parsed.token };
-    }
-  } catch {}
-  return null;
 }
 
 function browserStorage(


### PR DESCRIPTION
## Summary
- remove recurring background polling from `HeaderStateProvider`
- keep initial refresh, focus/visibility refresh with TTL, and explicit forced refreshes after user actions
- delete now-unused refresh lock and poll scheduling helpers/tests

## Test plan
- bun run check
- bun test src/lib/header-state.test.ts
- git diff --check
- rg -n 'HEADER_STATE_POLL_MS|HEADER_STATE_REFRESH_LOCK_MS|HeaderStateRefreshClaim|nextHeaderStatePollDelay|claimHeaderStateRefresh|releaseHeaderStateRefreshClaim|headerStateRefreshLockKey|parseRefreshLock|setInterval\\(poll|setTimeout\\(' src/components/header-state-provider.tsx src/lib/header-state.ts src/lib/header-state.test.ts\n