### PR TITLE
fix(cli): write canonical [features].hooks key instead of deprecated codex_hooks

### DIFF
--- a/packages/petdex-cli/package.json
+++ b/packages/petdex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "petdex",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "CLI for Petdex. Install, browse, and submit Codex pets from your terminal.",
   "homepage": "https://petdex.dev",
   "repository": {

--- a/packages/petdex-cli/src/desktop/doctor.ts
+++ b/packages/petdex-cli/src/desktop/doctor.ts
@@ -325,30 +325,34 @@ function checkCodexFeatureFlag(): CheckResult {
   if (!existsSync(tomlPath)) {
     return {
       status: "info",
-      label: "Codex codex_hooks flag",
+      label: "Codex hooks flag",
       detail: "config.toml absent (Codex not installed?)",
     };
   }
   try {
     const text = readFileSync(tomlPath, "utf8");
     // Naive but matches `petdex hooks install`'s own inspectFeaturesCodexHooks.
-    if (/\[features\][\s\S]*?codex_hooks\s*=\s*true/.test(text)) {
+    // hooks is the canonical key; codex_hooks is deprecated but still counts
+    // as enabled when a previous install left it set (#558).
+    if (
+      /\[features\][\s\S]*?(?:^|\n)\s*(?:codex_)?hooks\s*=\s*true/.test(text)
+    ) {
       return {
         status: "ok",
-        label: "Codex codex_hooks flag",
-        detail: "[features] codex_hooks = true",
+        label: "Codex hooks flag",
+        detail: "[features] hooks = true",
       };
     }
     return {
       status: "warn",
-      label: "Codex codex_hooks flag",
+      label: "Codex hooks flag",
       detail: "missing or set to non-true",
       hint: "Re-run `petdex hooks install` and accept the auto-fix prompt.",
     };
   } catch {
     return {
       status: "warn",
-      label: "Codex codex_hooks flag",
+      label: "Codex hooks flag",
       detail: "config.toml unreadable",
     };
   }

--- a/packages/petdex-cli/src/hooks/agents.test.ts
+++ b/packages/petdex-cli/src/hooks/agents.test.ts
@@ -7,6 +7,8 @@ import { dirname, join } from "node:path";
 import {
   AGENTS,
   antigravityMcpConfigPath,
+  applyCodexHooksFix,
+  inspectFeaturesCodexHooks,
   resolveOpenCodeConfigDir,
   SIDECAR_URL,
 } from "./agents";
@@ -362,5 +364,60 @@ describe("OpenCode config path resolution", () => {
     expect(resolveOpenCodeConfigDir({}, "/home/example")).toBe(
       "/home/example/.config/opencode",
     );
+  });
+});
+
+describe("codex [features] hooks flag (#558)", () => {
+  test("hooks = true is enabled", () => {
+    expect(inspectFeaturesCodexHooks("[features]\nhooks = true\n").state).toBe(
+      "enabled",
+    );
+  });
+
+  test("legacy codex_hooks = true still counts as enabled", () => {
+    expect(
+      inspectFeaturesCodexHooks("[features]\ncodex_hooks = true\n").state,
+    ).toBe("enabled");
+  });
+
+  test("hooks key wins over legacy key when both are present", () => {
+    const inspection = inspectFeaturesCodexHooks(
+      "[features]\ncodex_hooks = true\nhooks = false\n",
+    );
+    expect(inspection).toEqual({ state: "wrong-value", replaceLine: 2 });
+  });
+
+  test("keys outside [features] do not count", () => {
+    expect(inspectFeaturesCodexHooks("[other]\nhooks = true\n").state).toBe(
+      "no-features-section",
+    );
+  });
+
+  test("fix rewrites a false hooks value in place, keeping comments", () => {
+    const text = "[features]\nhooks = false # keep me\n";
+    const next = applyCodexHooksFix(text, inspectFeaturesCodexHooks(text));
+    expect(next).toBe("[features]\nhooks = true # keep me\n");
+  });
+
+  test("fix inserts the canonical key and never writes codex_hooks", () => {
+    const text = "[features]\nother = 1\n";
+    const next = applyCodexHooksFix(text, inspectFeaturesCodexHooks(text));
+    expect(next).toContain("hooks = true");
+    expect(next).not.toContain("codex_hooks");
+  });
+
+  test("fix leaves an existing legacy codex_hooks = false line untouched", () => {
+    const text = "[features]\ncodex_hooks = false\n";
+    const next = applyCodexHooksFix(text, inspectFeaturesCodexHooks(text));
+    expect(next).toContain("codex_hooks = false");
+    expect(next).toContain("hooks = true");
+  });
+
+  test("fix appends a [features] block when the section is missing", () => {
+    const next = applyCodexHooksFix(
+      'model = "gpt-5.4"',
+      inspectFeaturesCodexHooks('model = "gpt-5.4"'),
+    );
+    expect(next).toBe('model = "gpt-5.4"\n\n[features]\nhooks = true\n');
   });
 });

--- a/packages/petdex-cli/src/hooks/agents.ts
+++ b/packages/petdex-cli/src/hooks/agents.ts
@@ -88,7 +88,7 @@ export type Agent = {
   /**
    * Optional follow-up checks the wizard runs after writing the config.
    * Used to surface agent-specific feature flags or steps the user must
-   * still take (e.g. Codex requires `[features] codex_hooks = true` in
+   * still take (e.g. Codex requires `[features] hooks = true` in
    * config.toml before hooks load).
    */
   postInstallChecks?(): Promise<PostInstallNote[]>;
@@ -287,12 +287,14 @@ export const AGENTS: Agent[] = [
       { event: "Stop", kind: "session.end" },
     ],
     async postInstallChecks() {
-      // Codex only loads hooks.json when [features] codex_hooks = true is
-      // present in ~/.codex/config.toml. The detect + edit pair below is
-      // section-aware: a top-level codex_hooks or a codex_hooks under a
-      // different table doesn't count, and an existing
-      // [features].codex_hooks gets its value rewritten in place rather
-      // than appended (which would produce ambiguous TOML).
+      // Codex loads hooks.json when [features] hooks = true is present in
+      // ~/.codex/config.toml (current Codex enables it by default; older
+      // builds used the now-deprecated codex_hooks key, which we still
+      // accept as enabled but no longer write, see #558). The detect +
+      // edit pair below is section-aware: a top-level hooks key or one
+      // under a different table doesn't count, and an existing
+      // [features].hooks gets its value rewritten in place rather than
+      // appended (which would produce ambiguous TOML).
       const { readFile } = await import("node:fs/promises");
       const tomlPath = path.join(HOME, ".codex", "config.toml");
       let exists = true;
@@ -307,7 +309,7 @@ export const AGENTS: Agent[] = [
           return [
             {
               level: "warn",
-              message: `Could not read ${tomlPath} (${code ?? "io_error"}). Make sure [features] codex_hooks = true is set there before Codex picks up the hooks.`,
+              message: `Could not read ${tomlPath} (${code ?? "io_error"}). Make sure [features] hooks = true is set there before Codex picks up the hooks.`,
             },
           ];
         }
@@ -321,23 +323,19 @@ export const AGENTS: Agent[] = [
       const fix = {
         prompt:
           inspection.state === "missing-file"
-            ? `Create ${tildePath(tomlPath)} with [features] codex_hooks = true?`
+            ? `Create ${tildePath(tomlPath)} with [features] hooks = true?`
             : inspection.state === "wrong-value"
-              ? `Set codex_hooks = true under [features] in ${tildePath(tomlPath)}? (a .bak of the current file is created first)`
-              : `Add codex_hooks = true under [features] in ${tildePath(tomlPath)}? (a .bak of the current file is created first)`,
+              ? `Set hooks = true under [features] in ${tildePath(tomlPath)}? (a .bak of the current file is created first)`
+              : `Add hooks = true under [features] in ${tildePath(tomlPath)}? (a .bak of the current file is created first)`,
         apply: async () => {
           const { writeFile, mkdir } = await import("node:fs/promises");
           await mkdir(path.dirname(tomlPath), { recursive: true });
           if (!exists) {
             try {
-              await writeFile(
-                tomlPath,
-                "[features]\ncodex_hooks = true\n",
-                "utf8",
-              );
+              await writeFile(tomlPath, "[features]\nhooks = true\n", "utf8");
               return {
                 ok: true,
-                message: `Created ${tildePath(tomlPath)} with [features] codex_hooks = true`,
+                message: `Created ${tildePath(tomlPath)} with [features] hooks = true`,
               };
             } catch (err) {
               return {
@@ -361,7 +359,7 @@ export const AGENTS: Agent[] = [
             await writeFile(tomlPath, next, "utf8");
             return {
               ok: true,
-              message: `codex_hooks = true set in ${tildePath(tomlPath)} (backup: ${path.basename(backup)})`,
+              message: `hooks = true set in ${tildePath(tomlPath)} (backup: ${path.basename(backup)})`,
             };
           } catch (err) {
             return {
@@ -375,7 +373,7 @@ export const AGENTS: Agent[] = [
       return [
         {
           level: "action",
-          message: `Codex needs codex_hooks = true under [features] in ${tildePath(tomlPath)} before it loads ${tildePath(path.join(HOME, ".codex", "hooks.json"))}.`,
+          message: `Codex needs hooks = true under [features] in ${tildePath(tomlPath)} before it loads ${tildePath(path.join(HOME, ".codex", "hooks.json"))}.`,
           fix,
         },
       ];
@@ -858,10 +856,15 @@ function tildePath(p: string): string {
 // walk the file line by line tracking the current section. This is
 // deliberately conservative: it only recognizes top-level standard tables
 // like [features] and [features.something], and it won't try to handle
-// inline tables, dotted keys at the top level (e.g. features.codex_hooks),
+// inline tables, dotted keys at the top level (e.g. features.hooks),
 // or array-of-tables — Codex's own config doesn't use those for this flag,
 // and refusing to act is safer than rewriting structure we don't fully
 // understand.
+//
+// The canonical key is [features].hooks; codex_hooks is deprecated (#558).
+// A codex_hooks = true left by an older install still counts as enabled so
+// we don't nag users whose setup works, but every write path emits the
+// canonical key and existing codex_hooks lines are never touched.
 
 type CodexHooksInspection =
   | { state: "missing-file" }
@@ -870,12 +873,16 @@ type CodexHooksInspection =
   | { state: "no-key"; insertAfterLine: number }
   | { state: "wrong-value"; replaceLine: number };
 
-function inspectFeaturesCodexHooks(text: string): CodexHooksInspection {
+export function inspectFeaturesCodexHooks(text: string): CodexHooksInspection {
   const lines = text.split("\n");
   const sectionHeaderRe = /^\s*\[([^[\]]+)\]\s*(?:#.*)?$/;
-  const keyRe = /^\s*codex_hooks\s*=\s*(.+?)\s*(?:#.*)?$/;
+  const keyRe = /^\s*hooks\s*=\s*(.+?)\s*(?:#.*)?$/;
+  const legacyKeyRe = /^\s*codex_hooks\s*=\s*(.+?)\s*(?:#.*)?$/;
   let currentSection: string | null = null;
   let featuresHeaderLine: number | null = null;
+  let hooksLine: number | null = null;
+  let hooksValue: string | null = null;
+  let legacyEnabled = false;
 
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i];
@@ -889,17 +896,25 @@ function inspectFeaturesCodexHooks(text: string): CodexHooksInspection {
     }
     if (currentSection !== "features") continue;
     const keyMatch = line.match(keyRe);
-    if (!keyMatch) continue;
-    const value = keyMatch[1].trim();
-    if (value === "true") return { state: "enabled" };
-    return { state: "wrong-value", replaceLine: i };
+    if (keyMatch && hooksLine === null) {
+      hooksLine = i;
+      hooksValue = keyMatch[1].trim();
+      continue;
+    }
+    const legacyMatch = line.match(legacyKeyRe);
+    if (legacyMatch && legacyMatch[1].trim() === "true") legacyEnabled = true;
   }
 
+  if (hooksLine !== null) {
+    if (hooksValue === "true") return { state: "enabled" };
+    return { state: "wrong-value", replaceLine: hooksLine };
+  }
+  if (legacyEnabled) return { state: "enabled" };
   if (featuresHeaderLine === null) return { state: "no-features-section" };
   return { state: "no-key", insertAfterLine: featuresHeaderLine };
 }
 
-function applyCodexHooksFix(
+export function applyCodexHooksFix(
   text: string,
   inspection: CodexHooksInspection,
 ): string {
@@ -913,19 +928,17 @@ function applyCodexHooksFix(
     // Preserve indentation and any trailing comment by replacing only the
     // value portion of the matched line.
     const original = lines[inspection.replaceLine];
-    const valueRe = /^(\s*codex_hooks\s*=\s*)([^#\n]+?)(\s*(?:#.*)?)$/;
+    const valueRe = /^(\s*hooks\s*=\s*)([^#\n]+?)(\s*(?:#.*)?)$/;
     const m = original.match(valueRe);
-    lines[inspection.replaceLine] = m
-      ? `${m[1]}true${m[3]}`
-      : "codex_hooks = true";
+    lines[inspection.replaceLine] = m ? `${m[1]}true${m[3]}` : "hooks = true";
     return lines.join("\n");
   }
   if (inspection.state === "no-key") {
-    lines.splice(inspection.insertAfterLine + 1, 0, "codex_hooks = true");
+    lines.splice(inspection.insertAfterLine + 1, 0, "hooks = true");
     return lines.join("\n");
   }
   // no-features-section: append a fresh [features] block at EOF without
   // collapsing existing trailing content.
   const sep = text.endsWith("\n") || text.length === 0 ? "" : "\n";
-  return `${text}${sep}\n[features]\ncodex_hooks = true\n`;
+  return `${text}${sep}\n[features]\nhooks = true\n`;
 }


### PR DESCRIPTION
Fixes #558.

Codex documentation marks `[features].codex_hooks` as deprecated; the canonical key is `[features].hooks`.

## Changes

- `petdex hooks install` / `petdex init` auto-fix now writes `hooks = true` on every path (fresh config.toml, missing key, wrong value) and never emits `codex_hooks` again.
- A legacy `codex_hooks = true` left by an older install still counts as enabled, so working setups are not nagged into churn. Existing `codex_hooks` lines are never rewritten or removed.
- When both keys are present, `hooks` wins (current Codex ignores the deprecated key).
- `petdex doctor` accepts either key as enabled and reports the flag as "Codex hooks flag".
- Unit tests for the TOML inspector and fix helpers (8 new cases including comment preservation and both-keys precedence).

CLI bumped to 0.4.5. After merge I will push the `cli-v0.4.5` tag so the npm release workflow publishes it.