### PR TITLE
feat: support hatch-pet v2 8x11 atlases in the sprite viewer

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -483,14 +483,18 @@ input {
   --sprite-frames: 6;
   --sprite-duration: 1100ms;
   --sprite-sheet-width: 1536px;
-  --sprite-sheet-height: 1872px;
   --sprite-y: calc(var(--sprite-row) * -208px);
   --sprite-end-x: calc(var(--sprite-frames) * -192px);
   width: 192px;
   height: 208px;
   background-image: var(--sprite-url);
   background-repeat: no-repeat;
-  background-size: var(--sprite-sheet-width) var(--sprite-sheet-height);
+  /* Width-only sizing: forcing both dimensions squashed any sheet whose
+     row count differs from the classic 9. v2 hatch atlases are 8x11
+     (rows 9-10 hold the 16 look directions); auto height preserves the
+     sheet's aspect so every 208px row lands on its true offset no
+     matter how many rows exist below the ones we animate. */
+  background-size: var(--sprite-sheet-width) auto;
   image-rendering: pixelated;
   /* translateZ(0) forces a GPU-composited layer so background-image
      decode + animation stay on the compositor thread instead of being
@@ -530,7 +534,9 @@ input {
   height: 208px;
   background-image: var(--sprite-url);
   background-repeat: no-repeat;
-  background-size: 1536px 1872px;
+  /* Width-only for the same reason as .pet-sprite: v2 sheets have 11
+     rows and a forced 1872px height would squash them. */
+  background-size: 1536px auto;
   background-position: 0 var(--sprite-y);
   image-rendering: pixelated;
   transform: scale(var(--pet-scale, 1));

--- a/src/components/pets/pet-sprite.tsx
+++ b/src/components/pets/pet-sprite.tsx
@@ -34,7 +34,6 @@ type PetSpriteProps = {
 };
 
 const ATLAS_SHEET_WIDTH = 1536;
-const ATLAS_SHEET_HEIGHT = 1872;
 
 function PetSpriteImpl({
   src,
@@ -52,11 +51,12 @@ function PetSpriteImpl({
     : fixedAnimation;
 
   // A row strip only carries a single animation row, so it always plays
-  // row 0 and the sheet is exactly one frame strip wide/tall.
+  // row 0 and the sheet is exactly one frame strip wide/tall. Height is
+  // never forced — the CSS sizes the background by width only so both
+  // classic 8x9 and v2 8x11 atlases keep their row offsets intact.
   const isRow = layout === "row";
   const spriteRow = isRow ? 0 : animation.row;
   const sheetWidth = isRow ? animation.frames * 192 : ATLAS_SHEET_WIDTH;
-  const sheetHeight = isRow ? 208 : ATLAS_SHEET_HEIGHT;
 
   return (
     <div
@@ -78,7 +78,6 @@ function PetSpriteImpl({
             "--sprite-frames": animation.frames,
             "--sprite-duration": `${animation.durationMs}ms`,
             "--sprite-sheet-width": `${sheetWidth}px`,
-            "--sprite-sheet-height": `${sheetHeight}px`,
           } as CSSProperties
         }
       />

--- a/src/components/submit/pet-submit-form.tsx
+++ b/src/components/submit/pet-submit-form.tsx
@@ -234,6 +234,8 @@ export function PetSubmitForm() {
       let height = 0;
       if (spritesheetUrl) {
         ({ width, height } = await measureImage(spritesheetUrl));
+        const isClassicGrid = width * 1872 === height * 1536;
+        const isV2Grid = width * 2288 === height * 1536;
         if (width === 0 || height === 0) {
           issues.push(t("issues.unreadableSpritesheet"));
         } else if (width < 256 || height < 256) {
@@ -245,6 +247,10 @@ export function PetSubmitForm() {
               recommendedHeight: REQUIRED.height,
             }),
           );
+        } else if (!isClassicGrid && !isV2Grid) {
+          // Mirror the server-side grid check so the preview never says
+          // "ready" for a sheet /api/submit will reject.
+          issues.push(t("issues.badGrid", { width, height }));
         }
       }
 

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -318,7 +318,8 @@
         "zipMissingSpritesheet": "Missing spritesheet.webp (or .png) at zip root. Found: {present}",
         "invalidJson": "pet.json is not valid JSON.",
         "unreadableSpritesheet": "Spritesheet image is unreadable.",
-        "tooSmall": "Spritesheet seems too small ({width}×{height}). Use an 8×9 frame grid (recommended {recommendedWidth}×{recommendedHeight})."
+        "tooSmall": "Spritesheet seems too small ({width}×{height}). Use an 8×9 frame grid (recommended {recommendedWidth}×{recommendedHeight}).",
+        "badGrid": "Spritesheet grid is {width}×{height}, which doesn't match the 8×9 (1536×1872) or v2 8×11 (1536×2288) frame grid, so frames would render misaligned."
       }
     }
   },

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -318,7 +318,8 @@
         "zipMissingSpritesheet": "Falta spritesheet.webp (o .png) en la raíz del zip. Encontrado: {present}",
         "invalidJson": "pet.json no es JSON válido.",
         "unreadableSpritesheet": "No se puede leer la imagen del spritesheet.",
-        "tooSmall": "El spritesheet parece muy pequeño ({width}×{height}). Usa una grilla de 8×9 frames (recomendado {recommendedWidth}×{recommendedHeight})."
+        "tooSmall": "El spritesheet parece muy pequeño ({width}×{height}). Usa una grilla de 8×9 frames (recomendado {recommendedWidth}×{recommendedHeight}).",
+        "badGrid": "La grilla del spritesheet es {width}×{height}, que no coincide con la grilla 8×9 (1536×1872) ni la v2 8×11 (1536×2288), así que los frames se verían desalineados."
       }
     }
   },

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -339,7 +339,8 @@
         "zipMissingSpritesheet": "zip 根目录缺少精灵图集文件 spritesheet.webp（或 .png）。找到的文件：{present}",
         "invalidJson": "pet.json 不是有效的 JSON。",
         "unreadableSpritesheet": "无法读取精灵图集 Spritesheet 图片。",
