### PR TITLE
fix(cli): release petdex.dev URL patch

### DIFF
--- a/packages/petdex-cli/bin/petdex.ts
+++ b/packages/petdex-cli/bin/petdex.ts
@@ -114,7 +114,7 @@ async function getAuth(): Promise<ClerkCliAuth> {
   return _auth;
 }
 
-const VERSION = "0.4.2";
+const VERSION = "0.4.4";
 
 // ─── entrypoint ────────────────────────────────────────────────────────────
 main().catch((err) => {

--- a/packages/petdex-cli/package.json
+++ b/packages/petdex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "petdex",
-  "version": "0.4.2",
+  "version": "0.4.4",
   "description": "CLI for Petdex. Install, browse, and submit Codex pets from your terminal.",
   "homepage": "https://petdex.dev",
   "repository": {

--- a/packages/petdex-cli/src/release-contract.test.ts
+++ b/packages/petdex-cli/src/release-contract.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+
+const packageJsonPath = new URL("../package.json", import.meta.url);
+const cliSourcePath = new URL("../bin/petdex.ts", import.meta.url);
+
+describe("CLI release contract", () => {
+  test("keeps package version and CLI version in sync", async () => {
+    const [packageJsonRaw, cliSource] = await Promise.all([
+      readFile(packageJsonPath, "utf8"),
+      readFile(cliSourcePath, "utf8"),
+    ]);
+    const packageJson = JSON.parse(packageJsonRaw) as { version?: string };
+    const versionMatch = cliSource.match(/const VERSION = "([^"]+)";/);
+
+    expect(versionMatch?.[1]).toBe(packageJson.version);
+  });
+
+  test("defaults production traffic to petdex.dev", async () => {
+    const cliSource = await readFile(cliSourcePath, "utf8");
+
+    expect(cliSource).toContain(
+      'const PETDEX_URL = process.env.PETDEX_URL ?? "https://petdex.dev";',
+    );
+    expect(cliSource).not.toContain("petdex.crafter.run");
+  });
+});


### PR DESCRIPTION
## Summary

- bump the CLI package and runtime version to 0.4.4 for a new npm release
- keep the production CLI default pointed at https://petdex.dev
- add a release contract test so package version, CLI version, and the production URL do not drift again

## Root cause

The published `petdex@0.4.3` package still defaulted to the legacy `https://petdex.crafter.run` base URL. Asset downloads therefore sent `Referer: https://petdex.crafter.run/`, which is blocked by the current `assets.petdex.dev` hotlink/WAF policy. Overriding `PETDEX_URL=https://petdex.dev` makes the install succeed, so the fix is to publish a fresh CLI package with the canonical default.

## Validation

- `bun run build`
- `bun run typecheck`
- `bun test`
- `node dist/petdex.js --version` -> `0.4.4`
- `npm pack --silent` -> `petdex-0.4.4.tgz`
- `rg "petdex\\.crafter\\.run" dist/petdex.js` -> no matches
- temporary-HOME smoke: `PETDEX_TELEMETRY=0 HOME="$tmp_home" node ./dist/petdex.js install 11` wrote both `.petdex/pets/11` and `.codex/pets/11`

## Release handoff

After merge, an npm maintainer should publish from `packages/petdex-cli`:

```bash
bun install --frozen-lockfile
bun run build
bun run typecheck
bun test
npm publish --access public
npm view petdex version
```

Then verify npm latest without an env override:

```bash
tmp_home="$(mktemp -d)"
HOME="$tmp_home" npx -y petdex@latest install 11
rm -rf "$tmp_home"
```