### PR TITLE
fix(web): collection search, pending-name display, footer scroll trap

### DIFF
--- a/src/components/collection-pet-grid.tsx
+++ b/src/components/collection-pet-grid.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import { useLocale } from "next-intl";
+import { Search, X } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
 
 import type { PetWithMetrics } from "@/lib/pets";
 import { cn } from "@/lib/utils";
@@ -19,14 +20,29 @@ type Props = {
 
 export function CollectionPetGrid({ pets, dexMap, caughtSlugs = [] }: Props) {
   const isZh = useLocale() === "zh";
+  const t = useTranslations("collectionDetail");
+  const [query, setQuery] = useState("");
   const [pageCount, setPageCount] = useState(1);
   const caughtSet = useMemo(() => new Set(caughtSlugs), [caughtSlugs]);
 
+  const normalizedQuery = query.trim().toLowerCase();
+  const filtered = useMemo(() => {
+    if (!normalizedQuery) return pets;
+    return pets.filter((pet) =>
+      pet.displayName.toLowerCase().includes(normalizedQuery),
+    );
+  }, [pets, normalizedQuery]);
+
+  const onQueryChange = (value: string) => {
+    setQuery(value);
+    setPageCount(1);
+  };
+
   const slice = useMemo(
-    () => pets.slice(0, pageCount * PAGE_SIZE),
-    [pets, pageCount],
+    () => filtered.slice(0, pageCount * PAGE_SIZE),
+    [filtered, pageCount],
   );
-  const hasMore = slice.length < pets.length;
+  const hasMore = slice.length < filtered.length;
 
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
@@ -37,7 +53,7 @@ export function CollectionPetGrid({ pets, dexMap, caughtSlugs = [] }: Props) {
       (entries) => {
         if (entries[0]?.isIntersecting) setPageCount((p) => p + 1);
       },
-      { rootMargin: "800px" },
+      { rootMargin: "150px" },
     );
     obs.observe(el);
     return () => obs.disconnect();
@@ -46,29 +62,61 @@ export function CollectionPetGrid({ pets, dexMap, caughtSlugs = [] }: Props) {
   if (pets.length === 0) {
     return (
       <div className="rounded-3xl border border-dashed border-border-base bg-surface/60 p-10 text-center text-sm text-muted-2">
-        This collection has no approved pets yet.
+        {t("empty")}
       </div>
     );
   }
 
+  const showSearch = pets.length > PAGE_SIZE;
+
   return (
     <>
-      <div
-        className={cn(
-          "grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5",
-          isZh ? "md:gap-3" : "md:gap-5",
-        )}
-      >
-        {slice.map((pet, index) => (
-          <PetCard
-            key={pet.slug}
-            pet={pet}
-            index={index}
-            dexNumber={dexMap[pet.slug] ?? null}
-            caught={caughtSet.has(pet.slug)}
+      {showSearch ? (
+        <div className="relative mb-5">
+          <Search className="pointer-events-none absolute top-1/2 left-4 size-4 -translate-y-1/2 text-muted-3" />
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => onQueryChange(e.target.value)}
+            placeholder={t("searchPlaceholder")}
+            aria-label={t("searchAria")}
+            className="h-11 w-full rounded-2xl border border-border-base bg-surface/60 pr-10 pl-11 text-sm text-foreground outline-none placeholder:text-muted-3 focus:border-foreground/30"
           />
-        ))}
-      </div>
+          {query ? (
+            <button
+              type="button"
+              onClick={() => onQueryChange("")}
+              aria-label={t("clearSearchAria")}
+              className="absolute top-1/2 right-3 -translate-y-1/2 rounded-full p-1 text-muted-3 hover:text-foreground"
+            >
+              <X className="size-4" />
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+
+      {filtered.length === 0 ? (
+        <div className="rounded-3xl border border-dashed border-border-base bg-surface/60 p-10 text-center text-sm text-muted-2">
+          {t("noResults", { query })}
+        </div>
+      ) : (
+        <div
+          className={cn(
+            "grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5",
+            isZh ? "md:gap-3" : "md:gap-5",
+          )}
+        >
+          {slice.map((pet, index) => (
+            <PetCard
+              key={pet.slug}
+              pet={pet}
+              index={index}
+              dexNumber={dexMap[pet.slug] ?? null}
+              caught={caughtSet.has(pet.slug)}
+            />
+          ))}
+        </div>
+      )}
 
       {hasMore ? (
         <div
@@ -76,11 +124,11 @@ export function CollectionPetGrid({ pets, dexMap, caughtSlugs = [] }: Props) {
           aria-hidden="true"
           className="flex h-24 items-center justify-center text-xs text-muted-3"
         >
-          Loading more pets…
+          {t("loadingMore")}
         </div>
-      ) : pets.length > PAGE_SIZE ? (
+      ) : filtered.length > PAGE_SIZE ? (
         <p className="pt-4 text-center text-xs text-muted-3">
-          End of collection · {pets.length} pets
+          {t("endOfCollection", { count: filtered.length })}
         </p>
       ) : null}
     </>

--- a/src/components/my-pets-view.tsx
+++ b/src/components/my-pets-view.tsx
@@ -287,6 +287,7 @@ export function SubmissionCard({ submission }: { submission: Submission }) {
   const [withdrawn, setWithdrawn] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const locale = useLocale();
+  const t = useTranslations("myPets");
 
   if (withdrawn) {
     return (
@@ -393,12 +394,18 @@ export function SubmissionCard({ submission }: { submission: Submission }) {
       <div className="flex flex-col gap-2 border-t border-black/[0.06] px-5 py-4 dark:border-white/[0.06]">
         <div className="flex items-center justify-between gap-2">
           <h3 className="text-lg font-semibold tracking-tight text-foreground">
-            {submission.displayName}
+            {submission.pending?.displayName ?? submission.displayName}
           </h3>
           <span className="font-mono text-[10px] tracking-[0.18em] text-muted-4 uppercase">
             {submission.kind}
           </span>
         </div>
+        {submission.pending?.displayName &&
+        submission.pending.displayName !== submission.displayName ? (
+          <p className="font-mono text-[10px] tracking-[0.12em] text-amber-600 uppercase dark:text-amber-500">
+            {t("edit.pendingReview")}
+          </p>
+        ) : null}
         <p className="line-clamp-2 text-sm leading-6 text-muted-2">
           {submission.description}
         </p>

--- a/src/components/my-pets-view.tsx
+++ b/src/components/my-pets-view.tsx
@@ -287,7 +287,6 @@ export function SubmissionCard({ submission }: { submission: Submission }) {
   const [withdrawn, setWithdrawn] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const locale = useLocale();
-  const t = useTranslations("myPets");
 
   if (withdrawn) {
     return (
@@ -394,18 +393,12 @@ export function SubmissionCard({ submission }: { submission: Submission }) {
       <div className="flex flex-col gap-2 border-t border-black/[0.06] px-5 py-4 dark:border-white/[0.06]">
         <div className="flex items-center justify-between gap-2">
           <h3 className="text-lg font-semibold tracking-tight text-foreground">
-            {submission.pending?.displayName ?? submission.displayName}
+            {submission.displayName}
           </h3>
           <span className="font-mono text-[10px] tracking-[0.18em] text-muted-4 uppercase">
             {submission.kind}
           </span>
         </div>
-        {submission.pending?.displayName &&
-        submission.pending.displayName !== submission.displayName ? (
-          <p className="font-mono text-[10px] tracking-[0.12em] text-amber-600 uppercase dark:text-amber-500">
-            {t("edit.pendingReview")}
-          </p>
-        ) : null}
         <p className="line-clamp-2 text-sm leading-6 text-muted-2">
           {submission.description}
         </p>

--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -256,7 +256,7 @@ export function PetGallery({
       (entries) => {
         if (entries[0]?.isIntersecting) loadMore();
       },
-      { rootMargin: "400px" },
+      { rootMargin: "100px" },
     );
     obs.observe(el);
     return () => obs.disconnect();

--- a/src/components/profile-tabs.tsx
+++ b/src/components/profile-tabs.tsx
@@ -410,7 +410,10 @@ function submissionToPet(submission: Submission): PetWithMetrics {
   return {
     id: submission.id,
     slug: submission.slug,
-    displayName: submission.displayName,
+    // A queued name edit lives in pending.displayName until an admin
+    // approves it. Surface it here so the owner sees their rename in
+    // flight instead of the stale live name (e.g. "Untitled pet").
+    displayName: submission.pending?.displayName ?? submission.displayName,
     description: submission.description,
     spritesheetPath: submission.spritesheetUrl,
     petJsonPath: "",

--- a/src/i18n/client-messages.ts
+++ b/src/i18n/client-messages.ts
@@ -6,6 +6,7 @@ export const CLIENT_MESSAGE_PATHS = [
   "advertise.form",
   "claim",
   "collectionActionMenu",
+  "collectionDetail",
   "collectionEditor",
   "commandLine",
   "common",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1223,7 +1223,14 @@
     }
   },
   "collectionDetail": {
-    "backToCollections": "← All collections"
+    "backToCollections": "← All collections",
+    "searchPlaceholder": "Search pets in this collection",
+    "searchAria": "Search pets in this collection",
+    "clearSearchAria": "Clear search",
+    "noResults": "No pets match \"{query}\" in this collection.",
+    "empty": "This collection has no approved pets yet.",
+    "loadingMore": "Loading more pets…",
+    "endOfCollection": "End of collection · {count} pets"
   },
   "download": {
     "eyebrow": "Terminal-first setup",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -1223,7 +1223,14 @@
     }
   },
   "collectionDetail": {
-    "backToCollections": "← Ver todas las colecciones"
+    "backToCollections": "← Ver todas las colecciones",
+    "searchPlaceholder": "Busca mascotas en esta colección",
+    "searchAria": "Busca mascotas en esta colección",
+    "clearSearchAria": "Limpiar búsqueda",
+    "noResults": "Ninguna mascota coincide con \"{query}\" en esta colección.",
+    "empty": "Esta colección aún no tiene mascotas aprobadas.",
+    "loadingMore": "Cargando más mascotas…",
+    "endOfCollection": "Fin de la colección · {count} mascotas"
   },
   "download": {
     "eyebrow": "Setup desde la terminal",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -1415,7 +1415,14 @@
     }
   },
   "collectionDetail": {
-    "backToCollections": "← 返回全部合集"
+    "backToCollections": "← 返回全部合集",
+    "searchPlaceholder": "在此合集中搜索宠物",
+    "searchAria": "在此合集中搜索宠物",
+    "clearSearchAria": "清除搜索",
+    "noResults": "此合集中没有匹配 \"{query}\" 的宠物。",
+    "empty": "此合集还没有已通过审核的宠物。",
+    "loadingMore": "正在加载更多宠物…",
+    "endOfCollection": "已到合集末尾 · 共 {count} 个宠物"
   },
   "download": {
     "eyebrow": "终端优先安装",


### PR DESCRIPTION
Addresses three recurring items from the feedback inbox (most from `/zh`).

## 1. Search inside collections
Multiple users could not find a specific pet within a collection:
- 搜索不了 (can't search) on `/zh`
- 加个搜索功能呗，找不到咕咕嘎嘎 (add search, can't find this pet) on `/zh/collections`
- 没有单个宠物的搜索栏 (no search bar for individual pets) on `/zh/collections`

The home gallery already had a search bar; collection detail pages did not. Added a name filter to `CollectionPetGrid` (client-side, since all collection pets are already passed as props). Only renders when a collection has more than one page of pets.

## 2. 'Untitled Pet' rename not visible
A user renamed their pet but the card kept showing the old name. Name edits queue as `pendingDisplayName` awaiting review, but the my-pets card only rendered the live `displayName`, so the rename looked broken. The card now shows the pending name with a 'pending review' hint, so the change is visibly in flight.

## 3. Infinite scroll trapped the footer
`网页loadmore 导致一直很难滚动到底部看到网页的footer` (load-more makes it very hard to reach the footer). The observer used `rootMargin: 400px` on the home gallery and `800px` on collections, loading the next page long before the footer was reachable. Reduced to `100px` / `150px`.

## i18n
Added `collectionDetail` search / empty / pagination keys in en, zh, es, and registered the namespace in `CLIENT_MESSAGE_PATHS` (now used client-side).

## Verification
- `biome check` clean on all changed files
- `tsc --noEmit` — no new type errors (pre-existing `bun:test` typing noise in `.test.ts` unaffected)
- `bun test src/i18n/client-messages.test.ts` passes (namespace parity)

Not touched: desktop right-click bug (separate app), the AI frame-cutting skill request (R&D), and the review-queue backlog (operational, not a code change).