### PR TITLE
Lazy load pet card footer

### DIFF
--- a/src/components/pet-card-footer.tsx
+++ b/src/components/pet-card-footer.tsx
@@ -14,6 +14,16 @@ import { useHeaderState } from "@/components/header-state-provider";
 import { PetSoundButton } from "@/components/pet-sound-button";
 import { Button } from "@/components/ui/button";
 
+export type PetCardFooterProps = {
+  slug: string;
+  displayName: string;
+  zipUrl?: string;
+  soundUrl: string | null;
+  installCount: number;
+  likeCount: number;
+  initialLiked?: boolean;
+};
+
 // Inline footer bar at the bottom of each gallery card. Surfaces the
 // four most-used actions (like, install, download, share) without
 // forcing the user to open the pet page or the overflow menu.
@@ -28,15 +38,7 @@ function PetCardFooterImpl({
   installCount,
   likeCount,
   initialLiked,
-}: {
-  slug: string;
-  displayName: string;
-  zipUrl?: string;
-  soundUrl: string | null;
-  installCount: number;
-  likeCount: number;
-  initialLiked?: boolean;
-}) {
+}: PetCardFooterProps) {
   const router = useRouter();
   const clerk = useClerk();
   const locale = useLocale();

--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -27,7 +27,7 @@ import { cn } from "@/lib/utils";
 
 import { useHeaderState } from "@/components/header-state-provider";
 import { PetActionMenu } from "@/components/pet-action-menu";
-import { PetCardFooter } from "@/components/pet-card-footer";
+import type { PetCardFooterProps } from "@/components/pet-card-footer";
 import { PetSprite } from "@/components/pet-sprite";
 import { ProfilePinButton } from "@/components/profile-pin-button";
 import { Badge } from "@/components/ui/badge";
@@ -101,6 +101,14 @@ const FeedAdSlot = dynamic<{ ad: PublicFeedAd }>(
   () => import("@/components/ads/feed-ad-slot").then((mod) => mod.FeedAdSlot),
   {
     loading: FeedAdSlotLoading,
+    ssr: false,
+  },
+);
+
+const PetCardFooter = dynamic<PetCardFooterProps>(
+  () => import("@/components/pet-card-footer").then((mod) => mod.PetCardFooter),
+  {
+    loading: PetCardFooterLoading,
     ssr: false,
   },
 );
@@ -728,6 +736,22 @@ function FeedAdSlotLoading() {
       </div>
       <div className="mt-auto min-h-[52px] border-border-base border-t px-5 py-2" />
     </article>
+  );
+}
+
+function PetCardFooterLoading() {
+  return (
+    <div
+      aria-hidden="true"
+      className="flex min-h-[49px] items-center border-t border-black/[0.05] px-2 py-2 dark:border-white/[0.05]"
+    >
+      <div className="flex items-center gap-1">
+        <div className="h-8 w-14 rounded-full bg-surface-muted/70" />
+        <div className="h-8 w-16 rounded-full bg-surface-muted/70" />
+        <div className="size-8 rounded-full bg-surface-muted/70" />
+        <div className="size-8 rounded-full bg-surface-muted/70" />
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- defer the card footer action bundle behind a lightweight skeleton
- keep the existing like/copy/download/share footer behavior unchanged
- export footer props for a typed dynamic import from the gallery

## Validation
- bun run check
- bun run i18n:check
- git diff --check
- TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build