### PR TITLE
Default pet gallery to install sorting

### DIFF
--- a/src/app/[locale]/page.test.ts
+++ b/src/app/[locale]/page.test.ts
@@ -8,7 +8,7 @@ describe("home gallery payload", () => {
 
     expect(source).toContain("const HOME_INITIAL_GALLERY_LIMIT = 10;");
     expect(source).toContain(
-      'searchPets({ sort: "alpha", limit: HOME_INITIAL_GALLERY_LIMIT })',
+      'searchPets({ sort: "installed", limit: HOME_INITIAL_GALLERY_LIMIT })',
     );
     expect(source).not.toContain("getDexNumberMap");
     expect(source).not.toContain("dexMap=");

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -39,7 +39,7 @@ import { WechatCommunityDialog } from "@/components/wechat-community-dialog";
 
 import { hasLocale, locales } from "@/i18n/config";
 
-// ISR. The home page renders an alpha-ordered, anon shell.
+// ISR. The home page renders an install-count ordered, anon shell.
 // visitor's shuffle seed and caught-slug set are pulled client-side
 // after interaction; /api/me/header-state feeds the "caught" highlight.
 // With a 24h ceiling and tag-based
@@ -92,7 +92,7 @@ export default async function Home({
   const [heroPets, initialSearch, collections, feedAds, randomPet] =
     await Promise.all([
       getFeaturedPetsWithMetrics(6),
-      searchPets({ sort: "alpha", limit: HOME_INITIAL_GALLERY_LIMIT }),
+      searchPets({ sort: "installed", limit: HOME_INITIAL_GALLERY_LIMIT }),
       getCollectionsBySlugs(LANDING_COLLECTION_ORDER, 6),
       getActiveFeedAds(6),
       getRandomPet(),

--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -134,7 +134,7 @@ export function PetGallery({
   const [activeVibes, setActiveVibes] = useState<Set<PetVibe>>(new Set());
   const [activeColors, setActiveColors] = useState<Set<ColorFamily>>(new Set());
   const [activeBatches, setActiveBatches] = useState<Set<string>>(new Set());
-  const [sort, setSort] = useState<SortKey>("alpha");
+  const [sort, setSort] = useState<SortKey>("installed");
   const [sortTouched, setSortTouched] = useState(false);
   const caughtSet = new Set(caughtSlugs ?? []);
 
@@ -183,7 +183,7 @@ export function PetGallery({
 
   useEffect(() => {
     if (sortTouched) return;
-    setSort(trimmedQuery ? "curated" : "alpha");
+    setSort(trimmedQuery ? "curated" : "installed");
   }, [sortTouched, trimmedQuery]);
 
   // Re-fetch on filter / sort / query changes (debounced for the query).


### PR DESCRIPTION
## Summary

- Default the home pet gallery to the existing `installed` sort.
- Surface pets by install/download activity first, so visitors see the most-used pets earlier in the browsing experience.
- Keep the `/api/pets/search` default behavior unchanged.
- Update the home payload test to match the new web default.

## Motivation

This improves the platform browsing experience by making the default gallery order more useful for discovery. Instead of showing pets alphabetically, the homepage now highlights pets with stronger usage signals first.

## Validation

- `bun test 'src/app/[locale]/page.test.ts'`
- `bun test src/app/api/pets/search/route.test.ts`
- `git diff --check`
- `TELEMETRY_RATELIMIT_SECRET=petdex-build-check-secret bun --env-file=.env.mock run build`
- Local preview at `http://localhost:3002`

## Notes

This keeps the change scoped to the web gallery. The API still defaults to `alpha` when no `sort` parameter is provided; the homepage now explicitly requests `sort: "installed"`.
