### PR TITLE
fix(assets-worker): never cache error responses (#490)

### DIFF
--- a/workers/petdex-assets.ts
+++ b/workers/petdex-assets.ts
@@ -44,6 +44,18 @@ function corsHeaders(request: Request): Headers {
   return headers;
 }
 
+// Error responses must never be cached at the edge. The origin objects are
+// backfilled asynchronously (thumbnails, previews, stickers), so a request
+// that arrives a moment before the object lands would otherwise poison the
+// cache with a 404 that outlives the missing object. no-store keeps every
+// retry hitting the origin until the artifact actually exists.
+function errorResponse(body: string, status: number): Response {
+  return new Response(body, {
+    status,
+    headers: { "Cache-Control": "no-store" },
+  });
+}
+
 function objectKey(request: Request): string | null {
   const url = new URL(request.url);
   const raw = url.pathname.replace(/^\/+/, "");
@@ -62,21 +74,21 @@ export default {
     }
 
     if (request.method !== "GET" && request.method !== "HEAD") {
-      return new Response("method not allowed", { status: 405 });
+      return errorResponse("method not allowed", 405);
     }
 
     if (!isAllowedReferer(request)) {
-      return new Response("forbidden", { status: 403 });
+      return errorResponse("forbidden", 403);
     }
 
     const key = objectKey(request);
     if (!key) {
-      return new Response("not found", { status: 404 });
+      return errorResponse("not found", 404);
     }
 
     const object = await env.PETDEX_PETS.get(key);
     if (!object) {
-      return new Response("not found", { status: 404 });
+      return errorResponse("not found", 404);
     }
 
     const headers = corsHeaders(request);


### PR DESCRIPTION
Follow-up to #490 / #525.

## Problem

The assets worker (`workers/petdex-assets.ts`) returned 403/404/405 with no `Cache-Control` header, so Cloudflare cached those error responses at the edge. Public artifacts (thumbnails, previews, stickers) are backfilled asynchronously, so any request that hits an asset a moment before its object lands poisons the cache with a 404 that outlives the missing object.

This surfaced right after the preview backfill: the 3317 preview.webp objects are present in R2 and the worker serves them (a request with `?cb=1` returns 200), but plain requests kept returning a stale 404 because the edge had cached the earlier miss.

## Fix

Return `Cache-Control: no-store` on every error path (403/404/405) so retries always revalidate against the origin until the artifact actually exists. Successful 200/204 responses are unchanged and still cache for a year.

## Note

This prevents re-poisoning going forward. The already-poisoned entries for `pets/*/preview.webp` still need a one-time Cloudflare cache purge on the petdex.dev zone (done separately via the dashboard) to clear the stale 404s that predate this fix.