### PR TITLE
perf: trim public middleware work

### DIFF
--- a/src/lib/public-clerk-bypass.test.ts
+++ b/src/lib/public-clerk-bypass.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+
+import { shouldBypassClerkMiddleware } from "@/lib/public-clerk-bypass";
+
+describe("shouldBypassClerkMiddleware", () => {
+  it("bypasses Clerk for public read-only HTML pages", () => {
+    for (const pathname of [
+      "/",
+      "/es",
+      "/built-with",
+      "/zh/docs",
+      "/download",
+      "/leaderboard/",
+      "/requests",
+      "/legal/takedown",
+      "/pets/boba",
+      "/es/collections/cute-coders",
+      "/kind/cat",
+      "/zh/vibe/cozy",
+    ]) {
+      expect(shouldBypassClerkMiddleware({ method: "GET", pathname })).toBe(
+        true,
+      );
+      expect(shouldBypassClerkMiddleware({ method: "HEAD", pathname })).toBe(
+        true,
+      );
+    }
+  });
+
+  it("bypasses Clerk for public catalog APIs", () => {
+    for (const pathname of [
+      "/api/manifest",
+      "/api/manifest/v2",
+      "/api/pets/random",
+      "/api/pets/search",
+      "/api/pets/boba/metrics",
+      "/api/pets/boba/thumb",
+      "/api/pets/boba/sticker",
+      "/api/pets/boba/wastickers",
+      "/api/pets/boba/variants",
+      "/api/pets/boba/codex-theme",
+      "/api/install-pet/boba",
+      "/api/desktop/latest-release",
+    ]) {
+      expect(shouldBypassClerkMiddleware({ method: "GET", pathname })).toBe(
+        true,
+      );
+    }
+  });
+
+  it("keeps Clerk on auth, profile, feedback, submit, and full manifest surfaces", () => {
+    for (const pathname of [
+      "/u/hunter",
+      "/es/u/hunter",
+      "/submit",
+      "/es/submit",
+      "/my-feedback",
+      "/advertise/dashboard",
+      "/advertise/new",
+      "/api/manifest/full",
+      "/api/me/header-state",
+      "/api/profile",
+      "/api/profile/gallery-order",
+      "/api/feedback",
+      "/api/pet-requests",
+      "/api/submit",
+      "/api/pets/boba/like",
+      "/api/pets/boba/owner",
+      "/api/pets/boba/owner-state",
+      "/api/pets/boba/can-delete",
+    ]) {
+      expect(shouldBypassClerkMiddleware({ method: "GET", pathname })).toBe(
+        false,
+      );
+    }
+  });
+
+  it("keeps Clerk on mutations even for public catalog read paths", () => {
+    for (const method of ["POST", "PUT", "PATCH", "DELETE"]) {
+      expect(
+        shouldBypassClerkMiddleware({
+          method,
+          pathname: "/api/pets/boba/metrics",
+        }),
+      ).toBe(false);
+    }
+  });
+});

