### PR TITLE
perf: render public utility pages statically

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -144,8 +144,11 @@ const publicStaticHtmlPaths = [
   "/community",
   "/create",
   "/docs",
+  "/download",
+  "/leaderboard",
   "/legal/takedown",
   "/legal/telemetry",
+  "/requests",
 ];
 
 const publicHtmlCacheSources = [

--- a/src/app/[locale]/download/page.tsx
+++ b/src/app/[locale]/download/page.tsx
@@ -12,24 +12,24 @@ import {
   Sparkles,
   Zap,
 } from "lucide-react";
-import { getLocale, getTranslations } from "next-intl/server";
+import { getLocale, getMessages, getTranslations } from "next-intl/server";
 
 import { buildLocaleAlternates } from "@/lib/locale-routing";
 import { getPet } from "@/lib/pets";
 
-import { CommandLine } from "@/components/command-line";
-import { DownloadCTA } from "@/components/download-cta";
+import {
+  DownloadHeroActions,
+  DownloadSetupSteps,
+} from "@/components/download-activation-islands";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 import { StaticPetSprite } from "@/components/static-pet-sprite";
 
 import { hasLocale } from "@/i18n/config";
-import { buildSetupSteps, parsePendingInstallSlugs } from "./setup-steps";
 
 const SITE_URL = "https://petdex.dev";
 const DEFAULT_PREVIEW_PET_SLUG = "boba";
 const DEFAULT_PREVIEW_PET = {
-  displayName: "Boba",
   spritesheetPath: "https://assets.petdex.dev/curated/boba/spritesheet.webp",
 };
 
@@ -75,44 +75,20 @@ export async function generateMetadata({
   };
 }
 
-// Force-dynamic so the latest-release fetch runs per request —
-// otherwise users see a cached release tag that drifts behind
-// what's actually on GitHub.
-export const dynamic = "force-dynamic";
+export const dynamic = "force-static";
+export const revalidate = 3600;
 
-type DownloadPageProps = {
-  searchParams: Promise<{ next?: string | string[] }>;
-};
-
-export default async function DownloadPage({
-  searchParams,
-}: DownloadPageProps) {
+export default async function DownloadPage() {
   const t = await getTranslations("download");
   const locale = await getLocale();
-  const params = await searchParams;
-  const pendingInstallSlugs = parsePendingInstallSlugs(params.next);
-  const activationCommand =
-    pendingInstallSlugs && pendingInstallSlugs.length > 0
-      ? `npx petdex init && npx petdex install ${pendingInstallSlugs.join(" ")}`
-      : "npx petdex init";
-  const pendingLabel =
-    pendingInstallSlugs && pendingInstallSlugs.length > 0
-      ? pendingInstallSlugs.length === 1
-        ? pendingInstallSlugs[0]
-        : pendingInstallSlugs.join(", ")
-      : null;
-  const previewIsPending = (pendingInstallSlugs?.length ?? 0) > 0;
-  const previewSlug = pendingInstallSlugs?.[0] ?? DEFAULT_PREVIEW_PET_SLUG;
-  const resolvedPreviewPet = await getPet(previewSlug);
-  const previewPet = resolvedPreviewPet
-    ? {
-        displayName: resolvedPreviewPet.displayName,
-        spritesheetPath: resolvedPreviewPet.spritesheetPath,
-      }
-    : previewSlug === DEFAULT_PREVIEW_PET_SLUG
-      ? DEFAULT_PREVIEW_PET
-      : null;
-  const previewPetName = previewPet?.displayName ?? pendingLabel;
+  const setupTemplates = getDownloadSetupTemplates(await getMessages());
+  const resolvedPreviewPet = await getPet(DEFAULT_PREVIEW_PET_SLUG);
+  const previewPet = {
+    displayName: t("preview.defaultPet"),
+    spritesheetPath:
+      resolvedPreviewPet?.spritesheetPath ??
+      DEFAULT_PREVIEW_PET.spritesheetPath,
+  };
 
   const features = [
     {
@@ -182,27 +158,17 @@ export default async function DownloadPage({
               {t("subtitle")}
             </p>
 
-            {pendingLabel ? (
-              <div className="mt-6 inline-flex max-w-full items-center gap-2 rounded-lg border border-brand/20 bg-brand-tint px-3 py-2 text-sm text-brand-deep dark:bg-brand-tint-dark dark:text-brand-light">
-                <Sparkles className="size-4 shrink-0" />
-                <span className="min-w-0">
-                  {t("pendingPet.messageBefore")}{" "}
-                  <code className="rounded bg-surface/80 px-1.5 py-0.5 font-mono text-xs">
-                    {pendingLabel}
-                  </code>{" "}
-                  {t("pendingPet.messageAfter")}
-                </span>
-              </div>
-            ) : null}
-
-            <DownloadCTA
-              primaryLabel={t("hero.primaryTitle")}
-              cliCommand={activationCommand}
-              cliSubtext={t("hero.cliSubtext")}
-              manualLabel={t("hero.manualLabel")}
-              manualSubtext={t("hero.manualSubtext")}
-              comingSoonLabel={t("hero.comingSoon")}
-              desktopOnlyLabel={t("hero.desktopOnly")}
+            <DownloadHeroActions
+              labels={{
+                primaryLabel: t("hero.primaryTitle"),
+                cliSubtext: t("hero.cliSubtext"),
+                manualLabel: t("hero.manualLabel"),
+                manualSubtext: t("hero.manualSubtext"),
+                comingSoonLabel: t("hero.comingSoon"),
+                desktopOnlyLabel: t("hero.desktopOnly"),
+                pendingBefore: t("pendingPet.messageBefore"),
+                pendingAfter: t("pendingPet.messageAfter"),
+              }}
             />
 
             <div className="mt-5 grid gap-2 sm:grid-cols-3">
@@ -222,19 +188,13 @@ export default async function DownloadPage({
           </div>
 
           <DesktopActivationPreview
-            pendingLabel={previewPetName}
+            pendingLabel={null}
             pendingPet={previewPet}
             title={t("preview.title")}
             status={t("preview.status")}
             terminalLabel={t("preview.terminalLabel")}
             agentLabel={t("preview.agentLabel")}
-            petLabel={
-              previewPetName
-                ? previewIsPending
-                  ? t("preview.pendingPet", { slug: previewPetName })
-                  : t("preview.demoPet", { slug: previewPetName })
-                : t("preview.defaultPet")
-            }
+            petLabel={t("preview.defaultPet")}
           />
         </div>
       </section>
@@ -289,32 +249,18 @@ export default async function DownloadPage({
             {t("setup.title")}
           </h2>
 
-          <ol className="mt-10 flex flex-col gap-8">
-            {buildSetupSteps(t, pendingInstallSlugs).map((step, idx) => {
-              const number = idx + 1;
-              const dotClass = step.dimmed
-                ? "mt-0.5 grid size-7 shrink-0 place-items-center rounded-full bg-surface font-mono text-xs font-semibold text-muted-2 ring-1 ring-border-base"
-                : "mt-0.5 grid size-7 shrink-0 place-items-center rounded-full bg-brand font-mono text-xs font-semibold text-on-inverse";
-              return (
-                <li key={step.key} className="flex gap-5">
-                  <span className={dotClass}>{number}</span>
-                  <div className="flex flex-col gap-2">
-                    <p className="font-semibold text-foreground">
-                      {step.title}
-                    </p>
-                    <CommandLine
-                      command={step.command}
-                      source={`download-${step.key}`}
-                      className="w-full max-w-sm"
-                    />
-                    {step.hint ? (
-                      <p className="text-xs text-muted-3">{step.hint}</p>
-                    ) : null}
-                  </div>
-                </li>
-              );
-            })}
-          </ol>
+          <DownloadSetupSteps
+            labels={{
+              step1Title: t("setup.step1.title"),
+              step1Hint: t("setup.step1.hint"),
+              installPetTitle: setupTemplates.installPetTitle,
+              installPetHint: t("setup.installPet.hint"),
+              installPetsTitle: setupTemplates.installPetsTitle,
+              installPetsHint: t("setup.installPets.hint"),
+              stayUpdatedTitle: t("setup.stayUpdated.title"),
+              stayUpdatedHint: t("setup.stayUpdated.hint"),
+            }}
+          />
         </div>
       </section>
 
@@ -371,6 +317,34 @@ export default async function DownloadPage({
       <SiteFooter />
     </main>
   );
+}
+
+function getDownloadSetupTemplates(
+  messages: Awaited<ReturnType<typeof getMessages>>,
+) {
+  return {
+    installPetTitle: getMessageString(
+      messages,
+      ["download", "setup", "installPet", "title"],
+      "Install {slug}",
+    ),
+    installPetsTitle: getMessageString(
+      messages,
+      ["download", "setup", "installPets", "title"],
+      "Install {count} pets",
+    ),
+  };
+}
+
+function getMessageString(messages: unknown, path: string[], fallback: string) {
+  let current = messages;
+  for (const part of path) {
+    if (!current || typeof current !== "object" || !(part in current)) {
+      return fallback;
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+  return typeof current === "string" ? current : fallback;
 }
 
 function DesktopActivationPreview({

--- a/src/app/[locale]/leaderboard/page.tsx
+++ b/src/app/[locale]/leaderboard/page.tsx
@@ -3,7 +3,6 @@ import { getTranslations } from "next-intl/server";
 import {
   getLeaderboard,
   getLeaderboardPetThumbs,
-  type LeaderboardMetric,
   type LeaderboardRow,
 } from "@/lib/leaderboard";
 import { buildLocaleAlternates } from "@/lib/locale-routing";
@@ -15,7 +14,8 @@ import { SiteHeader } from "@/components/site-header";
 
 import { hasLocale } from "@/i18n/config";
 
-export const dynamic = "force-dynamic";
+export const dynamic = "force-static";
+export const revalidate = 3600;
 
 export async function generateMetadata({
   params,
@@ -38,28 +38,8 @@ export async function generateMetadata({
   };
 }
 
-const METRIC_VALUES: LeaderboardMetric[] = [
-  "pets",
-  "likes",
-  "installs",
-  "rising",
-  "collectors",
-];
-
-type SP = { tab?: string };
-
-export default async function LeaderboardPage({
-  searchParams,
-}: {
-  searchParams: Promise<SP>;
-}) {
+export default async function LeaderboardPage() {
   const t = await getTranslations("leaderboard");
-  const { tab } = await searchParams;
-  const active: LeaderboardMetric = METRIC_VALUES.includes(
-    tab as LeaderboardMetric,
-  )
-    ? (tab as LeaderboardMetric)
-    : "pets";
 
   // Fetch every variant in parallel so the tabs feel instant when the
   // user clicks between them — Next will serve cached HTML for the tab
@@ -118,7 +98,7 @@ export default async function LeaderboardPage({
 
       <section className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-5 py-10 md:px-8 md:py-14">
         <LeaderboardView
-          active={active}
+          defaultActive="pets"
           credits={serializeCredits(credits)}
           petThumbs={petThumbs}
           rows={{

--- a/src/app/[locale]/requests/page.tsx
+++ b/src/app/[locale]/requests/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-import { auth, clerkClient } from "@clerk/nextjs/server";
+import { clerkClient } from "@clerk/nextjs/server";
 import { desc, inArray, sql } from "drizzle-orm";
 import { getTranslations } from "next-intl/server";
 
@@ -13,7 +13,8 @@ import { SiteHeader } from "@/components/site-header";
 
 import { hasLocale } from "@/i18n/config";
 
-export const dynamic = "force-dynamic";
+export const dynamic = "force-static";
+export const revalidate = 3600;
 
 const VISIBLE_VOTER_LIMIT = 3;
 
@@ -37,7 +38,6 @@ export async function generateMetadata({
 
 export default async function RequestsPage() {
   const t = await getTranslations("requests");
-  const { userId } = await auth();
 
   // Pull everything (open + fulfilled + dismissed) so the sort tabs in
   // RequestsView can switch instantly without a refetch. The list is
@@ -192,7 +192,7 @@ export default async function RequestsPage() {
           </Link>
         </header>
 
-        <RequestsView initial={initial} refreshOnMount={Boolean(userId)} />
+        <RequestsView initial={initial} />
       </section>
       <SiteFooter />
     </main>

--- a/src/components/download-activation-islands.tsx
+++ b/src/components/download-activation-islands.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+
+import { Sparkles } from "lucide-react";
+
+import { CommandLine } from "@/components/command-line";
+import { DownloadCTA } from "@/components/download-cta";
+
+import {
+  buildSetupSteps,
+  parsePendingInstallSlugs,
+} from "@/app/[locale]/download/setup-steps";
+
+type HeroLabels = {
+  primaryLabel: string;
+  cliSubtext: string;
+  manualLabel: string;
+  manualSubtext: string;
+  comingSoonLabel: string;
+  desktopOnlyLabel: string;
+  pendingBefore: string;
+  pendingAfter: string;
+};
+
+type SetupLabels = {
+  step1Title: string;
+  step1Hint: string;
+  installPetTitle: string;
+  installPetHint: string;
+  installPetsTitle: string;
+  installPetsHint: string;
+  stayUpdatedTitle: string;
+  stayUpdatedHint: string;
+};
+
+export function DownloadHeroActions({ labels }: { labels: HeroLabels }) {
+  return (
+    <Suspense fallback={<DownloadHeroActionsContent labels={labels} />}>
+      <DownloadHeroActionsInner labels={labels} />
+    </Suspense>
+  );
+}
+
+function DownloadHeroActionsInner({ labels }: { labels: HeroLabels }) {
+  return (
+    <DownloadHeroActionsContent
+      labels={labels}
+      pendingInstallSlugs={usePendingInstallSlugs()}
+    />
+  );
+}
+
+function DownloadHeroActionsContent({
+  labels,
+  pendingInstallSlugs,
+}: {
+  labels: HeroLabels;
+  pendingInstallSlugs?: string[] | null;
+}) {
+  const pendingLabel = formatPendingLabel(pendingInstallSlugs);
+  const activationCommand = pendingInstallSlugs?.length
+    ? `npx petdex init && npx petdex install ${pendingInstallSlugs.join(" ")}`
+    : "npx petdex init";
+
+  return (
+    <>
+      {pendingLabel ? (
+        <div className="mt-6 inline-flex max-w-full items-center gap-2 rounded-lg border border-brand/20 bg-brand-tint px-3 py-2 text-sm text-brand-deep dark:bg-brand-tint-dark dark:text-brand-light">
+          <Sparkles className="size-4 shrink-0" />
+          <span className="min-w-0">
+            {labels.pendingBefore}{" "}
+            <code className="rounded bg-surface/80 px-1.5 py-0.5 font-mono text-xs">
+              {pendingLabel}
+            </code>{" "}
+            {labels.pendingAfter}
+          </span>
+        </div>
+      ) : null}
+
+      <DownloadCTA
+        primaryLabel={labels.primaryLabel}
+        cliCommand={activationCommand}
+        cliSubtext={labels.cliSubtext}
+        manualLabel={labels.manualLabel}
+        manualSubtext={labels.manualSubtext}
+        comingSoonLabel={labels.comingSoonLabel}
+        desktopOnlyLabel={labels.desktopOnlyLabel}
+      />
+    </>
+  );
+}
+
+export function DownloadSetupSteps({ labels }: { labels: SetupLabels }) {
+  return (
+    <Suspense fallback={<DownloadSetupStepsContent labels={labels} />}>
+      <DownloadSetupStepsInner labels={labels} />
+    </Suspense>
+  );
+}
+
+function DownloadSetupStepsInner({ labels }: { labels: SetupLabels }) {
+  return (
+    <DownloadSetupStepsContent
+      labels={labels}
+      pendingInstallSlugs={usePendingInstallSlugs()}
+    />
+  );
+}
+
+function DownloadSetupStepsContent({
+  labels,
+  pendingInstallSlugs,
+}: {
+  labels: SetupLabels;
+  pendingInstallSlugs?: string[] | null;
+}) {
+  return (
+    <ol className="mt-10 flex flex-col gap-8">
+      {buildSetupSteps(
+        makeSetupTranslator(labels),
+        pendingInstallSlugs ?? null,
+      ).map((step, idx) => {
+        const number = idx + 1;
+        const dotClass = step.dimmed
+          ? "mt-0.5 grid size-7 shrink-0 place-items-center rounded-full bg-surface font-mono text-xs font-semibold text-muted-2 ring-1 ring-border-base"
+          : "mt-0.5 grid size-7 shrink-0 place-items-center rounded-full bg-brand font-mono text-xs font-semibold text-on-inverse";
+        return (
+          <li key={step.key} className="flex gap-5">
+            <span className={dotClass}>{number}</span>
+            <div className="flex flex-col gap-2">
+              <p className="font-semibold text-foreground">{step.title}</p>
+              <CommandLine
+                command={step.command}
+                source={`download-${step.key}`}
+                className="w-full max-w-sm"
+              />
+              {step.hint ? (
+                <p className="text-xs text-muted-3">{step.hint}</p>
+              ) : null}
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+function usePendingInstallSlugs() {
+  const searchParams = useSearchParams();
+  const all = searchParams.getAll("next");
+  return parsePendingInstallSlugs(
+    all.length > 1 ? all : (searchParams.get("next") ?? undefined),
+  );
+}
+
+function formatPendingLabel(pendingInstallSlugs?: string[] | null) {
+  if (!pendingInstallSlugs?.length) return null;
+  return pendingInstallSlugs.length === 1
+    ? pendingInstallSlugs[0]
+    : pendingInstallSlugs.join(", ");
+}
+
+function makeSetupTranslator(labels: SetupLabels) {
+  return (key: string, values?: Record<string, string>) => {
+    const text =
+      key === "setup.step1.title"
+        ? labels.step1Title
+        : key === "setup.step1.hint"
+          ? labels.step1Hint
+          : key === "setup.installPet.title"
+            ? labels.installPetTitle
+            : key === "setup.installPet.hint"
+              ? labels.installPetHint
+              : key === "setup.installPets.title"
+                ? labels.installPetsTitle
+                : key === "setup.installPets.hint"
+                  ? labels.installPetsHint
+                  : key === "setup.stayUpdated.title"
+                    ? labels.stayUpdatedTitle
+                    : key === "setup.stayUpdated.hint"
+                      ? labels.stayUpdatedHint
+                      : key;
+    return formatTemplate(text, values);
+  };
+}
+
+function formatTemplate(text: string, values?: Record<string, string>) {
+  if (!values) return text;
+  return Object.entries(values).reduce(
+    (current, [key, value]) => current.replaceAll(`{${key}}`, value),
+    text,
+  );
+}

--- a/src/components/leaderboard-view.tsx
+++ b/src/components/leaderboard-view.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
 
 import { Heart, Sparkles, TerminalSquare, Trophy, Users } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
@@ -78,35 +79,84 @@ export type LeaderboardPetThumb = {
 };
 
 type LeaderboardViewProps = {
-  active: LeaderboardMetric;
+  defaultActive: LeaderboardMetric;
   credits: CreditMap;
   petThumbs: Record<string, LeaderboardPetThumb[]>;
   rows: Record<LeaderboardMetric, LeaderboardRow[]>;
 };
 
-export function LeaderboardView({
-  active,
+const METRIC_VALUES = TABS.map((tab) => tab.id);
+
+export function LeaderboardView(props: LeaderboardViewProps) {
+  return (
+    <Suspense
+      fallback={
+        <LeaderboardTable
+          active={props.defaultActive}
+          credits={props.credits}
+          onSelect={() => {}}
+          petThumbs={props.petThumbs}
+          rows={props.rows}
+        />
+      }
+    >
+      <LeaderboardViewInner {...props} />
+    </Suspense>
+  );
+}
+
+function LeaderboardViewInner({
+  defaultActive,
   credits,
   petThumbs,
   rows,
 }: LeaderboardViewProps) {
-  const t = useTranslations("leaderboard");
-  const locale = useLocale();
-  const router = useRouter();
   const params = useSearchParams();
+  const [active, setActive] = useState(defaultActive);
 
-  const activeTab = TABS.find((t) => t.id === active) ?? TABS[0];
-  const data = rows[active];
+  useEffect(() => {
+    setActive(resolveTab(params?.get("tab")));
+  }, [params]);
 
   function selectTab(id: LeaderboardMetric) {
+    setActive(id);
     const next = new URLSearchParams(params?.toString() ?? "");
     if (id === "pets") next.delete("tab");
     else next.set("tab", id);
     const qs = next.toString();
-    router.replace(qs ? `/leaderboard?${qs}` : "/leaderboard", {
-      scroll: false,
-    });
+    const pathname = window.location.pathname || "/leaderboard";
+    window.history.replaceState(null, "", qs ? `${pathname}?${qs}` : pathname);
   }
+
+  return (
+    <LeaderboardTable
+      active={active}
+      credits={credits}
+      onSelect={selectTab}
+      petThumbs={petThumbs}
+      rows={rows}
+    />
+  );
+}
+
+function LeaderboardTable({
+  active,
+  credits,
+  onSelect,
+  petThumbs,
+  rows,
+}: {
+  active: LeaderboardMetric;
+  credits: CreditMap;
+  onSelect: (id: LeaderboardMetric) => void;
+  petThumbs: Record<string, LeaderboardPetThumb[]>;
+  rows: Record<LeaderboardMetric, LeaderboardRow[]>;
+}) {
+  const t = useTranslations("leaderboard");
+  const locale = useLocale();
+
+  const activeTab = TABS.find((t) => t.id === active) ?? TABS[0];
+  const data = rows[active];
 
   return (
     <div className="flex flex-col gap-5">
@@ -124,7 +174,7 @@ export function LeaderboardView({
               type="button"
               role="tab"
               aria-selected={isActive}
-              onClick={() => selectTab(tab.id)}
+              onClick={() => onSelect(tab.id)}
               className={`inline-flex h-9 items-center gap-1.5 rounded-full border px-3 text-xs font-medium transition ${
                 isActive
                   ? "border-inverse bg-inverse text-on-inverse"
@@ -177,6 +227,12 @@ export function LeaderboardView({
       )}
     </div>
   );
+}
+
+function resolveTab(raw: string | null): LeaderboardMetric {
+  return METRIC_VALUES.includes(raw as LeaderboardMetric)
+    ? (raw as LeaderboardMetric)
+    : "pets";
 }
 
 function LeaderboardRowItem({

--- a/src/components/requests-view.tsx
+++ b/src/components/requests-view.tsx
@@ -24,6 +24,7 @@ import {
 import { useTranslations } from "next-intl";
 
 import { ClaimRequestButton } from "@/components/claim-request-button";
+import { useHeaderState } from "@/components/header-state-provider";
 
 type ClerkInfo = {
   handle: string;
@@ -59,14 +60,9 @@ const COLLECTION_PREFIX = "Collection:";
 type Sort = "top" | "new" | "fulfilled";
 type RequestKind = "pet" | "collection";
 
-export function RequestsView({
-  initial,
-  refreshOnMount,
-}: {
-  initial: RequestRow[];
-  refreshOnMount: boolean;
-}) {
+export function RequestsView({ initial }: { initial: RequestRow[] }) {
   const t = useTranslations("requests.view");
+  const { state } = useHeaderState();
   const [requests, setRequests] = useState<RequestRow[]>(initial);
   const [pending, setPending] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
@@ -92,7 +88,7 @@ export function RequestsView({
   // We always pull status=all so all three sort tabs work without
   // another roundtrip when the user toggles them.
   useEffect(() => {
-    if (!refreshOnMount) return;
+    if (!state.signedIn) return;
     let cancelled = false;
     void (async () => {
       try {
@@ -108,7 +104,7 @@ export function RequestsView({
     return () => {
       cancelled = true;
     };
-  }, [refreshOnMount]);
+  }, [state.signedIn]);
 
   const counts = useMemo(() => {
     return {


### PR DESCRIPTION
## Summary
- Render /requests, /leaderboard, and /download as force-static with hourly revalidation.
- Keep signed-in /requests freshness through the existing /api/pet-requests client refetch.
- Move leaderboard tab changes and download next-channel activation into client islands.
- Extend public HTML cache headers for the three static utility routes.

## Validation
- bun run check
- bun run i18n:check
- bun test --env-file=.env.mock
- git diff --check
- TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build