### PR TITLE
fix: enforce canonical sheet grid on submit and purge Cloudflare on revalidate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,13 @@ PETDEX_ROUTE_COST_SAMPLE_RATE=
 # cache tags after approve/reject/edit. Must match the admin app's value.
 PETDEX_REVALIDATE_SECRET=
 
+# Optional: lets /api/revalidate also purge the Cloudflare edge cache for
+# pet URLs. Cloudflare fronts petdex.dev with a cache-everything rule that
+# holds 404/500 HTML for ~1h after the origin is fixed. Token needs
+# Zone.Cache Purge on the petdex.dev zone.
+CLOUDFLARE_ZONE_ID=
+CLOUDFLARE_PURGE_TOKEN=
+
 # Email notifications
 RESEND_API_KEY=
 RESEND_FROM=

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -58,6 +58,11 @@ export async function POST(req: Request): Promise<Response> {
     // pet's cache tags, so it survives revalidateTag for the page's
     // whole 24h ISR window. Purge the route cache entries directly.
     await revalidatePetPaths(slugs);
+    // Cloudflare sits in front of Vercel with a cache-everything rule
+    // that also caches 404/500 HTML at the edge for ~1h, so a fixed
+    // origin can keep serving the broken page until the edge TTL
+    // expires. Purge the pet URLs there too when zone creds exist.
+    await purgeCloudflarePetUrls(slugs);
   }
   if (tags && tags.length > 0) {
     await expireNextCacheTags(...tags);
@@ -81,6 +86,41 @@ async function revalidatePetPaths(slugs: string[]): Promise<void> {
     }
   } catch {
     /* next/cache unavailable in some runtime contexts (tests, scripts) */
+  }
+}
+
+async function purgeCloudflarePetUrls(slugs: string[]): Promise<void> {
+  const zoneId = process.env.CLOUDFLARE_ZONE_ID;
+  const token = process.env.CLOUDFLARE_PURGE_TOKEN;
+  if (!zoneId || !token) return;
+
+  const files = slugs.flatMap((slug) => [
+    `https://petdex.dev/pets/${slug}`,
+    ...locales.map((locale) => `https://petdex.dev/${locale}/pets/${slug}`),
+  ]);
+
+  try {
+    // The purge endpoint accepts up to 30 files per call.
+    for (let i = 0; i < files.length; i += 30) {
+      const res = await fetch(
+        `https://api.cloudflare.com/client/v4/zones/${zoneId}/purge_cache`,
+        {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${token}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ files: files.slice(i, i + 30) }),
+          signal: AbortSignal.timeout(5000),
+        },
+      );
+      if (!res.ok) {
+        console.error(`[revalidate] cloudflare purge failed: ${res.status}`);
+        return;
+      }
+    }
+  } catch (error) {
+    console.error("[revalidate] cloudflare purge failed", error);
   }
 }
 

--- a/src/lib/security.test.ts
+++ b/src/lib/security.test.ts
@@ -166,6 +166,28 @@ describe("validateSubmission", () => {
       expect(r.field).toBe("petJsonUrl");
     }
   });
+
+  it("rejects a sheet with extra rows (11-row 1536x2288)", () => {
+    const r = validateSubmission({
+      ...BASE_INPUT,
+      spritesheetWidth: 1536,
+      spritesheetHeight: 2288,
+    });
+    expect(r?.ok).toBe(false);
+    if (r && r.ok === false) {
+      expect(r.error).toBe("invalid_spritesheet");
+    }
+  });
+
+  it("accepts a clean scale of the canonical grid (768x936)", () => {
+    expect(
+      validateSubmission({
+        ...BASE_INPUT,
+        spritesheetWidth: 768,
+        spritesheetHeight: 936,
+      }),
+    ).toBeNull();
+  });
 });
 
 describe("posixInstallScript shell-injection", () => {

--- a/src/lib/submissions-validation.ts
+++ b/src/lib/submissions-validation.ts
@@ -71,6 +71,21 @@ export function validateSubmission(
       got: { width: body.spritesheetWidth, height: body.spritesheetHeight },
     };
   }
+  // The viewer (pet-sprite.tsx) force-renders every sheet at 1536x1872
+  // (8 columns x 9 rows), so any other aspect gets squashed and every
+  // frame crop lands mid-sprite. A sheet with extra rows passed the
+  // min-dim check and shipped visibly broken (pixie, 1536x2288 = 11
+  // rows), so enforce the canonical grid shape, allowing clean scales
+  // of it (768x936, 3072x3744, ...).
+  if (body.spritesheetWidth * 1872 !== body.spritesheetHeight * 1536) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_spritesheet",
+      message: `Spritesheet must be an 8x9 grid with a 1536:1872 aspect (ideal 1536x1872). Got ${body.spritesheetWidth}x${body.spritesheetHeight}, which the pet viewer would squash and misalign.`,
+      got: { width: body.spritesheetWidth, height: body.spritesheetHeight },
+    };
+  }
   // Reject any URL outside the allowlist. Without this, a malicious
   // submission could land javascript:, attacker.com, or LAN IPs into the
   // pet detail page (XSS) and the install script (RCE on every viewer who


### PR DESCRIPTION
Two follow-ups from today's incident (#545, #546):

**Sheet grid validation.** The viewer hardcodes the 1536x1872 atlas (8 cols x 9 rows) and squashes anything else, misaligning every frame crop. The submit validation only checked a minimum dimension, which let an 11-row 1536x2288 sheet through (pixie) and it rendered visibly broken. Now the canonical 1536:1872 aspect is enforced, accepting clean scales (768x936, 3072x3744). Added coverage in security.test.ts (42 pass).

**Cloudflare purge on revalidate.** Cloudflare fronts petdex.dev with a cache-everything rule that also caches 404/500 HTML for ~1h, so even after #546 fixed the origin, the edge kept serving stale 404s until TTL expiry (observed live today). /api/revalidate now purges the pet URLs at Cloudflare when CLOUDFLARE_ZONE_ID + CLOUDFLARE_PURGE_TOKEN are set; silent no-op otherwise. Token needs Zone.Cache Purge on the petdex.dev zone (pending: create it in the Crafter Station CF account and add both vars to Vercel).

Ideally the CF cache rule should also exclude 4xx/5xx responses from edge caching; that lives in the CF dashboard, not this repo.