### PR TITLE
perf: lazy load public auth shell

### DIFF
--- a/src/app/[locale]/advertise/dashboard/[campaignId]/edit/page.tsx
+++ b/src/app/[locale]/advertise/dashboard/[campaignId]/edit/page.tsx
@@ -8,6 +8,7 @@ import { getOwnedAdCampaignForEditing } from "@/lib/ads/queries";
 import { buildLocaleAlternates, withLocale } from "@/lib/locale-routing";
 
 import { AdCampaignEditor } from "@/components/ads/ad-campaign-editor";
+import { FullAuthProviders } from "@/components/auth-providers";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 
@@ -61,54 +62,56 @@ export default async function EditAdCampaignPage({
   const editable = campaign.status !== "deleted" && !campaign.deletedAt;
 
   return (
-    <main className="min-h-dvh bg-background text-foreground">
-      <SiteHeader />
-      <section className="petdex-cloud relative -mt-[84px] pt-[84px]">
-        <div className="relative mx-auto flex w-full max-w-[1200px] flex-col gap-8 px-5 pt-10 pb-16 md:px-8 md:pt-14 md:pb-20">
-          <header className="flex flex-col gap-5 md:flex-row md:items-end md:justify-between">
-            <div>
-              <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
-                {campaign.companyName}
-              </p>
-              <h1 className="mt-3 max-w-4xl text-balance text-4xl font-semibold tracking-tight md:text-6xl">
-                {t("title")}
-              </h1>
-              <p className="mt-4 max-w-2xl text-base leading-7 text-muted-2">
-                {t("body")}
-              </p>
-            </div>
-            <Link
-              href={dashboardHref}
-              className="inline-flex h-11 shrink-0 items-center justify-center rounded-full border border-border-base bg-surface/72 px-5 text-sm font-medium text-foreground backdrop-blur transition hover:border-border-strong"
-            >
-              {t("backToDashboard")}
-            </Link>
-          </header>
-
-          {editable ? (
-            <AdCampaignEditor
-              campaign={campaign}
-              dashboardHref={dashboardHref}
-            />
-          ) : (
-            <section className="rounded-[2rem] border border-border-base bg-surface/82 p-8 shadow-xl shadow-blue-950/5 backdrop-blur">
-              <h2 className="text-2xl font-semibold tracking-tight">
-                {t("notEditable.title")}
-              </h2>
-              <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-2">
-                {campaign.removalReason ?? t("notEditable.body")}
-              </p>
+    <FullAuthProviders>
+      <main className="min-h-dvh bg-background text-foreground">
+        <SiteHeader />
+        <section className="petdex-cloud relative -mt-[84px] pt-[84px]">
+          <div className="relative mx-auto flex w-full max-w-[1200px] flex-col gap-8 px-5 pt-10 pb-16 md:px-8 md:pt-14 md:pb-20">
+            <header className="flex flex-col gap-5 md:flex-row md:items-end md:justify-between">
+              <div>
+                <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
+                  {campaign.companyName}
+                </p>
+                <h1 className="mt-3 max-w-4xl text-balance text-4xl font-semibold tracking-tight md:text-6xl">
+                  {t("title")}
+                </h1>
+                <p className="mt-4 max-w-2xl text-base leading-7 text-muted-2">
+                  {t("body")}
+                </p>
+              </div>
               <Link
                 href={dashboardHref}
-                className="mt-6 inline-flex h-11 items-center justify-center rounded-full bg-inverse px-5 text-sm font-medium text-on-inverse transition hover:bg-inverse-hover"
+                className="inline-flex h-11 shrink-0 items-center justify-center rounded-full border border-border-base bg-surface/72 px-5 text-sm font-medium text-foreground backdrop-blur transition hover:border-border-strong"
               >
                 {t("backToDashboard")}
               </Link>
-            </section>
-          )}
-        </div>
-      </section>
-      <SiteFooter />
-    </main>
+            </header>
+
+            {editable ? (
+              <AdCampaignEditor
+                campaign={campaign}
+                dashboardHref={dashboardHref}
+              />
+            ) : (
+              <section className="rounded-[2rem] border border-border-base bg-surface/82 p-8 shadow-xl shadow-blue-950/5 backdrop-blur">
+                <h2 className="text-2xl font-semibold tracking-tight">
+                  {t("notEditable.title")}
+                </h2>
+                <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-2">
+                  {campaign.removalReason ?? t("notEditable.body")}
+                </p>
+                <Link
+                  href={dashboardHref}
+                  className="mt-6 inline-flex h-11 items-center justify-center rounded-full bg-inverse px-5 text-sm font-medium text-on-inverse transition hover:bg-inverse-hover"
+                >
+                  {t("backToDashboard")}
+                </Link>
+              </section>
+            )}
+          </div>
+        </section>
+        <SiteFooter />
+      </main>
+    </FullAuthProviders>
   );
 }

--- a/src/app/[locale]/advertise/dashboard/page.tsx
+++ b/src/app/[locale]/advertise/dashboard/page.tsx
@@ -7,6 +7,7 @@ import { getUserAdCampaigns } from "@/lib/ads/queries";
 import { buildLocaleAlternates, withLocale } from "@/lib/locale-routing";
 
 import { AdDashboard } from "@/components/ads/ad-dashboard";
+import { FullAuthProviders } from "@/components/auth-providers";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 
@@ -56,39 +57,41 @@ export default async function AdvertiseDashboardPage({
   const campaigns = await getUserAdCampaigns(userId);
 
   return (
-    <main className="min-h-dvh bg-background text-foreground">
-      <SiteHeader />
-      <section className="petdex-cloud relative -mt-[84px] overflow-clip pt-[84px]">
-        <div className="relative mx-auto flex w-full max-w-[1440px] flex-col gap-8 px-5 pb-12 md:px-8 md:pb-16">
-          <header className="mt-8 flex flex-col gap-5 md:flex-row md:items-end md:justify-between">
-            <div>
-              <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
-                {t("eyebrow")}
-              </p>
-              <h1 className="mt-3 text-balance text-4xl font-semibold tracking-tight md:text-6xl">
-                {t("title")}
-              </h1>
-              <p className="mt-4 max-w-2xl text-base leading-7 text-muted-2">
-                {t("body")}
-              </p>
-            </div>
-            <Link
-              href={withLocale("/advertise/new", localeValue)}
-              className="inline-flex h-11 shrink-0 items-center justify-center rounded-full bg-inverse px-5 text-sm font-medium text-on-inverse transition hover:bg-inverse-hover"
-            >
-              {t("newCampaign")}
-            </Link>
-          </header>
-          {checkout === "success" ? (
-            <div className="rounded-2xl bg-chip-success-bg p-4 text-sm leading-6 text-chip-success-fg">
-              <p className="font-semibold">{t("checkout.successTitle")}</p>
-              <p className="mt-1">{t("checkout.successBody")}</p>
-            </div>
-          ) : null}
-          <AdDashboard campaigns={campaigns} locale={localeValue} />
-        </div>
-      </section>
-      <SiteFooter />
-    </main>
+    <FullAuthProviders>
+      <main className="min-h-dvh bg-background text-foreground">
+        <SiteHeader />
+        <section className="petdex-cloud relative -mt-[84px] overflow-clip pt-[84px]">
+          <div className="relative mx-auto flex w-full max-w-[1440px] flex-col gap-8 px-5 pb-12 md:px-8 md:pb-16">
+            <header className="mt-8 flex flex-col gap-5 md:flex-row md:items-end md:justify-between">
+              <div>
+                <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
+                  {t("eyebrow")}
+                </p>
+                <h1 className="mt-3 text-balance text-4xl font-semibold tracking-tight md:text-6xl">
+                  {t("title")}
+                </h1>
+                <p className="mt-4 max-w-2xl text-base leading-7 text-muted-2">
+                  {t("body")}
+                </p>
+              </div>
+              <Link
+                href={withLocale("/advertise/new", localeValue)}
+                className="inline-flex h-11 shrink-0 items-center justify-center rounded-full bg-inverse px-5 text-sm font-medium text-on-inverse transition hover:bg-inverse-hover"
+              >
+                {t("newCampaign")}
+              </Link>
+            </header>
+            {checkout === "success" ? (
+              <div className="rounded-2xl bg-chip-success-bg p-4 text-sm leading-6 text-chip-success-fg">
+                <p className="font-semibold">{t("checkout.successTitle")}</p>
+                <p className="mt-1">{t("checkout.successBody")}</p>
+              </div>
+            ) : null}
+            <AdDashboard campaigns={campaigns} locale={localeValue} />
+          </div>
+        </section>
+        <SiteFooter />
+      </main>
+    </FullAuthProviders>
   );
 }

--- a/src/app/[locale]/advertise/new/page.tsx
+++ b/src/app/[locale]/advertise/new/page.tsx
@@ -6,6 +6,7 @@ import { getTranslations } from "next-intl/server";
 import { buildLocaleAlternates, withLocale } from "@/lib/locale-routing";
 
 import { AdvertiseForm } from "@/components/ads/advertise-form";
+import { FullAuthProviders } from "@/components/auth-providers";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 
@@ -53,55 +54,57 @@ export default async function NewAdvertisePage({
   }
 
   return (
-    <main className="min-h-dvh bg-background text-foreground">
-      <SiteHeader />
-      <section className="petdex-cloud relative -mt-[84px] pt-[84px]">
-        <div className="relative mx-auto flex w-full max-w-[1440px] flex-col gap-8 px-5 pt-10 pb-16 md:px-8 md:pt-14 md:pb-20">
-          <header className="flex flex-col gap-5 md:flex-row md:items-end md:justify-between">
-            <div>
-              <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
-                {t("create.eyebrow")}
-              </p>
-              <h1 className="mt-3 max-w-4xl text-balance text-4xl font-semibold tracking-tight md:text-6xl">
-                {t("create.title")}
-              </h1>
-              <p className="mt-4 max-w-2xl text-base leading-7 text-muted-2">
-                {t("create.body")}
-              </p>
-            </div>
-            <Link
-              href={withLocale("/advertise", localeValue)}
-              className="inline-flex h-11 shrink-0 items-center justify-center rounded-full border border-border-base bg-surface/72 px-5 text-sm font-medium text-foreground backdrop-blur transition hover:border-border-strong"
-            >
-              {t("create.backToLanding")}
-            </Link>
-          </header>
+    <FullAuthProviders>
+      <main className="min-h-dvh bg-background text-foreground">
+        <SiteHeader />
+        <section className="petdex-cloud relative -mt-[84px] pt-[84px]">
+          <div className="relative mx-auto flex w-full max-w-[1440px] flex-col gap-8 px-5 pt-10 pb-16 md:px-8 md:pt-14 md:pb-20">
+            <header className="flex flex-col gap-5 md:flex-row md:items-end md:justify-between">
+              <div>
+                <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
+                  {t("create.eyebrow")}
+                </p>
+                <h1 className="mt-3 max-w-4xl text-balance text-4xl font-semibold tracking-tight md:text-6xl">
+                  {t("create.title")}
+                </h1>
+                <p className="mt-4 max-w-2xl text-base leading-7 text-muted-2">
+                  {t("create.body")}
+                </p>
+              </div>
+              <Link
+                href={withLocale("/advertise", localeValue)}
+                className="inline-flex h-11 shrink-0 items-center justify-center rounded-full border border-border-base bg-surface/72 px-5 text-sm font-medium text-foreground backdrop-blur transition hover:border-border-strong"
+              >
+                {t("create.backToLanding")}
+              </Link>
+            </header>
 
-          {checkout === "cancelled" ? (
-            <div className="rounded-2xl bg-chip-warning-bg p-4 text-sm leading-6 text-chip-warning-fg">
-              <p className="font-semibold">{t("checkout.cancelTitle")}</p>
-              <p className="mt-1">{t("checkout.cancelBody")}</p>
-            </div>
-          ) : null}
+            {checkout === "cancelled" ? (
+              <div className="rounded-2xl bg-chip-warning-bg p-4 text-sm leading-6 text-chip-warning-fg">
+                <p className="font-semibold">{t("checkout.cancelTitle")}</p>
+                <p className="mt-1">{t("checkout.cancelBody")}</p>
+              </div>
+            ) : null}
 
-          <div className="grid gap-5 lg:grid-cols-[1fr_280px] lg:items-start">
-            <AdvertiseForm />
-            <aside className="grid gap-3 lg:sticky lg:top-24">
-              <HelperCard title={t("create.help.creative.title")}>
-                {t("create.help.creative.body")}
-              </HelperCard>
-              <HelperCard title={t("create.help.review.title")}>
-                {t("create.help.review.body")}
-              </HelperCard>
-              <HelperCard title={t("create.help.billing.title")}>
-                {t("create.help.billing.body")}
-              </HelperCard>
-            </aside>
+            <div className="grid gap-5 lg:grid-cols-[1fr_280px] lg:items-start">
+              <AdvertiseForm />
+              <aside className="grid gap-3 lg:sticky lg:top-24">
+                <HelperCard title={t("create.help.creative.title")}>
+                  {t("create.help.creative.body")}
+                </HelperCard>
+                <HelperCard title={t("create.help.review.title")}>
+                  {t("create.help.review.body")}
+                </HelperCard>
+                <HelperCard title={t("create.help.billing.title")}>
+                  {t("create.help.billing.body")}
+                </HelperCard>
+              </aside>
+            </div>
           </div>
-        </div>
-      </section>
-      <SiteFooter />
-    </main>
+        </section>
+        <SiteFooter />
+      </main>
+    </FullAuthProviders>
   );
 }
 

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -9,8 +9,8 @@ import {
   setRequestLocale,
 } from "next-intl/server";
 
-import { FeedbackWidget } from "@/components/feedback-widget";
-import { HeaderStateProvider } from "@/components/header-state-provider";
+import { AuthFeedbackWidget } from "@/components/auth-feedback-widget";
+import { ConditionalAuthProviders } from "@/components/conditional-auth-providers";
 import { AppProviders } from "@/components/theme-providers";
 import { TopPromoStrip } from "@/components/zh/top-promo-strip";
 import { ZhLayoutSpacer } from "@/components/zh/zh-layout-spacer";
@@ -110,11 +110,11 @@ export default async function LocaleLayout({ children, params }: Props) {
       <body className="min-h-full flex flex-col bg-background text-foreground">
         <NextIntlClientProvider messages={clientMessages}>
           <AppProviders>
-            {isZh && <TopPromoStrip />}
-            <HeaderStateProvider>
+            <ConditionalAuthProviders>
+              {isZh && <TopPromoStrip />}
               {isZh ? <ZhLayoutSpacer>{children}</ZhLayoutSpacer> : children}
-              <FeedbackWidget />
-            </HeaderStateProvider>
+              <AuthFeedbackWidget />
+            </ConditionalAuthProviders>
           </AppProviders>
         </NextIntlClientProvider>
       </body>

--- a/src/app/[locale]/my-feedback/[id]/page.tsx
+++ b/src/app/[locale]/my-feedback/[id]/page.tsx
@@ -7,6 +7,7 @@ import { getTranslations } from "next-intl/server";
 
 import { db, schema } from "@/lib/db/client";
 
+import { FullAuthProviders } from "@/components/auth-providers";
 import { FeedbackThread } from "@/components/feedback-thread";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
@@ -60,7 +61,7 @@ export default async function MyFeedbackThreadPage({
     .where(eq(schema.feedback.id, id));
 
   return (
-    <>
+    <FullAuthProviders>
       <SiteHeader />
       <main className="min-h-dvh pb-20">
         <section className="mx-auto flex w-full max-w-2xl flex-col gap-6 px-5 pt-10 pb-12 md:px-8 md:pt-14">
@@ -90,6 +91,6 @@ export default async function MyFeedbackThreadPage({
         </section>
       </main>
       <SiteFooter />
-    </>
+    </FullAuthProviders>
   );
 }

--- a/src/app/[locale]/my-feedback/page.tsx
+++ b/src/app/[locale]/my-feedback/page.tsx
@@ -8,6 +8,7 @@ import { getTranslations } from "next-intl/server";
 
 import { db, schema } from "@/lib/db/client";
 
+import { FullAuthProviders } from "@/components/auth-providers";
 import { MyFeedbackFilters } from "@/components/my-feedback-filters";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
@@ -177,119 +178,124 @@ export default async function MyFeedbackPage({
   });
 
   return (
-    <main className="min-h-dvh bg-background text-foreground">
-      <SiteHeader />
-      <section className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-5 pt-8 pb-20 md:px-8">
-        <header className="space-y-3">
-          <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
-            {t("eyebrow")}
-          </p>
-          <h1 className="text-4xl font-medium tracking-tight md:text-5xl">
-            {t("title")}
-          </h1>
-          <p className="text-sm text-muted-2">{t("subtitle")}</p>
-          {decorated.length > 0 ? (
-            <MyFeedbackFilters counts={counts} defaultFilter={defaultFilter} />
-          ) : null}
-        </header>
+    <FullAuthProviders>
+      <main className="min-h-dvh bg-background text-foreground">
+        <SiteHeader />
+        <section className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-5 pt-8 pb-20 md:px-8">
+          <header className="space-y-3">
+            <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
+              {t("eyebrow")}
+            </p>
+            <h1 className="text-4xl font-medium tracking-tight md:text-5xl">
+              {t("title")}
+            </h1>
+            <p className="text-sm text-muted-2">{t("subtitle")}</p>
+            {decorated.length > 0 ? (
+              <MyFeedbackFilters
+                counts={counts}
+                defaultFilter={defaultFilter}
+              />
+            ) : null}
+          </header>
 
-        {decorated.length === 0 ? (
-          <div className="rounded-2xl border border-dashed border-border-base bg-surface/60 p-10 text-center text-sm text-stone-600 dark:text-stone-400">
-            {t("empty")}
-          </div>
-        ) : visible.length === 0 ? (
-          <div className="rounded-2xl border border-dashed border-border-base bg-surface/60 p-10 text-center text-sm text-muted-2">
-            {t("emptyFiltered")}
-          </div>
-        ) : (
-          <ul className="space-y-2">
-            {visible.map(({ row: r, agg, unread, replied, waiting }) => {
-              const meta = KIND_META[r.kind] ?? KIND_META.other;
-              const lastAdminAt = agg?.latestAdminAt ?? null;
-              const lastAdminBody = agg?.latestAdminBody ?? null;
-              const replyCount = agg?.replyCount ?? 0;
+          {decorated.length === 0 ? (
+            <div className="rounded-2xl border border-dashed border-border-base bg-surface/60 p-10 text-center text-sm text-stone-600 dark:text-stone-400">
+              {t("empty")}
+            </div>
+          ) : visible.length === 0 ? (
+            <div className="rounded-2xl border border-dashed border-border-base bg-surface/60 p-10 text-center text-sm text-muted-2">
+              {t("emptyFiltered")}
+            </div>
+          ) : (
+            <ul className="space-y-2">
+              {visible.map(({ row: r, agg, unread, replied, waiting }) => {
+                const meta = KIND_META[r.kind] ?? KIND_META.other;
+                const lastAdminAt = agg?.latestAdminAt ?? null;
+                const lastAdminBody = agg?.latestAdminBody ?? null;
+                const replyCount = agg?.replyCount ?? 0;
 
-              return (
-                <li key={r.id}>
-                  <Link
-                    href={`/my-feedback/${r.id}`}
-                    className={`block rounded-2xl border p-4 transition hover:bg-white ${
-                      unread
-                        ? "border-brand/40 bg-white shadow-[0_0_0_1px_rgba(82,102,234,0.18),0_18px_45px_-26px_rgba(82,102,234,0.4)]"
-                        : "border-black/10 bg-surface/80 hover:border-black/30 dark:border-white/10 dark:hover:border-white/30"
-                    }`}
-                  >
-                    <div className="flex items-start gap-3">
-                      <div className="min-w-0 flex-1">
-                        <div className="flex flex-wrap items-center gap-2">
-                          <span
-                            className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-mono text-[10px] tracking-[0.12em] uppercase ring-1 ${meta.tone}`}
-                          >
-                            {meta.icon}
-                            {meta.label}
-                          </span>
-                          {unread ? (
-                            <span className="inline-flex items-center gap-1 rounded-full bg-brand px-2 py-0.5 font-mono text-[10px] tracking-[0.12em] text-white uppercase">
-                              {t("badges.newReply")}
+                return (
+                  <li key={r.id}>
+                    <Link
+                      href={`/my-feedback/${r.id}`}
+                      className={`block rounded-2xl border p-4 transition hover:bg-white ${
+                        unread
+                          ? "border-brand/40 bg-white shadow-[0_0_0_1px_rgba(82,102,234,0.18),0_18px_45px_-26px_rgba(82,102,234,0.4)]"
+                          : "border-black/10 bg-surface/80 hover:border-black/30 dark:border-white/10 dark:hover:border-white/30"
+                      }`}
+                    >
+                      <div className="flex items-start gap-3">
+                        <div className="min-w-0 flex-1">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span
+                              className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-mono text-[10px] tracking-[0.12em] uppercase ring-1 ${meta.tone}`}
+                            >
+                              {meta.icon}
+                              {meta.label}
                             </span>
-                          ) : replied ? (
-                            <span className="inline-flex items-center gap-1 rounded-full bg-chip-success-bg px-2 py-0.5 font-mono text-[10px] tracking-[0.12em] text-chip-success-fg uppercase ring-1 ring-chip-success-fg/20">
-                              {t("badges.replied")}
+                            {unread ? (
+                              <span className="inline-flex items-center gap-1 rounded-full bg-brand px-2 py-0.5 font-mono text-[10px] tracking-[0.12em] text-white uppercase">
+                                {t("badges.newReply")}
+                              </span>
+                            ) : replied ? (
+                              <span className="inline-flex items-center gap-1 rounded-full bg-chip-success-bg px-2 py-0.5 font-mono text-[10px] tracking-[0.12em] text-chip-success-fg uppercase ring-1 ring-chip-success-fg/20">
+                                {t("badges.replied")}
+                              </span>
+                            ) : waiting ? (
+                              <span className="inline-flex items-center gap-1 rounded-full bg-chip-warning-bg px-2 py-0.5 font-mono text-[10px] tracking-[0.12em] text-chip-warning-fg uppercase ring-1 ring-chip-warning-fg/20">
+                                {t("badges.waiting")}
+                              </span>
+                            ) : null}
+                            <span className="ml-auto font-mono text-[10px] tracking-[0.12em] text-muted-4 uppercase">
+                              {new Date(r.createdAt).toLocaleDateString()}
                             </span>
-                          ) : waiting ? (
-                            <span className="inline-flex items-center gap-1 rounded-full bg-chip-warning-bg px-2 py-0.5 font-mono text-[10px] tracking-[0.12em] text-chip-warning-fg uppercase ring-1 ring-chip-warning-fg/20">
-                              {t("badges.waiting")}
-                            </span>
-                          ) : null}
-                          <span className="ml-auto font-mono text-[10px] tracking-[0.12em] text-muted-4 uppercase">
-                            {new Date(r.createdAt).toLocaleDateString()}
-                          </span>
-                        </div>
-
-                        <p className="mt-2 line-clamp-2 text-sm leading-6 text-foreground">
-                          {r.message}
-                        </p>
-
-                        {lastAdminBody ? (
-                          <div className="mt-3 flex items-start gap-2 rounded-xl border border-emerald-200/60 bg-emerald-50/40 p-2.5 dark:border-emerald-800/40 dark:bg-emerald-950/30">
-                            <div className="grid size-6 shrink-0 place-items-center rounded-full bg-emerald-600 font-mono text-[10px] font-semibold text-white">
-                              H
-                            </div>
-                            <div className="min-w-0 flex-1">
-                              <div className="flex items-center gap-1.5 font-mono text-[10px] tracking-[0.12em] text-emerald-900/70 uppercase">
-                                {t("replyAuthor")}
-                                {lastAdminAt ? (
-                                  <span>
-                                    ·{" "}
-                                    {new Date(lastAdminAt).toLocaleDateString(
-                                      undefined,
-                                      { month: "short", day: "numeric" },
-                                    )}
-                                  </span>
-                                ) : null}
-                              </div>
-                              <p className="mt-0.5 line-clamp-2 text-sm leading-6 text-emerald-900 dark:text-emerald-300">
-                                {lastAdminBody}
-                              </p>
-                            </div>
                           </div>
-                        ) : null}
 
-                        <p className="mt-2 text-xs text-muted-3">
-                          {replyCount > 0
-                            ? t("replyCount", { count: replyCount })
-                            : t("noReplies")}
-                        </p>
+                          <p className="mt-2 line-clamp-2 text-sm leading-6 text-foreground">
+                            {r.message}
+                          </p>
+
+                          {lastAdminBody ? (
+                            <div className="mt-3 flex items-start gap-2 rounded-xl border border-emerald-200/60 bg-emerald-50/40 p-2.5 dark:border-emerald-800/40 dark:bg-emerald-950/30">
+                              <div className="grid size-6 shrink-0 place-items-center rounded-full bg-emerald-600 font-mono text-[10px] font-semibold text-white">
+                                H
+                              </div>
+                              <div className="min-w-0 flex-1">
+                                <div className="flex items-center gap-1.5 font-mono text-[10px] tracking-[0.12em] text-emerald-900/70 uppercase">
+                                  {t("replyAuthor")}
+                                  {lastAdminAt ? (
+                                    <span>
+                                      ·{" "}
+                                      {new Date(lastAdminAt).toLocaleDateString(
+                                        undefined,
+                                        { month: "short", day: "numeric" },
+                                      )}
+                                    </span>
+                                  ) : null}
+                                </div>
+                                <p className="mt-0.5 line-clamp-2 text-sm leading-6 text-emerald-900 dark:text-emerald-300">
+                                  {lastAdminBody}
+                                </p>
+                              </div>
+                            </div>
+                          ) : null}
+
+                          <p className="mt-2 text-xs text-muted-3">
+                            {replyCount > 0
+                              ? t("replyCount", { count: replyCount })
+                              : t("noReplies")}
+                          </p>
+                        </div>
                       </div>
-                    </div>
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
-        )}
-      </section>
-      <SiteFooter />
-    </main>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </section>
+        <SiteFooter />
+      </main>
+    </FullAuthProviders>
   );
 }

--- a/src/app/[locale]/submit/page.tsx
+++ b/src/app/[locale]/submit/page.tsx
@@ -5,6 +5,7 @@ import { getTranslations } from "next-intl/server";
 
 import { buildLocaleAlternates } from "@/lib/locale-routing";
 
+import { FullAuthProviders } from "@/components/auth-providers";
 import { PetSubmitForm } from "@/components/pet-submit-form";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
@@ -33,44 +34,46 @@ export default async function SubmitPage() {
   const t = await getTranslations("submit");
 
   return (
-    <main className="min-h-dvh bg-background">
-      <SiteHeader hideSubmitCta />
-      <section className="petdex-cloud relative -mt-[84px] overflow-clip pt-[84px]">
-        <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-10 px-5 pb-12 md:px-8 md:pb-16">
-          <header className="max-w-3xl">
-            <p className="text-sm font-medium text-brand-light">
-              {t("eyebrow")}
+    <FullAuthProviders>
+      <main className="min-h-dvh bg-background">
+        <SiteHeader hideSubmitCta />
+        <section className="petdex-cloud relative -mt-[84px] overflow-clip pt-[84px]">
+          <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-10 px-5 pb-12 md:px-8 md:pb-16">
+            <header className="max-w-3xl">
+              <p className="text-sm font-medium text-brand-light">
+                {t("eyebrow")}
+              </p>
+              <h1 className="mt-4 text-5xl leading-tight font-medium tracking-normal text-foreground md:text-7xl">
+                {t("title")}
+              </h1>
+              <p className="mt-6 text-lg leading-8 text-muted-2">{t("body")}</p>
+              <Link
+                href="/create"
+                className="mt-5 inline-flex items-center gap-2 rounded-full border border-border-base bg-surface/70 px-4 py-2 text-sm font-medium text-muted-2 backdrop-blur transition hover:bg-white hover:text-foreground dark:hover:bg-stone-800"
+              >
+                <Hammer className="size-4" />
+                {t("createCta")}
+                <ArrowRight className="size-4" />
+              </Link>
+            </header>
+
+            <PetSubmitForm />
+
+            <p className="max-w-3xl text-xs leading-5 text-muted-3">
+              {t("legalPrefix")}{" "}
+              <Link
+                href="/legal/takedown"
+                className="underline underline-offset-4 hover:text-foreground"
+              >
+                {t("legalLink")}
+              </Link>
+              {t("legalSuffix")}
             </p>
-            <h1 className="mt-4 text-5xl leading-tight font-medium tracking-normal text-foreground md:text-7xl">
-              {t("title")}
-            </h1>
-            <p className="mt-6 text-lg leading-8 text-muted-2">{t("body")}</p>
-            <Link
-              href="/create"
-              className="mt-5 inline-flex items-center gap-2 rounded-full border border-border-base bg-surface/70 px-4 py-2 text-sm font-medium text-muted-2 backdrop-blur transition hover:bg-white hover:text-foreground dark:hover:bg-stone-800"
-            >
-              <Hammer className="size-4" />
-              {t("createCta")}
-              <ArrowRight className="size-4" />
-            </Link>
-          </header>
+          </div>
+        </section>
 
-          <PetSubmitForm />
-
-          <p className="max-w-3xl text-xs leading-5 text-muted-3">
-            {t("legalPrefix")}{" "}
-            <Link
-              href="/legal/takedown"
-              className="underline underline-offset-4 hover:text-foreground"
-            >
-              {t("legalLink")}
-            </Link>
-            {t("legalSuffix")}
-          </p>
-        </div>
-      </section>
-
-      <SiteFooter />
-    </main>
+        <SiteFooter />
+      </main>
+    </FullAuthProviders>
   );
 }

--- a/src/app/[locale]/u/[handle]/page.tsx
+++ b/src/app/[locale]/u/[handle]/page.tsx
@@ -22,6 +22,7 @@ import { buildLocaleAlternates } from "@/lib/locale-routing";
 import { type PetWithMetrics, rowToPet } from "@/lib/pets";
 import { toCurrentR2PublicUrl } from "@/lib/r2-public-url";
 
+import { FullAuthProviders } from "@/components/auth-providers";
 import { JsonLd } from "@/components/json-ld";
 import type { Submission } from "@/components/my-pets-view";
 import { ProfileExternalLink } from "@/components/profile-external-link";
@@ -273,181 +274,183 @@ export default async function UserProfilePage({ params }: PageProps) {
   };
 
   return (
-    <main className="min-h-dvh bg-background text-foreground">
-      <JsonLd data={jsonLd} />
+    <FullAuthProviders>
+      <main className="min-h-dvh bg-background text-foreground">
+        <JsonLd data={jsonLd} />
 
-      <SiteHeader />
-      <section className="petdex-cloud relative -mt-[84px] overflow-clip pt-[84px]">
-        <div className="relative mx-auto flex w-full max-w-[1440px] flex-col px-5 pb-10 md:px-8">
-          <header className="mt-10 grid gap-8 md:mt-14 lg:grid-cols-[auto_1fr_auto] lg:items-start">
-            {/* Avatar */}
-            <div className="flex justify-center lg:block">
-              {avatarUrl ? (
-                // biome-ignore lint/performance/noImgElement: Clerk-hosted avatar
-                <img
-                  src={avatarUrl}
-                  alt={displayName ?? `@${publicHandle}`}
-                  className="size-28 rounded-3xl object-cover ring-1 ring-black/10 md:size-32"
-                />
-              ) : (
-                <div className="grid size-28 place-items-center rounded-3xl bg-surface font-mono text-3xl font-semibold text-muted-2 ring-1 ring-black/10 md:size-32">
-                  {fallbackInitial}
+        <SiteHeader />
+        <section className="petdex-cloud relative -mt-[84px] overflow-clip pt-[84px]">
+          <div className="relative mx-auto flex w-full max-w-[1440px] flex-col px-5 pb-10 md:px-8">
+            <header className="mt-10 grid gap-8 md:mt-14 lg:grid-cols-[auto_1fr_auto] lg:items-start">
+              {/* Avatar */}
+              <div className="flex justify-center lg:block">
+                {avatarUrl ? (
+                  // biome-ignore lint/performance/noImgElement: Clerk-hosted avatar
+                  <img
+                    src={avatarUrl}
+                    alt={displayName ?? `@${publicHandle}`}
+                    className="size-28 rounded-3xl object-cover ring-1 ring-black/10 md:size-32"
+                  />
+                ) : (
+                  <div className="grid size-28 place-items-center rounded-3xl bg-surface font-mono text-3xl font-semibold text-muted-2 ring-1 ring-black/10 md:size-32">
+                    {fallbackInitial}
+                  </div>
+                )}
+              </div>
+
+              {/* Identity */}
+              <div className="text-center lg:text-left">
+                <div className="flex flex-wrap items-center justify-center gap-2 lg:justify-start">
+                  <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
+                    {t("creatorBadge")}
+                  </p>
+                  {catchProgress ? (
+                    <p className="font-mono text-xs tracking-[0.22em] text-muted-3 uppercase">
+                      {t("yourAlbum", {
+                        caught: catchProgress.caught,
+                        total: catchProgress.total,
+                        pct: catchProgress.pct,
+                      })}
+                    </p>
+                  ) : null}
+                  {isOwnerAdmin ? (
+                    <span
+                      className="inline-flex items-center gap-1 rounded-full bg-brand px-2 py-0.5 font-mono text-[10px] tracking-[0.15em] text-white uppercase"
+                      title="One of the people who built Petdex"
+                    >
+                      <Trophy className="size-3" />
+                      {t("creatorOfPetdex")}
+                    </span>
+                  ) : rank ? (
+                    <Link
+                      href="/leaderboard"
+                      className="inline-flex items-center gap-1 rounded-full bg-chip-warning-bg px-2 py-0.5 font-mono text-[10px] tracking-[0.15em] text-chip-warning-fg uppercase transition hover:opacity-80"
+                      title={`Ranked #${rank.rank} of ${rank.total} by approved pets. See the full leaderboard`}
+                    >
+                      <Trophy className="size-3" />#{rank.rank} most pets
+                    </Link>
+                  ) : null}
                 </div>
-              )}
-            </div>
-
-            {/* Identity */}
-            <div className="text-center lg:text-left">
-              <div className="flex flex-wrap items-center justify-center gap-2 lg:justify-start">
-                <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
-                  {t("creatorBadge")}
-                </p>
-                {catchProgress ? (
-                  <p className="font-mono text-xs tracking-[0.22em] text-muted-3 uppercase">
-                    {t("yourAlbum", {
-                      caught: catchProgress.caught,
-                      total: catchProgress.total,
-                      pct: catchProgress.pct,
-                    })}
+                <h1 className="mt-3 text-balance text-[40px] leading-[1] font-semibold tracking-tight md:text-[56px]">
+                  {displayName ?? `@${publicHandle}`}
+                </h1>
+                {displayName ? (
+                  <p className="mt-2 font-mono text-sm tracking-[0.08em] text-muted-3">
+                    @{publicHandle}
                   </p>
                 ) : null}
-                {isOwnerAdmin ? (
-                  <span
-                    className="inline-flex items-center gap-1 rounded-full bg-brand px-2 py-0.5 font-mono text-[10px] tracking-[0.15em] text-white uppercase"
-                    title="One of the people who built Petdex"
-                  >
-                    <Trophy className="size-3" />
-                    {t("creatorOfPetdex")}
-                  </span>
-                ) : rank ? (
-                  <Link
-                    href="/leaderboard"
-                    className="inline-flex items-center gap-1 rounded-full bg-chip-warning-bg px-2 py-0.5 font-mono text-[10px] tracking-[0.15em] text-chip-warning-fg uppercase transition hover:opacity-80"
-                    title={`Ranked #${rank.rank} of ${rank.total} by approved pets. See the full leaderboard`}
-                  >
-                    <Trophy className="size-3" />#{rank.rank} most pets
-                  </Link>
+                {bio ? (
+                  <p className="mt-4 max-w-xl text-balance text-base leading-7 text-muted-1 md:text-lg">
+                    {bio}
+                  </p>
                 ) : null}
-              </div>
-              <h1 className="mt-3 text-balance text-[40px] leading-[1] font-semibold tracking-tight md:text-[56px]">
-                {displayName ?? `@${publicHandle}`}
-              </h1>
-              {displayName ? (
-                <p className="mt-2 font-mono text-sm tracking-[0.08em] text-muted-3">
-                  @{publicHandle}
-                </p>
-              ) : null}
-              {bio ? (
-                <p className="mt-4 max-w-xl text-balance text-base leading-7 text-muted-1 md:text-lg">
-                  {bio}
-                </p>
-              ) : null}
 
-              {/* Stats row */}
-              <div className="mt-5 flex flex-wrap items-center justify-center gap-x-5 gap-y-2 font-mono text-[11px] tracking-[0.18em] text-muted-3 uppercase lg:justify-start">
-                <span>{t("petsCount", { count: pets.length })}</span>
-                {totalLikes > 0 ? (
-                  <span className="inline-flex items-center gap-1.5">
-                    <Heart className="size-3" />
-                    {formatLocalizedNumber(totalLikes, locale)}
-                  </span>
-                ) : null}
-                {totalInstalls > 0 ? (
-                  <span className="inline-flex items-center gap-1.5">
-                    <TerminalSquare className="size-3" />
-                    {t("installs", {
-                      count: formatLocalizedNumber(totalInstalls, locale),
-                    })}
-                  </span>
-                ) : null}
-                {memberSince ? (
-                  <span>
-                    {t("joined", {
-                      date: new Date(memberSince).toLocaleDateString(
-                        locale === "zh"
-                          ? "zh-Hans-CN"
-                          : locale === "es"
-                            ? "es"
-                            : "en",
-                        { month: "long", year: "numeric" },
-                      ),
-                    })}
-                  </span>
-                ) : null}
-              </div>
-
-              {/* External links */}
-              {externalUrls.length > 0 ? (
-                <div className="mt-4 flex flex-wrap items-center justify-center gap-2 lg:justify-start">
-                  {externalUrls.map((e) => (
-                    <ProfileExternalLink
-                      key={e.url}
-                      handle={publicHandle}
-                      url={e.url}
-                      label={e.label}
-                    />
-                  ))}
+                {/* Stats row */}
+                <div className="mt-5 flex flex-wrap items-center justify-center gap-x-5 gap-y-2 font-mono text-[11px] tracking-[0.18em] text-muted-3 uppercase lg:justify-start">
+                  <span>{t("petsCount", { count: pets.length })}</span>
+                  {totalLikes > 0 ? (
+                    <span className="inline-flex items-center gap-1.5">
+                      <Heart className="size-3" />
+                      {formatLocalizedNumber(totalLikes, locale)}
+                    </span>
+                  ) : null}
+                  {totalInstalls > 0 ? (
+                    <span className="inline-flex items-center gap-1.5">
+                      <TerminalSquare className="size-3" />
+                      {t("installs", {
+                        count: formatLocalizedNumber(totalInstalls, locale),
+                      })}
+                    </span>
+                  ) : null}
+                  {memberSince ? (
+                    <span>
+                      {t("joined", {
+                        date: new Date(memberSince).toLocaleDateString(
+                          locale === "zh"
+                            ? "zh-Hans-CN"
+                            : locale === "es"
+                              ? "es"
+                              : "en",
+                          { month: "long", year: "numeric" },
+                        ),
+                      })}
+                    </span>
+                  ) : null}
                 </div>
-              ) : null}
-            </div>
 
-            {/* Owner + visitor actions. Share is on for everyone so a
+                {/* External links */}
+                {externalUrls.length > 0 ? (
+                  <div className="mt-4 flex flex-wrap items-center justify-center gap-2 lg:justify-start">
+                    {externalUrls.map((e) => (
+                      <ProfileExternalLink
+                        key={e.url}
+                        handle={publicHandle}
+                        url={e.url}
+                        label={e.label}
+                      />
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+
+              {/* Owner + visitor actions. Share is on for everyone so a
                 fan can spread a profile they liked, the same growth
                 motion as the creator promoting their own page. */}
-            <div className="flex flex-wrap items-center justify-center gap-2 lg:justify-end">
-              <ProfileShareButton
-                handle={publicHandle}
-                displayName={displayName}
-              />
-              {isOwner ? (
-                <ProfileInlineEditor
+              <div className="flex flex-wrap items-center justify-center gap-2 lg:justify-end">
+                <ProfileShareButton
                   handle={publicHandle}
-                  initialDisplayName={displayName}
-                  initialBio={bio}
-                  initialFeaturedSlugs={featuredSlugs}
-                  approvedPets={pets.map((p) => ({
-                    slug: p.slug,
-                    displayName: p.displayName,
-                  }))}
+                  displayName={displayName}
                 />
-              ) : null}
-            </div>
-          </header>
-        </div>
-      </section>
+                {isOwner ? (
+                  <ProfileInlineEditor
+                    handle={publicHandle}
+                    initialDisplayName={displayName}
+                    initialBio={bio}
+                    initialFeaturedSlugs={featuredSlugs}
+                    approvedPets={pets.map((p) => ({
+                      slug: p.slug,
+                      displayName: p.displayName,
+                    }))}
+                  />
+                ) : null}
+              </div>
+            </header>
+          </div>
+        </section>
 
-      <section className="mx-auto flex w-full max-w-[1440px] flex-col gap-8 px-5 py-12 md:px-8 md:py-16">
-        <ProfilePinningSurface
-          isOwner={isOwner}
-          publicHandle={publicHandle}
-          pets={pets}
-          initialPinnedSlugs={featuredSlugs}
-          ownerSubmissions={ownerSubmissions}
-          likedPets={likedPets}
-          collection={
-            collection
-              ? {
-                  slug: collection.slug,
-                  title: collection.title,
-                  description: collection.description,
-                  externalUrl: collection.externalUrl,
-                  coverPetSlug: collection.coverPetSlug,
-                  petSlugs: collection.pets.map((pet) => pet.slug),
-                }
-              : null
-          }
-          canManageCollections={canManageOwnCollection}
-          collectionApprovedPets={pets.map((p) => ({
-            slug: p.slug,
-            displayName: p.displayName,
-            spritesheetUrl: p.spritesheetPath,
-          }))}
-          ownerCollections={ownerCollectionsForTabs}
-          maxOwnerCollections={MAX_OWNER_COLLECTIONS}
-        />
-      </section>
+        <section className="mx-auto flex w-full max-w-[1440px] flex-col gap-8 px-5 py-12 md:px-8 md:py-16">
+          <ProfilePinningSurface
+            isOwner={isOwner}
+            publicHandle={publicHandle}
+            pets={pets}
+            initialPinnedSlugs={featuredSlugs}
+            ownerSubmissions={ownerSubmissions}
+            likedPets={likedPets}
+            collection={
+              collection
+                ? {
+                    slug: collection.slug,
+                    title: collection.title,
+                    description: collection.description,
+                    externalUrl: collection.externalUrl,
+                    coverPetSlug: collection.coverPetSlug,
+                    petSlugs: collection.pets.map((pet) => pet.slug),
+                  }
+                : null
+            }
+            canManageCollections={canManageOwnCollection}
+            collectionApprovedPets={pets.map((p) => ({
+              slug: p.slug,
+              displayName: p.displayName,
+              spritesheetUrl: p.spritesheetPath,
+            }))}
+            ownerCollections={ownerCollectionsForTabs}
+            maxOwnerCollections={MAX_OWNER_COLLECTIONS}
+          />
+        </section>
 
-      <SiteFooter />
-    </main>
+        <SiteFooter />
+      </main>
+    </FullAuthProviders>
   );
 }

--- a/src/components/auth-badge-auth.tsx
+++ b/src/components/auth-badge-auth.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import Image from "next/image";
+import { useCallback, useEffect, useState } from "react";
+
+import { SignInButton, useAuth, useClerk, useUser } from "@clerk/nextjs";
+import { useTranslations } from "next-intl";
+
+import { isAdminClientSafe } from "@/lib/admin";
+import { cn } from "@/lib/utils";
+
+import { useAuthIntent } from "@/components/auth-intent";
+import { useHeaderState } from "@/components/header-state-provider";
+import { NotificationsBell } from "@/components/notifications-bell";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { UserDropdownContentProps } from "@/components/user-dropdown-content";
+
+function loadUserDropdownContent() {
+  return import("@/components/user-dropdown-content");
+}
+
+function preloadUserDropdownContent() {
+  void loadUserDropdownContent();
+}
+
+const UserDropdownContent = dynamic<UserDropdownContentProps>(
+  () => loadUserDropdownContent().then((mod) => mod.UserDropdownContent),
+  {
+    loading: UserDropdownContentLoading,
+    ssr: false,
+  },
+);
+
+export function AuthBadge({ compact = false }: { compact?: boolean }) {
+  const { isLoaded, isSignedIn } = useAuth();
+  const { openSignIn } = useClerk();
+  const { consumeAuthIntent, intentVersion } = useAuthIntent();
+  const t = useTranslations("header");
+
+  useEffect(() => {
+    if (!isLoaded || isSignedIn || intentVersion === 0) return;
+    consumeAuthIntent(intentVersion);
+    openSignIn();
+  }, [consumeAuthIntent, intentVersion, isLoaded, isSignedIn, openSignIn]);
+
+  return (
+    <div className="flex items-center gap-2">
+      {!isLoaded ? (
+        // While Clerk hydrates, reserve space for the largest possible
+        // signed-in slot (bell + avatar) so the rest of the header
+        // doesn't shift when auth resolves.
+        <>
+          <BellSkeleton compact={compact} />
+          <AvatarSkeleton compact={compact} />
+        </>
+      ) : isSignedIn ? (
+        <>
+          <NotificationsBell compact={compact} />
+          <UserDropdown compact={compact} />
+        </>
+      ) : (
+        <SignInButton mode="modal">
+          <Button
+            variant="petdex-pill"
+            type="button"
+            className={cn(
+              "px-4 font-medium transition-[height,font-size] duration-200",
+              compact ? "h-9 text-xs" : "h-11 text-sm",
+            )}
+          >
+            {t("signIn")}
+          </Button>
+        </SignInButton>
+      )}
+    </div>
+  );
+}
+
+function BellSkeleton({ compact }: { compact: boolean }) {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "animate-pulse rounded-full border border-border-base bg-surface-muted/60 transition-[width,height] duration-200",
+        compact ? "size-9" : "size-11",
+      )}
+    />
+  );
+}
+
+function UserDropdown({ compact = false }: { compact?: boolean }) {
+  const { user, isLoaded } = useUser();
+  const { signOut, openUserProfile } = useClerk();
+  const showAdmin = isAdminClientSafe(user?.id);
+  const headerState = useHeaderState().state;
+  const unread = headerState.feedback.count;
+  const dbHandle = headerState.profile?.handle ?? null;
+  const t = useTranslations("header");
+  const [menuOpen, setMenuOpen] = useState(false);
+  const adminHref =
+    process.env.NEXT_PUBLIC_PETDEX_ADMIN_URL?.replace(/\/$/, "") ||
+    "https://admin.petdex.dev";
+  const handleManageAccount = useCallback(() => {
+    openUserProfile();
+  }, [openUserProfile]);
+  const handleSignOut = useCallback(() => {
+    void signOut({ redirectUrl: "/" });
+  }, [signOut]);
+
+  if (!isLoaded || !user) {
+    return <AvatarSkeleton compact={compact} />;
+  }
+
+  const handle =
+    dbHandle ??
+    (user.username
+      ? user.username.toLowerCase()
+      : user.id.slice(-8).toLowerCase());
+  const avatarUrl = user.imageUrl;
+  const displayName =
+    user.fullName || user.username || user.primaryEmailAddress?.emailAddress;
+  const email = user.primaryEmailAddress?.emailAddress ?? null;
+
+  return (
+    <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+      <DropdownMenuTrigger
+        render={
+          <button
+            type="button"
+            aria-label={t("openUserMenu")}
+            onFocus={preloadUserDropdownContent}
+            onPointerEnter={preloadUserDropdownContent}
+            className={cn(
+              "group/avatar relative grid place-items-center overflow-hidden rounded-full ring-1 ring-foreground/10 transition-[width,height] duration-200 hover:ring-foreground/30 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none data-popup-open:ring-foreground/30",
+              compact ? "size-9" : "size-11",
+            )}
+          />
+        }
+      >
+        <Image
+          src={avatarUrl}
+          alt={displayName ?? "User avatar"}
+          width={44}
+          height={44}
+          className="size-full object-cover"
+        />
+        {unread > 0 ? (
+          <span
+            aria-hidden
+            className="pointer-events-none absolute -top-0.5 -right-0.5 grid size-4 place-items-center rounded-full bg-brand font-mono text-[9px] font-semibold text-white ring-2 ring-surface"
+          >
+            {unread > 9 ? "9+" : unread}
+          </span>
+        ) : null}
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="end" sideOffset={8} className="w-64 p-1.5">
+        {menuOpen ? (
+          <UserDropdownContent
+            adminHref={adminHref}
+            displayName={displayName ?? null}
+            email={email}
+            handle={handle}
+            onManageAccount={handleManageAccount}
+            onSignOut={handleSignOut}
+            showAdmin={showAdmin}
+            unread={unread}
+          />
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function AvatarSkeleton({ compact = false }: { compact?: boolean }) {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "animate-pulse rounded-full bg-surface-muted ring-1 ring-foreground/10 transition-[width,height] duration-200",
+        compact ? "size-9" : "size-11",
+      )}
+    />
+  );
+}
+
+function UserDropdownContentLoading() {
+  return (
+    <div aria-hidden="true" className="space-y-1 p-2">
+      <div className="mb-2 space-y-1 px-1">
+        <div className="h-4 w-28 animate-pulse rounded bg-surface-muted" />
+        <div className="h-3 w-36 animate-pulse rounded bg-surface-muted/80" />
+      </div>
+      <div className="h-px bg-border-base" />
+      <div className="h-8 animate-pulse rounded-xl bg-surface-muted/70" />
+      <div className="h-8 animate-pulse rounded-xl bg-surface-muted/70" />
+      <div className="h-px bg-border-base" />
+      <div className="h-8 animate-pulse rounded-xl bg-surface-muted/70" />
+      <div className="h-8 animate-pulse rounded-xl bg-surface-muted/70" />
+    </div>
+  );
+}

--- a/src/components/auth-badge.tsx
+++ b/src/components/auth-badge.tsx
@@ -1,199 +1,46 @@
 "use client";
 
-import dynamic from "next/dynamic";
-import Image from "next/image";
-import { useCallback, useState } from "react";
+import { useEffect, useState } from "react";
 
-import { SignInButton, useAuth, useClerk, useUser } from "@clerk/nextjs";
 import { useTranslations } from "next-intl";
 
-import { isAdminClientSafe } from "@/lib/admin";
 import { cn } from "@/lib/utils";
 
-import { useHeaderState } from "@/components/header-state-provider";
-import { NotificationsBell } from "@/components/notifications-bell";
+import { useAuthIntent } from "@/components/auth-intent";
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import type { UserDropdownContentProps } from "@/components/user-dropdown-content";
 
-function loadUserDropdownContent() {
-  return import("@/components/user-dropdown-content");
-}
-
-function preloadUserDropdownContent() {
-  void loadUserDropdownContent();
-}
-
-const UserDropdownContent = dynamic<UserDropdownContentProps>(
-  () => loadUserDropdownContent().then((mod) => mod.UserDropdownContent),
-  {
-    loading: UserDropdownContentLoading,
-    ssr: false,
-  },
-);
+type AuthBadgeComponent = React.ComponentType<{ compact?: boolean }>;
 
 export function AuthBadge({ compact = false }: { compact?: boolean }) {
-  const { isLoaded, isSignedIn } = useAuth();
+  const { authActive, requestAuth } = useAuthIntent();
+  const [AuthBadgeAuth, setAuthBadgeAuth] = useState<AuthBadgeComponent | null>(
+    null,
+  );
   const t = useTranslations("header");
 
-  return (
-    <div className="flex items-center gap-2">
-      {!isLoaded ? (
-        // While Clerk hydrates, reserve space for the largest possible
-        // signed-in slot (bell + avatar) so the rest of the header
-        // doesn't shift when auth resolves.
-        <>
-          <BellSkeleton compact={compact} />
-          <AvatarSkeleton compact={compact} />
-        </>
-      ) : isSignedIn ? (
-        <>
-          <NotificationsBell compact={compact} />
-          <UserDropdown compact={compact} />
-        </>
-      ) : (
-        <SignInButton mode="modal">
-          <Button
-            variant="petdex-pill"
-            type="button"
-            className={cn(
-              "px-4 font-medium transition-[height,font-size] duration-200",
-              compact ? "h-9 text-xs" : "h-11 text-sm",
-            )}
-          >
-            {t("signIn")}
-          </Button>
-        </SignInButton>
-      )}
-    </div>
-  );
-}
+  useEffect(() => {
+    if (!authActive || AuthBadgeAuth) return;
+    let cancelled = false;
+    void import("@/components/auth-badge-auth").then((mod) => {
+      if (!cancelled) setAuthBadgeAuth(() => mod.AuthBadge);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [AuthBadgeAuth, authActive]);
 
-function BellSkeleton({ compact }: { compact: boolean }) {
+  if (authActive && AuthBadgeAuth) return <AuthBadgeAuth compact={compact} />;
   return (
-    <div
-      aria-hidden
+    <Button
+      variant="petdex-pill"
+      type="button"
+      onClick={requestAuth}
       className={cn(
-        "animate-pulse rounded-full border border-border-base bg-surface-muted/60 transition-[width,height] duration-200",
-        compact ? "size-9" : "size-11",
+        "px-4 font-medium transition-[height,font-size] duration-200",
+        compact ? "h-9 text-xs" : "h-11 text-sm",
       )}
-    />
-  );
-}
-
-function UserDropdown({ compact = false }: { compact?: boolean }) {
-  const { user, isLoaded } = useUser();
-  const { signOut, openUserProfile } = useClerk();
-  const showAdmin = isAdminClientSafe(user?.id);
-  const headerState = useHeaderState().state;
-  const unread = headerState.feedback.count;
-  const dbHandle = headerState.profile?.handle ?? null;
-  const t = useTranslations("header");
-  const [menuOpen, setMenuOpen] = useState(false);
-  const adminHref =
-    process.env.NEXT_PUBLIC_PETDEX_ADMIN_URL?.replace(/\/$/, "") ||
-    "https://admin.petdex.dev";
-  const handleManageAccount = useCallback(() => {
-    openUserProfile();
-  }, [openUserProfile]);
-  const handleSignOut = useCallback(() => {
-    void signOut({ redirectUrl: "/" });
-  }, [signOut]);
-
-  if (!isLoaded || !user) {
-    return <AvatarSkeleton compact={compact} />;
-  }
-
-  const handle =
-    dbHandle ??
-    (user.username
-      ? user.username.toLowerCase()
-      : user.id.slice(-8).toLowerCase());
-  const avatarUrl = user.imageUrl;
-  const displayName =
-    user.fullName || user.username || user.primaryEmailAddress?.emailAddress;
-  const email = user.primaryEmailAddress?.emailAddress ?? null;
-
-  return (
-    <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
-      <DropdownMenuTrigger
-        render={
-          <button
-            type="button"
-            aria-label={t("openUserMenu")}
-            onFocus={preloadUserDropdownContent}
-            onPointerEnter={preloadUserDropdownContent}
-            className={cn(
-              "group/avatar relative grid place-items-center overflow-hidden rounded-full ring-1 ring-foreground/10 transition-[width,height] duration-200 hover:ring-foreground/30 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none data-popup-open:ring-foreground/30",
-              compact ? "size-9" : "size-11",
-            )}
-          />
-        }
-      >
-        <Image
-          src={avatarUrl}
-          alt={displayName ?? "User avatar"}
-          width={44}
-          height={44}
-          className="size-full object-cover"
-        />
-        {unread > 0 ? (
-          <span
-            aria-hidden
-            className="pointer-events-none absolute -top-0.5 -right-0.5 grid size-4 place-items-center rounded-full bg-brand font-mono text-[9px] font-semibold text-white ring-2 ring-surface"
-          >
-            {unread > 9 ? "9+" : unread}
-          </span>
-        ) : null}
-      </DropdownMenuTrigger>
-
-      <DropdownMenuContent align="end" sideOffset={8} className="w-64 p-1.5">
-        {menuOpen ? (
-          <UserDropdownContent
-            adminHref={adminHref}
-            displayName={displayName ?? null}
-            email={email}
-            handle={handle}
-            onManageAccount={handleManageAccount}
-            onSignOut={handleSignOut}
-            showAdmin={showAdmin}
-            unread={unread}
-          />
-        ) : null}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
-
-function AvatarSkeleton({ compact = false }: { compact?: boolean }) {
-  return (
-    <div
-      aria-hidden
-      className={cn(
-        "animate-pulse rounded-full bg-surface-muted ring-1 ring-foreground/10 transition-[width,height] duration-200",
-        compact ? "size-9" : "size-11",
-      )}
-    />
-  );
-}
-
-function UserDropdownContentLoading() {
-  return (
-    <div aria-hidden="true" className="space-y-1 p-2">
-      <div className="mb-2 space-y-1 px-1">
-        <div className="h-4 w-28 animate-pulse rounded bg-surface-muted" />
-        <div className="h-3 w-36 animate-pulse rounded bg-surface-muted/80" />
-      </div>
-      <div className="h-px bg-border-base" />
-      <div className="h-8 animate-pulse rounded-xl bg-surface-muted/70" />
-      <div className="h-8 animate-pulse rounded-xl bg-surface-muted/70" />
-      <div className="h-px bg-border-base" />
-      <div className="h-8 animate-pulse rounded-xl bg-surface-muted/70" />
-      <div className="h-8 animate-pulse rounded-xl bg-surface-muted/70" />
-    </div>
+    >
+      {t("signIn")}
+    </Button>
   );
 }

--- a/src/components/auth-feedback-widget.tsx
+++ b/src/components/auth-feedback-widget.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { useAuthIntent } from "@/components/auth-intent";
+
+type FeedbackWidgetComponent = React.ComponentType;
+
+export function AuthFeedbackWidget() {
+  const { authActive } = useAuthIntent();
+  const [FeedbackWidget, setFeedbackWidget] =
+    useState<FeedbackWidgetComponent | null>(null);
+
+  useEffect(() => {
+    if (!authActive || FeedbackWidget) return;
+    let cancelled = false;
+    void import("@/components/feedback-widget").then((mod) => {
+      if (!cancelled) setFeedbackWidget(() => mod.FeedbackWidget);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [FeedbackWidget, authActive]);
+
+  if (!FeedbackWidget) return null;
+  return authActive ? <FeedbackWidget /> : null;
+}

--- a/src/components/auth-intent.tsx
+++ b/src/components/auth-intent.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+type AuthIntentContextValue = {
+  authActive: boolean;
+  intentVersion: number;
+  requestAuth: () => void;
+  consumeAuthIntent: (version: number) => void;
+};
+
+const AuthIntentContext = createContext<AuthIntentContextValue | null>(null);
+
+function hasClerkSessionCookie(): boolean {
+  return document.cookie.split(";").some((part) => {
+    const name = part.trim().split("=", 1)[0];
+    return name === "__session" || name.startsWith("__session_");
+  });
+}
+
+function urlRequestsAuth(): boolean {
+  const params = new URLSearchParams(window.location.search);
+  return (
+    params.get("signin") === "1" ||
+    params.get("signIn") === "1" ||
+    params.get("auth") === "1"
+  );
+}
+
+export function AuthIntentProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [authActive, setAuthActive] = useState(false);
+  const [intentVersion, setIntentVersion] = useState(0);
+
+  const requestAuth = useCallback(() => {
+    setAuthActive(true);
+    setIntentVersion((current) => current + 1);
+  }, []);
+
+  const consumeAuthIntent = useCallback((version: number) => {
+    setIntentVersion((current) => (current === version ? 0 : current));
+  }, []);
+
+  useEffect(() => {
+    if (hasClerkSessionCookie()) {
+      setAuthActive(true);
+    }
+    if (urlRequestsAuth()) {
+      requestAuth();
+    }
+    const onAuthIntent = () => requestAuth();
+    window.addEventListener("petdex:auth-intent", onAuthIntent);
+    return () => {
+      window.removeEventListener("petdex:auth-intent", onAuthIntent);
+    };
+  }, [requestAuth]);
+
+  const value = useMemo(
+    () => ({ authActive, consumeAuthIntent, intentVersion, requestAuth }),
+    [authActive, consumeAuthIntent, intentVersion, requestAuth],
+  );
+
+  return (
+    <AuthIntentContext.Provider value={value}>
+      {children}
+    </AuthIntentContext.Provider>
+  );
+}
+
+export function useAuthIntent(): AuthIntentContextValue {
+  const ctx = useContext(AuthIntentContext);
+  if (ctx) return ctx;
+  return {
+    authActive: false,
+    consumeAuthIntent: () => {},
+    intentVersion: 0,
+    requestAuth: () => {},
+  };
+}

--- a/src/components/auth-providers.tsx
+++ b/src/components/auth-providers.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { ClerkProvider } from "@clerk/nextjs";
+import { useLocale } from "next-intl";
+import { useTheme } from "next-themes";
+
+import { HeaderStateProvider } from "@/components/header-state-provider";
+
+type ClerkProviderProps = React.ComponentProps<typeof ClerkProvider>;
+type ClerkAppearance = NonNullable<ClerkProviderProps["appearance"]>;
+
+function ClerkWithTheme({ children }: { children: React.ReactNode }) {
+  const { resolvedTheme } = useTheme();
+  const locale = useLocale();
+  const [mounted, setMounted] = useState(false);
+  const [baseTheme, setBaseTheme] =
+    useState<ClerkAppearance["baseTheme"]>(undefined);
+  const [localization, setLocalization] =
+    useState<ClerkProviderProps["localization"]>(undefined);
+
+  useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (mounted && resolvedTheme === "dark") {
+      void import("@clerk/themes").then((mod) => {
+        if (!cancelled) setBaseTheme(mod.dark);
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+    setBaseTheme(undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [mounted, resolvedTheme]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (locale === "es") {
+      void import("@clerk/localizations/es-ES").then((mod) => {
+        if (cancelled) return;
+        setLocalization(mod.esES);
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+    if (locale === "zh") {
+      void import("@clerk/localizations/zh-CN").then((mod) => {
+        if (cancelled) return;
+        setLocalization(mod.zhCN);
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+    setLocalization(undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [locale]);
+
+  return (
+    <ClerkProvider appearance={{ baseTheme }} localization={localization}>
+      {children}
+    </ClerkProvider>
+  );
+}
+
+export function FullAuthProviders({ children }: { children: React.ReactNode }) {
+  return (
+    <ClerkWithTheme>
+      <HeaderStateProvider>{children}</HeaderStateProvider>
+    </ClerkWithTheme>
+  );
+}

--- a/src/components/claim-cta-auth.tsx
+++ b/src/components/claim-cta-auth.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { SignInButton, useUser } from "@clerk/nextjs";
+import { ArrowRight } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+// Inline "Is this you?" prompt shown on /pets/[slug] for discovered
+// pets when the viewer is either signed-out or signed in as someone
+// other than the listed author. Pushes them to sign in with the
+// expectation that the claim banner on /u/<handle> will pick the row
+// up automatically (case-insensitive github match landed earlier).
+export function ClaimCTA({
+  petName,
+  authorLabel,
+  githubUrl,
+}: {
+  petName: string;
+  authorLabel: string;
+  githubUrl: string | null;
+}) {
+  const t = useTranslations("claim");
+  const { isLoaded, isSignedIn, user } = useUser();
+  if (!isLoaded) return null;
+
+  // If signed in and the viewer's github already matches, hide. The
+  // banner on /u/<handle> will surface the actual claim button there.
+  // We only check github match here — if their email matches but no
+  // github linked, the banner still shows so they're nudged into
+  // adding GitHub OAuth which makes the claim cleaner.
+  if (isSignedIn && githubUrl && user) {
+    const externals = (user.externalAccounts ?? []) as Array<{
+      provider?: string;
+      username?: string;
+    }>;
+    const myGh = externals.find((a) => a.provider === "oauth_github")?.username;
+    if (myGh) {
+      const myGhUrl = `https://github.com/${myGh}`.toLowerCase();
+      if (myGhUrl === githubUrl.toLowerCase()) return null;
+    }
+  }
+
+  const inner = (
+    <span className="inline-flex h-10 items-center gap-1.5 rounded-full bg-inverse px-4 text-sm font-medium text-on-inverse transition hover:bg-inverse-hover">
+      {t("cta")}
+      <ArrowRight className="size-4" />
+    </span>
+  );
+
+  return (
+    <aside className="mt-3 flex flex-wrap items-center gap-3 rounded-2xl border border-chip-warning-fg/30 bg-chip-warning-bg p-4 text-sm text-chip-warning-fg">
+      <span className="flex-1 leading-6">
+        {t.rich("body", {
+          author: authorLabel,
+          petName,
+          strong: (chunks) => (
+            <strong className="font-semibold">{chunks}</strong>
+          ),
+        })}
+      </span>
+      {isSignedIn ? (
+        // Already signed in — send them to their own profile where the
+        // claim banner inside ProfileTabs does the actual transfer.
+        <a href={profileHrefForUser(user)} className="inline-flex">
+          {inner}
+        </a>
+      ) : (
+        <SignInButton mode="modal" forceRedirectUrl="/" fallbackRedirectUrl="/">
+          <button type="button" className="inline-flex">
+            {inner}
+          </button>
+        </SignInButton>
+      )}
+    </aside>
+  );
+}
+
+function profileHrefForUser(
+  user: { username?: string | null; id: string } | null | undefined,
+): string {
+  if (!user) return "/";
+  const handle = user.username
+    ? user.username.toLowerCase()
+    : user.id.slice(-8).toLowerCase();
+  return `/u/${handle}`;
+}

--- a/src/components/claim-cta.tsx
+++ b/src/components/claim-cta.tsx
@@ -1,43 +1,39 @@
 "use client";
 
-import { SignInButton, useUser } from "@clerk/nextjs";
+import { useEffect, useState } from "react";
+
 import { ArrowRight } from "lucide-react";
 import { useTranslations } from "next-intl";
 
-// Inline "Is this you?" prompt shown on /pets/[slug] for discovered
-// pets when the viewer is either signed-out or signed in as someone
-// other than the listed author. Pushes them to sign in with the
-// expectation that the claim banner on /u/<handle> will pick the row
-// up automatically (case-insensitive github match landed earlier).
-export function ClaimCTA({
-  petName,
-  authorLabel,
-  githubUrl,
-}: {
+import { useAuthIntent } from "@/components/auth-intent";
+
+type ClaimCTAProps = {
   petName: string;
   authorLabel: string;
   githubUrl: string | null;
-}) {
-  const t = useTranslations("claim");
-  const { isLoaded, isSignedIn, user } = useUser();
-  if (!isLoaded) return null;
+};
 
-  // If signed in and the viewer's github already matches, hide. The
-  // banner on /u/<handle> will surface the actual claim button there.
-  // We only check github match here — if their email matches but no
-  // github linked, the banner still shows so they're nudged into
-  // adding GitHub OAuth which makes the claim cleaner.
-  if (isSignedIn && githubUrl && user) {
-    const externals = (user.externalAccounts ?? []) as Array<{
-      provider?: string;
-      username?: string;
-    }>;
-    const myGh = externals.find((a) => a.provider === "oauth_github")?.username;
-    if (myGh) {
-      const myGhUrl = `https://github.com/${myGh}`.toLowerCase();
-      if (myGhUrl === githubUrl.toLowerCase()) return null;
-    }
-  }
+type ClaimCTAComponent = React.ComponentType<ClaimCTAProps>;
+
+export function ClaimCTA(props: ClaimCTAProps) {
+  const { authActive, requestAuth } = useAuthIntent();
+  const [AuthClaimCTA, setAuthClaimCTA] = useState<ClaimCTAComponent | null>(
+    null,
+  );
+  const t = useTranslations("claim");
+
+  useEffect(() => {
+    if (!authActive || AuthClaimCTA) return;
+    let cancelled = false;
+    void import("@/components/claim-cta-auth").then((mod) => {
+      if (!cancelled) setAuthClaimCTA(() => mod.ClaimCTA);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [AuthClaimCTA, authActive]);
+
+  if (authActive && AuthClaimCTA) return <AuthClaimCTA {...props} />;
 
   const inner = (
     <span className="inline-flex h-10 items-center gap-1.5 rounded-full bg-inverse px-4 text-sm font-medium text-on-inverse transition hover:bg-inverse-hover">
@@ -50,36 +46,16 @@ export function ClaimCTA({
     <aside className="mt-3 flex flex-wrap items-center gap-3 rounded-2xl border border-chip-warning-fg/30 bg-chip-warning-bg p-4 text-sm text-chip-warning-fg">
       <span className="flex-1 leading-6">
         {t.rich("body", {
-          author: authorLabel,
-          petName,
+          author: props.authorLabel,
+          petName: props.petName,
           strong: (chunks) => (
             <strong className="font-semibold">{chunks}</strong>
           ),
         })}
       </span>
-      {isSignedIn ? (
-        // Already signed in — send them to their own profile where the
-        // claim banner inside ProfileTabs does the actual transfer.
-        <a href={profileHrefForUser(user)} className="inline-flex">
-          {inner}
-        </a>
-      ) : (
-        <SignInButton mode="modal" forceRedirectUrl="/" fallbackRedirectUrl="/">
-          <button type="button" className="inline-flex">
-            {inner}
-          </button>
-        </SignInButton>
-      )}
+      <button type="button" onClick={requestAuth} className="inline-flex">
+        {inner}
+      </button>
     </aside>
   );
-}
-
-function profileHrefForUser(
-  user: { username?: string | null; id: string } | null | undefined,
-): string {
-  if (!user) return "/";
-  const handle = user.username
-    ? user.username.toLowerCase()
-    : user.id.slice(-8).toLowerCase();
-  return `/u/${handle}`;
 }

--- a/src/components/claim-request-button-auth.tsx
+++ b/src/components/claim-request-button-auth.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useState } from "react";
+
+import { useAuth, useClerk } from "@clerk/nextjs";
+import { Check, HandHeart, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+type ApprovedPet = {
+  id: string;
+  slug: string;
+  displayName: string;
+  spritesheetUrl: string;
+};
+
+export function ClaimRequestButton({
+  requestId,
+  requestQuery,
+}: {
+  requestId: string;
+  requestQuery: string;
+}) {
+  const { isLoaded, isSignedIn } = useAuth();
+  const { openSignIn } = useClerk();
+  const [open, setOpen] = useState(false);
+  const [pets, setPets] = useState<ApprovedPet[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  // Fetch approved pets only when the dialog opens (avoids one fetch
+  // per visible request card on /requests).
+  useEffect(() => {
+    if (!open || pets !== null) return;
+    setLoading(true);
+    setError(null);
+    void fetch("/api/my-pets/approved", { cache: "no-store" })
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error(`Failed (${res.status})`);
+        }
+        const data = (await res.json()) as { pets: ApprovedPet[] };
+        setPets(data.pets);
+      })
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [open, pets]);
+
+  function handleTriggerClick(e: React.MouseEvent) {
+    if (!isLoaded) return;
+    if (!isSignedIn) {
+      e.preventDefault();
+      openSignIn();
+    }
+  }
+
+  async function submit() {
+    if (!selected) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/pet-requests/${requestId}/candidates`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ petId: selected }),
+      });
+      if (!res.ok) {
+        const j = (await res.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        throw new Error(j?.error ?? `Failed (${res.status})`);
+      }
+      setDone(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function reset() {
+    setOpen(false);
+    setTimeout(() => {
+      setSelected(null);
+      setError(null);
+      setDone(false);
+    }, 200);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger
+        render={
+          <button
+            type="button"
+            onClick={handleTriggerClick}
+            className="inline-flex items-center gap-1.5 rounded-full border border-border-base bg-surface-muted px-2.5 py-1 font-mono text-[11px] tracking-[0.04em] text-muted-2 transition hover:border-brand/30 hover:bg-brand-tint hover:text-brand-deep dark:hover:bg-brand-tint-dark"
+          >
+            <HandHeart className="size-3" />I have a pet for this
+          </button>
+        }
+      />
+      <DialogContent className="sm:max-w-md">
+        {done ? (
+          <>
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2 text-base">
+                <Check className="size-4 text-chip-success-fg" />
+                Submitted
+              </DialogTitle>
+              <DialogDescription>
+                Your pet is now pending admin review for this request. You'll
+                get a notification if it's approved.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="petdex-cta"
+                onClick={reset}
+                className="px-4 text-sm"
+              >
+                Done
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle className="text-base">
+                Claim "{requestQuery}"
+              </DialogTitle>
+              <DialogDescription>
+                Pick one of your approved pets. Admin will review and confirm
+                the match.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="max-h-72 overflow-y-auto">
+              {loading ? (
+                <div className="flex items-center justify-center py-8">
+                  <Loader2 className="size-4 animate-spin text-muted-3" />
+                </div>
+              ) : pets && pets.length === 0 ? (
+                <div className="rounded-xl border border-dashed border-border-base p-4 text-center text-sm text-muted-2">
+                  You don't have any approved pets yet.
+                  <a
+                    href="/submit"
+                    className="ml-1 font-medium text-brand-deep underline"
+                  >
+                    Submit one →
+                  </a>
+                </div>
+              ) : (
+                <ul className="grid gap-1">
+                  {pets?.map((pet) => {
+                    const active = selected === pet.id;
+                    return (
+                      <li key={pet.id}>
+                        <button
+                          type="button"
+                          onClick={() => setSelected(pet.id)}
+                          className={`flex w-full items-center gap-3 rounded-xl border p-2 text-left transition ${
+                            active
+                              ? "border-brand bg-brand-tint dark:bg-brand-tint-dark"
+                              : "border-transparent hover:bg-surface-muted"
+                          }`}
+                        >
+                          <Image
+                            src={pet.spritesheetUrl}
+                            alt=""
+                            width={40}
+                            height={40}
+                            className="size-10 shrink-0 rounded-lg bg-surface-muted object-cover"
+                          />
+                          <span className="flex-1 truncate text-sm text-foreground">
+                            {pet.displayName}
+                          </span>
+                          {active ? (
+                            <Check className="size-4 shrink-0 text-brand" />
+                          ) : null}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+
+            {error ? (
+              <p className="rounded-lg bg-chip-danger-bg p-2 font-mono text-[10px] text-chip-danger-fg">
+                {error === "exists"
+                  ? "Already submitted as candidate."
+                  : error === "request_not_open"
+                    ? "This request is no longer open."
+                    : error === "pet_not_approved"
+                      ? "Pet must be approved first."
+                      : error}
+              </p>
+            ) : null}
+
+            <DialogFooter>
+              <DialogClose
+                render={
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="text-sm text-muted-2"
+                  >
+                    Cancel
+                  </Button>
+                }
+              />
+              <Button
+                type="button"
+                variant="petdex-cta"
+                disabled={!selected || submitting}
+                onClick={submit}
+                className="px-4 text-sm"
+              >
+                {submitting ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : null}
+                Submit candidate
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/claim-request-button.tsx
+++ b/src/components/claim-request-button.tsx
@@ -1,246 +1,45 @@
 "use client";
 
-import Image from "next/image";
 import { useEffect, useState } from "react";
 
-import { useAuth, useClerk } from "@clerk/nextjs";
-import { Check, HandHeart, Loader2 } from "lucide-react";
+import { HandHeart } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
+import { useAuthIntent } from "@/components/auth-intent";
 
-type ApprovedPet = {
-  id: string;
-  slug: string;
-  displayName: string;
-  spritesheetUrl: string;
-};
-
-export function ClaimRequestButton({
-  requestId,
-  requestQuery,
-}: {
+type ClaimRequestButtonProps = {
   requestId: string;
   requestQuery: string;
-}) {
-  const { isLoaded, isSignedIn } = useAuth();
-  const { openSignIn } = useClerk();
-  const [open, setOpen] = useState(false);
-  const [pets, setPets] = useState<ApprovedPet[] | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [selected, setSelected] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [done, setDone] = useState(false);
+};
 
-  // Fetch approved pets only when the dialog opens (avoids one fetch
-  // per visible request card on /requests).
+type ClaimRequestButtonComponent = React.ComponentType<ClaimRequestButtonProps>;
+
+export function ClaimRequestButton(props: ClaimRequestButtonProps) {
+  const { authActive, requestAuth } = useAuthIntent();
+  const [AuthClaimRequestButton, setAuthClaimRequestButton] =
+    useState<ClaimRequestButtonComponent | null>(null);
+
   useEffect(() => {
-    if (!open || pets !== null) return;
-    setLoading(true);
-    setError(null);
-    void fetch("/api/my-pets/approved", { cache: "no-store" })
-      .then(async (res) => {
-        if (!res.ok) {
-          throw new Error(`Failed (${res.status})`);
-        }
-        const data = (await res.json()) as { pets: ApprovedPet[] };
-        setPets(data.pets);
-      })
-      .catch((err) => setError(err.message))
-      .finally(() => setLoading(false));
-  }, [open, pets]);
+    if (!authActive || AuthClaimRequestButton) return;
+    let cancelled = false;
+    void import("@/components/claim-request-button-auth").then((mod) => {
+      if (!cancelled) setAuthClaimRequestButton(() => mod.ClaimRequestButton);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [AuthClaimRequestButton, authActive]);
 
-  function handleTriggerClick(e: React.MouseEvent) {
-    if (!isLoaded) return;
-    if (!isSignedIn) {
-      e.preventDefault();
-      openSignIn();
-    }
-  }
-
-  async function submit() {
-    if (!selected) return;
-    setSubmitting(true);
-    setError(null);
-    try {
-      const res = await fetch(`/api/pet-requests/${requestId}/candidates`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ petId: selected }),
-      });
-      if (!res.ok) {
-        const j = (await res.json().catch(() => null)) as {
-          error?: string;
-        } | null;
-        throw new Error(j?.error ?? `Failed (${res.status})`);
-      }
-      setDone(true);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Unknown error");
-    } finally {
-      setSubmitting(false);
-    }
-  }
-
-  function reset() {
-    setOpen(false);
-    setTimeout(() => {
-      setSelected(null);
-      setError(null);
-      setDone(false);
-    }, 200);
+  if (authActive && AuthClaimRequestButton) {
+    return <AuthClaimRequestButton {...props} />;
   }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger
-        render={
-          <button
-            type="button"
-            onClick={handleTriggerClick}
-            className="inline-flex items-center gap-1.5 rounded-full border border-border-base bg-surface-muted px-2.5 py-1 font-mono text-[11px] tracking-[0.04em] text-muted-2 transition hover:border-brand/30 hover:bg-brand-tint hover:text-brand-deep dark:hover:bg-brand-tint-dark"
-          >
-            <HandHeart className="size-3" />I have a pet for this
-          </button>
-        }
-      />
-      <DialogContent className="sm:max-w-md">
-        {done ? (
-          <>
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2 text-base">
-                <Check className="size-4 text-chip-success-fg" />
-                Submitted
-              </DialogTitle>
-              <DialogDescription>
-                Your pet is now pending admin review for this request. You'll
-                get a notification if it's approved.
-              </DialogDescription>
-            </DialogHeader>
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="petdex-cta"
-                onClick={reset}
-                className="px-4 text-sm"
-              >
-                Done
-              </Button>
-            </DialogFooter>
-          </>
-        ) : (
-          <>
-            <DialogHeader>
-              <DialogTitle className="text-base">
-                Claim "{requestQuery}"
-              </DialogTitle>
-              <DialogDescription>
-                Pick one of your approved pets. Admin will review and confirm
-                the match.
-              </DialogDescription>
-            </DialogHeader>
-
-            <div className="max-h-72 overflow-y-auto">
-              {loading ? (
-                <div className="flex items-center justify-center py-8">
-                  <Loader2 className="size-4 animate-spin text-muted-3" />
-                </div>
-              ) : pets && pets.length === 0 ? (
-                <div className="rounded-xl border border-dashed border-border-base p-4 text-center text-sm text-muted-2">
-                  You don't have any approved pets yet.
-                  <a
-                    href="/submit"
-                    className="ml-1 font-medium text-brand-deep underline"
-                  >
-                    Submit one →
-                  </a>
-                </div>
-              ) : (
-                <ul className="grid gap-1">
-                  {pets?.map((pet) => {
-                    const active = selected === pet.id;
-                    return (
-                      <li key={pet.id}>
-                        <button
-                          type="button"
-                          onClick={() => setSelected(pet.id)}
-                          className={`flex w-full items-center gap-3 rounded-xl border p-2 text-left transition ${
-                            active
-                              ? "border-brand bg-brand-tint dark:bg-brand-tint-dark"
-                              : "border-transparent hover:bg-surface-muted"
-                          }`}
-                        >
-                          <Image
-                            src={pet.spritesheetUrl}
-                            alt=""
-                            width={40}
-                            height={40}
-                            className="size-10 shrink-0 rounded-lg bg-surface-muted object-cover"
-                          />
-                          <span className="flex-1 truncate text-sm text-foreground">
-                            {pet.displayName}
-                          </span>
-                          {active ? (
-                            <Check className="size-4 shrink-0 text-brand" />
-                          ) : null}
-                        </button>
-                      </li>
-                    );
-                  })}
-                </ul>
-              )}
-            </div>
-
-            {error ? (
-              <p className="rounded-lg bg-chip-danger-bg p-2 font-mono text-[10px] text-chip-danger-fg">
-                {error === "exists"
-                  ? "Already submitted as candidate."
-                  : error === "request_not_open"
-                    ? "This request is no longer open."
-                    : error === "pet_not_approved"
-                      ? "Pet must be approved first."
-                      : error}
-              </p>
-            ) : null}
-
-            <DialogFooter>
-              <DialogClose
-                render={
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    className="text-sm text-muted-2"
-                  >
-                    Cancel
-                  </Button>
-                }
-              />
-              <Button
-                type="button"
-                variant="petdex-cta"
-                disabled={!selected || submitting}
-                onClick={submit}
-                className="px-4 text-sm"
-              >
-                {submitting ? (
-                  <Loader2 className="size-3 animate-spin" />
-                ) : null}
-                Submit candidate
-              </Button>
-            </DialogFooter>
-          </>
-        )}
-      </DialogContent>
-    </Dialog>
+    <button
+      type="button"
+      onClick={requestAuth}
+      className="inline-flex items-center gap-1.5 rounded-full border border-border-base bg-surface-muted px-2.5 py-1 font-mono text-[11px] tracking-[0.04em] text-muted-2 transition hover:border-brand/30 hover:bg-brand-tint hover:text-brand-deep dark:hover:bg-brand-tint-dark"
+    >
+      <HandHeart className="size-3" />I have a pet for this
+    </button>
   );
 }

--- a/src/components/collection-caught-progress-auth.tsx
+++ b/src/components/collection-caught-progress-auth.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { useHeaderState } from "@/components/header-state-provider";
+
+type Props = {
+  petSlugs: string[];
+};
+
+export function CollectionCaughtProgress({ petSlugs }: Props) {
+  const { state } = useHeaderState();
+  const caughtCount = useMemo(() => {
+    const caught = new Set(state.caught);
+    return petSlugs.filter((slug) => caught.has(slug)).length;
+  }, [petSlugs, state.caught]);
+
+  if (!state.signedIn) return null;
+
+  return (
+    <span>
+      caught {caughtCount}/{petSlugs.length}
+    </span>
+  );
+}

--- a/src/components/collection-caught-progress.tsx
+++ b/src/components/collection-caught-progress.tsx
@@ -1,25 +1,34 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useState } from "react";
 
-import { useHeaderState } from "@/components/header-state-provider";
+import { useAuthIntent } from "@/components/auth-intent";
 
 type Props = {
   petSlugs: string[];
 };
 
-export function CollectionCaughtProgress({ petSlugs }: Props) {
-  const { state } = useHeaderState();
-  const caughtCount = useMemo(() => {
-    const caught = new Set(state.caught);
-    return petSlugs.filter((slug) => caught.has(slug)).length;
-  }, [petSlugs, state.caught]);
+type CollectionCaughtProgressComponent = React.ComponentType<Props>;
 
-  if (!state.signedIn) return null;
+export function CollectionCaughtProgress(props: Props) {
+  const { authActive } = useAuthIntent();
+  const [AuthCollectionCaughtProgress, setAuthCollectionCaughtProgress] =
+    useState<CollectionCaughtProgressComponent | null>(null);
 
-  return (
-    <span>
-      caught {caughtCount}/{petSlugs.length}
-    </span>
-  );
+  useEffect(() => {
+    if (!authActive || AuthCollectionCaughtProgress) return;
+    let cancelled = false;
+    void import("@/components/collection-caught-progress-auth").then((mod) => {
+      if (!cancelled) {
+        setAuthCollectionCaughtProgress(() => mod.CollectionCaughtProgress);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [AuthCollectionCaughtProgress, authActive]);
+
+  return authActive && AuthCollectionCaughtProgress ? (
+    <AuthCollectionCaughtProgress {...props} />
+  ) : null;
 }

--- a/src/components/collection-pet-grid.tsx
+++ b/src/components/collection-pet-grid.tsx
@@ -7,7 +7,6 @@ import { useLocale } from "next-intl";
 import type { PetWithMetrics } from "@/lib/pets";
 import { cn } from "@/lib/utils";
 
-import { useHeaderState } from "@/components/header-state-provider";
 import { PetCard } from "@/components/pet-gallery";
 
 const PAGE_SIZE = 24;
@@ -20,13 +19,8 @@ type Props = {
 
 export function CollectionPetGrid({ pets, dexMap, caughtSlugs = [] }: Props) {
   const isZh = useLocale() === "zh";
-  const { state } = useHeaderState();
   const [pageCount, setPageCount] = useState(1);
-  const activeCaughtSlugs = state.signedIn ? state.caught : caughtSlugs;
-  const caughtSet = useMemo(
-    () => new Set(activeCaughtSlugs),
-    [activeCaughtSlugs],
-  );
+  const caughtSet = useMemo(() => new Set(caughtSlugs), [caughtSlugs]);
 
   const slice = useMemo(
     () => pets.slice(0, pageCount * PAGE_SIZE),

--- a/src/components/conditional-auth-providers.tsx
+++ b/src/components/conditional-auth-providers.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import { stripLocalePrefix } from "@/lib/locale-routing";
+
+import { useAuthIntent } from "@/components/auth-intent";
+
+type FullAuthProvidersComponent = React.ComponentType<{
+  children: React.ReactNode;
+}>;
+
+function isEagerAuthPath(pathname: string | null): boolean {
+  const path = stripLocalePrefix(pathname ?? "/");
+  return (
+    path === "/submit" ||
+    path === "/my-feedback" ||
+    path.startsWith("/my-feedback/") ||
+    path === "/advertise/new" ||
+    path === "/advertise/dashboard" ||
+    path.startsWith("/advertise/dashboard/") ||
+    path.startsWith("/u/")
+  );
+}
+
+export function ConditionalAuthProviders({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { authActive } = useAuthIntent();
+  const pathname = usePathname();
+  const eagerAuthPath = isEagerAuthPath(pathname);
+  const [FullAuthProviders, setFullAuthProviders] =
+    useState<FullAuthProvidersComponent | null>(null);
+
+  useEffect(() => {
+    if (eagerAuthPath || !authActive || FullAuthProviders) return;
+    let cancelled = false;
+    void import("@/components/auth-providers").then((mod) => {
+      if (!cancelled) setFullAuthProviders(() => mod.FullAuthProviders);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [FullAuthProviders, authActive, eagerAuthPath]);
+
+  if (eagerAuthPath || !authActive) return children;
+  if (!FullAuthProviders) return null;
+  return <FullAuthProviders>{children}</FullAuthProviders>;
+}

--- a/src/components/like-button-auth.tsx
+++ b/src/components/like-button-auth.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useEffect, useRef, useState, useTransition } from "react";
+
+import { useAuth, useClerk } from "@clerk/nextjs";
+import { Heart } from "lucide-react";
+import { useLocale } from "next-intl";
+
+import { formatLocalizedNumber } from "@/lib/format-number";
+import { loadPetMetrics } from "@/lib/pet-metrics-client";
+
+import { useHeaderState } from "@/components/header-state-provider";
+import { Button } from "@/components/ui/button";
+
+type LikeButtonProps = {
+  slug: string;
+};
+
+export function LikeButton({ slug }: LikeButtonProps) {
+  const [count, setCount] = useState<number | null>(null);
+  const [liked, setLiked] = useState(false);
+  const [likeStateLoading, setLikeStateLoading] = useState(false);
+  const [pending, start] = useTransition();
+  const locale = useLocale();
+  const { isLoaded, isSignedIn } = useAuth();
+  const clerk = useClerk();
+  const loadVersionRef = useRef(0);
+  const mutationVersionRef = useRef(0);
+  const { refresh } = useHeaderState();
+
+  useEffect(() => {
+    const loadVersion = loadVersionRef.current + 1;
+    loadVersionRef.current = loadVersion;
+
+    if (!isLoaded) {
+      setLikeStateLoading(true);
+      return;
+    }
+
+    const mutationVersion = mutationVersionRef.current;
+    const controller = new AbortController();
+    let active = true;
+    setLikeStateLoading(true);
+
+    // Signed-in users hit /like (returns authoritative count + their
+    // liked state). Anon visitors hit /metrics (CDN-cached, just the
+    // count). Both endpoints are safe to ignore on abort/error — the
+    // button stays in its skeleton state.
+    const url = isSignedIn
+      ? `/api/pets/${slug}/like`
+      : `/api/pets/${slug}/metrics`;
+
+    void (
+      isSignedIn
+        ? fetch(url, {
+            signal: controller.signal,
+            headers: { accept: "application/json" },
+          }).then((res) => (res.ok ? res.json() : null))
+        : loadPetMetrics(slug)
+    )
+      .then(
+        (
+          data: { liked?: boolean; count?: number; likeCount?: number } | null,
+        ) => {
+          if (!data) return;
+          if (!active) return;
+          if (loadVersionRef.current !== loadVersion) return;
+          if (mutationVersionRef.current !== mutationVersion) return;
+          if (isSignedIn) {
+            setLiked(Boolean(data.liked));
+            setCount(typeof data.count === "number" ? data.count : 0);
+          } else {
+            setLiked(false);
+            setCount(typeof data.likeCount === "number" ? data.likeCount : 0);
+          }
+        },
+      )
+      .catch((error: unknown) => {
+        if (!active) return;
+        if (loadVersionRef.current !== loadVersion) return;
+        if ((error as Error).name !== "AbortError") {
+          setLiked(false);
+        }
+      })
+      .finally(() => {
+        if (!active) return;
+        if (loadVersionRef.current === loadVersion) {
+          setLikeStateLoading(false);
+        }
+      });
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [isLoaded, isSignedIn, slug]);
+
+  function handleClick() {
+    if (!isLoaded || !isSignedIn) {
+      clerk.openSignIn({});
+      return;
+    }
+    if (pending || likeStateLoading) return;
+
+    const nextLiked = !liked;
+    const mutationVersion = mutationVersionRef.current + 1;
+    mutationVersionRef.current = mutationVersion;
+    setLiked(nextLiked);
+    setCount((c) => Math.max(0, (c ?? 0) + (nextLiked ? 1 : -1)));
+
+    start(async () => {
+      try {
+        const res = await fetch(`/api/pets/${slug}/like`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ liked: nextLiked }),
+        });
+        if (!res.ok) throw new Error("like failed");
+        const data = (await res.json()) as { liked: boolean; count: number };
+        if (mutationVersionRef.current !== mutationVersion) return;
+        setLiked(data.liked);
+        setCount(data.count);
+        void refresh({ force: true });
+      } catch {
+        if (mutationVersionRef.current !== mutationVersion) return;
+        setLiked(!nextLiked);
+        setCount((c) => Math.max(0, (c ?? 0) + (nextLiked ? -1 : 1)));
+      }
+    });
+  }
+
+  const disabled = pending || !isLoaded || likeStateLoading;
+
+  return (
+    <Button
+      variant="outline"
+      onClick={handleClick}
+      aria-pressed={liked}
+      aria-busy={disabled || undefined}
+      disabled={disabled}
+      className={`h-10 gap-2 rounded-full border px-4 text-sm font-medium transition disabled:opacity-60 ${
+        liked
+          ? "border-rose-300 bg-rose-50 text-rose-700 hover:bg-rose-100"
+          : "border-black/10 bg-surface text-muted-2 hover:border-rose-300 hover:text-rose-700"
+      } dark:bg-rose-950/40 dark:text-rose-300 dark:hover:border-rose-700`}
+    >
+      <Heart
+        className={`size-4 transition ${liked ? "fill-rose-500 text-rose-500" : ""}`}
+      />
+      <span className="font-mono text-xs tracking-[0.08em]">
+        {count === null ? "—" : formatLocalizedNumber(count, locale)}
+      </span>
+    </Button>
+  );
+}

--- a/src/components/like-button.tsx
+++ b/src/components/like-button.tsx
@@ -1,154 +1,73 @@
 "use client";
 
-import { useEffect, useRef, useState, useTransition } from "react";
+import { useEffect, useState } from "react";
 
-import { useAuth, useClerk } from "@clerk/nextjs";
 import { Heart } from "lucide-react";
 import { useLocale } from "next-intl";
 
 import { formatLocalizedNumber } from "@/lib/format-number";
 import { loadPetMetrics } from "@/lib/pet-metrics-client";
 
-import { useHeaderState } from "@/components/header-state-provider";
+import { useAuthIntent } from "@/components/auth-intent";
 import { Button } from "@/components/ui/button";
 
 type LikeButtonProps = {
   slug: string;
 };
 
+type LikeButtonComponent = React.ComponentType<LikeButtonProps>;
+
 export function LikeButton({ slug }: LikeButtonProps) {
+  const { authActive, requestAuth } = useAuthIntent();
   const [count, setCount] = useState<number | null>(null);
-  const [liked, setLiked] = useState(false);
-  const [likeStateLoading, setLikeStateLoading] = useState(false);
-  const [pending, start] = useTransition();
+  const [loading, setLoading] = useState(true);
+  const [AuthLikeButton, setAuthLikeButton] =
+    useState<LikeButtonComponent | null>(null);
   const locale = useLocale();
-  const { isLoaded, isSignedIn } = useAuth();
-  const clerk = useClerk();
-  const loadVersionRef = useRef(0);
-  const mutationVersionRef = useRef(0);
-  const { refresh } = useHeaderState();
 
   useEffect(() => {
-    const loadVersion = loadVersionRef.current + 1;
-    loadVersionRef.current = loadVersion;
+    if (!authActive || AuthLikeButton) return;
+    let cancelled = false;
+    void import("@/components/like-button-auth").then((mod) => {
+      if (!cancelled) setAuthLikeButton(() => mod.LikeButton);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [AuthLikeButton, authActive]);
 
-    if (!isLoaded) {
-      setLikeStateLoading(true);
-      return;
-    }
-
-    const mutationVersion = mutationVersionRef.current;
-    const controller = new AbortController();
+  useEffect(() => {
+    if (authActive) return;
     let active = true;
-    setLikeStateLoading(true);
-
-    // Signed-in users hit /like (returns authoritative count + their
-    // liked state). Anon visitors hit /metrics (CDN-cached, just the
-    // count). Both endpoints are safe to ignore on abort/error — the
-    // button stays in its skeleton state.
-    const url = isSignedIn
-      ? `/api/pets/${slug}/like`
-      : `/api/pets/${slug}/metrics`;
-
-    void (
-      isSignedIn
-        ? fetch(url, {
-            signal: controller.signal,
-            headers: { accept: "application/json" },
-          }).then((res) => (res.ok ? res.json() : null))
-        : loadPetMetrics(slug)
-    )
-      .then(
-        (
-          data: { liked?: boolean; count?: number; likeCount?: number } | null,
-        ) => {
-          if (!data) return;
-          if (!active) return;
-          if (loadVersionRef.current !== loadVersion) return;
-          if (mutationVersionRef.current !== mutationVersion) return;
-          if (isSignedIn) {
-            setLiked(Boolean(data.liked));
-            setCount(typeof data.count === "number" ? data.count : 0);
-          } else {
-            setLiked(false);
-            setCount(typeof data.likeCount === "number" ? data.likeCount : 0);
-          }
-        },
-      )
-      .catch((error: unknown) => {
+    setLoading(true);
+    void loadPetMetrics(slug)
+      .then((data) => {
         if (!active) return;
-        if (loadVersionRef.current !== loadVersion) return;
-        if ((error as Error).name !== "AbortError") {
-          setLiked(false);
-        }
+        setCount(typeof data?.likeCount === "number" ? data.likeCount : 0);
+      })
+      .catch(() => {
+        if (active) setCount(0);
       })
       .finally(() => {
-        if (!active) return;
-        if (loadVersionRef.current === loadVersion) {
-          setLikeStateLoading(false);
-        }
+        if (active) setLoading(false);
       });
-
     return () => {
       active = false;
-      controller.abort();
     };
-  }, [isLoaded, isSignedIn, slug]);
+  }, [authActive, slug]);
 
-  function handleClick() {
-    if (!isLoaded || !isSignedIn) {
-      clerk.openSignIn({});
-      return;
-    }
-    if (pending || likeStateLoading) return;
-
-    const nextLiked = !liked;
-    const mutationVersion = mutationVersionRef.current + 1;
-    mutationVersionRef.current = mutationVersion;
-    setLiked(nextLiked);
-    setCount((c) => Math.max(0, (c ?? 0) + (nextLiked ? 1 : -1)));
-
-    start(async () => {
-      try {
-        const res = await fetch(`/api/pets/${slug}/like`, {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ liked: nextLiked }),
-        });
-        if (!res.ok) throw new Error("like failed");
-        const data = (await res.json()) as { liked: boolean; count: number };
-        if (mutationVersionRef.current !== mutationVersion) return;
-        setLiked(data.liked);
-        setCount(data.count);
-        void refresh({ force: true });
-      } catch {
-        if (mutationVersionRef.current !== mutationVersion) return;
-        setLiked(!nextLiked);
-        setCount((c) => Math.max(0, (c ?? 0) + (nextLiked ? -1 : 1)));
-      }
-    });
-  }
-
-  const disabled = pending || !isLoaded || likeStateLoading;
+  if (authActive && AuthLikeButton) return <AuthLikeButton slug={slug} />;
 
   return (
     <Button
       variant="outline"
-      onClick={handleClick}
-      aria-pressed={liked}
-      aria-busy={disabled || undefined}
-      disabled={disabled}
-      className={`h-10 gap-2 rounded-full border px-4 text-sm font-medium transition disabled:opacity-60 ${
-        liked
-          ? "border-rose-300 bg-rose-50 text-rose-700 hover:bg-rose-100"
-          : "border-black/10 bg-surface text-muted-2 hover:border-rose-300 hover:text-rose-700"
-      } dark:bg-rose-950/40 dark:text-rose-300 dark:hover:border-rose-700`}
+      onClick={requestAuth}
+      aria-busy={loading || undefined}
+      className="h-10 gap-2 rounded-full border border-black/10 bg-surface px-4 text-sm font-medium text-muted-2 transition hover:border-rose-300 hover:text-rose-700 disabled:opacity-60 dark:bg-rose-950/40 dark:text-rose-300 dark:hover:border-rose-700"
     >
-      <Heart
-        className={`size-4 transition ${liked ? "fill-rose-500 text-rose-500" : ""}`}
-      />
+      <Heart className="size-4 transition" />
       <span className="font-mono text-xs tracking-[0.08em]">
-        {count === null ? "—" : formatLocalizedNumber(count, locale)}
+        {count === null ? "-" : formatLocalizedNumber(count, locale)}
       </span>
     </Button>
   );

--- a/src/components/mobile-header-settings.tsx
+++ b/src/components/mobile-header-settings.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { useTranslations } from "next-intl";
+
+type Controls = {
+  ThemeToggle: React.ComponentType;
+  LocaleSwitcher: React.ComponentType;
+};
+
+export function MobileHeaderSettings() {
+  const t = useTranslations("header");
+  const [controls, setControls] = useState<Controls | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void Promise.all([
+      import("@/components/theme-toggle"),
+      import("@/components/locale-switcher"),
+    ]).then(([theme, locale]) => {
+      if (!cancelled) {
+        setControls({
+          ThemeToggle: theme.ThemeToggle,
+          LocaleSwitcher: locale.LocaleSwitcher,
+        });
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div className="mt-2 border-border-base border-t px-1 pt-3">
+      <p className="px-2 pb-2 font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
+        {t("settings")}
+      </p>
+      <div className="flex items-center gap-2 px-2 pb-1">
+        {controls ? (
+          <>
+            <controls.ThemeToggle />
+            <controls.LocaleSwitcher />
+          </>
+        ) : (
+          <>
+            <span className="size-10 rounded-full border border-border-base bg-surface/70" />
+            <span className="h-10 w-20 rounded-full border border-border-base bg-surface/70" />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/optimistic-actions.test.ts
+++ b/src/components/optimistic-actions.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 
-const petCardFooterSource = readFileSync(
-  new URL("./pet-card-footer.tsx", import.meta.url),
+const petCardFooterAuthSource = readFileSync(
+  new URL("./pet-card-footer-auth.tsx", import.meta.url),
   "utf8",
 );
 
@@ -33,10 +33,12 @@ const pinnedReorderGridSource = readFileSync(
 
 describe("optimistic lightweight actions", () => {
   it("keeps card favorites instant without a loading spinner", () => {
-    expect(petCardFooterSource).not.toContain("Loader2");
-    expect(petCardFooterSource).not.toContain("setBusy");
-    expect(petCardFooterSource).toContain("JSON.stringify({ liked: next })");
-    expect(petCardFooterSource).toContain("likeRequestSeq.current !== seq");
+    expect(petCardFooterAuthSource).not.toContain("Loader2");
+    expect(petCardFooterAuthSource).not.toContain("setBusy");
+    expect(petCardFooterAuthSource).toContain(
+      "JSON.stringify({ liked: next })",
+    );
+    expect(petCardFooterAuthSource).toContain("likeRequestSeq.current !== seq");
   });
 
   it("keeps profile pins instant without a loading spinner", () => {
@@ -103,6 +105,6 @@ describe("optimistic lightweight actions", () => {
     expect(petGallerySource).not.toContain("CheckCircle2");
     expect(petGallerySource).not.toContain("caughtTitle");
     expect(petGallerySource).toContain("initialLiked={caught}");
-    expect(petCardFooterSource).toContain("setLiked(initialLiked)");
+    expect(petCardFooterAuthSource).toContain("setLiked(initialLiked)");
   });
 });

--- a/src/components/owner-pet-controls-auth.tsx
+++ b/src/components/owner-pet-controls-auth.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { useAuth } from "@clerk/nextjs";
+
+import { OwnerEditPanel } from "@/components/owner-edit-panel";
+import { SuggestCollectionButton } from "@/components/suggest-collection-button";
+
+type Pending = {
+  displayName: string | null;
+  description: string | null;
+  tags: string[] | null;
+  submittedAt: string | null;
+};
+
+type OwnerState = {
+  isOwner: boolean;
+  petId: string | null;
+  currentTags: string[];
+  pending: Pending | null;
+  lastRejection: string | null;
+  collectionSuggest: {
+    candidates: Array<{ slug: string; title: string }>;
+    alreadyRequested: string[];
+  } | null;
+};
+
+type OwnerPetControlsProps = {
+  slug: string;
+  currentDisplayName: string;
+  currentDescription: string;
+};
+
+export function OwnerPetControls({
+  slug,
+  currentDisplayName,
+  currentDescription,
+}: OwnerPetControlsProps) {
+  const { isLoaded, isSignedIn } = useAuth();
+  const [state, setState] = useState<OwnerState | null>(null);
+
+  useEffect(() => {
+    if (!isLoaded || !isSignedIn) {
+      setState(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    void fetch(`/api/pets/${slug}/owner-state`, {
+      signal: controller.signal,
+      headers: { accept: "application/json" },
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: OwnerState | null) => setState(data))
+      .catch((error: unknown) => {
+        if ((error as Error).name !== "AbortError") setState(null);
+      });
+
+    return () => controller.abort();
+  }, [isLoaded, isSignedIn, slug]);
+
+  if (!state?.isOwner || !state.petId) return null;
+
+  return (
+    <div className="flex flex-col items-start gap-3">
+      <OwnerEditPanel
+        petId={state.petId}
+        slug={slug}
+        currentDisplayName={currentDisplayName}
+        currentDescription={currentDescription}
+        currentTags={state.currentTags}
+        initialPending={state.pending}
+        initialRejection={state.lastRejection}
+      />
+      {state.collectionSuggest?.candidates.length ? (
+        <SuggestCollectionButton
+          petSlug={slug}
+          petDisplayName={currentDisplayName}
+          candidateCollections={state.collectionSuggest.candidates}
+          alreadyRequested={state.collectionSuggest.alreadyRequested}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/owner-pet-controls.tsx
+++ b/src/components/owner-pet-controls.tsx
@@ -2,29 +2,7 @@
 
 import { useEffect, useState } from "react";
 
-import { useAuth } from "@clerk/nextjs";
-
-import { OwnerEditPanel } from "@/components/owner-edit-panel";
-import { SuggestCollectionButton } from "@/components/suggest-collection-button";
-
-type Pending = {
-  displayName: string | null;
-  description: string | null;
-  tags: string[] | null;
-  submittedAt: string | null;
-};
-
-type OwnerState = {
-  isOwner: boolean;
-  petId: string | null;
-  currentTags: string[];
-  pending: Pending | null;
-  lastRejection: string | null;
-  collectionSuggest: {
-    candidates: Array<{ slug: string; title: string }>;
-    alreadyRequested: string[];
-  } | null;
-};
+import { useAuthIntent } from "@/components/auth-intent";
 
 type OwnerPetControlsProps = {
   slug: string;
@@ -32,55 +10,25 @@ type OwnerPetControlsProps = {
   currentDescription: string;
 };
 
-export function OwnerPetControls({
-  slug,
-  currentDisplayName,
-  currentDescription,
-}: OwnerPetControlsProps) {
-  const { isLoaded, isSignedIn } = useAuth();
-  const [state, setState] = useState<OwnerState | null>(null);
+type OwnerPetControlsComponent = React.ComponentType<OwnerPetControlsProps>;
+
+export function OwnerPetControls(props: OwnerPetControlsProps) {
+  const { authActive } = useAuthIntent();
+  const [AuthOwnerPetControls, setAuthOwnerPetControls] =
+    useState<OwnerPetControlsComponent | null>(null);
 
   useEffect(() => {
-    if (!isLoaded || !isSignedIn) {
-      setState(null);
-      return;
-    }
+    if (!authActive || AuthOwnerPetControls) return;
+    let cancelled = false;
+    void import("@/components/owner-pet-controls-auth").then((mod) => {
+      if (!cancelled) setAuthOwnerPetControls(() => mod.OwnerPetControls);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [AuthOwnerPetControls, authActive]);
 
-    const controller = new AbortController();
-    void fetch(`/api/pets/${slug}/owner-state`, {
-      signal: controller.signal,
-      headers: { accept: "application/json" },
-    })
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data: OwnerState | null) => setState(data))
-      .catch((error: unknown) => {
-        if ((error as Error).name !== "AbortError") setState(null);
-      });
-
-    return () => controller.abort();
-  }, [isLoaded, isSignedIn, slug]);
-
-  if (!state?.isOwner || !state.petId) return null;
-
-  return (
-    <div className="flex flex-col items-start gap-3">
-      <OwnerEditPanel
-        petId={state.petId}
-        slug={slug}
-        currentDisplayName={currentDisplayName}
-        currentDescription={currentDescription}
-        currentTags={state.currentTags}
-        initialPending={state.pending}
-        initialRejection={state.lastRejection}
-      />
-      {state.collectionSuggest?.candidates.length ? (
-        <SuggestCollectionButton
-          petSlug={slug}
-          petDisplayName={currentDisplayName}
-          candidateCollections={state.collectionSuggest.candidates}
-          alreadyRequested={state.collectionSuggest.alreadyRequested}
-        />
-      ) : null}
-    </div>
-  );
+  return authActive && AuthOwnerPetControls ? (
+    <AuthOwnerPetControls {...props} />
+  ) : null;
 }

--- a/src/components/pet-card-footer-auth.tsx
+++ b/src/components/pet-card-footer-auth.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-import { memo, useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 
+import { useClerk } from "@clerk/nextjs";
 import { Download, Heart, Share2, TerminalSquare } from "lucide-react";
 import { useLocale } from "next-intl";
 
 import { formatLocalizedNumber } from "@/lib/format-number";
 import { cn } from "@/lib/utils";
 
-import { useAuthIntent } from "@/components/auth-intent";
+import { useHeaderState } from "@/components/header-state-provider";
 import { PetSoundButton } from "@/components/pet-sound-button";
 import { Button } from "@/components/ui/button";
 
@@ -22,8 +24,12 @@ export type PetCardFooterProps = {
   initialLiked?: boolean;
 };
 
-type PetCardFooterComponent = React.ComponentType<PetCardFooterProps>;
-
+// Inline footer bar at the bottom of each gallery card. Surfaces the
+// four most-used actions (like, install, download, share) without
+// forcing the user to open the pet page or the overflow menu.
+//
+// Buttons stop propagation so a click on a footer action does not
+// also fire the card-wide Link wrapper that the parent renders.
 function PetCardFooterImpl({
   slug,
   displayName,
@@ -31,25 +37,74 @@ function PetCardFooterImpl({
   soundUrl,
   installCount,
   likeCount,
+  initialLiked,
 }: PetCardFooterProps) {
-  const { authActive, requestAuth } = useAuthIntent();
+  const router = useRouter();
+  const clerk = useClerk();
   const locale = useLocale();
+  const { refresh } = useHeaderState();
+
+  const [liked, setLiked] = useState(initialLiked ?? false);
+  const [count, setCount] = useState(likeCount);
   const [copied, setCopied] = useState(false);
-  const [AuthPetCardFooter, setAuthPetCardFooter] =
-    useState<PetCardFooterComponent | null>(null);
-  const formattedLikeCount = formatLocalizedNumber(likeCount, locale);
+  const likeRequestSeq = useRef(0);
+  const formattedLikeCount = formatLocalizedNumber(count, locale);
   const formattedInstallCount = formatLocalizedNumber(installCount, locale);
 
   useEffect(() => {
-    if (!authActive || AuthPetCardFooter) return;
-    let cancelled = false;
-    void import("@/components/pet-card-footer-auth").then((mod) => {
-      if (!cancelled) setAuthPetCardFooter(() => mod.PetCardFooter);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [AuthPetCardFooter, authActive]);
+    if (typeof initialLiked === "boolean") setLiked(initialLiked);
+  }, [initialLiked]);
+
+  const toggleLike = useCallback(
+    async (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (!clerk.loaded) return;
+      const session = clerk.session;
+      if (!session) {
+        router.push("/?signin=1");
+        return;
+      }
+      const seq = likeRequestSeq.current + 1;
+      likeRequestSeq.current = seq;
+      const previousLiked = liked;
+      const previousCount = count;
+      const next = !liked;
+      setLiked(next);
+      setCount((c) => Math.max(0, c + (next ? 1 : -1)));
+      try {
+        const res = await fetch(`/api/pets/${slug}/like`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ liked: next }),
+        });
+        if (!res.ok) {
+          if (likeRequestSeq.current === seq) {
+            setLiked(previousLiked);
+            setCount(previousCount);
+          }
+          return;
+        }
+        const j = (await res.json().catch(() => null)) as {
+          count?: number;
+          likeCount?: number;
+          liked?: boolean;
+        } | null;
+        if (likeRequestSeq.current !== seq) return;
+        const serverCount =
+          typeof j?.count === "number" ? j.count : j?.likeCount;
+        if (typeof serverCount === "number") setCount(serverCount);
+        if (typeof j?.liked === "boolean") setLiked(j.liked);
+        void refresh({ force: true });
+      } catch {
+        if (likeRequestSeq.current === seq) {
+          setLiked(previousLiked);
+          setCount(previousCount);
+        }
+      }
+    },
+    [clerk, count, liked, refresh, router, slug],
+  );
 
   const copyInstall = useCallback(
     async (e: React.MouseEvent) => {
@@ -60,7 +115,9 @@ function PetCardFooterImpl({
         await navigator.clipboard.writeText(cmd);
         setCopied(true);
         setTimeout(() => setCopied(false), 1400);
-      } catch {}
+      } catch {
+        /* swallow */
+      }
     },
     [slug],
   );
@@ -94,46 +151,37 @@ function PetCardFooterImpl({
         await navigator.clipboard.writeText(url);
         setCopied(true);
         setTimeout(() => setCopied(false), 1400);
-      } catch {}
+      } catch {
+        /* swallow */
+      }
     },
     [displayName, slug],
   );
-
-  const requestLikeAuth = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      requestAuth();
-    },
-    [requestAuth],
-  );
-
-  if (authActive && AuthPetCardFooter) {
-    return (
-      <AuthPetCardFooter
-        slug={slug}
-        displayName={displayName}
-        zipUrl={zipUrl}
-        soundUrl={soundUrl}
-        installCount={installCount}
-        likeCount={likeCount}
-      />
-    );
-  }
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-2 border-t border-black/[0.05] px-2 py-2 dark:border-white/[0.05]">
       <div className="flex min-w-0 flex-wrap items-center gap-0.5">
         <Button
           variant="ghost"
-          onClick={requestLikeAuth}
-          aria-label={`Like ${displayName}`}
-          title={`Like ${displayName}`}
-          className="h-8 gap-1 rounded-full px-2 text-stone-500 hover:bg-surface-muted hover:text-stone-900 dark:text-stone-400 dark:hover:text-stone-100"
+          onClick={toggleLike}
+          aria-label={`${liked ? "Unlike" : "Like"} ${displayName}`}
+          title={`${liked ? "Unlike" : "Like"} ${displayName}`}
+          className={cn(
+            "h-8 gap-1 rounded-full px-2",
+            liked
+              ? "bg-stone-100 text-stone-900 dark:text-stone-100"
+              : "text-stone-500 hover:bg-surface-muted hover:text-stone-900 dark:text-stone-400 dark:hover:text-stone-100",
+          )}
         >
-          <Heart className="size-3.5" />
-          {likeCount > 0 ? (
-            <span className="font-mono text-[11px] text-stone-500">
+          <Heart
+            className={`size-3.5 ${liked ? "fill-rose-500 text-rose-500" : ""}`}
+          />
+          {count > 0 ? (
+            <span
+              className={`font-mono text-[11px] ${
+                liked ? "text-rose-600" : "text-stone-500"
+              }`}
+            >
               {formattedLikeCount}
             </span>
           ) : null}

--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -25,9 +25,8 @@ import { PET_KINDS, PET_VIBES, type PetKind, type PetVibe } from "@/lib/types";
 import { isAllowedAvatarUrl } from "@/lib/url-allowlist";
 import { cn } from "@/lib/utils";
 
-import { useHeaderState } from "@/components/header-state-provider";
 import { PetActionMenu } from "@/components/pet-action-menu";
-import type { PetCardFooterProps } from "@/components/pet-card-footer";
+import { PetCardFooter } from "@/components/pet-card-footer";
 import { PetSprite } from "@/components/pet-sprite";
 import { ProfilePinButton } from "@/components/profile-pin-button";
 import { Badge } from "@/components/ui/badge";
@@ -105,14 +104,6 @@ const FeedAdSlot = dynamic<{ ad: PublicFeedAd }>(
   },
 );
 
-const PetCardFooter = dynamic<PetCardFooterProps>(
-  () => import("@/components/pet-card-footer").then((mod) => mod.PetCardFooter),
-  {
-    loading: PetCardFooterLoading,
-    ssr: false,
-  },
-);
-
 const FAMILY_DOT: Record<ColorFamily, string> = {
   red: "#ef4444",
   orange: "#f97316",
@@ -145,8 +136,7 @@ export function PetGallery({
   const [activeBatches, setActiveBatches] = useState<Set<string>>(new Set());
   const [sort, setSort] = useState<SortKey>("alpha");
   const [sortTouched, setSortTouched] = useState(false);
-  const headerCaught = useHeaderState().state.caught;
-  const caughtSet = new Set(caughtSlugs ?? headerCaught);
+  const caughtSet = new Set(caughtSlugs ?? []);
 
   const [pets, setPets] = useState<SearchPet[]>(initial.pets);
   const [total, setTotal] = useState<number>(initial.total);
@@ -736,22 +726,6 @@ function FeedAdSlotLoading() {
       </div>
       <div className="mt-auto min-h-[52px] border-border-base border-t px-5 py-2" />
     </article>
-  );
-}
-
-function PetCardFooterLoading() {
-  return (
-    <div
-      aria-hidden="true"
-      className="flex min-h-[49px] items-center border-t border-black/[0.05] px-2 py-2 dark:border-white/[0.05]"
-    >
-      <div className="flex items-center gap-1">
-        <div className="h-8 w-14 rounded-full bg-surface-muted/70" />
-        <div className="h-8 w-16 rounded-full bg-surface-muted/70" />
-        <div className="size-8 rounded-full bg-surface-muted/70" />
-        <div className="size-8 rounded-full bg-surface-muted/70" />
-      </div>
-    </div>
   );
 }
 

--- a/src/components/requests-auth-refresh.tsx
+++ b/src/components/requests-auth-refresh.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { useAuth } from "@clerk/nextjs";
+
+import type { RequestRow } from "@/components/requests-view";
+
+export function RequestsAuthRefresh({
+  onRefresh,
+}: {
+  onRefresh: (requests: RequestRow[]) => void;
+}) {
+  const { isSignedIn } = useAuth();
+
+  useEffect(() => {
+    if (!isSignedIn) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch("/api/pet-requests?status=all&limit=80");
+        if (!res.ok) return;
+        const data = (await res.json()) as { requests: RequestRow[] };
+        if (!cancelled) onRefresh(data.requests);
+      } catch {
+        return;
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isSignedIn, onRefresh]);
+
+  return null;
+}

--- a/src/components/requests-view.tsx
+++ b/src/components/requests-view.tsx
@@ -23,8 +23,8 @@ import {
 } from "lucide-react";
 import { useTranslations } from "next-intl";
 
+import { useAuthIntent } from "@/components/auth-intent";
 import { ClaimRequestButton } from "@/components/claim-request-button";
-import { useHeaderState } from "@/components/header-state-provider";
 
 type ClerkInfo = {
   handle: string;
@@ -60,10 +60,16 @@ const COLLECTION_PREFIX = "Collection:";
 type Sort = "top" | "new" | "fulfilled";
 type RequestKind = "pet" | "collection";
 
+type RequestsAuthRefreshComponent = React.ComponentType<{
+  onRefresh: (requests: RequestRow[]) => void;
+}>;
+
 export function RequestsView({ initial }: { initial: RequestRow[] }) {
   const t = useTranslations("requests.view");
-  const { state } = useHeaderState();
+  const { authActive } = useAuthIntent();
   const [requests, setRequests] = useState<RequestRow[]>(initial);
+  const [RequestsAuthRefresh, setRequestsAuthRefresh] =
+    useState<RequestsAuthRefreshComponent | null>(null);
   const [pending, setPending] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
   const [sort, setSort] = useState<Sort>("top");
@@ -84,27 +90,16 @@ export function RequestsView({ initial }: { initial: RequestRow[] }) {
     count: number;
   } | null>(null);
 
-  // Re-fetch with credentials so the user's own votes light up.
-  // We always pull status=all so all three sort tabs work without
-  // another roundtrip when the user toggles them.
   useEffect(() => {
-    if (!state.signedIn) return;
+    if (!authActive || RequestsAuthRefresh) return;
     let cancelled = false;
-    void (async () => {
-      try {
-        const res = await fetch("/api/pet-requests?status=all&limit=80");
-        if (!res.ok) return;
-        const data = (await res.json()) as { requests: RequestRow[] };
-        if (cancelled) return;
-        setRequests(data.requests);
-      } catch {
-        /* ignore */
-      }
-    })();
+    void import("@/components/requests-auth-refresh").then((mod) => {
+      if (!cancelled) setRequestsAuthRefresh(() => mod.RequestsAuthRefresh);
+    });
     return () => {
       cancelled = true;
     };
-  }, [state.signedIn]);
+  }, [RequestsAuthRefresh, authActive]);
 
   const counts = useMemo(() => {
     return {
@@ -163,6 +158,14 @@ export function RequestsView({ initial }: { initial: RequestRow[] }) {
     });
     previousRects.current = next;
   }, []);
+
+  const handleAuthRefresh = useCallback(
+    (nextRequests: RequestRow[]) => {
+      capturePositions();
+      setRequests(nextRequests);
+    },
+    [capturePositions],
+  );
 
   useLayoutEffect(() => {
     const before = previousRects.current;
@@ -333,6 +336,10 @@ export function RequestsView({ initial }: { initial: RequestRow[] }) {
 
   return (
     <div className="space-y-6">
+      {authActive && RequestsAuthRefresh ? (
+        <RequestsAuthRefresh onRefresh={handleAuthRefresh} />
+      ) : null}
+
       {/* Always-visible request form */}
       <form
         onSubmit={submitForm}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,50 +1,14 @@
-"use client";
-
-import dynamic from "next/dynamic";
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
 
-import {
-  BookOpenIcon,
-  CrownIcon,
-  DownloadSimpleIcon,
-  HandHeartIcon,
-  MegaphoneIcon,
-  PaintBrushIcon,
-  PuzzlePieceIcon,
-  StackIcon,
-  UploadSimpleIcon,
-  UsersThreeIcon,
-} from "@phosphor-icons/react";
-import { Menu, X } from "lucide-react";
-import { useLocale, useTranslations } from "next-intl";
+import { getLocale, getTranslations } from "next-intl/server";
 
 import { withLocale } from "@/lib/locale-routing";
-import { cn } from "@/lib/utils";
 
 import { AuthBadge } from "@/components/auth-badge";
-import { GithubStarsLink } from "@/components/github-stars-link";
+import { MobileHeaderSettings } from "@/components/mobile-header-settings";
 import { PetdexLogo } from "@/components/petdex-logo";
-import { SubmitCTA } from "@/components/submit-cta";
-import { Button, buttonVariants } from "@/components/ui/button";
-import {
-  NavigationMenu,
-  NavigationMenuContent,
-  NavigationMenuItem,
-  NavigationMenuLink,
-  NavigationMenuList,
-  NavigationMenuTrigger,
-} from "@/components/ui/navigation-menu";
 
 import { hasLocale, type Locale } from "@/i18n/config";
-
-const MobileHeaderMenu = dynamic(
-  () =>
-    import("@/components/mobile-header-menu").then(
-      (mod) => mod.MobileHeaderMenu,
-    ),
-  { loading: () => <MobileHeaderMenuLoading />, ssr: false },
-);
 
 type SiteHeaderProps = {
   hideSubmitCta?: boolean;
@@ -52,336 +16,135 @@ type SiteHeaderProps = {
 
 type NavItem = {
   href: string;
-  title: string;
-  description: string;
-  icon: React.ComponentType<{
-    className?: string;
-    weight?: "regular" | "fill" | "duotone" | "bold";
-  }>;
+  label: string;
   external?: boolean;
-  badge?: string;
+  ariaLabel?: string;
 };
 
-export function SiteHeader({ hideSubmitCta = false }: SiteHeaderProps) {
-  const [open, setOpen] = useState(false);
-  const locale = useLocale();
+export async function SiteHeader({ hideSubmitCta = false }: SiteHeaderProps) {
+  const locale = await getLocale();
   const currentLocale: Locale = hasLocale(locale) ? locale : "en";
-  const t = useTranslations("header");
-  const common = useTranslations("common");
-
-  // /download is public now (post pre-launch).
-  const showDownload = true;
-
-  function href(pathname: string) {
-    return withLocale(pathname, currentLocale);
-  }
-
-  const browseItems: NavItem[] = [
-    {
-      href: href("/collections"),
-      title: t("collections"),
-      description: t("collectionsDesc"),
-      icon: StackIcon,
-    },
-    {
-      href: href("/leaderboard"),
-      title: t("creators"),
-      description: t("creatorsDesc"),
-      icon: CrownIcon,
-    },
-    {
-      href: href("/requests"),
-      title: t("requests"),
-      description: t("requestsDesc"),
-      icon: HandHeartIcon,
-    },
-  ];
-
-  const buildItems: NavItem[] = [
-    ...(showDownload
-      ? [
-          {
-            href: href("/download"),
-            title: t("download"),
-            description: t("downloadDesc"),
-            icon: DownloadSimpleIcon,
-            badge: "new",
-          } as NavItem,
-        ]
-      : []),
-    {
-      href: href("/submit"),
-      title: t("submitCta"),
-      description: t("submitDesc"),
-      icon: UploadSimpleIcon,
-    },
-    {
-      href: href("/create"),
-      title: t("create"),
-      description: t("createDesc"),
-      icon: PaintBrushIcon,
-    },
-    {
-      href: href("/docs"),
-      title: t("docs"),
-      description: t("docsDesc"),
-      icon: BookOpenIcon,
-    },
-  ];
-
-  const earnItems: NavItem[] = [
-    {
-      href: href("/advertise"),
-      title: t("advertise"),
-      description: t("advertiseDesc"),
-      icon: MegaphoneIcon,
-    },
-    {
-      href: href("/built-with"),
-      title: t("builtWith"),
-      description: t("builtWithDesc"),
-      icon: PuzzlePieceIcon,
-      badge: "new",
-    },
+  const t = await getTranslations("header");
+  const common = await getTranslations("common");
+  const href = (pathname: string) => withLocale(pathname, currentLocale);
+  const primary: NavItem[] = [
+    { href: href("/collections"), label: t("collections") },
+    { href: href("/leaderboard"), label: t("creators") },
+    { href: href("/requests"), label: t("requests") },
+    { href: href("/download"), label: t("download") },
+    { href: href("/docs"), label: t("docs") },
+    { href: href("/advertise"), label: t("advertise") },
+    { href: href("/create"), label: t("create") },
+    { href: href("/built-with"), label: t("builtWith") },
     ...(process.env.NEXT_PUBLIC_DISCORD_INVITE_URL
-      ? [
-          {
-            href: href("/community"),
-            title: t("community"),
-            description: t("communityDesc"),
-            icon: UsersThreeIcon,
-          },
-        ]
+      ? [{ href: href("/community"), label: t("community") }]
       : []),
+    {
+      href: "https://github.com/crafter-station/petdex",
+      label: common("github"),
+      external: true,
+      ariaLabel: t("githubRepoAria"),
+    },
   ];
-
-  const scrolled = useScrolled(64);
-  const closeMenu = useCallback(() => setOpen(false), []);
-
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") closeMenu();
-    };
-    window.addEventListener("keydown", onKey);
-    document.body.style.overflow = "hidden";
-    return () => {
-      window.removeEventListener("keydown", onKey);
-      document.body.style.overflow = "";
-    };
-  }, [closeMenu, open]);
 
   return (
-    <>
-      <header
-        data-scrolled={scrolled || undefined}
-        className="sticky top-0 z-40 w-full border-b border-transparent transition-[border-color,background-color,backdrop-filter] duration-200 data-scrolled:border-foreground/[0.06] data-scrolled:bg-background/85 data-scrolled:backdrop-blur-md data-scrolled:supports-[backdrop-filter]:bg-background/65"
-      >
-        <nav
-          className={cn(
-            "mx-auto flex w-full max-w-[1440px] items-center justify-between gap-2 px-4 sm:gap-3 sm:px-5 md:px-8",
-            scrolled ? "py-2.5" : "py-4",
-          )}
-        >
-          <div className="flex min-w-0 items-center gap-4 lg:gap-6">
-            <PetdexLogo
-              href={href("/")}
-              ariaLabel={common("petdexHome")}
-              markClassName={cn(
-                "transition-[width,height] duration-200",
-                scrolled ? "size-7" : "size-8 sm:size-10",
-              )}
-              className={cn(
-                "transition-[font-size,gap] duration-200",
-                scrolled
-                  ? "gap-2 [&>span]:text-base"
-                  : "gap-2 [&>span]:hidden [&>span]:text-xl sm:[&>span]:inline sm:gap-3 sm:[&>span]:text-xl",
-              )}
-            />
+    <header className="sticky top-0 z-40 w-full border-b border-foreground/[0.06] bg-background/88 backdrop-blur-md supports-[backdrop-filter]:bg-background/70">
+      <nav className="mx-auto flex w-full max-w-[1440px] items-center justify-between gap-3 px-4 py-3 sm:px-5 md:px-8">
+        <div className="flex min-w-0 items-center gap-4 lg:gap-7">
+          <PetdexLogo
+            href={href("/")}
+            ariaLabel={common("petdexHome")}
+            markClassName="size-8 sm:size-9"
+            className="gap-2 sm:gap-3 [&>span]:hidden sm:[&>span]:inline sm:[&>span]:text-lg"
+          />
 
-            <NavigationMenu className="hidden lg:flex">
-              <NavigationMenuList className="gap-1">
-                <NavigationMenuItem>
-                  <NavigationMenuTrigger
-                    className={cn(
-                      "rounded-full bg-transparent text-muted-2 transition-[font-size,height] duration-200 hover:bg-surface-muted hover:text-foreground data-popup-open:bg-surface-muted data-popup-open:text-foreground",
-                      scrolled ? "h-7 text-xs" : "h-9 text-sm",
-                    )}
-                  >
-                    {t("discover")}
-                  </NavigationMenuTrigger>
-                  <NavigationMenuContent>
-                    <NavGrid items={browseItems} />
-                  </NavigationMenuContent>
-                </NavigationMenuItem>
-
-                <NavigationMenuItem>
-                  <NavigationMenuTrigger
-                    className={cn(
-                      "relative rounded-full bg-transparent text-muted-2 transition-[font-size,height] duration-200 hover:bg-surface-muted hover:text-foreground data-popup-open:bg-surface-muted data-popup-open:text-foreground",
-                      scrolled ? "h-7 text-xs" : "h-9 text-sm",
-                    )}
-                  >
-                    {t("make")}
-                    {buildItems.some((i) => i.badge === "new") ? (
-                      <NewDot />
-                    ) : null}
-                  </NavigationMenuTrigger>
-                  <NavigationMenuContent>
-                    <NavGrid items={buildItems} />
-                  </NavigationMenuContent>
-                </NavigationMenuItem>
-
-                <NavigationMenuItem>
-                  <NavigationMenuTrigger
-                    className={cn(
-                      "relative rounded-full bg-transparent text-muted-2 transition-[font-size,height] duration-200 hover:bg-surface-muted hover:text-foreground data-popup-open:bg-surface-muted data-popup-open:text-foreground",
-                      scrolled ? "h-7 text-xs" : "h-9 text-sm",
-                    )}
-                  >
-                    {t("promote")}
-                    {earnItems.some((i) => i.badge === "new") ? (
-                      <NewDot />
-                    ) : null}
-                  </NavigationMenuTrigger>
-                  <NavigationMenuContent>
-                    <NavGrid items={earnItems} />
-                  </NavigationMenuContent>
-                </NavigationMenuItem>
-              </NavigationMenuList>
-            </NavigationMenu>
+          <div className="hidden items-center gap-0.5 xl:flex">
+            {primary.map((item) => (
+              <HeaderNavLink
+                key={item.href}
+                item={item}
+                className="inline-flex h-9 items-center rounded-full px-2.5 text-sm font-medium text-muted-2 transition hover:bg-surface-muted hover:text-foreground"
+              />
+            ))}
           </div>
+        </div>
 
-          <div className="flex shrink-0 items-center gap-1.5 sm:gap-2">
-            {hideSubmitCta ? null : (
-              <div className="hidden md:contents">
-                <SubmitCTA
+        <div className="flex shrink-0 items-center gap-2">
+          {hideSubmitCta ? null : (
+            <Link
+              href={href("/submit")}
+              prefetch={false}
+              className="hidden h-10 items-center justify-center rounded-full bg-inverse px-4 text-sm font-medium text-on-inverse transition hover:bg-inverse-hover md:inline-flex"
+            >
+              {t("submitCta")}
+            </Link>
+          )}
+          <details className="group relative xl:hidden">
+            <summary
+              aria-label={t("openMenu")}
+              className="grid size-10 cursor-pointer list-none place-items-center rounded-full border border-border-base bg-surface/70 text-muted-2 transition hover:bg-surface hover:text-foreground [&::-webkit-details-marker]:hidden"
+            >
+              <span className="flex flex-col gap-1.5" aria-hidden="true">
+                <span className="h-0.5 w-4 rounded-full bg-current" />
+                <span className="h-0.5 w-4 rounded-full bg-current" />
+              </span>
+            </summary>
+            <div className="absolute top-12 right-0 z-50 w-[min(280px,calc(100vw-2rem))] rounded-2xl border border-border-base bg-surface p-2 shadow-xl shadow-blue-950/15">
+              {primary.map((item) => (
+                <HeaderNavLink
+                  key={item.href}
+                  item={item}
+                  className="flex rounded-xl px-3 py-2.5 text-sm font-medium text-foreground transition hover:bg-surface-muted"
+                />
+              ))}
+              {hideSubmitCta ? null : (
+                <Link
                   href={href("/submit")}
-                  className={cn(
-                    buttonVariants({ variant: "petdex-cta" }),
-                    "inline-flex items-center justify-center px-4 font-medium transition-[height,font-size] duration-200",
-                    scrolled ? "h-9 text-xs" : "h-11 text-sm",
-                  )}
+                  prefetch={false}
+                  className="mt-1 flex rounded-xl bg-inverse px-3 py-2.5 text-sm font-medium text-on-inverse transition hover:bg-inverse-hover"
                 >
                   {t("submitCta")}
-                </SubmitCTA>
-              </div>
-            )}
-            <div className="hidden lg:contents">
-              <GithubStarsLink
-                className={cn(
-                  buttonVariants({ variant: "petdex-pill" }),
-                  "inline-flex items-center gap-1.5 px-3 transition-[height] duration-200",
-                  scrolled ? "h-9" : "h-11",
-                )}
-              />
-            </div>
-            <Button
-              type="button"
-              variant="petdex-pill"
-              aria-label={open ? t("closeMenu") : t("openMenu")}
-              aria-expanded={open}
-              onClick={() => setOpen((v) => !v)}
-              className={cn(
-                "shrink-0 p-0 transition-[width,height] duration-200 lg:hidden",
-                scrolled ? "size-9" : "size-11",
+                </Link>
               )}
-            >
-              {open ? <X className="size-4" /> : <Menu className="size-4" />}
-            </Button>
-            <AuthBadge compact={scrolled} />
-          </div>
-        </nav>
-      </header>
-
-      {open ? (
-        <MobileHeaderMenu hideSubmitCta={hideSubmitCta} onClose={closeMenu} />
-      ) : null}
-    </>
+              <MobileHeaderSettings />
+            </div>
+          </details>
+          <AuthBadge compact />
+        </div>
+      </nav>
+    </header>
   );
 }
 
-function NewDot() {
+function HeaderNavLink({
+  item,
+  className,
+}: {
+  item: NavItem;
+  className: string;
+}) {
+  if (item.external) {
+    return (
+      <a
+        href={item.href}
+        target="_blank"
+        rel="noreferrer"
+        aria-label={item.ariaLabel}
+        className={className}
+      >
+        {item.label}
+      </a>
+    );
+  }
+
   return (
-    <span
-      aria-hidden="true"
-      className="pointer-events-none absolute top-1 right-1 grid size-1.5 place-items-center"
+    <Link
+      href={item.href}
+      prefetch={false}
+      aria-label={item.ariaLabel}
+      className={className}
     >
-      <span className="absolute inline-flex size-full animate-ping rounded-full bg-brand opacity-70" />
-      <span className="relative inline-flex size-full rounded-full bg-brand" />
-    </span>
+      {item.label}
+    </Link>
   );
-}
-
-function MobileHeaderMenuLoading() {
-  return (
-    <div
-      aria-hidden
-      className="fixed inset-0 z-30 bg-background/95 backdrop-blur lg:hidden"
-    />
-  );
-}
-
-function NavGrid({ items }: { items: NavItem[] }) {
-  return (
-    <ul className="grid w-[min(400px,calc(100vw-2rem))] auto-rows-min gap-1 p-2">
-      {items.map((item) => {
-        const Icon = item.icon;
-        return (
-          <li key={item.href}>
-            <NavigationMenuLink
-              render={<Link href={item.href} prefetch={false} />}
-              closeOnClick
-              className="group/item flex items-center gap-3 rounded-2xl p-2 pr-4 transition hover:bg-surface-muted focus:bg-surface-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
-            >
-              <span className="grid size-10 shrink-0 place-items-center rounded-full bg-brand-tint text-brand ring-1 ring-brand/15 transition group-hover/item:bg-brand group-hover/item:text-on-inverse group-hover/item:ring-brand dark:bg-brand-tint-dark dark:ring-brand/25">
-                <Icon weight="duotone" className="size-4" />
-              </span>
-              <div className="flex min-w-0 flex-1 flex-col gap-0.5 text-left">
-                <div className="flex items-center gap-2 text-sm font-medium text-foreground">
-                  {item.title}
-                  {item.badge ? (
-                    <span className="rounded-full bg-brand-tint px-1.5 py-0.5 font-mono text-[9px] font-semibold tracking-[0.12em] text-brand uppercase ring-1 ring-brand/30 dark:bg-brand-tint-dark">
-                      {item.badge}
-                    </span>
-                  ) : null}
-                </div>
-                <p className="truncate text-xs leading-relaxed text-muted-3">
-                  {item.description}
-                </p>
-              </div>
-            </NavigationMenuLink>
-          </li>
-        );
-      })}
-    </ul>
-  );
-}
-
-function useScrolled(threshold: number): boolean {
-  const [scrolled, setScrolled] = useState(false);
-  useEffect(() => {
-    let frame = 0;
-    // Hysteresis: enter compact at threshold, leave at threshold/2.
-    // Prevents oscillation when the header height change shifts scrollY
-    // back across the boundary. Frame-throttled to one update per paint.
-    const enter = threshold;
-    const exit = Math.max(0, threshold / 2);
-    const evaluate = () => {
-      frame = 0;
-      const y = window.scrollY;
-      setScrolled((prev) => (prev ? y > exit : y > enter));
-    };
-    const onScroll = () => {
-      if (frame) return;
-      frame = requestAnimationFrame(evaluate);
-    };
-    evaluate();
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => {
-      if (frame) cancelAnimationFrame(frame);
-      window.removeEventListener("scroll", onScroll);
-    };
-  }, [threshold]);
-  return scrolled;
 }

--- a/src/components/submit-cta.tsx
+++ b/src/components/submit-cta.tsx
@@ -2,8 +2,6 @@
 
 import Link from "next/link";
 
-import { SignInButton, useAuth } from "@clerk/nextjs";
-
 import { Button } from "@/components/ui/button";
 
 type SubmitCTAProps = {
@@ -20,27 +18,6 @@ export function SubmitCTA({
   children = "Submit a pet",
   href = "/submit",
 }: SubmitCTAProps) {
-  const { isLoaded, isSignedIn } = useAuth();
-
-  if (!isLoaded || !isSignedIn) {
-    return (
-      <SignInButton
-        mode="modal"
-        forceRedirectUrl={href}
-        signUpForceRedirectUrl={href}
-      >
-        <Button
-          variant="petdex-cta"
-          size="petdex-pill"
-          className={className}
-          render={<button type="button" />}
-        >
-          {children}
-        </Button>
-      </SignInButton>
-    );
-  }
-
   return (
     <Button
       variant="petdex-cta"

--- a/src/components/submitted-by.tsx
+++ b/src/components/submitted-by.tsx
@@ -3,10 +3,9 @@
 import Image from "next/image";
 import Link from "next/link";
 
-import { useUser } from "@clerk/nextjs";
 import { useTranslations } from "next-intl";
 
-import type { OwnerCredit, OwnerExternal } from "@/lib/owner-credit";
+import type { OwnerCredit } from "@/lib/owner-credit";
 import { isAllowedAvatarUrl } from "@/lib/url-allowlist";
 
 type SubmittedByProps = {
@@ -46,8 +45,7 @@ function XIcon({ className }: { className?: string }) {
 
 export function SubmittedBy({ credit }: SubmittedByProps) {
   const t = useTranslations("submittedBy");
-  const { user } = useUser();
-  const displayCredit = mergeCurrentUserCredit(credit, user);
+  const displayCredit = credit;
   const showAvatar =
     displayCredit.imageUrl && isAllowedAvatarUrl(displayCredit.imageUrl);
   const avatarUrl = showAvatar ? displayCredit.imageUrl : null;
@@ -122,68 +120,4 @@ export function SubmittedBy({ credit }: SubmittedByProps) {
       ) : null}
     </div>
   );
-}
-
-function mergeCurrentUserCredit(
-  credit: OwnerCredit,
-  user:
-    | {
-        id: string;
-        imageUrl?: string;
-        username?: string | null;
-        fullName?: string | null;
-        primaryEmailAddress?: { emailAddress?: string | null } | null;
-        externalAccounts?: Array<{ provider?: string; username?: string }>;
-      }
-    | null
-    | undefined,
-): OwnerCredit {
-  if (!user || user.id !== credit.userId) return credit;
-
-  const externals = externalsFor(user.externalAccounts ?? []);
-
-  return {
-    ...credit,
-    name:
-      credit.name === "anonymous"
-        ? user.fullName ||
-          user.username ||
-          user.primaryEmailAddress?.emailAddress ||
-          credit.name
-        : credit.name,
-    username: user.username ?? credit.username,
-    externals: externals.length > 0 ? externals : credit.externals,
-    imageUrl: user.imageUrl ?? credit.imageUrl,
-  };
-}
-
-function externalsFor(
-  externalAccounts: Array<{ provider?: string; username?: string }>,
-): OwnerExternal[] {
-  let github: OwnerExternal | null = null;
-  let x: OwnerExternal | null = null;
-
-  for (const account of externalAccounts) {
-    if (!account.username) continue;
-    if (account.provider === "oauth_github" && !github) {
-      github = {
-        provider: "github",
-        username: account.username,
-        url: `https://github.com/${account.username}`,
-      };
-    }
-    if (
-      (account.provider === "oauth_x" ||
-        account.provider === "oauth_twitter") &&
-      !x
-    ) {
-      x = {
-        provider: "x",
-        username: account.username,
-        url: `https://x.com/${account.username}`,
-      };
-    }
-  }
-
-  return [github, x].filter((item): item is OwnerExternal => Boolean(item));
 }

--- a/src/components/theme-providers.tsx
+++ b/src/components/theme-providers.tsx
@@ -1,73 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { ThemeProvider } from "next-themes";
 
-import { ClerkProvider } from "@clerk/nextjs";
-import { useLocale } from "next-intl";
-import { ThemeProvider, useTheme } from "next-themes";
-
-type ClerkProviderProps = React.ComponentProps<typeof ClerkProvider>;
-type ClerkAppearance = NonNullable<ClerkProviderProps["appearance"]>;
-
-function ClerkWithTheme({ children }: { children: React.ReactNode }) {
-  const { resolvedTheme } = useTheme();
-  const locale = useLocale();
-  const [mounted, setMounted] = useState(false);
-  const [baseTheme, setBaseTheme] =
-    useState<ClerkAppearance["baseTheme"]>(undefined);
-  const [localization, setLocalization] =
-    useState<ClerkProviderProps["localization"]>(undefined);
-
-  useEffect(() => setMounted(true), []);
-
-  useEffect(() => {
-    let cancelled = false;
-    if (mounted && resolvedTheme === "dark") {
-      void import("@clerk/themes").then((mod) => {
-        if (!cancelled) setBaseTheme(mod.dark);
-      });
-      return () => {
-        cancelled = true;
-      };
-    }
-    setBaseTheme(undefined);
-    return () => {
-      cancelled = true;
-    };
-  }, [mounted, resolvedTheme]);
-
-  useEffect(() => {
-    let cancelled = false;
-    if (locale === "es") {
-      void import("@clerk/localizations/es-ES").then((mod) => {
-        if (cancelled) return;
-        setLocalization(mod.esES);
-      });
-      return () => {
-        cancelled = true;
-      };
-    }
-    if (locale === "zh") {
-      void import("@clerk/localizations/zh-CN").then((mod) => {
-        if (cancelled) return;
-        setLocalization(mod.zhCN);
-      });
-      return () => {
-        cancelled = true;
-      };
-    }
-    setLocalization(undefined);
-    return () => {
-      cancelled = true;
-    };
-  }, [locale]);
-
-  return (
-    <ClerkProvider appearance={{ baseTheme }} localization={localization}>
-      {children}
-    </ClerkProvider>
-  );
-}
+import { AuthIntentProvider } from "@/components/auth-intent";
 
 export function AppProviders({ children }: { children: React.ReactNode }) {
   return (
@@ -77,7 +12,7 @@ export function AppProviders({ children }: { children: React.ReactNode }) {
       enableSystem
       disableTransitionOnChange
     >
-      <ClerkWithTheme>{children}</ClerkWithTheme>
+      <AuthIntentProvider>{children}</AuthIntentProvider>
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
## Summary
- Split global providers so the public layout stays theme and i18n first.
- Lazy load ClerkProvider, HeaderStateProvider, and feedback auth surfaces behind an auth intent island.
- Move signed-in behavior out of public shared components and into dynamic auth sub-islands.
- Keep submit, feedback, profile, and dashboard surfaces under eager full auth providers.

## Validation
- bun run check
- bun run i18n:check
- bun test --env-file=.env.mock
- git diff --check
- TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build

## Size check
- home initial client refs: 152.9KB gzip, 0 Clerk chunks
- /collections initial client refs: 46.7KB gzip, 0 Clerk chunks
- /docs initial client refs: 48.8KB gzip, 0 Clerk chunks