### PR TITLE
fix: stop 500s on freshly approved pets and add cross-app revalidate endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,11 @@ TELEMETRY_RATELIMIT_SECRET=
 PETDEX_ROUTE_COST_SECRET=
 PETDEX_ROUTE_COST_SAMPLE_RATE=
 
+# Shared secret for POST /api/revalidate. External writers that share the
+# DB/Upstash (admin.petdex.dev) call it to flush this app's Next data
+# cache tags after approve/reject/edit. Must match the admin app's value.
+PETDEX_REVALIDATE_SECRET=
+
 # Email notifications
 RESEND_API_KEY=
 RESEND_FROM=

--- a/src/app/api/pets/[slug]/variants/route.ts
+++ b/src/app/api/pets/[slug]/variants/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { getPet } from "@/lib/pets";
 import { getVariantsFor } from "@/lib/variants";
 
 export const runtime = "nodejs";
@@ -12,22 +13,19 @@ export async function GET(
 ): Promise<Response> {
   const { slug } = await ctx.params;
 
-  try {
-    const variants = await getVariantsFor(slug);
-
-    return NextResponse.json(
-      { variants },
-      {
-        headers: {
-          "Cache-Control": "public, max-age=300, s-maxage=600",
-        },
-      },
-    );
-  } catch (error) {
-    if (error instanceof Error && error.message === "PET_NOT_FOUND") {
-      return NextResponse.json({ error: "not_found" }, { status: 404 });
-    }
-
-    throw error;
+  const pet = await getPet(slug);
+  if (!pet) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
   }
+
+  const variants = await getVariantsFor(slug);
+
+  return NextResponse.json(
+    { variants },
+    {
+      headers: {
+        "Cache-Control": "public, max-age=300, s-maxage=600",
+      },
+    },
+  );
 }

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,0 +1,82 @@
+import { timingSafeEqual } from "node:crypto";
+
+import { NextResponse } from "next/server";
+
+import {
+  expireNextCacheTags,
+  revalidatePetTags,
+} from "@/lib/db/cached-aggregates";
+
+// Cross-app cache flush. revalidateTag only reaches the Next data cache
+// of the app that calls it, so external writers that share the DB and
+// Upstash (admin.petdex.dev approving submissions) still leave this
+// app's unstable_cache layer stale: pre-approval 404s for `pet:{slug}`
+// held for 24h, and the variant/dex indexes for up to their TTL. This
+// endpoint lets those writers flush our tags after a write.
+
+export const runtime = "nodejs";
+
+const MAX_ITEMS = 100;
+const MAX_ITEM_LENGTH = 200;
+
+export async function POST(req: Request): Promise<Response> {
+  const secret = process.env.PETDEX_REVALIDATE_SECRET;
+  if (!secret) {
+    return NextResponse.json({ error: "not_configured" }, { status: 503 });
+  }
+
+  const auth = req.headers.get("authorization") ?? "";
+  const provided = auth.startsWith("Bearer ") ? auth.slice(7) : "";
+  if (!timingSafeCompare(provided, secret)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const slugs = readStringArray(body, "slugs");
+  const tags = readStringArray(body, "tags");
+  if (!slugs && !tags) {
+    return NextResponse.json(
+      { error: "nothing_to_revalidate" },
+      {
+        status: 400,
+      },
+    );
+  }
+
+  if (slugs && slugs.length > 0) {
+    await revalidatePetTags(...slugs);
+  }
+  if (tags && tags.length > 0) {
+    await expireNextCacheTags(...tags);
+  }
+
+  return NextResponse.json({
+    revalidated: { slugs: slugs ?? [], tags: tags ?? [] },
+  });
+}
+
+function readStringArray(body: unknown, field: string): string[] | null {
+  if (typeof body !== "object" || body === null) return null;
+  const value = (body as Record<string, unknown>)[field];
+  if (!Array.isArray(value)) return null;
+  return value
+    .filter(
+      (item): item is string =>
+        typeof item === "string" &&
+        item.length > 0 &&
+        item.length <= MAX_ITEM_LENGTH,
+    )
+    .slice(0, MAX_ITEMS);
+}
+
+function timingSafeCompare(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  return bufA.length === bufB.length && timingSafeEqual(bufA, bufB);
+}

--- a/src/lib/db/cached-aggregates.ts
+++ b/src/lib/db/cached-aggregates.ts
@@ -213,7 +213,7 @@ export async function invalidateAggregates(...keys: string[]): Promise<void> {
   await expireNextCacheTags(...tags);
 }
 
-async function expireNextCacheTags(...tags: string[]): Promise<void> {
+export async function expireNextCacheTags(...tags: string[]): Promise<void> {
   const cleanTags = tags.filter(Boolean);
   if (cleanTags.length === 0) return;
 

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -68,8 +68,13 @@ export const getVariantsFor = cache(
     const rows = await getVariantIndex();
     const currentPet = rows.find((row) => row.slug === slug);
 
+    // The index snapshot can lag behind the pets table (it's cached with
+    // its own TTL and tag, and cross-app writers can't flush this app's
+    // data cache). A freshly approved pet may exist while missing from
+    // the snapshot, so an index miss means "no variants yet", never an
+    // error — callers that need existence checks use getPet.
     if (!currentPet) {
-      throw new Error("PET_NOT_FOUND");
+      return [];
     }
 
     if (!currentPet.dhash) {


### PR DESCRIPTION
## Problem

Every pet approved from admin.petdex.dev breaks on petdex.dev for a window after approval. Today's batch (17 pets, 2026-07-11 17:00 UTC) shipped 13 pages returning 500 and 4 returning 404. Earlier batches (Jul 4/9/10) went through the same window unnoticed because it self-heals.

Root cause: the admin split moved approvals to a separate Next app. Its `revalidateTag` calls only flush its own data cache, so petdex.dev's `unstable_cache` layer goes stale:

- **500s**: `getVariantsFor` threw `PET_NOT_FOUND` when the slug was missing from the cached variant index (tag `petdex:variant-index`, 600s), turning an index-freshness race into a render crash on every newly approved pet page (Vercel runtime error digest 4153699148).
- **404s**: visiting `/pets/{slug}` before approval caches `getPet`'s null under `pet:{slug}` with a 24h revalidate that nothing cross-app can flush. Redeploys don't clear it (Vercel Data Cache persists).

## Fix

1. `getVariantsFor` returns `[]` on an index miss instead of throwing. The page already validated existence via `getPet`; the variants API route keeps its 404 by checking `getPet` directly.
2. New `POST /api/revalidate` (Bearer `PETDEX_REVALIDATE_SECRET`, timing-safe compare) accepting `{ slugs, tags }`. Slugs flush `pet:{slug}` + `pet:list` via the existing `revalidatePetTags`; tags flush via `expireNextCacheTags` (now exported). The admin app calls it after approve/reject/edit (companion PR in petdex-admin).

`PETDEX_REVALIDATE_SECRET` is already set in Vercel (production + preview) for both projects.