### PR TITLE
fix(artifacts): backfill thumbs and stickers, log publish outcome on approve

### DIFF
--- a/scripts/publish-pet-previews.ts
+++ b/scripts/publish-pet-previews.ts
@@ -11,10 +11,15 @@ import {
   petPreviewKey,
   petPreviewUrl,
 } from "@/lib/pet-preview";
-import { renderPreviewStrip } from "@/lib/pet-public-artifacts";
+import {
+  publishPetPublicArtifacts,
+  renderPreviewStrip,
+} from "@/lib/pet-public-artifacts";
+import { petStickerKey } from "@/lib/pet-sticker-artifacts";
+import { petThumbnailKey } from "@/lib/pet-thumbnail";
 import { getAllApprovedPets } from "@/lib/pets";
 import { R2_BUCKET, r2 } from "@/lib/r2";
-import { keyFromR2PublicUrl } from "@/lib/r2-public-url";
+import { keyFromR2PublicUrl, R2_PUBLIC_BASE } from "@/lib/r2-public-url";
 import { isAllowedAssetUrl } from "@/lib/url-allowlist";
 
 type Mode = "check" | "apply";
@@ -139,6 +144,60 @@ if (mode === "apply") {
   await purgeCdnUrls(uploaded.map((result) => petPreviewUrl(result.slug)));
 
   if (failed.length > 0) process.exit(1);
+}
+
+// Thumbs and stickers are emitted at approval time by
+// publishPetPublicArtifacts but had no backfill: a pet from a failing
+// batch permanently lacked them until someone reran publish (issue #563).
+// Reconcile them here with the same skip-if-present semantics. Two HEADs
+// per pet act as the sentinel; publishPetPublicArtifacts re-checks each
+// key itself before rendering.
+const missingArtifacts = (
+  await mapLimit(validTasks, headConcurrency, async (task) => {
+    const [thumb, sticker] = await Promise.all([
+      previewExists(petThumbnailKey(task.slug)),
+      previewExists(petStickerKey(task.slug)),
+    ]);
+    return thumb && sticker ? null : task;
+  })
+).filter((task): task is PreviewTask => Boolean(task));
+
+console.log(`thumbs/stickers missing ${missingArtifacts.length}`);
+if (missingArtifacts.length > 0) {
+  console.log(
+    `thumbs/stickers sample ${missingArtifacts
+      .slice(0, 20)
+      .map((task) => task.slug)
+      .join(", ")}`,
+  );
+}
+
+if (mode === "apply" && missingArtifacts.length > 0) {
+  const publishedKeys: string[] = [];
+  const artifactFailures: Array<{ slug: string; key: string; reason: string }> =
+    [];
+  await mapLimit(missingArtifacts, publishConcurrency, async (task) => {
+    const result = await publishPetPublicArtifacts({
+      slug: task.slug,
+      spritesheetUrl: task.spritesheetPath,
+    });
+    publishedKeys.push(...result.published);
+    for (const failure of result.failed) {
+      artifactFailures.push({ slug: task.slug, ...failure });
+    }
+  });
+
+  console.log(`artifacts published ${publishedKeys.length}`);
+  console.log(`artifacts failed ${artifactFailures.length}`);
+  for (const failure of artifactFailures.slice(0, 20)) {
+    console.log(
+      `artifacts failed ${failure.slug} ${failure.key} ${failure.reason}`,
+    );
+  }
+
+  await purgeCdnUrls(publishedKeys.map((key) => `${R2_PUBLIC_BASE}/${key}`));
+
+  if (artifactFailures.length > 0) process.exit(1);
 }
 
 // The upload above writes straight to R2 over the S3 API, which does NOT

--- a/src/app/api/cli/submit/route.ts
+++ b/src/app/api/cli/submit/route.ts
@@ -9,8 +9,8 @@ import { NextResponse } from "next/server";
 import { isAdmin } from "@/lib/admin";
 import { verifyCliBearer } from "@/lib/cli-auth";
 import { presignPut } from "@/lib/r2";
-import { deriveSlug } from "@/lib/slug";
 import { cliVerifyRatelimit, submitRatelimit } from "@/lib/ratelimit";
+import { deriveSlug } from "@/lib/slug";
 
 export const runtime = "nodejs";
 

--- a/src/lib/submission-decisions.ts
+++ b/src/lib/submission-decisions.ts
@@ -280,6 +280,12 @@ async function publishApprovedPublicArtifacts(
         slug: row.slug,
         failed: artifacts.failed,
       });
+    } else {
+      console.log(`[${actor}] public artifacts published`, {
+        slug: row.slug,
+        published: artifacts.published,
+        skipped: artifacts.skipped,
+      });
     }
   } catch (e) {
     console.error(`[${actor}] public artifact publish failed`, e);


### PR DESCRIPTION
Refs #563 (two of its three next steps; the remaining one is catching a live failing batch in Vercel function logs).

## Changes

- `scripts/publish-pet-previews.ts`: after the preview pass, a reconciliation pass HEADs `pets/<slug>/thumb.webp` and `pets/<slug>/stickers/idle.webp` as sentinels and calls `publishPetPublicArtifacts` for pets missing either (it re-checks each key itself before rendering, so nothing is double-rendered). Published keys get the same Cloudflare purge as previews. Check mode reports the missing count without writing.
- `src/lib/submission-decisions.ts`: log `public artifacts published` with published/skipped keys on success, mirroring petdex-admin#3, so the auto-approve path can be confirmed or ruled out when the next failing batch appears.
- Import-order lint fix in `src/app/api/cli/submit/route.ts` that slipped through #571.

## Validation

- `bun run check` clean on touched files (only pre-existing `built-with.json` + `packages/petdex-cli` findings remain)
- `bun build --target=bun scripts/publish-pet-previews.ts` bundles
- `bun test --env-file=.env.mock src/lib/submission-decisions.test.ts` green
- Post-merge: I will dispatch `preview-snapshot.yml` in `check` mode and paste the dry-run counts, then in `apply` mode to backfill the missing thumbs (e.g. curly-dog-lady).