--- a/src/lib/public-clerk-bypass.ts
+++ b/src/lib/public-clerk-bypass.ts
@@ -1,0 +1,65 @@
+const READ_METHODS = new Set(["GET", "HEAD"]);
+const LOCALE_RE = /^\/(?:en|es|zh)(?=\/|$)/;
+
+const PUBLIC_HTML_PATHS = new Set([
+  "/",
+  "/about",
+  "/brand",
+  "/built-with",
+  "/collections",
+  "/community",
+  "/create",
+  "/docs",
+  "/download",
+  "/leaderboard",
+  "/legal/takedown",
+  "/legal/telemetry",
+  "/requests",
+]);
+
+const PUBLIC_API_PATHS = new Set([
+  "/api/desktop/latest-release",
+  "/api/manifest",
+  "/api/manifest/v2",
+  "/api/pets/random",
+  "/api/pets/search",
+]);
+
+export function shouldBypassClerkMiddleware(input: {
+  method: string;
+  pathname: string;
+}): boolean {
+  if (!READ_METHODS.has(input.method.toUpperCase())) return false;
+  const pathname = normalizePath(input.pathname);
+  if (isPublicHtmlPath(pathname)) return true;
+  if (isPublicCatalogApiPath(pathname)) return true;
+  return false;
+}
+
+function normalizePath(pathname: string): string {
+  const withoutLocale = pathname.replace(LOCALE_RE, "") || "/";
+  if (withoutLocale.length > 1) return withoutLocale.replace(/\/+$/, "");
+  return withoutLocale;
+}
+
+function isPublicHtmlPath(pathname: string): boolean {
+  if (PUBLIC_HTML_PATHS.has(pathname)) return true;
+  if (/^\/pets\/[^/]+$/.test(pathname)) return true;
+  if (/^\/collections\/[^/]+$/.test(pathname)) return true;
+  if (/^\/kind\/[^/]+$/.test(pathname)) return true;
+  if (/^\/vibe\/[^/]+$/.test(pathname)) return true;
+  return false;
+}
+
+function isPublicCatalogApiPath(pathname: string): boolean {
+  if (PUBLIC_API_PATHS.has(pathname)) return true;
+  if (
+    /^\/api\/pets\/[^/]+\/(?:codex-theme|metrics|sticker|thumb|variants|wastickers)$/.test(
+      pathname,
+    )
+  ) {
+    return true;
+  }
+  if (/^\/api\/install-pet\/[^/]+$/.test(pathname)) return true;
+  return false;
+}

