### PR TITLE
perf: define public html cache contract

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -128,6 +128,43 @@ const versionJsonHeaders = [
   },
 ];
 
+const publicHtmlCacheHeaders = [
+  {
+    key: "Cloudflare-CDN-Cache-Control",
+    value:
+      "public, max-age=300, stale-while-revalidate=86400, stale-if-error=86400",
+  },
+];
+
+const publicStaticHtmlPaths = [
+  "/about",
+  "/brand",
+  "/built-with",
+  "/collections",
+  "/community",
+  "/create",
+  "/docs",
+  "/legal/takedown",
+  "/legal/telemetry",
+];
+
+const publicHtmlCacheSources = [
+  "/",
+  "/:locale(en|es|zh)",
+  ...publicStaticHtmlPaths.flatMap((source) => [
+    source,
+    `/:locale(en|es|zh)${source}`,
+  ]),
+  "/pets/:slug",
+  "/:locale(en|es|zh)/pets/:slug",
+  "/collections/:slug",
+  "/:locale(en|es|zh)/collections/:slug",
+  "/kind/:kind",
+  "/:locale(en|es|zh)/kind/:kind",
+  "/vibe/:vibe",
+  "/:locale(en|es|zh)/vibe/:vibe",
+];
+
 const mockRoot = path.resolve(__dirname, "src/lib/mock");
 
 const nextConfig: NextConfig = {
@@ -160,6 +197,10 @@ const nextConfig: NextConfig = {
         source: "/version.json",
         headers: versionJsonHeaders,
       },
+      ...publicHtmlCacheSources.map((source) => ({
+        source,
+        headers: publicHtmlCacheHeaders,
+      })),
       {
         source: "/:path*",
         headers: securityHeaders,

--- a/src/components/locale-switcher.tsx
+++ b/src/components/locale-switcher.tsx
@@ -3,7 +3,6 @@
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useState, useTransition } from "react";
 
-import { useAuth } from "@clerk/nextjs";
 import { Globe } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 
@@ -16,8 +15,6 @@ import {
 } from "@/components/ui/popover";
 
 import { hasLocale, type Locale } from "@/i18n/config";
-
-const COOKIE_MAX_AGE = 60 * 60 * 24 * 30;
 
 const OPTIONS: Array<{ locale: Locale; code: string; label: string }> = [
   { locale: "en", code: "EN", label: "English" },
@@ -48,7 +45,6 @@ function LocaleSwitcherInner() {
   const currentLocale = hasLocale(locale) ? locale : "en";
   const current =
     OPTIONS.find((option) => option.locale === currentLocale) ?? OPTIONS[0];
-  const { isSignedIn } = useAuth();
   const pathname = usePathname() ?? "/";
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -62,36 +58,11 @@ function LocaleSwitcherInner() {
       return;
     }
 
-    const cookieStore = (
-      window as Window & {
-        cookieStore?: {
-          set(input: {
-            name: string;
-            value: string;
-            path: string;
-            expires: number;
-            sameSite: "lax";
-          }): Promise<void>;
-        };
-      }
-    ).cookieStore;
-    // biome-ignore lint/suspicious/noDocumentCookie: cookieStore is not available in every supported browser yet.
-    document.cookie = `NEXT_LOCALE=${nextLocale}; Path=/; Max-Age=${COOKIE_MAX_AGE}; SameSite=Lax`;
-    void cookieStore?.set({
-      name: "NEXT_LOCALE",
-      value: nextLocale,
-      path: "/",
-      expires: Date.now() + COOKIE_MAX_AGE * 1000,
-      sameSite: "lax",
+    void fetch("/api/profile", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ preferredLocale: nextLocale }),
     });
-
-    if (isSignedIn) {
-      void fetch("/api/profile", {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ preferredLocale: nextLocale }),
-      });
-    }
 
     const basePath = stripLocalePrefix(pathname);
     const query = searchParams.toString();

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -63,6 +63,8 @@ const handleI18nRouting = createMiddleware({
   locales,
   defaultLocale,
   localePrefix: "as-needed",
+  localeDetection: false,
+  localeCookie: false,
 });
 
 // In mock auth mode the user is always signed in, so we skip
@@ -80,7 +82,9 @@ const baseMiddleware = async (req: NextRequest, event?: NextFetchEvent) => {
   if (new URL(req.url).pathname.startsWith("/api")) {
     return NextResponse.next();
   }
-  return handleI18nRouting(req as Parameters<typeof handleI18nRouting>[0]);
+  return handleI18nRoutingWithoutLocaleCookie(
+    req as Parameters<typeof handleI18nRouting>[0],
+  );
 };
 
 export default IS_MOCK_AUTH
@@ -102,7 +106,7 @@ export default IS_MOCK_AUTH
         return NextResponse.next();
       }
 
-      return handleI18nRouting(req);
+      return handleI18nRoutingWithoutLocaleCookie(req);
     });
 
 export const config = {
@@ -214,6 +218,16 @@ function normalizeBaseUrl(raw: string | null | undefined, fallback: string) {
 
 function normalizeHost(raw: string | null): string {
   return raw?.split(":")[0]?.toLowerCase() ?? "";
+}
+
+function handleI18nRoutingWithoutLocaleCookie(
+  req: Parameters<typeof handleI18nRouting>[0],
+) {
+  const response = handleI18nRouting(req);
+  if (req.cookies.has("NEXT_LOCALE")) {
+    response.cookies.delete("NEXT_LOCALE");
+  }
+  return response;
 }
 
 function scheduleRouteCostSample(req: NextRequest, event?: NextFetchEvent) {


### PR DESCRIPTION
## Summary
- Disable next-intl locale cookie writes for cache correctness.
- Delete stale NEXT_LOCALE only when the incoming request already carries it.
- Add Cloudflare-CDN-Cache-Control headers for static public HTML routes.
- Remove locale switcher cookie writes and its direct Clerk hook.

## Validation
- bun run check
- bun run i18n:check
- bun test --env-file=.env.mock
- git diff --check
- TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build