### PR TITLE
20260628 reddoctor fix

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "petdex",

--- a/packages/petdex-cli/bin/petdex.ts
+++ b/packages/petdex-cli/bin/petdex.ts
@@ -1747,8 +1747,17 @@ async function cmdDesktop(args: string[]) {
   }
   switch (sub) {
     case "start":
-      await cmdDesktopStart();
-      emit("cli_desktop_start_success", { cli_version: VERSION });
+      {
+        const startArgs = args.slice(1);
+        await cmdDesktopStart(startArgs);
+        if (
+          !startArgs.some((arg) =>
+            ["--help", "-h", "help"].includes(arg),
+          )
+        ) {
+          emit("cli_desktop_start_success", { cli_version: VERSION });
+        }
+      }
       break;
     case "stop":
       await cmdDesktopStop();
@@ -1779,8 +1788,12 @@ function printDesktopHelp() {
       `    ${pc.bold("stop")}      Terminate the running petdex-desktop process`,
       `    ${pc.bold("status")}    Show whether petdex-desktop is running`,
       "",
+      `  ${c("Start options")}`,
+      `    ${pc.bold("--direct")}  Launch the executable directly instead of the macOS app bundle`,
+      "",
       `  ${c("Examples")}`,
       `    ${dim("$")} petdex desktop start`,
+      `    ${dim("$")} petdex desktop start --direct`,
       `    ${dim("$")} petdex desktop status`,
       `    ${dim("$")} petdex desktop stop`,
       "",

--- a/packages/petdex-cli/src/desktop/process.test.ts
+++ b/packages/petdex-cli/src/desktop/process.test.ts
@@ -1,11 +1,22 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { execFileSync, spawn } from "node:child_process";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  openSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { createServer, type Server } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { desktopStatus, stopDesktop, waitForPortRelease } from "./process";
+import {
+  _startDesktopForTest,
+  desktopStatus,
+  stopDesktop,
+  waitForPortRelease,
+} from "./process";
 
 // Pick high ports so we don't fight the real sidecar at :7777 if a
 // dev happens to have it running. These tests open a TCP listener,
@@ -91,6 +102,93 @@ describe("waitForPortRelease", () => {
     // shorter (otherwise update.ts would race the sidecar even
     // when it shouldn't).
     expect(elapsed).toBeGreaterThanOrEqual(350);
+  });
+});
+
+describe("startDesktop", () => {
+  let realHome: string | undefined;
+  let tmpHome: string;
+
+  beforeEach(() => {
+    realHome = process.env.HOME;
+    tmpHome = join(
+      tmpdir(),
+      `petdex-start-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(join(tmpHome, ".petdex"), { recursive: true });
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    if (realHome !== undefined) process.env.HOME = realHome;
+    if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  test("spawns the resolved binary directly", async () => {
+    const spawnCalls: Array<{
+      command: string;
+      args: string[];
+      detached: boolean;
+      stdio: Array<unknown>;
+    }> = [];
+    const openCalls: string[] = [];
+    const writes: Array<{ path: string; contents: string }> = [];
+
+    const result = await _startDesktopForTest({
+      desktopStatus: () => ({ state: "stopped" }),
+      desktopBinPath: () =>
+        "/Applications/Petdex.app/Contents/MacOS/petdex-desktop",
+      existsSync: () => true,
+      mkdir: async () => {},
+      openSync: ((filePath: unknown) => {
+        openCalls.push(String(filePath));
+        return 42;
+      }) as typeof openSync,
+      spawn: ((command: string, args: string[], options: any) => {
+        spawnCalls.push({
+          command,
+          args,
+          detached: Boolean(options.detached),
+          stdio: options.stdio,
+        });
+        return {
+          pid: 2468,
+          unref() {},
+        } as ReturnType<typeof spawn>;
+      }) as typeof spawn,
+      writeFile: (async (filePath: unknown, contents: unknown) => {
+        writes.push({ path: String(filePath), contents: String(contents) });
+      }) as typeof import("node:fs/promises").writeFile,
+      logFile: () => join(tmpHome, ".petdex", "desktop.log"),
+      recordLstart: () => "Mon Jan  1 00:00:00 2026",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      pid: 2468,
+      alreadyRunning: false,
+    });
+    expect(spawnCalls).toEqual([
+      {
+        command: "/Applications/Petdex.app/Contents/MacOS/petdex-desktop",
+        args: [],
+        detached: true,
+        stdio: ["ignore", 42, 42],
+      },
+    ]);
+    expect(openCalls).toEqual([
+      join(tmpHome, ".petdex", "desktop.log"),
+      join(tmpHome, ".petdex", "desktop.log"),
+    ]);
+    expect(writes).toEqual([
+      {
+        path: join(tmpHome, ".petdex", "desktop.pid"),
+        contents: JSON.stringify({
+          pid: 2468,
+          lstart: "Mon Jan  1 00:00:00 2026",
+        }),
+      },
+    ]);
   });
 });
 

--- a/packages/petdex-cli/src/desktop/process.test.ts
+++ b/packages/petdex-cli/src/desktop/process.test.ts
@@ -124,12 +124,12 @@ describe("startDesktop", () => {
     if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
   });
 
-  test("spawns the resolved binary directly", async () => {
+  test("launches app bundles through open by default", async () => {
     const spawnCalls: Array<{
       command: string;
       args: string[];
       detached: boolean;
-      stdio: Array<unknown>;
+      stdio: unknown;
     }> = [];
     const openCalls: string[] = [];
     const writes: Array<{ path: string; contents: string }> = [];
@@ -156,6 +156,7 @@ describe("startDesktop", () => {
           unref() {},
         } as ReturnType<typeof spawn>;
       }) as typeof spawn,
+      pgrepPetdexDesktop: () => 2468,
       writeFile: (async (filePath: unknown, contents: unknown) => {
         writes.push({ path: String(filePath), contents: String(contents) });
       }) as typeof import("node:fs/promises").writeFile,
@@ -170,10 +171,10 @@ describe("startDesktop", () => {
     });
     expect(spawnCalls).toEqual([
       {
-        command: "/Applications/Petdex.app/Contents/MacOS/petdex-desktop",
-        args: [],
+        command: "open",
+        args: ["-gj", "/Applications/Petdex.app"],
         detached: true,
-        stdio: ["ignore", 42, 42],
+        stdio: "ignore",
       },
     ]);
     expect(openCalls).toEqual([
@@ -187,6 +188,56 @@ describe("startDesktop", () => {
           pid: 2468,
           lstart: "Mon Jan  1 00:00:00 2026",
         }),
+      },
+    ]);
+  });
+
+  test("spawns app bundle executables directly with --direct", async () => {
+    const spawnCalls: Array<{
+      command: string;
+      args: string[];
+      detached: boolean;
+      stdio: unknown;
+    }> = [];
+
+    const result = await _startDesktopForTest(
+      {
+        desktopStatus: () => ({ state: "stopped" }),
+        desktopBinPath: () =>
+          "/Applications/Petdex.app/Contents/MacOS/petdex-desktop",
+        existsSync: () => true,
+        mkdir: async () => {},
+        openSync: (() => 42) as typeof openSync,
+        spawn: ((command: string, args: string[], options: any) => {
+          spawnCalls.push({
+            command,
+            args,
+            detached: Boolean(options.detached),
+            stdio: options.stdio,
+          });
+          return {
+            pid: 2468,
+            unref() {},
+          } as ReturnType<typeof spawn>;
+        }) as typeof spawn,
+        writeFile:
+          (async () => {}) as typeof import("node:fs/promises").writeFile,
+        recordLstart: () => "Mon Jan  1 00:00:00 2026",
+      },
+      { direct: true },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      pid: 2468,
+      alreadyRunning: false,
+    });
+    expect(spawnCalls).toEqual([
+      {
+        command: "/Applications/Petdex.app/Contents/MacOS/petdex-desktop",
+        args: [],
+        detached: true,
+        stdio: ["ignore", 42, 42],
       },
     ]);
   });

--- a/packages/petdex-cli/src/desktop/process.ts
+++ b/packages/petdex-cli/src/desktop/process.ts
@@ -5,7 +5,7 @@
  * detect a previous instance and avoid spawning duplicates.
  */
 import { execFileSync, spawn } from "node:child_process";
-import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { existsSync, openSync, readFileSync, unlinkSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
@@ -190,42 +190,68 @@ export type StartResult =
   | { ok: true; pid: number; alreadyRunning: boolean }
   | { ok: false; reason: string };
 
+type StartDesktopDeps = {
+  desktopStatus: typeof desktopStatus;
+  clearPidFile: () => void;
+  desktopBinPath: typeof desktopBinPath;
+  existsSync: typeof existsSync;
+  mkdir: typeof mkdir;
+  openSync: typeof openSync;
+  spawn: typeof spawn;
+  writeFile: typeof writeFile;
+  logFile: () => string;
+  recordLstart: typeof recordLstart;
+};
+
+const defaultStartDesktopDeps: StartDesktopDeps = {
+  desktopStatus,
+  clearPidFile,
+  desktopBinPath,
+  existsSync,
+  mkdir,
+  openSync,
+  spawn,
+  writeFile,
+  logFile,
+  recordLstart,
+};
+
 export async function startDesktop(): Promise<StartResult> {
-  const status = desktopStatus();
+  return startDesktopImpl(defaultStartDesktopDeps);
+}
+
+export async function _startDesktopForTest(
+  deps: Partial<StartDesktopDeps>,
+): Promise<StartResult> {
+  return startDesktopImpl({ ...defaultStartDesktopDeps, ...deps });
+}
+
+async function startDesktopImpl(deps: StartDesktopDeps): Promise<StartResult> {
+  const status = deps.desktopStatus();
   if (status.state === "running") {
     return { ok: true, pid: status.pid, alreadyRunning: true };
   }
-  if (status.state === "stale") clearPidFile();
+  if (status.state === "stale") deps.clearPidFile();
 
-  const bin = desktopBinPath();
-  if (!existsSync(bin)) {
+  const bin = deps.desktopBinPath();
+  if (!deps.existsSync(bin)) {
     return {
       ok: false,
       reason: `petdex-desktop binary not found at ${bin}. Run \`petdex install desktop\` first.`,
     };
   }
 
-  await mkdir(path.dirname(logFile()), { recursive: true });
+  await deps.mkdir(path.dirname(deps.logFile()), { recursive: true });
 
-  const out = await import("node:fs").then((fs) => fs.openSync(logFile(), "a"));
-  const err = await import("node:fs").then((fs) => fs.openSync(logFile(), "a"));
+  const logPath = deps.logFile();
+  const out = deps.openSync(logPath, "a");
+  const err = deps.openSync(logPath, "a");
 
-  // If the binary is inside an .app bundle, launch via `open -a` so
-  // macOS treats it as a proper application (Dock icon, LaunchServices
-  // registration, correct menubar title from CFBundleName, app
-  // activation policy). Spawning the bare executable directly skips
-  // all of that and the user sees an unstyled raw process.
-  //
-  // Trade-off: `open` returns immediately and doesn't give us the
-  // child's pid. We grep for it via pgrep right after launch. A few
-  // ms of delay is fine because petdex-desktop binds :7777 quickly
-  // anyway and pgrep is cheap.
-  const appBundle = findEnclosingAppBundle(bin);
-  if (appBundle) {
-    return startViaOpen(appBundle);
-  }
-
-  const child = spawn(bin, [], {
+  // Launch the resolved executable directly.
+  // This avoids the macOS `open`/LaunchServices path, which proved
+  // unstable for the bundle install and crashed before the window
+  // could finish creating.
+  const child = deps.spawn(bin, [], {
     detached: true,
     stdio: ["ignore", out, err],
   });
@@ -238,75 +264,12 @@ export async function startDesktop(): Promise<StartResult> {
   // Capture the start-time so a future `petdex desktop stop` can
   // verify identity before signalling. recordLstart() handles the
   // POSIX (ps) and Windows (sentinel) cases.
-  const record: PidRecord = { pid: child.pid, lstart: recordLstart(child.pid) };
-  await writeFile(pidFile(), JSON.stringify(record));
+  const record: PidRecord = {
+    pid: child.pid,
+    lstart: deps.recordLstart(child.pid),
+  };
+  await deps.writeFile(pidFile(), JSON.stringify(record));
   return { ok: true, pid: child.pid, alreadyRunning: false };
-}
-
-// Walks up from /…/Petdex.app/Contents/MacOS/petdex-desktop and returns
-// the .app path if found. Returns null for bare-binary installs (e.g.
-// ~/.petdex/bin/petdex-desktop).
-function findEnclosingAppBundle(binPath: string): string | null {
-  // The binary always lives at <bundle>/Contents/MacOS/<name>.
-  const macosDir = path.dirname(binPath);
-  if (path.basename(macosDir) !== "MacOS") return null;
-  const contentsDir = path.dirname(macosDir);
-  if (path.basename(contentsDir) !== "Contents") return null;
-  const bundle = path.dirname(contentsDir);
-  if (!bundle.endsWith(".app")) return null;
-  return bundle;
-}
-
-async function startViaOpen(appBundle: string): Promise<StartResult> {
-  // `open -gj` keeps Petdex from stealing focus from the user's
-  // terminal/agent. -W would wait for the app to exit, which we
-  // don't want; we want fire-and-forget. -n forces a new instance
-  // (we already verified state was stopped above, so this is just
-  // belt-and-braces).
-  const result = spawn("open", ["-gj", appBundle], {
-    stdio: "ignore",
-    detached: true,
-  });
-  result.unref();
-
-  // Poll for the child process — open returns immediately so we
-  // need to discover the pid LaunchServices spawned. Cap at 3s so
-  // a misconfigured bundle doesn't hang the CLI.
-  const deadline = Date.now() + 3_000;
-  let pid: number | null = null;
-  while (Date.now() < deadline) {
-    pid = pgrepPetdexDesktop();
-    if (pid) break;
-    await new Promise((resolve) => setTimeout(resolve, 100));
-  }
-  if (!pid) {
-    return {
-      ok: false,
-      reason: `Launched ${appBundle} but couldn't find the resulting process. Check ${logFile()}.`,
-    };
-  }
-
-  const record: PidRecord = { pid, lstart: recordLstart(pid) };
-  await writeFile(pidFile(), JSON.stringify(record));
-  return { ok: true, pid, alreadyRunning: false };
-}
-
-function pgrepPetdexDesktop(): number | null {
-  try {
-    // Match the executable name inside the bundle (Contents/MacOS/petdex-desktop).
-    // -f matches against the full command line so the path inside the bundle counts.
-    const out = execFileSync("pgrep", ["-f", "petdex-desktop"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-    if (!out) return null;
-    // pgrep returns one pid per line; take the most recent (last).
-    const lines = out.split("\n").filter((l) => l.length > 0);
-    const pid = Number(lines[lines.length - 1]);
-    return Number.isFinite(pid) && pid > 0 ? pid : null;
-  } catch {
-    return null;
-  }
 }
 
 export type StopResult =

--- a/packages/petdex-cli/src/desktop/process.ts
+++ b/packages/petdex-cli/src/desktop/process.ts
@@ -201,6 +201,7 @@ type StartDesktopDeps = {
   writeFile: typeof writeFile;
   logFile: () => string;
   recordLstart: typeof recordLstart;
+  pgrepPetdexDesktop: typeof pgrepPetdexDesktop;
 };
 
 const defaultStartDesktopDeps: StartDesktopDeps = {
@@ -214,19 +215,30 @@ const defaultStartDesktopDeps: StartDesktopDeps = {
   writeFile,
   logFile,
   recordLstart,
+  pgrepPetdexDesktop,
 };
 
-export async function startDesktop(): Promise<StartResult> {
-  return startDesktopImpl(defaultStartDesktopDeps);
+export type StartDesktopOptions = {
+  direct?: boolean;
+};
+
+export async function startDesktop(
+  options: StartDesktopOptions = {},
+): Promise<StartResult> {
+  return startDesktopImpl(defaultStartDesktopDeps, options);
 }
 
 export async function _startDesktopForTest(
   deps: Partial<StartDesktopDeps>,
+  options: StartDesktopOptions = {},
 ): Promise<StartResult> {
-  return startDesktopImpl({ ...defaultStartDesktopDeps, ...deps });
+  return startDesktopImpl({ ...defaultStartDesktopDeps, ...deps }, options);
 }
 
-async function startDesktopImpl(deps: StartDesktopDeps): Promise<StartResult> {
+async function startDesktopImpl(
+  deps: StartDesktopDeps,
+  options: StartDesktopOptions,
+): Promise<StartResult> {
   const status = deps.desktopStatus();
   if (status.state === "running") {
     return { ok: true, pid: status.pid, alreadyRunning: true };
@@ -247,10 +259,11 @@ async function startDesktopImpl(deps: StartDesktopDeps): Promise<StartResult> {
   const out = deps.openSync(logPath, "a");
   const err = deps.openSync(logPath, "a");
 
-  // Launch the resolved executable directly.
-  // This avoids the macOS `open`/LaunchServices path, which proved
-  // unstable for the bundle install and crashed before the window
-  // could finish creating.
+  const appBundle = findEnclosingAppBundle(bin);
+  if (!options.direct && appBundle) {
+    return startViaOpen(appBundle, deps);
+  }
+
   const child = deps.spawn(bin, [], {
     detached: true,
     stdio: ["ignore", out, err],
@@ -270,6 +283,71 @@ async function startDesktopImpl(deps: StartDesktopDeps): Promise<StartResult> {
   };
   await deps.writeFile(pidFile(), JSON.stringify(record));
   return { ok: true, pid: child.pid, alreadyRunning: false };
+}
+
+// Walks up from /…/Petdex.app/Contents/MacOS/petdex-desktop and returns
+// the .app path if found. Returns null for bare-binary installs (e.g.
+// ~/.petdex/bin/petdex-desktop).
+function findEnclosingAppBundle(binPath: string): string | null {
+  // The binary always lives at <bundle>/Contents/MacOS/<name>.
+  const macosDir = path.dirname(binPath);
+  if (path.basename(macosDir) !== "MacOS") return null;
+  const contentsDir = path.dirname(macosDir);
+  if (path.basename(contentsDir) !== "Contents") return null;
+  const bundle = path.dirname(contentsDir);
+  if (!bundle.endsWith(".app")) return null;
+  return bundle;
+}
+
+async function startViaOpen(
+  appBundle: string,
+  deps: StartDesktopDeps,
+): Promise<StartResult> {
+  // Default path: let LaunchServices start the app bundle so macOS
+  // preserves the normal application semantics. Use --direct only as
+  // a workaround for machines where that path crashes.
+  const result = deps.spawn("open", ["-gj", appBundle], {
+    stdio: "ignore",
+    detached: true,
+  });
+  result.unref();
+
+  // Poll for the child process because `open` returns immediately.
+  const deadline = Date.now() + 3_000;
+  let pid: number | null = null;
+  while (Date.now() < deadline) {
+    pid = deps.pgrepPetdexDesktop();
+    if (pid) break;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  if (!pid) {
+    return {
+      ok: false,
+      reason: `Launched ${appBundle} but couldn't find the resulting process. Check ${deps.logFile()}.`,
+    };
+  }
+
+  const record: PidRecord = { pid, lstart: deps.recordLstart(pid) };
+  await deps.writeFile(pidFile(), JSON.stringify(record));
+  return { ok: true, pid, alreadyRunning: false };
+}
+
+function pgrepPetdexDesktop(): number | null {
+  try {
+    // Match the executable name inside the bundle (Contents/MacOS/petdex-desktop).
+    // -f matches against the full command line so the path inside the bundle counts.
+    const out = execFileSync("pgrep", ["-f", "petdex-desktop"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (!out) return null;
+    // pgrep returns one pid per line; take the most recent (last).
+    const lines = out.split("\n").filter((l) => l.length > 0);
+    const pid = Number(lines[lines.length - 1]);
+    return Number.isFinite(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
 }
 
 export type StopResult =
@@ -375,8 +453,29 @@ export async function stopDesktop(
   return { ok: true, pid, portReleased };
 }
 
-export async function cmdDesktopStart(): Promise<void> {
-  const result = await startDesktop();
+export async function cmdDesktopStart(args: string[] = []): Promise<void> {
+  if (args.includes("--help") || args.includes("-h") || args.includes("help")) {
+    console.log(
+      [
+        "",
+        "  petdex desktop start [--direct]",
+        "",
+        "  Options",
+        "    --direct   Launch the petdex-desktop executable directly instead of the macOS app bundle",
+        "",
+      ].join("\n"),
+    );
+    return;
+  }
+
+  const unknown = args.filter((arg) => arg !== "--direct");
+  if (unknown.length > 0) {
+    console.error(`${pc.red("✗")} Unknown option: ${unknown[0]}`);
+    console.error(pc.dim("  Usage: petdex desktop start [--direct]"));
+    process.exit(1);
+  }
+
+  const result = await startDesktop({ direct: args.includes("--direct") });
   if (!result.ok) {
     console.error(`${pc.red("✗")} ${result.reason}`);
     process.exit(1);

--- a/packages/petdex-cli/src/types/napi-rs-keyring.d.ts
+++ b/packages/petdex-cli/src/types/napi-rs-keyring.d.ts
@@ -1,0 +1,8 @@
+declare module "@napi-rs/keyring" {
+  export class Entry {
+    constructor(service: string, account: string);
+    getPassword(): string | null;
+    setPassword(password: string): void;
+    deletePassword(): void;
+  }
+}

--- a/packages/petdex-cli/tsconfig.json
+++ b/packages/petdex-cli/tsconfig.json
@@ -12,5 +12,5 @@
     "allowImportingTsExtensions": true,
     "types": ["node", "bun-types"]
   },
-  "include": ["bin/**/*.ts", "src/**/*.ts"]
+  "include": ["bin/**/*.ts", "src/**/*.ts", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
feat(desktop): 添加 macOS 应用包启动支持和 --direct 选项

- 实现通过 open 命令启动 macOS 应用包，默认行为
- 添加 --direct 选项以直接启动可执行文件而不是应用包
- 添加 napi-rs-keyring 类型声明文件
- 修改桌面启动逻辑以检测和处理应用包
- 添加 findEnclosingAppBundle 函数来查找封装的应用包
- 实现 startViaOpen 函数通过 open 命令启动应用
- 添加 pgrepPetdexDesktop 函数来查找进程 ID
- 更新命令行帮助信息显示新选项
- 添加相关测试用例验证直接启动功能