--- a/src/lib/public-traffic-guard.test.ts
+++ b/src/lib/public-traffic-guard.test.ts
@@ -97,25 +97,25 @@ describe("public traffic guard", () => {
     ).toBe("catalog");
     expect(
       publicTrafficGuardRule({ method: "GET", pathname: "/zh/pets/nukey" }),
-    ).toBe("page");
+    ).toBeNull();
     expect(
       publicTrafficGuardRule({
         method: "GET",
         pathname: "/kind/cat",
       }),
-    ).toBe("page");
+    ).toBeNull();
     expect(
       publicTrafficGuardRule({
         method: "GET",
         pathname: "/collections/cute-coders",
       }),
-    ).toBe("page");
+    ).toBeNull();
     expect(
       publicTrafficGuardRule({ method: "GET", pathname: "/zh/vibe/cozy" }),
-    ).toBe("page");
+    ).toBeNull();
     expect(
       publicTrafficGuardRule({ method: "GET", pathname: "/leaderboard" }),
-    ).toBe("page");
+    ).toBeNull();
   });
 
   it("does not target non-read methods or private surfaces", () => {

--- a/src/lib/public-traffic-guard.ts
+++ b/src/lib/public-traffic-guard.ts
@@ -9,7 +9,6 @@ export type PublicTrafficGuardRule =
   | "catalog"
   | "metadata"
   | "pack"
-  | "page"
   | "state"
   | "sticker";
 
@@ -52,7 +51,6 @@ export function publicTrafficGuardRule(input: {
   if (/^\/(?:en\/|es\/|zh\/)?install\/[^/]+\/?$/.test(pathname)) {
     return "catalog";
   }
-  if (isPublicPagePath(pathname)) return "page";
   return null;
 }
 
@@ -80,28 +78,4 @@ function readHeader(headers: HeaderBag | undefined, name: string): string {
   }
   const bag = headers as Record<string, string | null | undefined>;
   return bag[name] ?? bag[name.toLowerCase()] ?? bag[name.toUpperCase()] ?? "";
-}
-
-function isPublicPagePath(pathname: string): boolean {
-  const path = pathname.replace(/^\/(?:en|es|zh)(?=\/|$)/, "") || "/";
-  if (path === "/") return true;
-  if (/^\/pets\/[^/]+\/?$/.test(path)) return true;
-  if (/^\/collections\/[^/]+\/?$/.test(path)) return true;
-  if (/^\/kind\/[^/]+\/?$/.test(path)) return true;
-  if (/^\/u\/[^/]+\/?$/.test(path)) return true;
-  if (/^\/vibe\/[^/]+\/?$/.test(path)) return true;
-  return [
-    "/about",
-    "/advertise",
-    "/brand",
-    "/built-with",
-    "/collections",
-    "/community",
-    "/docs",
-    "/download",
-    "/leaderboard",
-    "/legal/takedown",
-    "/legal/telemetry",
-    "/requests",
-  ].includes(path);
 }

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -93,12 +93,6 @@ export const publicStateRatelimit = createRatelimit({
   prefix: "petdex:public-state",
 });
 
-export const publicPageRatelimit = createRatelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(600, "1 h"),
-  prefix: "petdex:public-page",
-});
-
 export const publicMetadataRatelimit = createRatelimit({
   redis,
   limiter: Ratelimit.slidingWindow(120, "1 h"),

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -7,6 +7,7 @@ import {
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import createMiddleware from "next-intl/middleware";
 
+import { shouldBypassClerkMiddleware } from "@/lib/public-clerk-bypass";
 import {
   publicTrafficGuardKey,
   publicTrafficGuardRule,
@@ -16,7 +17,6 @@ import {
   packAssetRatelimit,
   publicCatalogRatelimit,
   publicMetadataRatelimit,
-  publicPageRatelimit,
   publicStateRatelimit,
   publicTrafficBurstRatelimit,
   stickerAssetRatelimit,
@@ -87,27 +87,38 @@ const baseMiddleware = async (req: NextRequest, event?: NextFetchEvent) => {
   );
 };
 
-export default IS_MOCK_AUTH
-  ? baseMiddleware
-  : clerkMiddleware(async (auth, req, event) => {
-      const legacyRedirect = legacyHostRedirect(req);
-      if (legacyRedirect) return legacyRedirect;
-      const adminSurface = adminSurfaceResponse(req);
-      if (adminSurface) return adminSurface;
-      scheduleRouteCostSample(req, event);
-      const guard = await guardPublicTraffic(req);
-      if (guard) return guard;
+const clerkBackedMiddleware = clerkMiddleware(async (auth, req, event) => {
+  const legacyRedirect = legacyHostRedirect(req);
+  if (legacyRedirect) return legacyRedirect;
+  const adminSurface = adminSurfaceResponse(req);
+  if (adminSurface) return adminSurface;
+  scheduleRouteCostSample(req, event);
+  const guard = await guardPublicTraffic(req);
+  if (guard) return guard;
 
-      if (isProtected(req)) {
-        await auth.protect();
-      }
+  if (isProtected(req)) {
+    await auth.protect();
+  }
 
-      if (req.nextUrl.pathname.startsWith("/api")) {
-        return NextResponse.next();
-      }
+  if (req.nextUrl.pathname.startsWith("/api")) {
+    return NextResponse.next();
+  }
 
-      return handleI18nRoutingWithoutLocaleCookie(req);
-    });
+  return handleI18nRoutingWithoutLocaleCookie(req);
+});
+
+export default function proxy(req: NextRequest, event: NextFetchEvent) {
+  if (
+    IS_MOCK_AUTH ||
+    shouldBypassClerkMiddleware({
+      method: req.method,
+      pathname: req.nextUrl.pathname,
+    })
+  ) {
+    return baseMiddleware(req, event);
+  }
+  return clerkBackedMiddleware(req, event);
+}
 
 export const config = {
   matcher: [
@@ -150,9 +161,7 @@ async function guardPublicTraffic(
           ? await publicMetadataRatelimit.limit(key)
           : rule === "state"
             ? await publicStateRatelimit.limit(key)
-            : rule === "page"
-              ? await publicPageRatelimit.limit(key)
-              : await publicCatalogRatelimit.limit(key);
+            : await publicCatalogRatelimit.limit(key);
   if (limit.success) return null;
 
   return rateLimitedResponse(limit.reset);


### PR DESCRIPTION
## Summary
- Remove page-view Upstash work from the public traffic guard.
- Add a tested helper for Clerk middleware bypass classification.
- Bypass Clerk only for GET/HEAD public static HTML and safe public catalog APIs.
- Keep protected pages, mutating APIs, profiles, feedback, submit, and full manifest behind the normal middleware path.

## Validation
- bun run check
- bun run i18n:check
- bun test --env-file=.env.mock
- git diff --check
- TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build