### PR TITLE
ci: republish CLI manifest snapshots on a schedule

### DIFF
--- a/.github/workflows/manifest-snapshot.yml
+++ b/.github/workflows/manifest-snapshot.yml
@@ -1,0 +1,53 @@
+name: manifest-snapshot
+
+# Republishes the static CLI manifest snapshots to R2. The CLI reads pets
+# from manifests/petdex-v1.json (and v2), which are built from the DB but
+# only ever written by `manifest:snapshot:apply`. Without this, a pet that
+# gets approved never appears in `petdex list`/`install` until someone runs
+# the script by hand (see #482). Runs daily and on demand.
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "check (dry-run, no upload) or apply (write to R2)"
+        required: false
+        default: "apply"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: manifest-snapshot
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish manifest snapshots
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: manifest-snapshot
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Publish snapshots
+        run: |
+          bun --conditions react-server \
+            scripts/publish-manifest-snapshots.ts \
+            "${{ github.event.inputs.mode || 'apply' }}"
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}

--- a/.github/workflows/manifest-snapshot.yml
+++ b/.github/workflows/manifest-snapshot.yml
@@ -13,8 +13,12 @@ on:
     inputs:
       mode:
         description: "check (dry-run, no upload) or apply (write to R2)"
+        type: choice
         required: false
         default: "apply"
+        options:
+          - apply
+          - check
 
 permissions:
   contents: read
@@ -33,6 +37,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          # Always run reviewed code from the default branch. A manual
+          # dispatch can target any ref, and this job holds prod R2 write
+          # credentials, so we never run a non-main branch here.
+          ref: main
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -41,11 +50,12 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Publish snapshots
-        run: |
-          bun --conditions react-server \
-            scripts/publish-manifest-snapshots.ts \
-            "${{ github.event.inputs.mode || 'apply' }}"
+        # MODE is validated to check|apply by the script; the choice input
+        # already constrains it, and passing via env (not interpolation)
+        # avoids any shell-injection surface.
+        run: bun --conditions react-server scripts/publish-manifest-snapshots.ts "$MODE"
         env:
+          MODE: ${{ github.event.inputs.mode || 'apply' }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Problem (#482)

`https://petdex.dev/pets/k-on-girl` is live, but `npx petdex install k-on-girl` returns "No pets matched" and `petdex list` omits it. Verified still broken in production today.

## Root cause

The CLI does not query the DB. It reads a **static snapshot** at `manifests/petdex-v1.json` in R2 (served via the `/api/manifest` redirect). That snapshot is built by `scripts/publish-manifest-snapshots.ts`, which only runs when someone manually invokes `bun manifest:snapshot:apply`. There is no cron and no post-approval hook.

So any pet approved after the last manual run is invisible to the CLI until someone re-runs the script by hand. `k-on-girl` was approved 2026-06-12 and never made it into the snapshot.

## Fix

A scheduled workflow (every 6h + `workflow_dispatch`) rebuilds the v1/v2 manifest and collection-preview snapshots from the DB and uploads them to R2. Newly approved pets now appear in the CLI within the cycle, no manual step.

`workflow_dispatch` accepts a `mode` input (`check` for a dry-run that prints counts/sha without uploading, `apply` to write). Default is `apply`.

## Before merge

Add these repo secrets under a `manifest-snapshot` environment:
- `DATABASE_URL`
- `R2_ACCOUNT_ID`
- `R2_ACCESS_KEY_ID`
- `R2_SECRET_ACCESS_KEY`
- `R2_BUCKET`

(`R2_PUBLIC_BASE` defaults to `assets.petdex.dev`, no secret needed.)

To unblock `k-on-girl` immediately, run `bun manifest:snapshot:apply` locally (or dispatch this workflow once after secrets are set).

Fixes #482