### PR TITLE
Use static command line on public pages

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -5,10 +5,10 @@ import { getTranslations } from "next-intl/server";
 import { buildLocaleAlternates, withLocale } from "@/lib/locale-routing";
 import { getApprovedPetCount } from "@/lib/pets";
 
-import { CommandLine } from "@/components/command-line";
 import { JsonLd } from "@/components/json-ld";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
+import { StaticCommandLine } from "@/components/static-command-line";
 
 import { hasLocale } from "@/i18n/config";
 
@@ -111,9 +111,8 @@ export default async function AboutPage({
                 strong: (chunks) => <strong>{chunks}</strong>,
               })}
             </p>
-            <CommandLine
+            <StaticCommandLine
               command="npx petdex install boba"
-              source="about-hero"
               className="mt-5 w-full max-w-sm"
             />
           </div>

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -3,9 +3,9 @@ import Link from "next/link";
 import { ArrowRight, Search, Sparkles } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 
-import { CommandLine } from "@/components/command-line";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
+import { StaticCommandLine } from "@/components/static-command-line";
 
 export async function generateMetadata({
   params,
@@ -75,9 +75,8 @@ export default async function NotFound() {
           <p className="font-mono text-[10px] tracking-[0.22em] text-muted-3 uppercase">
             {t("terminalEyebrow")}
           </p>
-          <CommandLine
+          <StaticCommandLine
             command="npx petdex install boba"
-            source="not-found"
             className="mt-3"
           />
         </div>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -18,7 +18,6 @@ import { cn } from "@/lib/utils";
 
 import { CollectionActionMenu } from "@/components/collection-action-menu";
 import { CollectionCover } from "@/components/collection-cover";
-import { CommandLine } from "@/components/command-line";
 import { DiscordLink } from "@/components/discord-link";
 import { DownloadDesktopCTA } from "@/components/download-desktop-cta";
 import { DiscordIcon } from "@/components/icons/wechat-icon";
@@ -27,6 +26,7 @@ import { PetGallery } from "@/components/pet-gallery";
 import { PetSprite } from "@/components/pet-sprite";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
+import { StaticCommandLine } from "@/components/static-command-line";
 import { SubmitCTA } from "@/components/submit-cta";
 import { SurprisePetCard } from "@/components/surprise-pet-card";
 import {
@@ -164,9 +164,8 @@ export default async function Home({
               })}
             </p>
             <div className="mt-5 flex w-full flex-col items-stretch justify-center gap-2 sm:flex-row sm:items-center">
-              <CommandLine
+              <StaticCommandLine
                 command="npx petdex install boba"
-                source="hero"
                 className="w-full sm:w-auto"
               />
               <DownloadDesktopCTA

--- a/src/components/facet-page.tsx
+++ b/src/components/facet-page.tsx
@@ -9,10 +9,10 @@ import { getLocale } from "next-intl/server";
 import type { SearchPet } from "@/lib/pet-search";
 import { cn } from "@/lib/utils";
 
-import { CommandLine } from "@/components/command-line";
 import { PetCard } from "@/components/pet-gallery";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
+import { StaticCommandLine } from "@/components/static-command-line";
 
 type FacetPageProps = {
   eyebrow: string;
@@ -53,11 +53,7 @@ export async function FacetPage({
             <p className="mt-5 max-w-2xl text-balance text-base leading-7 text-muted-1 md:text-lg">
               {intro}
             </p>
-            <CommandLine
-              command={cmd}
-              source="facet-hero"
-              className="mt-5 w-full max-w-sm"
-            />
+            <StaticCommandLine command={cmd} className="mt-5 w-full max-w-sm" />
             <p className="mt-3 font-mono text-[11px] tracking-[0.18em] text-muted-3 uppercase">
               {countLabel}
             </p>

--- a/src/components/static-command-line.tsx
+++ b/src/components/static-command-line.tsx
@@ -1,0 +1,81 @@
+import { Fragment } from "react";
+
+type StaticCommandLineProps = {
+  command: string;
+  prefix?: string;
+  className?: string;
+  wrap?: boolean;
+};
+
+function tokenize(command: string) {
+  const parts = command.split(/(\s+|\||&&|\|\||;)/g).filter((s) => s !== "");
+  let cmdSeen = false;
+  let firstWordSeen = false;
+  let offset = 0;
+
+  return parts.map((p) => {
+    const key = `${offset}:${p}`;
+    offset += p.length;
+    if (/^\s+$/.test(p)) {
+      return <Fragment key={key}>{p}</Fragment>;
+    }
+    if (p === "|" || p === "&&" || p === "||" || p === ";") {
+      return (
+        <span key={key} className="text-muted-4">
+          {p}
+        </span>
+      );
+    }
+    if (!firstWordSeen) {
+      firstWordSeen = true;
+      cmdSeen = true;
+      return (
+        <span key={key} className="font-medium text-brand-deep">
+          {p}
+        </span>
+      );
+    }
+    if (p.startsWith("-")) {
+      return (
+        <span key={key} className="text-brand">
+          {p}
+        </span>
+      );
+    }
+    if (cmdSeen && /^[a-z][a-z0-9-]*$/.test(p)) {
+      cmdSeen = false;
+      return (
+        <span key={key} className="font-medium text-foreground">
+          {p}
+        </span>
+      );
+    }
+    return (
+      <span key={key} className="text-muted-2">
+        {p}
+      </span>
+    );
+  });
+}
+
+export function StaticCommandLine({
+  command,
+  prefix = "$ ",
+  className = "",
+  wrap = false,
+}: StaticCommandLineProps) {
+  const rootLayoutClass = wrap ? "items-start" : "items-center";
+  const commandClass = wrap
+    ? "flex-1 whitespace-normal break-words leading-5"
+    : "flex-1 truncate";
+
+  return (
+    <div
+      style={{ fontFamily: "var(--font-geist-mono), ui-monospace, monospace" }}
+      className={`inline-flex ${rootLayoutClass} gap-2 rounded-xl border border-border-base bg-surface/80 px-3 py-2 text-left text-[12px] text-foreground backdrop-blur ${className}`}
+    >
+      <span className="select-none text-brand">{prefix}</span>
+      <span className={commandClass}>{tokenize(command)}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a server-rendered StaticCommandLine for decorative public command snippets
- remove the client CommandLine bundle from home, facet pages, about, and not-found
- keep the interactive copyable CommandLine in docs/download/pet detail where copy is core UX

## Bundle evidence
After build, client reference manifests for home/kind/vibe/collections no longer include command-line.tsx.

Compared with the previous main snapshot:
- /en/collections: 423 KB gzip referenced JS -> 344 KB gzip
- /en/kind/character: 354 KB gzip -> 352 KB gzip
- /en: 361 KB gzip -> 360 KB gzip

## Test Plan
- bun run check
- bun run i18n:check
- bun test
- TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build