### PR TITLE
fix: add lightweight pet preview artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "manifest:snapshot:apply": "bun --env-file=.env.local --env-file=.env.production.local --conditions react-server scripts/publish-manifest-snapshots.ts apply",
     "thumbs:snapshot:check": "bun --env-file=.env.local --env-file=.env.production.local --conditions react-server scripts/publish-pet-thumbnails.ts check",
     "thumbs:snapshot:apply": "bun --env-file=.env.local --env-file=.env.production.local --conditions react-server scripts/publish-pet-thumbnails.ts apply",
+    "previews:snapshot:check": "bun --env-file=.env.local --env-file=.env.production.local --conditions react-server scripts/publish-pet-previews.ts check",
+    "previews:snapshot:apply": "bun --env-file=.env.local --env-file=.env.production.local --conditions react-server scripts/publish-pet-previews.ts apply",
     "stickers:snapshot:check": "bun --env-file=.env.local --env-file=.env.production.local --conditions react-server scripts/publish-pet-sticker-artifacts.ts check",
     "stickers:snapshot:apply": "bun --env-file=.env.local --env-file=.env.production.local --conditions react-server scripts/publish-pet-sticker-artifacts.ts apply",
     "cost:report": "bun scripts/vercel-cost-report.ts --project petdex",

--- a/scripts/publish-pet-previews.ts
+++ b/scripts/publish-pet-previews.ts
@@ -1,0 +1,257 @@
+import { createHash } from "node:crypto";
+
+import {
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import sharp from "sharp";
+
+import {
+  PET_PREVIEW_CACHE_HEADER,
+  PET_PREVIEW_FRAME_COUNT,
+  PET_PREVIEW_FRAME_HEIGHT,
+  PET_PREVIEW_FRAME_WIDTH,
+  PET_PREVIEW_QUALITY,
+  petPreviewKey,
+  petPreviewUrl,
+} from "@/lib/pet-preview";
+import { getAllApprovedPets } from "@/lib/pets";
+import { R2_BUCKET, r2 } from "@/lib/r2";
+import { keyFromR2PublicUrl } from "@/lib/r2-public-url";
+import { isAllowedAssetUrl } from "@/lib/url-allowlist";
+
+type Mode = "check" | "apply";
+
+type PreviewTask = {
+  slug: string;
+  displayName: string;
+  spritesheetPath: string;
+  spritesheetKey: string;
+  key: string;
+  url: string;
+};
+
+type PublishResult =
+  | { ok: true; slug: string; bytes: number; sha256: string }
+  | { ok: false; slug: string; reason: string };
+
+const mode = parseMode(process.argv[2]);
+const force = process.argv.includes("--force");
+const limit = parseLimit(process.argv);
+const headConcurrency = parseConcurrency("PETDEX_PREVIEW_HEAD_CONCURRENCY", 24);
+const publishConcurrency = parseConcurrency(
+  "PETDEX_PREVIEW_PUBLISH_CONCURRENCY",
+  4,
+);
+
+const allPets = await getAllApprovedPets();
+const selectedPets =
+  typeof limit === "number" ? allPets.slice(0, limit) : allPets;
+const tasks = selectedPets.map((pet) => {
+  const spritesheetKey = keyFromR2PublicUrl(pet.spritesheetPath);
+  return {
+    slug: pet.slug,
+    displayName: pet.displayName,
+    spritesheetPath: pet.spritesheetPath,
+    spritesheetKey: spritesheetKey ?? "",
+    key: petPreviewKey(pet.slug),
+    url: petPreviewUrl(pet.slug),
+  };
+});
+const validTasks = tasks.filter(
+  (task) => isAllowedAssetUrl(task.spritesheetPath) && task.spritesheetKey,
+);
+const invalidTasks = tasks.filter(
+  (task) => !isAllowedAssetUrl(task.spritesheetPath) || !task.spritesheetKey,
+);
+
+const existing = force
+  ? new Set<string>()
+  : new Set(
+      (
+        await mapLimit(validTasks, headConcurrency, async (task) =>
+          (await previewExists(task.key)) ? task.slug : null,
+        )
+      ).filter((slug): slug is string => Boolean(slug)),
+    );
+const pending = force
+  ? validTasks
+  : validTasks.filter((task) => !existing.has(task.slug));
+
+console.log(`pet previews ${mode}`);
+console.log(`approved ${allPets.length}`);
+console.log(`selected ${selectedPets.length}`);
+console.log(`valid ${validTasks.length}`);
+console.log(`invalid ${invalidTasks.length}`);
+console.log(`existing ${existing.size}`);
+console.log(`pending ${pending.length}`);
+console.log(`force ${force ? "yes" : "no"}`);
+
+if (pending.length > 0) {
+  console.log(
+    `pending sample ${pending
+      .slice(0, 20)
+      .map((task) => task.slug)
+      .join(", ")}`,
+  );
+}
+
+if (invalidTasks.length > 0) {
+  console.log(
+    `invalid sample ${invalidTasks
+      .slice(0, 20)
+      .map((task) => task.slug)
+      .join(", ")}`,
+  );
+}
+
+if (mode === "apply") {
+  let completed = 0;
+  const results = await mapLimit(pending, publishConcurrency, async (task) => {
+    const result = await publishPreview(task);
+    completed += 1;
+    if (completed % 100 === 0 || completed === pending.length) {
+      console.log(`progress ${completed}/${pending.length}`);
+    }
+    return result;
+  });
+  const uploaded = results.filter(
+    (result): result is Extract<PublishResult, { ok: true }> => result.ok,
+  );
+  const failed = results.filter(
+    (result): result is Extract<PublishResult, { ok: false }> => !result.ok,
+  );
+  const bytes = uploaded.reduce((total, result) => total + result.bytes, 0);
+  const hash = createHash("sha256");
+  for (const result of uploaded) {
+    hash.update(result.slug);
+    hash.update("\0");
+    hash.update(result.sha256);
+    hash.update("\0");
+  }
+
+  console.log(`uploaded ${uploaded.length}`);
+  console.log(`uploaded bytes ${bytes}`);
+  console.log(`uploaded sha256 ${hash.digest("hex")}`);
+  console.log(`failed ${failed.length}`);
+
+  for (const result of failed.slice(0, 20)) {
+    console.log(`failed ${result.slug} ${result.reason}`);
+  }
+
+  if (failed.length > 0) process.exit(1);
+}
+
+async function publishPreview(task: PreviewTask): Promise<PublishResult> {
+  try {
+    const source = await getR2ObjectBuffer(task.spritesheetKey);
+    const body = await sharp(source)
+      .extract({
+        left: 0,
+        top: 0,
+        width: PET_PREVIEW_FRAME_WIDTH * PET_PREVIEW_FRAME_COUNT,
+        height: PET_PREVIEW_FRAME_HEIGHT,
+      })
+      .webp({ quality: PET_PREVIEW_QUALITY })
+      .toBuffer();
+    const sha256 = createHash("sha256").update(body).digest("hex");
+
+    await r2.send(
+      new PutObjectCommand({
+        Bucket: R2_BUCKET,
+        Key: task.key,
+        Body: body,
+        ContentType: "image/webp",
+        CacheControl: PET_PREVIEW_CACHE_HEADER,
+        ContentDisposition: `inline; filename="${task.slug}-preview.webp"`,
+        Metadata: {
+          "petdex-slug": task.slug,
+          "petdex-source-sha256": createHash("sha256")
+            .update(source)
+            .digest("hex"),
+          "petdex-sha256": sha256,
+        },
+      }),
+    );
+
+    return { ok: true, slug: task.slug, bytes: body.byteLength, sha256 };
+  } catch (error) {
+    return { ok: false, slug: task.slug, reason: errorReason(error) };
+  }
+}
+
+async function getR2ObjectBuffer(key: string): Promise<Buffer> {
+  const response = await r2.send(
+    new GetObjectCommand({ Bucket: R2_BUCKET, Key: key }),
+  );
+  if (!response.Body) throw new Error("missing body");
+  return Buffer.from(await response.Body.transformToByteArray());
+}
+
+async function previewExists(key: string): Promise<boolean> {
+  try {
+    await r2.send(new HeadObjectCommand({ Bucket: R2_BUCKET, Key: key }));
+    return true;
+  } catch (error) {
+    if (isMissingObjectError(error)) return false;
+    throw error;
+  }
+}
+
+async function mapLimit<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    async () => {
+      while (next < items.length) {
+        const index = next;
+        next += 1;
+        results[index] = await fn(items[index], index);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+function parseMode(raw: string | undefined): Mode {
+  if (raw === "check" || raw === "apply") return raw;
+  console.error("usage: bun scripts/publish-pet-previews.ts <check|apply>");
+  process.exit(2);
+}
+
+function parseLimit(args: string[]): number | null {
+  const raw = args.find((arg) => arg.startsWith("--limit="));
+  if (!raw) return null;
+  const value = Number.parseInt(raw.slice("--limit=".length), 10);
+  if (Number.isFinite(value) && value > 0) return value;
+  console.error("invalid --limit");
+  process.exit(2);
+}
+
+function parseConcurrency(key: string, fallback: number): number {
+  const value = Number.parseInt(process.env[key] ?? "", 10);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function isMissingObjectError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const name = "name" in error ? (error as { name?: unknown }).name : null;
+  const httpStatus =
+    "$metadata" in error
+      ? (error as { $metadata?: { httpStatusCode?: number } }).$metadata
+          ?.httpStatusCode
+      : null;
+  return name === "NotFound" || httpStatus === 404;
+}
+
+function errorReason(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -482,13 +482,15 @@ input {
   --sprite-row: 0;
   --sprite-frames: 6;
   --sprite-duration: 1100ms;
+  --sprite-sheet-width: 1536px;
+  --sprite-sheet-height: 1872px;
   --sprite-y: calc(var(--sprite-row) * -208px);
   --sprite-end-x: calc(var(--sprite-frames) * -192px);
   width: 192px;
   height: 208px;
   background-image: var(--sprite-url);
   background-repeat: no-repeat;
-  background-size: 1536px 1872px;
+  background-size: var(--sprite-sheet-width) var(--sprite-sheet-height);
   image-rendering: pixelated;
   /* translateZ(0) forces a GPU-composited layer so background-image
      decode + animation stay on the compositor thread instead of being

--- a/src/components/collection-cover.tsx
+++ b/src/components/collection-cover.tsx
@@ -9,6 +9,8 @@
 // server picks one offset and the client picks another; a slug-derived
 // pseudo-hash gives both sides the same answer without coordination.
 
+import { petPreviewUrlForSource } from "@/lib/pet-preview";
+
 import { PetSprite } from "@/components/pet-sprite";
 
 export type CollectionCoverPet = {
@@ -73,15 +75,21 @@ export function CollectionCover({
   );
 
   if (lineup.length === 1) {
+    const pet = lineup[0];
+    const previewSrc = petPreviewUrlForSource(pet.slug, pet.spritesheetPath);
     return (
       <div
         className={`pet-sprite-stage relative grid aspect-[16/9] place-items-center overflow-hidden ${className}`}
       >
         <PetSprite
-          src={lineup[0].spritesheetPath}
-          cycleStates
+          src={previewSrc ?? pet.spritesheetPath}
+          fallbackSrc={previewSrc ? pet.spritesheetPath : undefined}
+          layout={previewSrc ? "row" : "atlas"}
+          fallbackLayout="atlas"
+          state="idle"
+          cycleStates={!previewSrc}
           scale={scale * 1.5}
-          label={`${lineup[0].displayName} animated`}
+          label={`${pet.displayName} animated`}
         />
       </div>
     );
@@ -138,6 +146,10 @@ export function CollectionCover({
         const isLead =
           pet.slug === lineup[0].slug && i === Math.floor((n - 1) / 2);
         const h = hashSlug(pet.slug);
+        const previewSrc = petPreviewUrlForSource(
+          pet.slug,
+          pet.spritesheetPath,
+        );
 
         // Compute slot center inside the inner band. The first/last pets
         // sit at innerLeft / innerRight respectively; the middle ones
@@ -177,8 +189,12 @@ export function CollectionCover({
             }}
           >
             <PetSprite
-              src={pet.spritesheetPath}
-              cycleStates
+              src={previewSrc ?? pet.spritesheetPath}
+              fallbackSrc={previewSrc ? pet.spritesheetPath : undefined}
+              layout={previewSrc ? "row" : "atlas"}
+              fallbackLayout="atlas"
+              state="idle"
+              cycleStates={!previewSrc}
               scale={petScale}
               label={`${pet.displayName} animated`}
             />

--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -19,6 +19,7 @@ import type { PublicFeedAd } from "@/lib/ads/queries";
 import { COLOR_FAMILIES, type ColorFamily } from "@/lib/color-families";
 import { formatBatchLabel, getBatchKey } from "@/lib/dex-batch";
 import { formatLocalizedNumber } from "@/lib/format-number";
+import { petPreviewUrlForSource } from "@/lib/pet-preview";
 import type { SearchPet } from "@/lib/pet-search";
 import { petStates } from "@/lib/pet-states";
 import { PET_KINDS, PET_VIBES, type PetKind, type PetVibe } from "@/lib/types";
@@ -863,6 +864,7 @@ function PetCardImpl({
   const isDiscovered = pet.source === "discover";
   const href = `/pets/${pet.slug}`;
   const formattedInstallCount = formatLocalizedNumber(installCount, locale);
+  const previewSrc = petPreviewUrlForSource(pet.slug, pet.spritesheetPath);
   const batchLabel = pet.approvedAt
     ? formatBatchLabel(getBatchKey(new Date(pet.approvedAt)))
     : null;
@@ -932,8 +934,12 @@ function PetCardImpl({
           }
         >
           <PetSprite
-            src={pet.spritesheetPath}
-            cycleStates
+            src={previewSrc ?? pet.spritesheetPath}
+            fallbackSrc={previewSrc ? pet.spritesheetPath : undefined}
+            layout={previewSrc ? "row" : "atlas"}
+            fallbackLayout="atlas"
+            state="idle"
+            cycleStates={!previewSrc}
             scale={0.7}
             label={`${pet.displayName} animated`}
           />

--- a/src/components/pet-sprite.tsx
+++ b/src/components/pet-sprite.tsx
@@ -1,15 +1,20 @@
 "use client";
 
-import { type CSSProperties, memo } from "react";
+import { type CSSProperties, memo, useEffect, useState } from "react";
 
 import { type PetStateId, petStates } from "@/lib/pet-states";
 
+type PetSpriteLayout = "atlas" | "row";
+
 type PetSpriteProps = {
   src: string;
+  fallbackSrc?: string;
   state?: PetStateId;
   scale?: number;
   label?: string;
   className?: string;
+  layout?: PetSpriteLayout;
+  fallbackLayout?: PetSpriteLayout;
   /**
    * When true, the rendered animation state is picked deterministically
    * from `src` so cards across the gallery look visually diverse without
@@ -26,17 +31,46 @@ type PetSpriteProps = {
 
 function PetSpriteImpl({
   src,
+  fallbackSrc,
   state = "idle",
   scale = 1,
   label,
   className = "",
+  layout = "atlas",
+  fallbackLayout = "atlas",
   cycleStates = false,
 }: PetSpriteProps) {
+  const [resolved, setResolved] = useState({ src, layout });
+
+  useEffect(() => {
+    setResolved({ src, layout });
+    if (!fallbackSrc) return;
+
+    let cancelled = false;
+    const image = new window.Image();
+    image.onload = () => {
+      if (!cancelled) setResolved({ src, layout });
+    };
+    image.onerror = () => {
+      if (!cancelled) {
+        setResolved({ src: fallbackSrc, layout: fallbackLayout });
+      }
+    };
+    image.src = src;
+
+    return () => {
+      cancelled = true;
+    };
+  }, [src, fallbackSrc, layout, fallbackLayout]);
+
   const fixedAnimation =
     petStates.find((item) => item.id === state) ?? petStates[0];
   const animation = cycleStates
     ? petStates[hashString(src) % petStates.length]
     : fixedAnimation;
+  const spriteRow = resolved.layout === "row" ? 0 : animation.row;
+  const sheetWidth = resolved.layout === "row" ? animation.frames * 192 : 1536;
+  const sheetHeight = resolved.layout === "row" ? 208 : 1872;
 
   return (
     <div
@@ -53,10 +87,12 @@ function PetSpriteImpl({
         className="pet-sprite"
         style={
           {
-            "--sprite-url": `url("${src.replace(/"/g, '\\"')}")`,
-            "--sprite-row": animation.row,
+            "--sprite-url": `url("${resolved.src.replace(/"/g, '\\"')}")`,
+            "--sprite-row": spriteRow,
             "--sprite-frames": animation.frames,
             "--sprite-duration": `${animation.durationMs}ms`,
+            "--sprite-sheet-width": `${sheetWidth}px`,
+            "--sprite-sheet-height": `${sheetHeight}px`,
           } as CSSProperties
         }
       />

--- a/src/lib/pet-preview.test.ts
+++ b/src/lib/pet-preview.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  petPreviewKey,
+  petPreviewUrl,
+  petPreviewUrlForSource,
+} from "@/lib/pet-preview";
+
+describe("pet preview artifact helpers", () => {
+  it("builds the public preview key and URL", () => {
+    expect(petPreviewKey("cai-chao")).toBe("pets/cai-chao/preview.webp");
+    expect(petPreviewUrl("cai-chao")).toBe(
+      "https://assets.petdex.dev/pets/cai-chao/preview.webp",
+    );
+  });
+
+  it("only derives preview URLs for recognized R2 sources", () => {
+    expect(
+      petPreviewUrlForSource(
+        "cai-chao",
+        "https://assets.petdex.dev/pets/cai-chao/spritesheet.webp",
+      ),
+    ).toBe("https://assets.petdex.dev/pets/cai-chao/preview.webp");
+    expect(
+      petPreviewUrlForSource(
+        "cai-chao",
+        "https://example.com/pets/cai-chao/spritesheet.webp",
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/lib/pet-preview.ts
+++ b/src/lib/pet-preview.ts
@@ -1,0 +1,23 @@
+import { keyFromR2PublicUrl, R2_PUBLIC_BASE } from "@/lib/r2-public-url";
+
+export const PET_PREVIEW_FRAME_WIDTH = 192;
+export const PET_PREVIEW_FRAME_HEIGHT = 208;
+export const PET_PREVIEW_FRAME_COUNT = 6;
+export const PET_PREVIEW_QUALITY = 70;
+export const PET_PREVIEW_CACHE_HEADER =
+  "public, max-age=31536000, s-maxage=31536000, immutable";
+
+export function petPreviewKey(slug: string): string {
+  return `pets/${slug}/preview.webp`;
+}
+
+export function petPreviewUrl(slug: string): string {
+  return `${R2_PUBLIC_BASE}/${petPreviewKey(slug)}`;
+}
+
+export function petPreviewUrlForSource(
+  slug: string,
+  spritesheetPath: string,
+): string | null {
+  return keyFromR2PublicUrl(spritesheetPath) ? petPreviewUrl(slug) : null;
+}

--- a/src/lib/pet-public-artifact-keys.test.ts
+++ b/src/lib/pet-public-artifact-keys.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
+import { petPreviewKey } from "@/lib/pet-preview";
 import { petPublicArtifactKeys } from "@/lib/pet-public-artifact-keys";
 import {
   PET_STICKER_FORMATS,
@@ -8,10 +9,11 @@ import {
 import { petThumbnailKey } from "@/lib/pet-thumbnail";
 
 describe("pet public artifact keys", () => {
-  it("covers thumbnails, every sticker derivative, and packs", () => {
+  it("covers thumbnails, previews, every sticker derivative, and packs", () => {
     const keys = petPublicArtifactKeys("cai-chao");
 
     expect(keys).toContain(petThumbnailKey("cai-chao"));
+    expect(keys).toContain(petPreviewKey("cai-chao"));
     expect(keys).toContain("pets/cai-chao/wastickers.zip");
 
     for (const state of PET_STICKER_STATES) {

--- a/src/lib/pet-public-artifact-keys.ts
+++ b/src/lib/pet-public-artifact-keys.ts
@@ -1,3 +1,4 @@
+import { petPreviewKey } from "@/lib/pet-preview";
 import {
   PET_STICKER_FORMATS,
   PET_STICKER_STATES,
@@ -9,6 +10,7 @@ import { petThumbnailKey } from "@/lib/pet-thumbnail";
 export function petPublicArtifactKeys(slug: string): string[] {
   return [
     petThumbnailKey(slug),
+    petPreviewKey(slug),
     ...PET_STICKER_STATES.flatMap((state) =>
       PET_STICKER_FORMATS.map((format) => petStickerKey(slug, state, format)),
     ),

--- a/src/lib/pet-public-artifacts.ts
+++ b/src/lib/pet-public-artifacts.ts
@@ -8,6 +8,14 @@ import {
 import sharp from "sharp";
 
 import {
+  PET_PREVIEW_CACHE_HEADER,
+  PET_PREVIEW_FRAME_COUNT,
+  PET_PREVIEW_FRAME_HEIGHT,
+  PET_PREVIEW_FRAME_WIDTH,
+  PET_PREVIEW_QUALITY,
+  petPreviewKey,
+} from "@/lib/pet-preview";
+import {
   PET_STICKER_CACHE_HEADER,
   petStickerFilename,
   petStickerKey,
@@ -53,6 +61,7 @@ export async function publishPetPublicArtifacts(input: {
   };
   const refs = [
     { key: petThumbnailKey(input.slug), kind: "thumbnail" as const },
+    { key: petPreviewKey(input.slug), kind: "preview" as const },
     { key: petStickerKey(input.slug), kind: "sticker" as const },
   ];
   const pending = [];
@@ -73,7 +82,9 @@ export async function publishPetPublicArtifacts(input: {
       const artifact =
         ref.kind === "thumbnail"
           ? await buildThumbnailArtifact(input.slug, source)
-          : await buildStickerArtifact(input.slug, source);
+          : ref.kind === "preview"
+            ? await buildPreviewArtifact(input.slug, source)
+            : await buildStickerArtifact(input.slug, source);
       await r2.send(
         new PutObjectCommand({
           Bucket: R2_BUCKET,
@@ -97,6 +108,25 @@ export async function publishPetPublicArtifacts(input: {
   }
 
   return result;
+}
+
+async function buildPreviewArtifact(slug: string, source: Buffer) {
+  const body = await sharp(source)
+    .extract({
+      left: 0,
+      top: 0,
+      width: PET_PREVIEW_FRAME_WIDTH * PET_PREVIEW_FRAME_COUNT,
+      height: PET_PREVIEW_FRAME_HEIGHT,
+    })
+    .webp({ quality: PET_PREVIEW_QUALITY })
+    .toBuffer();
+  return {
+    body,
+    contentType: "image/webp",
+    cacheControl: PET_PREVIEW_CACHE_HEADER,
+    contentDisposition: `inline; filename="${slug}-preview.webp"`,
+    sha256: createHash("sha256").update(body).digest("hex"),
+  };
 }
 
 async function buildThumbnailArtifact(slug: string, source: Buffer) {


### PR DESCRIPTION
Fixes #490

Summary:
- Add a `pets/<slug>/preview.webp` artifact that crops the idle animation row from the canonical spritesheet.
- Publish previews for newly approved pets and add a `previews:snapshot:*` script for backfilling existing R2 assets.
- Use preview strips on gallery cards and animated collection covers, with a client fallback to the full spritesheet when the preview file is missing or the pet is not backed by R2.

Validation:
- `npx --yes bun@1.2.22 test src/lib/pet-preview.test.ts src/lib/pet-public-artifact-keys.test.ts`
- `npx --yes bun@1.2.22 test`
- `npx --yes bun@1.2.22 run check`
- `npx --yes bun@1.2.22 run build` compiled and completed TypeScript, then stopped during page data collection because local `DATABASE_URL`, `UPSTASH_REDIS_REST_URL`, and `UPSTASH_REDIS_REST_TOKEN` are not set.
