### PR TITLE
fix(r2): disable flexible checksums on presigned PUT URLs

### DIFF
--- a/src/lib/r2.test.ts
+++ b/src/lib/r2.test.ts
@@ -1,0 +1,59 @@
+// Regression tests for presigned R2 upload URLs.
+//
+// Run: bun test src/lib/r2.test.ts
+//
+// Issue #465: AWS SDK v3 started injecting flexible-checksum query params
+// (x-amz-checksum-crc32, x-amz-sdk-checksum-algorithm) into presigned
+// PutObject URLs. Because the presign runs with an empty body, the signed
+// checksum is for zero bytes, so the browser's real PUT of pet.json is
+// rejected by R2 as an opaque CORS network error. The S3 client is
+// configured with requestChecksumCalculation: "WHEN_REQUIRED" to suppress
+// this. These tests lock that behavior in.
+
+import { describe, expect, it } from "bun:test";
+
+process.env.R2_ACCOUNT_ID ??= "test-account";
+process.env.R2_ACCESS_KEY_ID ??= "test-access-key";
+process.env.R2_SECRET_ACCESS_KEY ??= "test-secret-key";
+process.env.R2_BUCKET ??= "petdex-pets";
+
+const { presignPut } = await import("@/lib/r2");
+
+describe("presignPut", () => {
+  it("does not include flexible-checksum query params", async () => {
+    const { uploadUrl } = await presignPut(
+      "submissions/test/pet.json",
+      "application/json",
+    );
+    const url = new URL(uploadUrl);
+
+    expect(url.searchParams.has("x-amz-checksum-crc32")).toBe(false);
+    expect(url.searchParams.has("x-amz-sdk-checksum-algorithm")).toBe(false);
+    // Catch any other checksum variant the SDK might add (crc32c, sha256...).
+    for (const key of url.searchParams.keys()) {
+      expect(key.toLowerCase()).not.toContain("checksum");
+    }
+  });
+
+  it("signs content-type so the browser PUT matches the signature", async () => {
+    const { uploadUrl } = await presignPut(
+      "submissions/test/pet.json",
+      "application/json",
+    );
+    const signedHeaders = new URL(uploadUrl).searchParams.get(
+      "X-Amz-SignedHeaders",
+    );
+
+    expect(signedHeaders).toContain("content-type");
+  });
+
+  it("returns the public URL and key for the object", async () => {
+    const result = await presignPut(
+      "submissions/test/pet.json",
+      "application/json",
+    );
+
+    expect(result.key).toBe("submissions/test/pet.json");
+    expect(result.publicUrl).toContain("submissions/test/pet.json");
+  });
+});

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -22,6 +22,15 @@ if (!ACCOUNT_ID || !ACCESS_KEY_ID || !SECRET_ACCESS_KEY) {
 export const r2 = new S3Client({
   region: "auto",
   endpoint: `https://${ACCOUNT_ID ?? "missing"}.r2.cloudflarestorage.com`,
+  // AWS SDK v3 defaults to adding flexible-checksum query params
+  // (x-amz-checksum-crc32, x-amz-sdk-checksum-algorithm) to presigned
+  // PutObject URLs. The presign runs with an empty body, so the signed
+  // checksum is for zero bytes (AAAAAA==); the browser then PUTs a real
+  // pet.json and R2 rejects the mismatch as an opaque CORS network error
+  // ("xhr network error"). WHEN_REQUIRED only adds checksums for operations
+  // that mandate them, keeping presigned PUTs on UNSIGNED-PAYLOAD as R2
+  // expects. See issue #465.
+  requestChecksumCalculation: "WHEN_REQUIRED",
   credentials: {
     accessKeyId: ACCESS_KEY_ID ?? "",
     secretAccessKey: SECRET_ACCESS_KEY ?? "",


### PR DESCRIPTION
## Problem

Every web pet submission was failing after presign with:

\`\`\`
Upload failed: R2 PUT network error: xhr network error (size=290, type=application/json)
\`\`\`

## Root cause

\`@aws-sdk/client-s3@^3.1041.0\` injects flexible-checksum query params (\`x-amz-checksum-crc32\`, \`x-amz-sdk-checksum-algorithm\`) into presigned \`PutObject\` URLs by default. The presign runs server-side with no body, so the signed checksum is for an empty payload (\`AAAAAA==\`). The browser then PUTs a real \`pet.json\`, R2 rejects the checksum mismatch, and the opaque CORS response surfaces as a generic \`xhr network error\`.

Full diagnosis by @henryjing96 in #465.

## Fix

Set \`requestChecksumCalculation: "WHEN_REQUIRED"\` on the shared R2 \`S3Client\` so presigned PUTs stay on \`UNSIGNED-PAYLOAD\`. Centralized in \`src/lib/r2.ts\`, so it covers every \`presignPut()\` caller:

- web pet submission
- CLI submission presign
- owner edit presign + CLI edit presign
- ad image uploads
- pet request image uploads

## Test

\`src/lib/r2.test.ts\` (new) asserts the presigned URL has no checksum query params, keeps \`content-type\` signed, and returns the right key/publicUrl. Verified the test **fails** without the client change (not a placebo).

\`\`\`
bun test src/lib/r2.test.ts   # 3 pass
bun run check                 # clean
TELEMETRY_RATELIMIT_SECRET=… bun --env-file=.env.mock run build  # ok
\`\`\`

Closes #465.