### PR TITLE
fix(submit): derive a stable slug for non-Latin pet ids instead of hard-failing

### DIFF
--- a/packages/petdex-cli/bin/petdex.ts
+++ b/packages/petdex-cli/bin/petdex.ts
@@ -665,15 +665,15 @@ async function cmdSubmit(args: string[]) {
   let skipped = 0;
   if (ownedSlugs.size > 0) {
     const dupes = candidates.filter((c) =>
-      ownedSlugs.has(slugify(c.petIdHint)),
+      ownedSlugs.has(deriveSlug(c.petIdHint)),
     );
     const fresh = candidates.filter(
-      (c) => !ownedSlugs.has(slugify(c.petIdHint)),
+      (c) => !ownedSlugs.has(deriveSlug(c.petIdHint)),
     );
     p.note(
       dupes
         .map((c) => {
-          const owned = ownedSlugs.get(slugify(c.petIdHint));
+          const owned = ownedSlugs.get(deriveSlug(c.petIdHint));
           const status = owned?.status ?? "unknown";
           return `${pc.yellow("•")} ${pc.bold(c.label)} ${pc.dim(`(${status})`)}`;
         })
@@ -1084,7 +1084,7 @@ async function submitOne(
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      slugHint: slugify(cand.petIdHint),
+      slugHint: deriveSlug(cand.petIdHint),
       petId: cand.petIdHint,
       spritesheetExt: cand.spritesheetExt,
     }),
@@ -1228,7 +1228,7 @@ async function fetchOwnedSlugs(
       body: JSON.stringify({
         candidates: cands.map((c) => ({
           petId: c.petIdHint,
-          slugHint: slugify(c.petIdHint),
+          slugHint: deriveSlug(c.petIdHint),
         })),
       }),
       signal: AbortSignal.timeout(8000),
@@ -1335,6 +1335,22 @@ function slugify(value: string): string {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
     .slice(0, 40);
+}
+
+/** Mirrors deriveSlug in the web app's src/lib/slug.ts: a non-Latin pet id
+ *  falls back to a deterministic pet-<hash> slug instead of "", so dedup
+ *  and slugHint agree with what the server derives. Keep in sync. */
+function deriveSlug(petId: string): string {
+  const direct = slugify(petId);
+  if (direct) return direct;
+  const seed = petId.trim();
+  if (!seed) return "";
+  let hash = 0x811c9dc5;
+  for (const byte of new TextEncoder().encode(seed)) {
+    hash ^= byte;
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return `pet-${hash.toString(36).padStart(7, "0")}`;
 }
 
 function parseImageDims(buf: Buffer): { width: number; height: number } {

--- a/src/app/api/cli/submit/check/route.ts
+++ b/src/app/api/cli/submit/check/route.ts
@@ -13,7 +13,7 @@ import { and, eq, inArray } from "drizzle-orm";
 import { verifyCliBearer } from "@/lib/cli-auth";
 import { db, schema } from "@/lib/db/client";
 import { cliVerifyRatelimit } from "@/lib/ratelimit";
-import { slugify } from "@/lib/submissions";
+import { deriveSlug } from "@/lib/submissions";
 
 export const runtime = "nodejs";
 
@@ -59,7 +59,7 @@ export async function POST(req: Request): Promise<Response> {
   const slugSet = new Set<string>();
   for (const c of candidates) {
     const raw = (c.petId ?? c.slugHint ?? "").toString();
-    const s = slugify(raw);
+    const s = deriveSlug(raw);
     if (s) slugSet.add(s);
   }
   const slugs = Array.from(slugSet);

--- a/src/app/api/cli/submit/route.ts
+++ b/src/app/api/cli/submit/route.ts
@@ -9,6 +9,7 @@ import { NextResponse } from "next/server";
 import { isAdmin } from "@/lib/admin";
 import { verifyCliBearer } from "@/lib/cli-auth";
 import { presignPut } from "@/lib/r2";
+import { deriveSlug } from "@/lib/slug";
 import { cliVerifyRatelimit, submitRatelimit } from "@/lib/ratelimit";
 
 export const runtime = "nodejs";
@@ -63,10 +64,10 @@ export async function POST(req: Request): Promise<Response> {
     return NextResponse.json({ error: "invalid_json" }, { status: 400 });
   }
 
-  const slugHint = sanitizeSlug(body.slugHint ?? body.petId ?? "pet");
-  if (!slugHint) {
-    return NextResponse.json({ error: "invalid_slug_hint" }, { status: 400 });
-  }
+  const slugHint =
+    sanitizeSlug(body.slugHint || body.petId || "") ||
+    deriveSlug(body.petId || body.slugHint || "") ||
+    "pet";
   const ext: "webp" | "png" = body.spritesheetExt === "png" ? "png" : "webp";
   const spriteCT = ext === "png" ? "image/png" : "image/webp";
 

--- a/src/components/submit/pet-submit-form.tsx
+++ b/src/components/submit/pet-submit-form.tsx
@@ -17,6 +17,7 @@ import {
 import { useTranslations } from "next-intl";
 
 import { petStates } from "@/lib/pet-states";
+import { deriveSlug } from "@/lib/slug";
 
 type ParsedPet = {
   petId: string;
@@ -300,12 +301,12 @@ export function PetSubmitForm() {
       parsed.spritesheetExt === "png" ? "image/png" : "image/webp";
     const spriteFile = new File(
       [parsed.spritesheetBlob],
-      `${slugify(parsed.petId)}-spritesheet.${parsed.spritesheetExt}`,
+      `${deriveSlug(parsed.petId, parsed.displayName)}-spritesheet.${parsed.spritesheetExt}`,
       { type: spriteMime },
     );
     const petJsonFile = new File(
       [parsed.petJsonString],
-      `${slugify(parsed.petId)}-pet.json`,
+      `${deriveSlug(parsed.petId, parsed.displayName)}-pet.json`,
       { type: "application/json" },
     );
 
@@ -323,7 +324,7 @@ export function PetSubmitForm() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          slugHint: slugify(parsed.petId),
+          slugHint: deriveSlug(parsed.petId, parsed.displayName),
           files: [
             {
               role: "zip",
@@ -899,15 +900,6 @@ function xhrPut(
     xhr.onabort = () => reject(new Error("xhr aborted"));
     xhr.send(body);
   });
-}
-
-function slugify(value: string): string {
-  return value
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 40);
 }
 
 function buildIssueUrl(

--- a/src/lib/slug.test.ts
+++ b/src/lib/slug.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+
+import { deriveSlug, slugify } from "@/lib/slug";
+
+describe("slugify", () => {
+  test("keeps latin ids untouched", () => {
+    expect(slugify("Lulu Capybara")).toBe("lulu-capybara");
+  });
+
+  test("strips CJK to empty", () => {
+    expect(slugify("绘梨衣")).toBe("");
+  });
+});
+
+describe("deriveSlug", () => {
+  test("prefers the petId when it slugifies", () => {
+    expect(deriveSlug("feifei", "菲菲")).toBe("feifei");
+  });
+
+  test("keeps the latin part of a mixed id", () => {
+    expect(deriveSlug("绘梨衣-chan", "")).toBe("chan");
+  });
+
+  test("falls back to displayName", () => {
+    expect(deriveSlug("绘梨衣", "Erii Chan")).toBe("erii-chan");
+  });
+
+  test("CJK-only input derives a stable pet-<hash> slug", () => {
+    const slug = deriveSlug("绘梨衣", "绘梨衣");
+    expect(slug).toMatch(/^pet-[a-z0-9]{7}$/);
+    expect(deriveSlug("绘梨衣", "绘梨衣")).toBe(slug);
+  });
+
+  test("different CJK ids derive different slugs", () => {
+    expect(deriveSlug("绘梨衣")).not.toBe(deriveSlug("菲菲"));
+  });
+
+  test("hash falls back to displayName seed when petId is empty", () => {
+    expect(deriveSlug("", "菲菲")).toBe(deriveSlug("菲菲"));
+  });
+
+  test("returns empty only when both inputs are empty", () => {
+    expect(deriveSlug("", "")).toBe("");
+    expect(deriveSlug("   ", "")).toBe("");
+  });
+});

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -1,0 +1,31 @@
+export function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+}
+
+/** Slug that never hard-fails on non-Latin input: petId → displayName →
+ *  deterministic `pet-<hash>` so a CJK-only id (common in the Chinese
+ *  community) still derives a stable slug. Returns "" only when both
+ *  inputs are empty. Uniqueness is still resolveUniqueSlug's job. */
+export function deriveSlug(petId: string, displayName = ""): string {
+  const direct = slugify(petId);
+  if (direct) return direct;
+  const fromName = slugify(displayName);
+  if (fromName) return fromName;
+  const seed = petId.trim() || displayName.trim();
+  if (!seed) return "";
+  return `pet-${fnv1a36(seed)}`;
+}
+
+function fnv1a36(value: string): string {
+  let hash = 0x811c9dc5;
+  for (const byte of new TextEncoder().encode(value)) {
+    hash ^= byte;
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(36).padStart(7, "0");
+}

--- a/src/lib/submissions-validation.ts
+++ b/src/lib/submissions-validation.ts
@@ -136,11 +136,4 @@ export function validateSubmission(
   return null;
 }
 
-export function slugify(value: string): string {
-  return value
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 40);
-}
+export { deriveSlug, slugify } from "@/lib/slug";

--- a/src/lib/submissions.ts
+++ b/src/lib/submissions.ts
@@ -14,6 +14,7 @@ import type { SubmissionReview, SubmittedPet } from "@/lib/db/schema";
 import { renderNewSubmissionEmail } from "@/lib/email-templates/new-submission";
 import { fallbackHandle, handleForUser } from "@/lib/handles";
 import {
+  deriveSlug,
   type SubmissionInput,
   slugify as slugifySubmission,
 } from "@/lib/submissions-validation";
@@ -21,6 +22,7 @@ import { getPreferredLocaleForUser } from "@/lib/user-locale";
 
 export type { SubmissionInput } from "@/lib/submissions-validation";
 export {
+  deriveSlug,
   MIN_SPRITE_DIM,
   REQUIRED_FIELDS,
   validateSubmission,
@@ -75,7 +77,7 @@ export async function persistSubmission(
   body: SubmissionInput,
   principal: SubmissionPrincipal,
 ): Promise<SubmissionResult> {
-  const requestedSlug = slugify(body.petId || body.displayName);
+  const requestedSlug = deriveSlug(body.petId, body.displayName);
   if (!requestedSlug) {
     return { ok: false, status: 400, error: "invalid_slug" };
   }


### PR DESCRIPTION
Fixes #562.

## Problem

A CJK-only pet id (common in the Chinese community, see #561) slugifies to an empty string, so:

- Web submit returned 400 `invalid_slug` after the upload already happened.
- CLI presign returned 400 `invalid_slug_hint`: the CLI sends `slugHint: ""` for CJK ids and `body.slugHint ?? body.petId` never falls through on an empty string.
- CLI dedup (`ownedSlugs.has(slugify(petIdHint))`) could not match CJK pets at all.

## Fix

New shared `deriveSlug(petId, displayName)` in `src/lib/slug.ts`:

1. `slugify(petId)` when non-empty (identical behavior for Latin ids)
2. else `slugify(displayName)`
3. else deterministic `pet-<fnv1a-base36>` from the raw id, so the same pet always derives the same slug and `resolveUniqueSlug` still owns uniqueness
4. returns empty only when both inputs are empty, which still 400s

Wired through: web form (filenames + slugHint + no more post-upload hard fail), `persistSubmission`, `/api/cli/submit` presign (empty-string fallback chain), `/api/cli/submit/check` (dedup sees the same derived slug), and a mirrored copy in `packages/petdex-cli/bin/petdex.ts` (independent package, kept in sync by comment).

The editable-slug UI from the issue is deferred: the hard fail is the blocker, and pet.json id remains the way to adjust the slug.

## Validation

- `bun test src/lib/slug.test.ts` 9/9 (CJK, mixed, fallback order, determinism, empty)
- `bun test --env-file=.env.mock` full suite: 466 pass, 2 pre-existing failures in `pet-preview.test.ts` (also red on main)
- `bun run i18n:check` clean, mock-env `next build` clean
- petdex-cli: `bun run build && bun run typecheck && bun test` 178/178
- Biome findings limited to pre-existing `packages/petdex-cli` + `built-with.json` issues (also red on main)

Related: #566 (its capture shows a Latin id `feifei`; that failure is `presign 404` at the auth layer, tracked separately) and #568 (CLI path for CJK ids now derives a usable slugHint).