### PR TITLE
fix: purge asset CDN urls so cached preview 404s stop poisoning Newest

### DIFF
--- a/.github/workflows/preview-snapshot.yml
+++ b/.github/workflows/preview-snapshot.yml
@@ -9,7 +9,12 @@ name: preview-snapshot
 
 on:
   schedule:
-    - cron: "0 7 * * *"
+    # Every 6 hours: approvals happen around 08:00 UTC (China review) and a
+    # missing preview lets Cloudflare cache a 404 until the next backfill,
+    # so a daily run left the Newest tab imageless for up to a day (#553).
+    # Re-runs are cheap because the script skips pets that already have a
+    # preview.
+    - cron: "0 */6 * * *"
   workflow_dispatch:
     inputs:
       mode:
@@ -62,3 +67,5 @@ jobs:
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          CLOUDFLARE_PURGE_TOKEN: ${{ secrets.CLOUDFLARE_PURGE_TOKEN }}

--- a/scripts/publish-pet-previews.ts
+++ b/scripts/publish-pet-previews.ts
@@ -136,7 +136,48 @@ if (mode === "apply") {
     console.log(`failed ${result.slug} ${result.reason}`);
   }
 
+  await purgeCdnUrls(uploaded.map((result) => petPreviewUrl(result.slug)));
+
   if (failed.length > 0) process.exit(1);
+}
+
+// The upload above writes straight to R2 over the S3 API, which does NOT
+// touch the Cloudflare cache in front of assets.petdex.dev. Any gallery
+// request that raced the upload has already cached a 404 for the preview
+// URL with a one year TTL, and R2 custom domains do not auto-purge on
+// overwrite, so a freshly backfilled preview stays invisible forever
+// unless we purge its URL explicitly (issue #553).
+async function purgeCdnUrls(urls: string[]): Promise<void> {
+  if (urls.length === 0) return;
+  const zoneId = process.env.CLOUDFLARE_ZONE_ID;
+  const token = process.env.CLOUDFLARE_PURGE_TOKEN;
+  if (!zoneId || !token) {
+    console.log(`cloudflare purge skipped (no creds) for ${urls.length} urls`);
+    return;
+  }
+  let purged = 0;
+  // The purge endpoint accepts up to 30 files per call.
+  for (let i = 0; i < urls.length; i += 30) {
+    const batch = urls.slice(i, i + 30);
+    const res = await fetch(
+      `https://api.cloudflare.com/client/v4/zones/${zoneId}/purge_cache`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ files: batch }),
+        signal: AbortSignal.timeout(10_000),
+      },
+    );
+    if (!res.ok) {
+      console.log(`cloudflare purge failed ${res.status}`);
+      return;
+    }
+    purged += batch.length;
+  }
+  console.log(`cloudflare purged ${purged}`);
 }
 
 async function publishPreview(task: PreviewTask): Promise<PublishResult> {

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -6,6 +6,9 @@ import {
   expireNextCacheTags,
   revalidatePetTags,
 } from "@/lib/db/cached-aggregates";
+import { petPreviewUrl } from "@/lib/pet-preview";
+import { petStickerUrl } from "@/lib/pet-sticker-artifacts";
+import { petThumbnailUrl } from "@/lib/pet-thumbnail";
 
 import { locales } from "@/i18n/config";
 
@@ -97,6 +100,14 @@ async function purgeCloudflarePetUrls(slugs: string[]): Promise<void> {
   const files = slugs.flatMap((slug) => [
     `https://petdex.dev/pets/${slug}`,
     ...locales.map((locale) => `https://petdex.dev/${locale}/pets/${slug}`),
+    // assets.petdex.dev sits behind the same zone with a cache-everything
+    // rule that also caches 404s for a year. Gallery cards request these
+    // artifact URLs the moment a pet becomes visible, which can be before
+    // the artifacts finish uploading, so the poisoned 404 outlives the
+    // upload forever unless we purge it here (issue #553).
+    petPreviewUrl(slug),
+    petThumbnailUrl(slug),
+    petStickerUrl(slug),
   ]);
 
   try {


### PR DESCRIPTION
Fixes #553.

## Problem

The Newest tab showed almost no preview images. Root cause chain:

1. Approval-time artifact publish has been failing silently on admin.petdex.dev (companion PR in petdex-admin), so a new pet has no `pets/{slug}/preview.webp` until the daily backfill cron runs, up to 24h later.
2. During that window, gallery cards request the preview URL and Cloudflare's cache-everything rule on assets.petdex.dev caches the 404 with a one year TTL.
3. Nothing ever heals it: the cron writes to R2 over the S3 API (no CDN purge), R2 custom domains do not auto purge on overwrite (verified empirically with a self CopyObject), and `purgeCloudflarePetUrls` only covered pet page URLs and was a silent no-op in prod because `CLOUDFLARE_ZONE_ID` / `CLOUDFLARE_PURGE_TOKEN` were never set.

Verified: the 264 newest pets all served a poisoned 404 for their preview while the object existed in R2 (cache-busted GET returned 200 for all of them).

## Changes

- `/api/revalidate` purges the preview, thumb, and sticker asset URLs together with the pet page URLs, so the admin's post-approval revalidate call clears any 404 cached during the publish race.
- `scripts/publish-pet-previews.ts` purges each uploaded preview URL from Cloudflare after the R2 write (skips with a log line when zone creds are absent).
- `preview-snapshot` workflow now runs every 6 hours (script skips existing previews, so re-runs are cheap) and passes the new Cloudflare secrets.

## Ops done outside this PR

- Purged the 264 poisoned preview URLs manually: Newest renders again as of today.
- Added `CLOUDFLARE_ZONE_ID` and `CLOUDFLARE_PURGE_TOKEN` to Vercel prod env (takes effect on next deploy, i.e. this PR's merge).
- Adding the same values as GitHub environment secrets (`manifest-snapshot`) for the workflow.

Follow-up worth doing in the Cloudflare dash: a cache rule on assets.petdex.dev that keeps 4xx/5xx edge TTL short so this whole failure class dies.