### PR TITLE
feat(gallery): lightweight animated card previews (#490)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,11 @@ PETDEX_MANIFEST_V2_SNAPSHOT_KEY=
 PETDEX_COLLECTION_PREVIEWS_URL=
 PETDEX_COLLECTION_PREVIEWS_SNAPSHOT_KEY=
 
+# Lightweight animated card previews (cropped idle-row strip per pet).
+# Off by default: only flip to "true" after running `bun previews:snapshot:apply`
+# so cards never point at a preview that doesn't exist yet in R2.
+NEXT_PUBLIC_PETDEX_PET_PREVIEWS_ENABLED=
+
 # AI / similarity / review / autotag / sound
 # Embeddings and automated review use Vercel AI Gateway via AI SDK.
 AI_GATEWAY_API_KEY=

--- a/.github/workflows/preview-snapshot.yml
+++ b/.github/workflows/preview-snapshot.yml
@@ -1,0 +1,64 @@
+name: preview-snapshot
+
+# Backfills the lightweight animated card previews (pets/<slug>/preview.webp)
+# to R2. Each preview is the first animation row cropped from the canonical
+# spritesheet, ~39x smaller than animating the full atlas on gallery cards
+# (see #490). publishPetPublicArtifacts already emits previews for newly
+# approved pets; this job reconciles older pets and anything that was missed.
+# The script skips pets that already have a preview, so re-runs are cheap.
+
+on:
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "check (dry-run, no upload) or apply (write to R2)"
+        type: choice
+        required: false
+        default: "apply"
+        options:
+          - apply
+          - check
+
+permissions:
+  contents: read
+
+concurrency:
+  group: preview-snapshot
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish pet previews
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: manifest-snapshot
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          # Always run reviewed code from the default branch. A manual
+          # dispatch can target any ref, and this job holds prod R2 write
+          # credentials, so we never run a non-main branch here.
+          ref: main
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Publish previews
+        # MODE is validated to check|apply by the script; the choice input
+        # already constrains it, and passing via env (not interpolation)
+        # avoids any shell-injection surface.
+        run: bun --conditions react-server scripts/publish-pet-previews.ts "$MODE"
+        env:
+          MODE: ${{ github.event.inputs.mode || 'apply' }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "manifest:snapshot:apply": "bun --env-file=.env.local --env-file=.env.production.local --conditions react-server scripts/publish-manifest-snapshots.ts apply",
     "thumbs:snapshot:check": "bun --env-file=.env.local --env-file=.env.production.local --conditions react-server scripts/publish-pet-thumbnails.ts check",
     "thumbs:snapshot:apply": "bun --env-file=.env.local --env-file=.env.production.local --conditions react-server scripts/publish-pet-thumbnails.ts apply",
+    "previews:snapshot:check": "bun --env-file=.env.local --env-file=.env.production.local --conditions react-server scripts/publish-pet-previews.ts check",
+    "previews:snapshot:apply": "bun --env-file=.env.local --env-file=.env.production.local --conditions react-server scripts/publish-pet-previews.ts apply",
     "stickers:snapshot:check": "bun --env-file=.env.local --env-file=.env.production.local --conditions react-server scripts/publish-pet-sticker-artifacts.ts check",
     "stickers:snapshot:apply": "bun --env-file=.env.local --env-file=.env.production.local --conditions react-server scripts/publish-pet-sticker-artifacts.ts apply",
     "cost:report": "bun scripts/vercel-cost-report.ts --project petdex",

--- a/scripts/publish-pet-previews.ts
+++ b/scripts/publish-pet-previews.ts
@@ -1,0 +1,257 @@
+import { createHash } from "node:crypto";
+
+import {
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import sharp from "sharp";
+
+import {
+  PET_PREVIEW_CACHE_HEADER,
+  PET_PREVIEW_FRAME_COUNT,
+  PET_PREVIEW_FRAME_HEIGHT,
+  PET_PREVIEW_FRAME_WIDTH,
+  PET_PREVIEW_QUALITY,
+  petPreviewKey,
+  petPreviewUrl,
+} from "@/lib/pet-preview";
+import { getAllApprovedPets } from "@/lib/pets";
+import { R2_BUCKET, r2 } from "@/lib/r2";
+import { keyFromR2PublicUrl } from "@/lib/r2-public-url";
+import { isAllowedAssetUrl } from "@/lib/url-allowlist";
+
+type Mode = "check" | "apply";
+
+type PreviewTask = {
+  slug: string;
+  displayName: string;
+  spritesheetPath: string;
+  spritesheetKey: string;
+  key: string;
+  url: string;
+};
+
+type PublishResult =
+  | { ok: true; slug: string; bytes: number; sha256: string }
+  | { ok: false; slug: string; reason: string };
+
+const mode = parseMode(process.argv[2]);
+const force = process.argv.includes("--force");
+const limit = parseLimit(process.argv);
+const headConcurrency = parseConcurrency("PETDEX_PREVIEW_HEAD_CONCURRENCY", 24);
+const publishConcurrency = parseConcurrency(
+  "PETDEX_PREVIEW_PUBLISH_CONCURRENCY",
+  4,
+);
+
+const allPets = await getAllApprovedPets();
+const selectedPets =
+  typeof limit === "number" ? allPets.slice(0, limit) : allPets;
+const tasks = selectedPets.map((pet) => {
+  const spritesheetKey = keyFromR2PublicUrl(pet.spritesheetPath);
+  return {
+    slug: pet.slug,
+    displayName: pet.displayName,
+    spritesheetPath: pet.spritesheetPath,
+    spritesheetKey: spritesheetKey ?? "",
+    key: petPreviewKey(pet.slug),
+    url: petPreviewUrl(pet.slug),
+  };
+});
+const validTasks = tasks.filter(
+  (task) => isAllowedAssetUrl(task.spritesheetPath) && task.spritesheetKey,
+);
+const invalidTasks = tasks.filter(
+  (task) => !isAllowedAssetUrl(task.spritesheetPath) || !task.spritesheetKey,
+);
+
+const existing = force
+  ? new Set<string>()
+  : new Set(
+      (
+        await mapLimit(validTasks, headConcurrency, async (task) =>
+          (await previewExists(task.key)) ? task.slug : null,
+        )
+      ).filter((slug): slug is string => Boolean(slug)),
+    );
+const pending = force
+  ? validTasks
+  : validTasks.filter((task) => !existing.has(task.slug));
+
+console.log(`pet previews ${mode}`);
+console.log(`approved ${allPets.length}`);
+console.log(`selected ${selectedPets.length}`);
+console.log(`valid ${validTasks.length}`);
+console.log(`invalid ${invalidTasks.length}`);
+console.log(`existing ${existing.size}`);
+console.log(`pending ${pending.length}`);
+console.log(`force ${force ? "yes" : "no"}`);
+
+if (pending.length > 0) {
+  console.log(
+    `pending sample ${pending
+      .slice(0, 20)
+      .map((task) => task.slug)
+      .join(", ")}`,
+  );
+}
+
+if (invalidTasks.length > 0) {
+  console.log(
+    `invalid sample ${invalidTasks
+      .slice(0, 20)
+      .map((task) => task.slug)
+      .join(", ")}`,
+  );
+}
+
+if (mode === "apply") {
+  let completed = 0;
+  const results = await mapLimit(pending, publishConcurrency, async (task) => {
+    const result = await publishPreview(task);
+    completed += 1;
+    if (completed % 100 === 0 || completed === pending.length) {
+      console.log(`progress ${completed}/${pending.length}`);
+    }
+    return result;
+  });
+  const uploaded = results.filter(
+    (result): result is Extract<PublishResult, { ok: true }> => result.ok,
+  );
+  const failed = results.filter(
+    (result): result is Extract<PublishResult, { ok: false }> => !result.ok,
+  );
+  const bytes = uploaded.reduce((total, result) => total + result.bytes, 0);
+  const hash = createHash("sha256");
+  for (const result of uploaded) {
+    hash.update(result.slug);
+    hash.update("\0");
+    hash.update(result.sha256);
+    hash.update("\0");
+  }
+
+  console.log(`uploaded ${uploaded.length}`);
+  console.log(`uploaded bytes ${bytes}`);
+  console.log(`uploaded sha256 ${hash.digest("hex")}`);
+  console.log(`failed ${failed.length}`);
+
+  for (const result of failed.slice(0, 20)) {
+    console.log(`failed ${result.slug} ${result.reason}`);
+  }
+
+  if (failed.length > 0) process.exit(1);
+}
+
+async function publishPreview(task: PreviewTask): Promise<PublishResult> {
+  try {
+    const source = await getR2ObjectBuffer(task.spritesheetKey);
+    const body = await sharp(source)
+      .extract({
+        left: 0,
+        top: 0,
+        width: PET_PREVIEW_FRAME_WIDTH * PET_PREVIEW_FRAME_COUNT,
+        height: PET_PREVIEW_FRAME_HEIGHT,
+      })
+      .webp({ quality: PET_PREVIEW_QUALITY })
+      .toBuffer();
+    const sha256 = createHash("sha256").update(body).digest("hex");
+
+    await r2.send(
+      new PutObjectCommand({
+        Bucket: R2_BUCKET,
+        Key: task.key,
+        Body: body,
+        ContentType: "image/webp",
+        CacheControl: PET_PREVIEW_CACHE_HEADER,
+        ContentDisposition: `inline; filename="${task.slug}-preview.webp"`,
+        Metadata: {
+          "petdex-slug": task.slug,
+          "petdex-source-sha256": createHash("sha256")
+            .update(source)
+            .digest("hex"),
+          "petdex-sha256": sha256,
+        },
+      }),
+    );
+
+    return { ok: true, slug: task.slug, bytes: body.byteLength, sha256 };
+  } catch (error) {
+    return { ok: false, slug: task.slug, reason: errorReason(error) };
+  }
+}
+
+async function getR2ObjectBuffer(key: string): Promise<Buffer> {
+  const response = await r2.send(
+    new GetObjectCommand({ Bucket: R2_BUCKET, Key: key }),
+  );
+  if (!response.Body) throw new Error("missing body");
+  return Buffer.from(await response.Body.transformToByteArray());
+}
+
+async function previewExists(key: string): Promise<boolean> {
+  try {
+    await r2.send(new HeadObjectCommand({ Bucket: R2_BUCKET, Key: key }));
+    return true;
+  } catch (error) {
+    if (isMissingObjectError(error)) return false;
+    throw error;
+  }
+}
+
+async function mapLimit<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    async () => {
+      while (next < items.length) {
+        const index = next;
+        next += 1;
+        results[index] = await fn(items[index], index);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+function parseMode(raw: string | undefined): Mode {
+  if (raw === "check" || raw === "apply") return raw;
+  console.error("usage: bun scripts/publish-pet-previews.ts <check|apply>");
+  process.exit(2);
+}
+
+function parseLimit(args: string[]): number | null {
+  const raw = args.find((arg) => arg.startsWith("--limit="));
+  if (!raw) return null;
+  const value = Number.parseInt(raw.slice("--limit=".length), 10);
+  if (Number.isFinite(value) && value > 0) return value;
+  console.error("invalid --limit");
+  process.exit(2);
+}
+
+function parseConcurrency(key: string, fallback: number): number {
+  const value = Number.parseInt(process.env[key] ?? "", 10);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function isMissingObjectError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const name = "name" in error ? (error as { name?: unknown }).name : null;
+  const httpStatus =
+    "$metadata" in error
+      ? (error as { $metadata?: { httpStatusCode?: number } }).$metadata
+          ?.httpStatusCode
+      : null;
+  return name === "NotFound" || httpStatus === 404;
+}
+
+function errorReason(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -482,13 +482,15 @@ input {
   --sprite-row: 0;
   --sprite-frames: 6;
   --sprite-duration: 1100ms;
+  --sprite-sheet-width: 1536px;
+  --sprite-sheet-height: 1872px;
   --sprite-y: calc(var(--sprite-row) * -208px);
   --sprite-end-x: calc(var(--sprite-frames) * -192px);
   width: 192px;
   height: 208px;
   background-image: var(--sprite-url);
   background-repeat: no-repeat;
-  background-size: 1536px 1872px;
+  background-size: var(--sprite-sheet-width) var(--sprite-sheet-height);
   image-rendering: pixelated;
   /* translateZ(0) forces a GPU-composited layer so background-image
      decode + animation stay on the compositor thread instead of being

--- a/src/components/collection-cover.tsx
+++ b/src/components/collection-cover.tsx
@@ -9,6 +9,8 @@
 // server picks one offset and the client picks another; a slug-derived
 // pseudo-hash gives both sides the same answer without coordination.
 
+import { petPreviewUrlForSource } from "@/lib/pet-preview";
+
 import { PetSprite } from "@/components/pet-sprite";
 
 export type CollectionCoverPet = {
@@ -73,15 +75,19 @@ export function CollectionCover({
   );
 
   if (lineup.length === 1) {
+    const pet = lineup[0];
+    const previewSrc = petPreviewUrlForSource(pet.slug, pet.spritesheetPath);
     return (
       <div
         className={`pet-sprite-stage relative grid aspect-[16/9] place-items-center overflow-hidden ${className}`}
       >
         <PetSprite
-          src={lineup[0].spritesheetPath}
-          cycleStates
+          src={previewSrc ?? pet.spritesheetPath}
+          layout={previewSrc ? "row" : "atlas"}
+          state="idle"
+          cycleStates={!previewSrc}
           scale={scale * 1.5}
-          label={`${lineup[0].displayName} animated`}
+          label={`${pet.displayName} animated`}
         />
       </div>
     );
@@ -138,6 +144,10 @@ export function CollectionCover({
         const isLead =
           pet.slug === lineup[0].slug && i === Math.floor((n - 1) / 2);
         const h = hashSlug(pet.slug);
+        const previewSrc = petPreviewUrlForSource(
+          pet.slug,
+          pet.spritesheetPath,
+        );
 
         // Compute slot center inside the inner band. The first/last pets
         // sit at innerLeft / innerRight respectively; the middle ones
@@ -177,8 +187,10 @@ export function CollectionCover({
             }}
           >
             <PetSprite
-              src={pet.spritesheetPath}
-              cycleStates
+              src={previewSrc ?? pet.spritesheetPath}
+              layout={previewSrc ? "row" : "atlas"}
+              state="idle"
+              cycleStates={!previewSrc}
               scale={petScale}
               label={`${pet.displayName} animated`}
             />

--- a/src/components/pet-gallery.tsx
+++ b/src/components/pet-gallery.tsx
@@ -19,6 +19,7 @@ import type { PublicFeedAd } from "@/lib/ads/queries";
 import { COLOR_FAMILIES, type ColorFamily } from "@/lib/color-families";
 import { formatBatchLabel, getBatchKey } from "@/lib/dex-batch";
 import { formatLocalizedNumber } from "@/lib/format-number";
+import { petPreviewUrlForSource } from "@/lib/pet-preview";
 import type { SearchPet } from "@/lib/pet-search";
 import { petStates } from "@/lib/pet-states";
 import { PET_KINDS, PET_VIBES, type PetKind, type PetVibe } from "@/lib/types";
@@ -863,6 +864,7 @@ function PetCardImpl({
   const isDiscovered = pet.source === "discover";
   const href = `/pets/${pet.slug}`;
   const formattedInstallCount = formatLocalizedNumber(installCount, locale);
+  const previewSrc = petPreviewUrlForSource(pet.slug, pet.spritesheetPath);
   const batchLabel = pet.approvedAt
     ? formatBatchLabel(getBatchKey(new Date(pet.approvedAt)))
     : null;
@@ -932,8 +934,10 @@ function PetCardImpl({
           }
         >
           <PetSprite
-            src={pet.spritesheetPath}
-            cycleStates
+            src={previewSrc ?? pet.spritesheetPath}
+            layout={previewSrc ? "row" : "atlas"}
+            state="idle"
+            cycleStates={!previewSrc}
             scale={0.7}
             label={`${pet.displayName} animated`}
           />

--- a/src/components/pet-sprite.tsx
+++ b/src/components/pet-sprite.tsx
@@ -4,12 +4,21 @@ import { type CSSProperties, memo } from "react";
 
 import { type PetStateId, petStates } from "@/lib/pet-states";
 
+type PetSpriteLayout = "atlas" | "row";
+
 type PetSpriteProps = {
   src: string;
   state?: PetStateId;
   scale?: number;
   label?: string;
   className?: string;
+  /**
+   * "atlas" reads a row out of the full spritesheet (the canonical asset).
+   * "row" treats `src` as a single pre-cropped frame strip (preview.webp),
+   * so the strip is the whole image and the animation walks its only row.
+   * Both render with pure CSS — no React state, no extra network probes.
+   */
+  layout?: PetSpriteLayout;
   /**
    * When true, the rendered animation state is picked deterministically
    * from `src` so cards across the gallery look visually diverse without
@@ -24,12 +33,16 @@ type PetSpriteProps = {
   cycleIntervalMs?: number;
 };
 
+const ATLAS_SHEET_WIDTH = 1536;
+const ATLAS_SHEET_HEIGHT = 1872;
+
 function PetSpriteImpl({
   src,
   state = "idle",
   scale = 1,
   label,
   className = "",
+  layout = "atlas",
   cycleStates = false,
 }: PetSpriteProps) {
   const fixedAnimation =
@@ -37,6 +50,13 @@ function PetSpriteImpl({
   const animation = cycleStates
     ? petStates[hashString(src) % petStates.length]
     : fixedAnimation;
+
+  // A row strip only carries a single animation row, so it always plays
+  // row 0 and the sheet is exactly one frame strip wide/tall.
+  const isRow = layout === "row";
+  const spriteRow = isRow ? 0 : animation.row;
+  const sheetWidth = isRow ? animation.frames * 192 : ATLAS_SHEET_WIDTH;
+  const sheetHeight = isRow ? 208 : ATLAS_SHEET_HEIGHT;
 
   return (
     <div
@@ -54,9 +74,11 @@ function PetSpriteImpl({
         style={
           {
             "--sprite-url": `url("${src.replace(/"/g, '\\"')}")`,
-            "--sprite-row": animation.row,
+            "--sprite-row": spriteRow,
             "--sprite-frames": animation.frames,
             "--sprite-duration": `${animation.durationMs}ms`,
+            "--sprite-sheet-width": `${sheetWidth}px`,
+            "--sprite-sheet-height": `${sheetHeight}px`,
           } as CSSProperties
         }
       />

--- a/src/lib/pet-preview.test.ts
+++ b/src/lib/pet-preview.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import {
+  petPreviewKey,
+  petPreviewUrl,
+  petPreviewUrlForSource,
+} from "@/lib/pet-preview";
+
+const originalFlag = process.env.NEXT_PUBLIC_PETDEX_PET_PREVIEWS_ENABLED;
+
+afterEach(() => {
+  if (originalFlag === undefined) {
+    delete process.env.NEXT_PUBLIC_PETDEX_PET_PREVIEWS_ENABLED;
+  } else {
+    process.env.NEXT_PUBLIC_PETDEX_PET_PREVIEWS_ENABLED = originalFlag;
+  }
+});
+
+describe("pet preview artifact helpers", () => {
+  it("builds the public preview key and URL", () => {
+    expect(petPreviewKey("cai-chao")).toBe("pets/cai-chao/preview.webp");
+    expect(petPreviewUrl("cai-chao")).toBe(
+      "https://assets.petdex.dev/pets/cai-chao/preview.webp",
+    );
+  });
+
+  it("only derives preview URLs for recognized R2 sources when enabled", () => {
+    process.env.NEXT_PUBLIC_PETDEX_PET_PREVIEWS_ENABLED = "true";
+
+    expect(
+      petPreviewUrlForSource(
+        "cai-chao",
+        "https://assets.petdex.dev/pets/cai-chao/spritesheet.webp",
+      ),
+    ).toBe("https://assets.petdex.dev/pets/cai-chao/preview.webp");
+    expect(
+      petPreviewUrlForSource(
+        "cai-chao",
+        "https://example.com/pets/cai-chao/spritesheet.webp",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null while the feature flag is off", () => {
+    delete process.env.NEXT_PUBLIC_PETDEX_PET_PREVIEWS_ENABLED;
+
+    expect(
+      petPreviewUrlForSource(
+        "cai-chao",
+        "https://assets.petdex.dev/pets/cai-chao/spritesheet.webp",
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/lib/pet-preview.ts
+++ b/src/lib/pet-preview.ts
@@ -1,0 +1,40 @@
+import { keyFromR2PublicUrl, R2_PUBLIC_BASE } from "@/lib/r2-public-url";
+
+export const PET_PREVIEW_FRAME_WIDTH = 192;
+export const PET_PREVIEW_FRAME_HEIGHT = 208;
+export const PET_PREVIEW_FRAME_COUNT = 6;
+export const PET_PREVIEW_QUALITY = 70;
+export const PET_PREVIEW_CACHE_HEADER =
+  "public, max-age=31536000, s-maxage=31536000, immutable";
+
+// The preview strip is the first animation row cropped from the canonical
+// spritesheet, so the rendered surface is exactly one frame strip wide.
+export const PET_PREVIEW_SHEET_WIDTH =
+  PET_PREVIEW_FRAME_WIDTH * PET_PREVIEW_FRAME_COUNT;
+export const PET_PREVIEW_SHEET_HEIGHT = PET_PREVIEW_FRAME_HEIGHT;
+
+export function petPreviewKey(slug: string): string {
+  return `pets/${slug}/preview.webp`;
+}
+
+export function petPreviewUrl(slug: string): string {
+  return `${R2_PUBLIC_BASE}/${petPreviewKey(slug)}`;
+}
+
+// Previews are an opt-in optimization: the cropped strip only exists in R2
+// after the backfill script runs. Gating the card swap behind a flag lets
+// the code ship without pointing any card at a possibly-missing preview,
+// which is what regressed the first attempt (cards 404'd then fell back at
+// runtime). NEXT_PUBLIC_ so the gallery client bundle can read it too —
+// same dual-var pattern as NEXT_PUBLIC_PETDEX_ADMIN_USER_IDS.
+export function isPetPreviewEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_PETDEX_PET_PREVIEWS_ENABLED === "true";
+}
+
+export function petPreviewUrlForSource(
+  slug: string,
+  spritesheetPath: string,
+): string | null {
+  if (!isPetPreviewEnabled()) return null;
+  return keyFromR2PublicUrl(spritesheetPath) ? petPreviewUrl(slug) : null;
+}

--- a/src/lib/pet-public-artifact-keys.test.ts
+++ b/src/lib/pet-public-artifact-keys.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
+import { petPreviewKey } from "@/lib/pet-preview";
 import { petPublicArtifactKeys } from "@/lib/pet-public-artifact-keys";
 import {
   PET_STICKER_FORMATS,
@@ -8,10 +9,11 @@ import {
 import { petThumbnailKey } from "@/lib/pet-thumbnail";
 
 describe("pet public artifact keys", () => {
-  it("covers thumbnails, every sticker derivative, and packs", () => {
+  it("covers thumbnails, previews, every sticker derivative, and packs", () => {
     const keys = petPublicArtifactKeys("cai-chao");
 
     expect(keys).toContain(petThumbnailKey("cai-chao"));
+    expect(keys).toContain(petPreviewKey("cai-chao"));
     expect(keys).toContain("pets/cai-chao/wastickers.zip");
 
     for (const state of PET_STICKER_STATES) {

--- a/src/lib/pet-public-artifact-keys.ts
+++ b/src/lib/pet-public-artifact-keys.ts
@@ -1,3 +1,4 @@
+import { petPreviewKey } from "@/lib/pet-preview";
 import {
   PET_STICKER_FORMATS,
   PET_STICKER_STATES,
@@ -9,6 +10,7 @@ import { petThumbnailKey } from "@/lib/pet-thumbnail";
 export function petPublicArtifactKeys(slug: string): string[] {
   return [
     petThumbnailKey(slug),
+    petPreviewKey(slug),
     ...PET_STICKER_STATES.flatMap((state) =>
       PET_STICKER_FORMATS.map((format) => petStickerKey(slug, state, format)),
     ),

--- a/src/lib/pet-public-artifacts.ts
+++ b/src/lib/pet-public-artifacts.ts
@@ -8,6 +8,14 @@ import {
 import sharp from "sharp";
 
 import {
+  PET_PREVIEW_CACHE_HEADER,
+  PET_PREVIEW_FRAME_COUNT,
+  PET_PREVIEW_FRAME_HEIGHT,
+  PET_PREVIEW_FRAME_WIDTH,
+  PET_PREVIEW_QUALITY,
+  petPreviewKey,
+} from "@/lib/pet-preview";
+import {
   PET_STICKER_CACHE_HEADER,
   petStickerFilename,
   petStickerKey,
@@ -53,6 +61,7 @@ export async function publishPetPublicArtifacts(input: {
   };
   const refs = [
     { key: petThumbnailKey(input.slug), kind: "thumbnail" as const },
+    { key: petPreviewKey(input.slug), kind: "preview" as const },
     { key: petStickerKey(input.slug), kind: "sticker" as const },
   ];
   const pending = [];
@@ -73,7 +82,9 @@ export async function publishPetPublicArtifacts(input: {
       const artifact =
         ref.kind === "thumbnail"
           ? await buildThumbnailArtifact(input.slug, source)
-          : await buildStickerArtifact(input.slug, source);
+          : ref.kind === "preview"
+            ? await buildPreviewArtifact(input.slug, source)
+            : await buildStickerArtifact(input.slug, source);
       await r2.send(
         new PutObjectCommand({
           Bucket: R2_BUCKET,
@@ -97,6 +108,25 @@ export async function publishPetPublicArtifacts(input: {
   }
 
   return result;
+}
+
+async function buildPreviewArtifact(slug: string, source: Buffer) {
+  const body = await sharp(source)
+    .extract({
+      left: 0,
+      top: 0,
+      width: PET_PREVIEW_FRAME_WIDTH * PET_PREVIEW_FRAME_COUNT,
+      height: PET_PREVIEW_FRAME_HEIGHT,
+    })
+    .webp({ quality: PET_PREVIEW_QUALITY })
+    .toBuffer();
+  return {
+    body,
+    contentType: "image/webp",
+    cacheControl: PET_PREVIEW_CACHE_HEADER,
+    contentDisposition: `inline; filename="${slug}-preview.webp"`,
+    sha256: createHash("sha256").update(body).digest("hex"),
+  };
 }
 
 async function buildThumbnailArtifact(slug: string, source: Buffer) {


### PR DESCRIPTION
Closes #490.

## What

Adds a pre-generated `pets/<slug>/preview.webp` artifact (the first animation row cropped from the canonical spritesheet) for gallery and collection cards. Cards animate from a single frame strip instead of the full atlas, cutting per-card bytes roughly 39x (45.5 MB to 1.16 MB across the 25-pet sample in the issue).

Pet detail pages, CLI installs, desktop pets, and downloads keep using the full `sprite.webp`.

## Why this is safe to merge as-is

This reimplements #383/#374 without the runtime fallback that caused the earlier revert (9d8fb67 to e0a75c4). The previous attempt pointed cards at `preview.webp` and fell back to the spritesheet via an in-client 404 + `new Image()` probe, which regressed every card while previews were not backfilled and broke the zero-state PetSprite model.

Here the swap is gated behind `NEXT_PUBLIC_PETDEX_PET_PREVIEWS_ENABLED`, off by default. With the flag off, `petPreviewUrlForSource` returns null and the gallery renders exactly as it does today. No card ever points at a preview that does not exist yet. The new `PetSprite` `layout="row"` mode is pure CSS, no client state, no extra network probe.

## Rollout

1. Merge this (inert while the flag is off).
2. Backfill R2: `bun previews:snapshot:check` then `bun previews:snapshot:apply` (needs R2 creds). Start with `--limit=10`.
3. Set `NEXT_PUBLIC_PETDEX_PET_PREVIEWS_ENABLED=true` in Vercel and redeploy (it is inlined into the client bundle).
4. Verify cards request `preview.webp` (~45 KB) instead of `sprite.webp` (~1.9 MB).

Newly approved pets already get a preview through `publishPetPublicArtifacts`. The added `preview-snapshot` workflow reconciles the long tail of older pets daily (skips pets that already have one).

## Changes

- `src/lib/pet-preview.ts` (+test): keys/URLs/constants + the `NEXT_PUBLIC` flag gate
- `src/lib/pet-public-artifacts.ts`: builds the preview alongside thumb/sticker
- `src/lib/pet-public-artifact-keys.ts` (+test): includes the preview key for cleanup
- `scripts/publish-pet-previews.ts` + `previews:snapshot:{check,apply}` scripts
- `src/components/pet-sprite.tsx` + `globals.css`: pure-CSS `layout="row"` mode
- `src/components/pet-gallery.tsx`, `src/components/collection-cover.tsx`: swap to preview when the flag is on
- `.github/workflows/preview-snapshot.yml`: scheduled R2 reconciliation
- `.env.example`: documents the flag

## Verification

`bun test` (preview + artifact-keys suites) and `biome check` pass on all touched files.