### PR TITLE
fix: update SEO test file paths and correct README spritesheet dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Every pet is two files:
 ```text
 my-pet/
 ├── pet.json                Metadata: name, slug, tags, vibes, kind, frame size, animation states
-└── spritesheet.webp        8 rows × 9 cols = 72 frames of 192×208 px each (or .png)
+└── spritesheet.webp        9 rows × 8 cols = 72 frames of 192×208 px each (or .png)
 ```
 
 Animation states are the rows: `idle`, `wave`, `run`, `failed`, `review`, `jump`, `extra1`, `extra2`. Codex maps these to its agent activity hooks. Loop timing defaults to 1100ms at 6 frames per state.

--- a/src/lib/seo-canonical.test.ts
+++ b/src/lib/seo-canonical.test.ts
@@ -27,7 +27,7 @@ const SEO_SOURCE_FILES = [
   "src/app/robots.ts",
   "src/app/layout.tsx",
   "src/app/[locale]/layout.tsx",
-  "src/components/json-ld.tsx",
+  "src/components/layout/json-ld.tsx",
   "src/app/[locale]/page.tsx",
   "src/app/[locale]/about/page.tsx",
   "src/app/[locale]/brand/page.tsx",
@@ -44,9 +44,9 @@ const SEO_SOURCE_FILES = [
   "src/app/[locale]/download/opengraph-image.tsx",
   "src/app/[locale]/pets/[slug]/opengraph-image.tsx",
   "src/app/[locale]/u/[handle]/opengraph-image.tsx",
-  "src/components/collection-action-menu.tsx",
-  "src/components/pet-action-menu.tsx",
-  "src/components/profile-share-button.tsx",
+  "src/components/collections/collection-action-menu.tsx",
+  "src/components/pets/pet-action-menu.tsx",
+  "src/components/profile/profile-share-button.tsx",
 ];
 
 describe("SEO canonical domain", () => {


### PR DESCRIPTION
- Fix 4 wrong paths in seo-canonical.test.ts that cause ENOENT errors (files were reorganized into subdirectories)
- Correct spritesheet grid dimensions in README from '8 rows × 9 cols' to '9 rows × 8 cols' (1536÷192=8 cols, 1872÷208=9 rows)