-        "tooSmall": "精灵图集 Spritesheet 看起来太小（{width}×{height}）。请使用 8×9 帧网格（推荐 {recommendedWidth}×{recommendedHeight}）。"
+        "tooSmall": "精灵图集 Spritesheet 看起来太小（{width}×{height}）。请使用 8×9 帧网格（推荐 {recommendedWidth}×{recommendedHeight}）。",
+        "badGrid": "精灵图集 Spritesheet 网格为 {width}×{height}，不符合 8×9（1536×1872）或 v2 8×11（1536×2288）帧网格，帧会错位显示。"
       }
     }
   },

--- a/src/lib/security.test.ts
+++ b/src/lib/security.test.ts
@@ -167,19 +167,17 @@ describe("validateSubmission", () => {
     }
   });
 
-  it("rejects a sheet with extra rows (11-row 1536x2288)", () => {
-    const r = validateSubmission({
-      ...BASE_INPUT,
-      spritesheetWidth: 1536,
-      spritesheetHeight: 2288,
-    });
-    expect(r?.ok).toBe(false);
-    if (r && r.ok === false) {
-      expect(r.error).toBe("invalid_spritesheet");
-    }
+  it("accepts a v2 8x11 atlas (1536x2288)", () => {
+    expect(
+      validateSubmission({
+        ...BASE_INPUT,
+        spritesheetWidth: 1536,
+        spritesheetHeight: 2288,
+      }),
+    ).toBeNull();
   });
 
-  it("accepts a clean scale of the canonical grid (768x936)", () => {
+  it("accepts a clean scale of the classic grid (768x936)", () => {
     expect(
       validateSubmission({
         ...BASE_INPUT,
@@ -187,6 +185,18 @@ describe("validateSubmission", () => {
         spritesheetHeight: 936,
       }),
     ).toBeNull();
+  });
+
+  it("rejects an off-grid sheet (1536x2000)", () => {
+    const r = validateSubmission({
+      ...BASE_INPUT,
+      spritesheetWidth: 1536,
+      spritesheetHeight: 2000,
+    });
+    expect(r?.ok).toBe(false);
+    if (r && r.ok === false) {
+      expect(r.error).toBe("invalid_spritesheet");
+    }
   });
 });
 

--- a/src/lib/submissions-validation.ts
+++ b/src/lib/submissions-validation.ts
@@ -71,18 +71,22 @@ export function validateSubmission(
       got: { width: body.spritesheetWidth, height: body.spritesheetHeight },
     };
   }
-  // The viewer (pet-sprite.tsx) force-renders every sheet at 1536x1872
-  // (8 columns x 9 rows), so any other aspect gets squashed and every
-  // frame crop lands mid-sprite. A sheet with extra rows passed the
-  // min-dim check and shipped visibly broken (pixie, 1536x2288 = 11
-  // rows), so enforce the canonical grid shape, allowing clean scales
-  // of it (768x936, 3072x3744, ...).
-  if (body.spritesheetWidth * 1872 !== body.spritesheetHeight * 1536) {
+  // The viewer walks 192x208 cells on an 8-column grid, so only two
+  // atlas shapes render correctly: the classic 8x9 (1536x1872) and the
+  // hatch-pet v2 8x11 (1536x2288, rows 9-10 hold the 16 look
+  // directions). Clean scales of either are fine (768x936, 3072x4576).
+  // Anything else gets squashed with every frame crop landing
+  // mid-sprite, which is how an early v2 sheet shipped visibly broken.
+  const isClassicGrid =
+    body.spritesheetWidth * 1872 === body.spritesheetHeight * 1536;
+  const isV2Grid =
+    body.spritesheetWidth * 2288 === body.spritesheetHeight * 1536;
+  if (!isClassicGrid && !isV2Grid) {
     return {
       ok: false,
       status: 400,
       error: "invalid_spritesheet",
-      message: `Spritesheet must be an 8x9 grid with a 1536:1872 aspect (ideal 1536x1872). Got ${body.spritesheetWidth}x${body.spritesheetHeight}, which the pet viewer would squash and misalign.`,
+      message: `Spritesheet must be an 8x9 grid (1536x1872) or a v2 8x11 grid (1536x2288). Got ${body.spritesheetWidth}x${body.spritesheetHeight}, which the pet viewer would squash and misalign.`,
       got: { width: body.spritesheetWidth, height: body.spritesheetHeight },
     };
   }


### PR DESCRIPTION
Context: #547 added grid validation after an 11-row sheet shipped broken (pixie). Turns out those sheets are not malformed: the Codex hatch-pet skill intentionally packages every new pet as a v2 8x11 atlas, rows 0-8 being the standard animations and rows 9-10 the 16 look directions (spriteVersionNumber 2). petdex was behind the format.

**Viewer**: .pet-sprite and .pet-sprite-static forced background-size to 1536x1872, squashing v2 sheets. Now the background is sized by width only (`background-size: <width> auto`), so the sheet keeps its natural aspect and the fixed 208px row offsets are correct for 8x9, 8x11, and clean scales of either. The look rows are simply never selected. No per-pet metadata needed.

**Validation**: the server check from #547 now accepts both the classic 1536:1872 aspect and the v2 1536:2288 aspect, still rejecting off-grid dimensions. The client-side submission check previously only enforced a 256px minimum and showed 'Looks ready to submit' for sheets the server rejects; it now mirrors the server grid check (new i18n key in en/es/zh).

Tests: 43 pass (v2 accepted, classic scale accepted, off-grid rejected).