### PR TITLE
fix: prevent r2 presigned put checksum mismatch

### DIFF
--- a/src/lib/r2.test.ts
+++ b/src/lib/r2.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+
+describe("presignPut", () => {
+  it("does not sign an empty payload checksum for browser uploads", async () => {
+    process.env.R2_ACCOUNT_ID = "62819ee0a8411123c2635cbf37b577c1";
+    process.env.R2_ACCESS_KEY_ID = "test";
+    process.env.R2_SECRET_ACCESS_KEY = "test";
+    process.env.R2_BUCKET = "petdex-pets";
+
+    const { presignPut } = await import("./r2");
+    const presigned = await presignPut(
+      "pets/test-upload/petjson.json",
+      "application/json",
+    );
+
+    const url = new URL(presigned.uploadUrl);
+    expect(url.searchParams.get("X-Amz-SignedHeaders")).toContain(
+      "content-type",
+    );
+    expect(url.searchParams.get("X-Amz-Content-Sha256")).toBe(
+      "UNSIGNED-PAYLOAD",
+    );
+    expect(url.searchParams.has("x-amz-checksum-crc32")).toBe(false);
+    expect(url.searchParams.has("x-amz-sdk-checksum-algorithm")).toBe(false);
+  });
+});

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -22,6 +22,7 @@ if (!ACCOUNT_ID || !ACCESS_KEY_ID || !SECRET_ACCESS_KEY) {
 export const r2 = new S3Client({
   region: "auto",
   endpoint: `https://${ACCOUNT_ID ?? "missing"}.r2.cloudflarestorage.com`,
+  requestChecksumCalculation: "WHEN_REQUIRED",
   credentials: {
     accessKeyId: ACCESS_KEY_ID ?? "",
     secretAccessKey: SECRET_ACCESS_KEY ?? "",


### PR DESCRIPTION
## Summary

Fixes crafter-station/petdex#465

This PR applies an analysis-driven fix for the `/submit` upload failure where browser-side R2 PUT requests surfaced as a generic `xhr network error`.

The investigation found that AWS SDK v3 was adding flexible checksum query parameters to presigned `PutObject` URLs. In this flow, the server signs the URL without the real browser upload body, so the generated URL can include an empty-payload checksum. When the browser later uploads a non-empty `pet.json`, R2 can reject the request, and the browser reports it as a generic XHR network error.

This fix comes from the issue analysis result.

## Changes

- Configure the shared R2 `S3Client` with `requestChecksumCalculation: "WHEN_REQUIRED"`.
- Add a regression test for `presignPut()` to ensure generated URLs:
  - still sign `content-type`
  - use `UNSIGNED-PAYLOAD`
  - do not include `x-amz-checksum-crc32`
  - do not include `x-amz-sdk-checksum-algorithm`

## Verification

Passed locally:

- `bun test src/lib/r2.test.ts`
- `bun run check`
- `TELEMETRY_RATELIMIT_SECRET=petdex-build-check-secret bun --env-file=.env.mock run build`

## Validation Status

This has not yet completed full end-to-end verification against the real deployed `/submit` flow.

Real R2 upload validation was not performed locally because the environment does not have a confirmed usable Cloudflare API token or real R2 write credentials.

Required follow-up validation after deploy:

- Open `/submit`.
- Upload a valid pet pack.
- Confirm `pet.json`, sprite, and zip R2 PUT requests succeed.
- Confirm the submission is created and enters pending state.