### PR TITLE
Remove sound generation from approval hot path

### DIFF
--- a/src/lib/submission-decisions.ts
+++ b/src/lib/submission-decisions.ts
@@ -232,20 +232,6 @@ async function runPostApprovalEffects(
     })();
   }
 
-  if (process.env.ELEVENLABS_API_KEY) {
-    void (async () => {
-      try {
-        const { getApprovedPetMissingSoundBySlug, processPetSound } =
-          await import("@/lib/pet-sound");
-        const pet = await getApprovedPetMissingSoundBySlug(row.slug);
-        if (!pet) return;
-        await processPetSound(pet, { workerKey: `${actor}-${row.slug}` });
-      } catch (e) {
-        console.error("sound gen failed", e);
-      }
-    })();
-  }
-
   // Suggest matching open requests as candidates for admin review.
   // Background only — never blocks the approve response. Failures
   // are logged and swallowed; the admin can still create candidates


### PR DESCRIPTION
## Summary
- stop auto-generating ElevenLabs/FFmpeg pet sounds during post-approval side effects
- keep approval artifacts, similarity refresh, color extraction, and request candidate suggestions intact
- remove pet-sound from the /api/submit build trace so the hot submit route no longer pulls that heavy graph

## Test Plan
- bun run check
- bun run i18n:check
- bun test
- TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build