### PR TITLE
fix: accept single-pet folder zip uploads

### DIFF
--- a/src/components/pet-submit-form.tsx
+++ b/src/components/pet-submit-form.tsx
@@ -17,6 +17,7 @@ import {
 import { useTranslations } from "next-intl";
 
 import { petStates } from "@/lib/pet-states";
+import { locatePetZipEntries } from "@/lib/pet-zip";
 
 type ParsedPet = {
   petId: string;
@@ -181,39 +182,53 @@ export function PetSubmitForm() {
 
         const buf = await zipFile.arrayBuffer();
         const zip = await JSZip.loadAsync(buf);
-        const petJsonEntry = zip.file("pet.json");
-        const webpEntry = zip.file("spritesheet.webp");
-        const pngEntry = zip.file("spritesheet.png");
-        const spriteEntry = webpEntry ?? pngEntry;
-        spritesheetExt = webpEntry ? "webp" : "png";
+        const located = locatePetZipEntries(zip);
 
-        // Detect "petdex-approved.zip" — the all-pets bundle, not a single pet.
-        const allFiles = Object.keys(zip.files);
-        const looksLikeBundle =
-          !petJsonEntry &&
-          allFiles.some((p) => p.includes("/pet.json")) &&
-          allFiles.length > 4;
-
-        if (looksLikeBundle) {
+        if (located.kind === "allPetsBundle") {
           issues.push(t("issues.allPetsBundle"));
+        } else if (located.kind === "missingPetJson") {
+          issues.push(t("issues.zipMissingPetJson"));
         } else {
-          if (!petJsonEntry) issues.push(t("issues.zipMissingPetJson"));
-          if (!spriteEntry) {
+          petJsonString = await located.petJsonEntry.async("string");
+          petIdFromName =
+            located.petDirName ?? zipFile.name.replace(/\.zip$/i, "");
+
+          if (located.kind === "missingSpritesheet") {
             issues.push(
               t("issues.zipMissingSpritesheet", {
-                present: allFiles.slice(0, 5).join(", "),
+                present: located.present.slice(0, 5).join(", "),
               }),
             );
+          } else {
+            spritesheetExt = located.spritesheetExt;
+            spritesheetBlob = await located.spriteEntry.async("blob");
+
+            if (
+              located.petJsonPath === "pet.json" &&
+              located.spritePath === `spritesheet.${spritesheetExt}`
+            ) {
+              zipBlob = new Blob([buf], { type: "application/zip" });
+              zipFileName = zipFile.name;
+            } else {
+              const normalizedZip = new JSZip();
+              normalizedZip.file("pet.json", petJsonString);
+              normalizedZip.file(
+                `spritesheet.${spritesheetExt}`,
+                spritesheetBlob,
+              );
+              zipBlob = await normalizedZip.generateAsync({
+                type: "blob",
+                compression: "DEFLATE",
+              });
+              zipFileName = `${petIdFromName}.zip`;
+            }
           }
         }
 
-        petJsonString = petJsonEntry ? await petJsonEntry.async("string") : "";
-        spritesheetBlob = spriteEntry
-          ? await spriteEntry.async("blob")
-          : new Blob();
-        zipBlob = new Blob([buf], { type: "application/zip" });
-        zipFileName = zipFile.name;
-        petIdFromName = zipFile.name.replace(/\.zip$/i, "");
+        if (!zipFileName) {
+          zipBlob = new Blob([buf], { type: "application/zip" });
+          zipFileName = zipFile.name;
+        }
       }
 
       // ── Common: parse pet.json, validate sprite dims ──────────────────

--- a/src/lib/pet-zip.test.ts
+++ b/src/lib/pet-zip.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "bun:test";
+
+import JSZip from "jszip";
+
+import { locatePetZipEntries } from "@/lib/pet-zip";
+
+describe("locatePetZipEntries", () => {
+  it("accepts a pet zip with files at the root", () => {
+    const zip = new JSZip();
+    zip.file("pet.json", "{}");
+    zip.file("spritesheet.webp", "sprite");
+
+    const result = locatePetZipEntries(zip);
+
+    expect(result.kind).toBe("pet");
+    if (result.kind !== "pet") return;
+    expect(result.petJsonPath).toBe("pet.json");
+    expect(result.spritePath).toBe("spritesheet.webp");
+    expect(result.petDirName).toBeNull();
+    expect(result.spritesheetExt).toBe("webp");
+  });
+
+  it("accepts a zip made from one pet folder", () => {
+    const zip = new JSZip();
+    zip.file("boba/pet.json", "{}");
+    zip.file("boba/spritesheet.png", "sprite");
+
+    const result = locatePetZipEntries(zip);
+
+    expect(result.kind).toBe("pet");
+    if (result.kind !== "pet") return;
+    expect(result.petJsonPath).toBe("boba/pet.json");
+    expect(result.spritePath).toBe("boba/spritesheet.png");
+    expect(result.petDirName).toBe("boba");
+    expect(result.spritesheetExt).toBe("png");
+  });
+
+  it("keeps a single pet folder valid when the zip has hidden macOS files", () => {
+    const zip = new JSZip();
+    zip.file("boba/pet.json", "{}");
+    zip.file("boba/spritesheet.webp", "sprite");
+    zip.file("boba/.DS_Store", "noise");
+    zip.file("__MACOSX/boba/._pet.json", "noise");
+    zip.file("__MACOSX/boba/._spritesheet.webp", "noise");
+
+    const result = locatePetZipEntries(zip);
+
+    expect(result.kind).toBe("pet");
+    if (result.kind !== "pet") return;
+    expect(result.petDirName).toBe("boba");
+    expect(result.present).not.toContain("__MACOSX/boba/._pet.json");
+  });
+
+  it("rejects a bundle with multiple complete pet folders", () => {
+    const zip = new JSZip();
+    zip.file("boba/pet.json", "{}");
+    zip.file("boba/spritesheet.webp", "sprite");
+    zip.file("kebo/pet.json", "{}");
+    zip.file("kebo/spritesheet.webp", "sprite");
+
+    const result = locatePetZipEntries(zip);
+
+    expect(result.kind).toBe("allPetsBundle");
+    if (result.kind !== "allPetsBundle") return;
+    expect(result.petJsonPaths).toEqual(["boba/pet.json", "kebo/pet.json"]);
+  });
+
+  it("prefers root pet files when a nested pet folder is also present", () => {
+    const zip = new JSZip();
+    zip.file("pet.json", "{}");
+    zip.file("spritesheet.webp", "root sprite");
+    zip.file("boba/pet.json", "{}");
+    zip.file("boba/spritesheet.webp", "nested sprite");
+
+    const result = locatePetZipEntries(zip);
+
+    expect(result.kind).toBe("pet");
+    if (result.kind !== "pet") return;
+    expect(result.petJsonPath).toBe("pet.json");
+    expect(result.spritePath).toBe("spritesheet.webp");
+    expect(result.petDirName).toBeNull();
+  });
+
+  it("uses a complete nested pet when root pet.json has no root spritesheet", () => {
+    const zip = new JSZip();
+    zip.file("pet.json", "{}");
+    zip.file("boba/pet.json", "{}");
+    zip.file("boba/spritesheet.webp", "nested sprite");
+
+    const result = locatePetZipEntries(zip);
+
+    expect(result.kind).toBe("pet");
+    if (result.kind !== "pet") return;
+    expect(result.petJsonPath).toBe("boba/pet.json");
+    expect(result.spritePath).toBe("boba/spritesheet.webp");
+    expect(result.petDirName).toBe("boba");
+  });
+
+  it("keeps root pet files valid when macOS metadata includes pet-like names", () => {
+    const zip = new JSZip();
+    zip.file("pet.json", "{}");
+    zip.file("spritesheet.webp", "root sprite");
+    zip.file("__MACOSX/._pet.json", "noise");
+    zip.file("__MACOSX/._spritesheet.webp", "noise");
+
+    const result = locatePetZipEntries(zip);
+
+    expect(result.kind).toBe("pet");
+    if (result.kind !== "pet") return;
+    expect(result.petJsonPath).toBe("pet.json");
+    expect(result.present).toEqual(["pet.json", "spritesheet.webp"]);
+  });
+
+  it("ignores system pet-like files when deciding whether pet.json exists", () => {
+    const zip = new JSZip();
+    zip.file("__MACOSX/._pet.json", "noise");
+    zip.file("__MACOSX/._spritesheet.webp", "noise");
+
+    const result = locatePetZipEntries(zip);
+
+    expect(result).toEqual({ kind: "missingPetJson", present: [] });
+  });
+});

--- a/src/lib/pet-zip.ts
+++ b/src/lib/pet-zip.ts
@@ -1,0 +1,174 @@
+import type JSZip from "jszip";
+
+type ZipEntry = JSZip.JSZipObject;
+
+type PetZipCandidate = {
+  petJsonEntry: ZipEntry;
+  petJsonPath: string;
+  petDir: string;
+  spriteEntry: ZipEntry | null;
+  spritePath: string | null;
+  spritesheetExt: "webp" | "png";
+};
+
+export type LocatedPetZip =
+  | {
+      kind: "pet";
+      petJsonEntry: ZipEntry;
+      petJsonPath: string;
+      spriteEntry: ZipEntry;
+      spritePath: string;
+      spritesheetExt: "webp" | "png";
+      petDirName: string | null;
+      present: string[];
+    }
+  | {
+      kind: "missingPetJson";
+      present: string[];
+    }
+  | {
+      kind: "missingSpritesheet";
+      petJsonEntry: ZipEntry;
+      petJsonPath: string;
+      petDirName: string | null;
+      present: string[];
+    }
+  | {
+      kind: "allPetsBundle";
+      petJsonPaths: string[];
+      present: string[];
+    };
+
+export function locatePetZipEntries(zip: JSZip): LocatedPetZip {
+  const files = Object.values(zip.files).filter(
+    (entry) => !entry.dir && !isSystemZipArtifact(entry.name),
+  );
+  const present = files.map((entry) => entry.name);
+  const petJsonEntries = files.filter(
+    (entry) => baseName(entry.name).toLowerCase() === "pet.json",
+  );
+
+  if (petJsonEntries.length === 0) {
+    return { kind: "missingPetJson", present };
+  }
+
+  const candidates = petJsonEntries.map((petJsonEntry) =>
+    candidateForPetJson(files, petJsonEntry),
+  );
+  const completeCandidates = candidates.filter(hasSpriteEntry);
+  const rootCandidate = candidates.find((candidate) => candidate.petDir === "");
+
+  if (rootCandidate && hasSpriteEntry(rootCandidate)) {
+    return toLocatedPet(rootCandidate, present);
+  }
+
+  const completeNestedCandidates = completeCandidates.filter(
+    (candidate) => candidate.petDir !== "",
+  );
+
+  if (completeNestedCandidates.length === 1) {
+    return toLocatedPet(completeNestedCandidates[0], present);
+  }
+
+  if (completeNestedCandidates.length > 1) {
+    return {
+      kind: "allPetsBundle",
+      petJsonPaths: completeNestedCandidates.map(
+        (candidate) => candidate.petJsonPath,
+      ),
+      present,
+    };
+  }
+
+  if (!rootCandidate && candidates.length > 1) {
+    return {
+      kind: "allPetsBundle",
+      petJsonPaths: candidates.map((candidate) => candidate.petJsonPath),
+      present,
+    };
+  }
+
+  const candidate = rootCandidate ?? candidates[0];
+  return {
+    kind: "missingSpritesheet",
+    petJsonEntry: candidate.petJsonEntry,
+    petJsonPath: candidate.petJsonPath,
+    petDirName: candidate.petDir ? baseName(candidate.petDir) : null,
+    present,
+  };
+}
+
+function hasSpriteEntry(
+  candidate: PetZipCandidate,
+): candidate is PetZipCandidate & { spriteEntry: ZipEntry } {
+  return Boolean(candidate.spriteEntry);
+}
+
+function toLocatedPet(
+  candidate: PetZipCandidate & { spriteEntry: ZipEntry },
+  present: string[],
+): LocatedPetZip {
+  return {
+    kind: "pet",
+    petJsonEntry: candidate.petJsonEntry,
+    petJsonPath: candidate.petJsonPath,
+    spriteEntry: candidate.spriteEntry,
+    spritePath: candidate.spritePath ?? "",
+    spritesheetExt: candidate.spritesheetExt,
+    petDirName: candidate.petDir ? baseName(candidate.petDir) : null,
+    present,
+  };
+}
+
+function candidateForPetJson(
+  files: ZipEntry[],
+  petJsonEntry: ZipEntry,
+): PetZipCandidate {
+  const petDir = dirName(petJsonEntry.name);
+  const webpEntry = findSibling(files, petDir, "spritesheet.webp");
+  const pngEntry = findSibling(files, petDir, "spritesheet.png");
+  const spriteEntry = webpEntry ?? pngEntry;
+
+  return {
+    petJsonEntry,
+    petJsonPath: petJsonEntry.name,
+    petDir,
+    spriteEntry,
+    spritePath: spriteEntry?.name ?? null,
+    spritesheetExt: webpEntry ? "webp" : "png",
+  };
+}
+
+function findSibling(files: ZipEntry[], dir: string, fileName: string) {
+  return (
+    files.find(
+      (entry) =>
+        dirName(entry.name) === dir &&
+        baseName(entry.name).toLowerCase() === fileName,
+    ) ?? null
+  );
+}
+
+function isSystemZipArtifact(path: string) {
+  return path
+    .split("/")
+    .filter(Boolean)
+    .some(
+      (segment) =>
+        segment === "__MACOSX" ||
+        segment === ".DS_Store" ||
+        segment.startsWith("._"),
+    );
+}
+
+function dirName(path: string) {
+  const normalized = path.replaceAll("\\", "/").replace(/^\/+/, "");
+  const index = normalized.lastIndexOf("/");
+  return index === -1 ? "" : normalized.slice(0, index);
+}
+
+function baseName(path: string) {
+  const normalized = path.replaceAll("\\", "/").replace(/\/+$/, "");
+  const index = normalized.lastIndexOf("/");
+  return index === -1 ? normalized : normalized.slice(index + 1);
+}


### PR DESCRIPTION
Support ZIP uploads where pet.json and spritesheet.webp/png are inside a single top-level pet folder. Prefer root-level pet files when both root and nested pet structures exist, and ignore macOS/system metadata files during ZIP classification.

Add regression coverage for root ZIPs, nested single-pet ZIPs, hidden system files, and multi-pet bundle detection.