### PR TITLE
fix(previews): graceful fallback for non-standard spritesheets (#490)

### DIFF
--- a/scripts/publish-pet-previews.ts
+++ b/scripts/publish-pet-previews.ts
@@ -5,17 +5,13 @@ import {
   HeadObjectCommand,
   PutObjectCommand,
 } from "@aws-sdk/client-s3";
-import sharp from "sharp";
 
 import {
   PET_PREVIEW_CACHE_HEADER,
-  PET_PREVIEW_FRAME_COUNT,
-  PET_PREVIEW_FRAME_HEIGHT,
-  PET_PREVIEW_FRAME_WIDTH,
-  PET_PREVIEW_QUALITY,
   petPreviewKey,
   petPreviewUrl,
 } from "@/lib/pet-preview";
+import { renderPreviewStrip } from "@/lib/pet-public-artifacts";
 import { getAllApprovedPets } from "@/lib/pets";
 import { R2_BUCKET, r2 } from "@/lib/r2";
 import { keyFromR2PublicUrl } from "@/lib/r2-public-url";
@@ -146,15 +142,7 @@ if (mode === "apply") {
 async function publishPreview(task: PreviewTask): Promise<PublishResult> {
   try {
     const source = await getR2ObjectBuffer(task.spritesheetKey);
-    const body = await sharp(source)
-      .extract({
-        left: 0,
-        top: 0,
-        width: PET_PREVIEW_FRAME_WIDTH * PET_PREVIEW_FRAME_COUNT,
-        height: PET_PREVIEW_FRAME_HEIGHT,
-      })
-      .webp({ quality: PET_PREVIEW_QUALITY })
-      .toBuffer();
+    const body = await renderPreviewStrip(source);
     const sha256 = createHash("sha256").update(body).digest("hex");
 
     await r2.send(

--- a/src/lib/pet-public-artifacts.ts
+++ b/src/lib/pet-public-artifacts.ts
@@ -111,15 +111,7 @@ export async function publishPetPublicArtifacts(input: {
 }
 
 async function buildPreviewArtifact(slug: string, source: Buffer) {
-  const body = await sharp(source)
-    .extract({
-      left: 0,
-      top: 0,
-      width: PET_PREVIEW_FRAME_WIDTH * PET_PREVIEW_FRAME_COUNT,
-      height: PET_PREVIEW_FRAME_HEIGHT,
-    })
-    .webp({ quality: PET_PREVIEW_QUALITY })
-    .toBuffer();
+  const body = await renderPreviewStrip(source);
   return {
     body,
     contentType: "image/webp",
@@ -127,6 +119,53 @@ async function buildPreviewArtifact(slug: string, source: Buffer) {
     contentDisposition: `inline; filename="${slug}-preview.webp"`,
     sha256: createHash("sha256").update(body).digest("hex"),
   };
+}
+
+export async function renderPreviewStrip(source: Buffer): Promise<Buffer> {
+  const stripWidth = PET_PREVIEW_FRAME_WIDTH * PET_PREVIEW_FRAME_COUNT;
+  try {
+    return await sharp(source)
+      .extract({
+        left: 0,
+        top: 0,
+        width: stripWidth,
+        height: PET_PREVIEW_FRAME_HEIGHT,
+      })
+      .webp({ quality: PET_PREVIEW_QUALITY })
+      .toBuffer();
+  } catch (error) {
+    if (!isExtractAreaError(error)) throw error;
+    // Non-standard spritesheet (not the canonical 192x208 grid): there is no
+    // animation row to crop. Build a strip that repeats one static frame
+    // across all cells so the card's steps() animation lands on the same
+    // image every step, so it reads as a still preview with no flicker.
+    // Every approved pet still gets a preview.webp and the flag stays safe.
+    const frame = await sharp(source)
+      .resize(PET_PREVIEW_FRAME_WIDTH, PET_PREVIEW_FRAME_HEIGHT, {
+        fit: "contain",
+        kernel: "nearest",
+        background: { r: 0, g: 0, b: 0, alpha: 0 },
+      })
+      .png()
+      .toBuffer();
+    return sharp({
+      create: {
+        width: stripWidth,
+        height: PET_PREVIEW_FRAME_HEIGHT,
+        channels: 4,
+        background: { r: 0, g: 0, b: 0, alpha: 0 },
+      },
+    })
+      .composite(
+        Array.from({ length: PET_PREVIEW_FRAME_COUNT }, (_, i) => ({
+          input: frame,
+          left: i * PET_PREVIEW_FRAME_WIDTH,
+          top: 0,
+        })),
+      )
+      .webp({ quality: PET_PREVIEW_QUALITY })
+      .toBuffer();
+  }
 }
 
 async function buildThumbnailArtifact(slug: string, source: Buffer) {


### PR DESCRIPTION
Follow-up to #525.

## Problem

`buildPreviewArtifact` cropped a fixed 1152x208 strip from the spritesheet. Sprites that are not the canonical 192x208 grid (a handful of older pets at 1024x1024, 837x1024, etc.) throw `extract_area: bad extract area`, so 5 of 3317 pets ended up without a `preview.webp`. With `NEXT_PUBLIC_PETDEX_PET_PREVIEWS_ENABLED` on, those cards would point at a missing artifact and 404, which is the exact regression #525 was built to avoid.

## Fix

Extract a shared `renderPreviewStrip` helper. On the standard path it crops the idle row as before. On `extract_area` it falls back to a strip that repeats one contained static frame across all six cells, so the card's `steps()` animation lands on the same image every step and reads as a still preview with no flicker. The backfill script now reuses this helper instead of its own inline crop, removing the duplicated logic.

Result: every approved pet gets a `preview.webp`, so enabling the gallery flag is safe for the whole catalog.

## Verification

- Backfill re-run against prod R2: 3317/3317 pets covered, 0 pending, the 5 previously-failing pets now serve 200.
- `renderPreviewStrip` validated on synthetic 1536x1872 (crops to 1152x208) and 1024x1024 (fallback to 1152x208).
- `bun test` and `biome check` pass.