### PR TITLE
chore(cli): bump petdex to 0.4.4

### DIFF
--- a/packages/petdex-cli/package.json
+++ b/packages/petdex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "petdex",
-  "version": "0.4.2",
+  "version": "0.4.4",
   "description": "CLI for Petdex. Install, browse, and submit Codex pets from your terminal.",
   "homepage": "https://petdex.dev",
   "repository": {


### PR DESCRIPTION
## What

Bumps `packages/petdex-cli/package.json` from `0.4.2` → `0.4.4`.

## Why

`0.4.3` is burned on npm — it was published manually from a state that still had the legacy `petdex.crafter.run` base URL, which 403s against the `assets.petdex.dev` hotlink WAF (#463). `main` already defaults to `petdex.dev`, so the code fix is in place; this just sets the version to release.

## Ship sequence

1. Merge #500 (release workflow) + this PR.
2. Tag `cli-v0.4.4` on main → `cli-release.yml` builds from main and publishes to npm automatically.

Fixes #463