### PR TITLE
chore: clear Biome debt and make pet-preview tests env-agnostic

### DIFF
--- a/packages/petdex-cli/bin/petdex.ts
+++ b/packages/petdex-cli/bin/petdex.ts
@@ -1766,11 +1766,7 @@ async function cmdDesktop(args: string[]) {
       {
         const startArgs = args.slice(1);
         await cmdDesktopStart(startArgs);
-        if (
-          !startArgs.some((arg) =>
-            ["--help", "-h", "help"].includes(arg),
-          )
-        ) {
+        if (!startArgs.some((arg) => ["--help", "-h", "help"].includes(arg))) {
           emit("cli_desktop_start_success", { cli_version: VERSION });
         }
       }

--- a/packages/petdex-cli/src/desktop/process.test.ts
+++ b/packages/petdex-cli/src/desktop/process.test.ts
@@ -3,7 +3,7 @@ import { execFileSync, spawn } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
-  openSync,
+  type openSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -144,7 +144,11 @@ describe("startDesktop", () => {
         openCalls.push(String(filePath));
         return 42;
       }) as typeof openSync,
-      spawn: ((command: string, args: string[], options: any) => {
+      spawn: ((
+        command: string,
+        args: string[],
+        options: { detached?: boolean; stdio?: unknown },
+      ) => {
         spawnCalls.push({
           command,
           args,
@@ -208,7 +212,11 @@ describe("startDesktop", () => {
         existsSync: () => true,
         mkdir: async () => {},
         openSync: (() => 42) as typeof openSync,
-        spawn: ((command: string, args: string[], options: any) => {
+        spawn: ((
+          command: string,
+          args: string[],
+          options: { detached?: boolean; stdio?: unknown },
+        ) => {
           spawnCalls.push({
             command,
             args,

--- a/src/data/built-with.json
+++ b/src/data/built-with.json
@@ -38,10 +38,7 @@
       "homepage": "https://pawpause.vercel.app",
       "stars": 42,
       "language": "TypeScript",
-      "platforms": [
-        "macOS",
-        "Windows"
-      ],
+      "platforms": ["macOS", "Windows"],
       "addedAt": "2026-05-10",
       "evidence": {
         "type": "readme",
@@ -59,9 +56,7 @@
       "homepage": null,
       "stars": 2,
       "language": "Swift",
-      "platforms": [
-        "macOS"
-      ],
+      "platforms": ["macOS"],
       "addedAt": "2026-05-10",
       "evidence": {
         "type": "readme",
@@ -79,11 +74,7 @@
       "homepage": null,
       "stars": 1,
       "language": "TypeScript",
-      "platforms": [
-        "macOS",
-        "Windows",
-        "Linux"
-      ],
+      "platforms": ["macOS", "Windows", "Linux"],
       "addedAt": "2026-05-10",
       "evidence": {
         "type": "readme",
@@ -101,11 +92,7 @@
       "homepage": "https://www.npmjs.com/package/petdex-cc",
       "stars": 15,
       "language": "TypeScript",
-      "platforms": [
-        "macOS",
-        "Windows",
-        "Linux"
-      ],
+      "platforms": ["macOS", "Windows", "Linux"],
       "addedAt": "2026-05-10",
       "evidence": {
         "type": "readme",
@@ -123,9 +110,7 @@
       "homepage": null,
       "stars": 111,
       "language": "Swift",
-      "platforms": [
-        "macOS"
-      ],
+      "platforms": ["macOS"],
       "addedAt": "2026-05-10",
       "evidence": {
         "type": "code",
@@ -143,11 +128,7 @@
       "homepage": null,
       "stars": 1265,
       "language": "Rust",
-      "platforms": [
-        "macOS",
-        "Windows",
-        "Linux"
-      ],
+      "platforms": ["macOS", "Windows", "Linux"],
       "addedAt": "2026-05-10",
       "evidence": {
         "type": "code",
@@ -165,10 +146,7 @@
       "homepage": null,
       "stars": 2,
       "language": "Swift",
-      "platforms": [
-        "iOS",
-        "watchOS"
-      ],
+      "platforms": ["iOS", "watchOS"],
       "addedAt": "2026-05-10",
       "evidence": {
         "type": "readme",
@@ -186,9 +164,7 @@
       "homepage": null,
       "stars": 0,
       "language": "Python",
-      "platforms": [
-        "Garmin"
-      ],
+      "platforms": ["Garmin"],
       "addedAt": "2026-05-10",
       "evidence": {
         "type": "code",
@@ -206,10 +182,7 @@
       "homepage": null,
       "stars": 3,
       "language": "Swift",
-      "platforms": [
-        "iOS",
-        "macOS"
-      ],
+      "platforms": ["iOS", "macOS"],
       "addedAt": "2026-05-10",
       "evidence": {
         "type": "readme",
@@ -227,11 +200,7 @@
       "homepage": null,
       "stars": 51,
       "language": "TypeScript",
-      "platforms": [
-        "macOS",
-        "Windows",
-        "Linux"
-      ],
+      "platforms": ["macOS", "Windows", "Linux"],
       "addedAt": "2026-05-10",
       "evidence": {
         "type": "readme",
@@ -249,11 +218,7 @@
       "homepage": null,
       "stars": 6097,
       "language": "Svelte",
-      "platforms": [
-        "macOS",
-        "Windows",
-        "Linux"
-      ],
+      "platforms": ["macOS", "Windows", "Linux"],
       "addedAt": "2026-05-10",
       "evidence": {
         "type": "code",
@@ -271,11 +236,7 @@
       "homepage": "https://open-design.ai",
       "stars": 73126,
       "language": "TypeScript",
-      "platforms": [
-        "macOS",
-        "Windows",
-        "Web"
-      ],
+      "platforms": ["macOS", "Windows", "Web"],
       "addedAt": "2026-06-30",
       "evidence": {
         "type": "code",
@@ -329,10 +290,7 @@
       "homepage": "https://github.com/dylan-labs/nom-pet/releases/latest",
       "stars": 72,
       "language": "TypeScript",
-      "platforms": [
-        "macOS",
-        "Windows"
-      ],
+      "platforms": ["macOS", "Windows"],
       "addedAt": "2026-05-11",
       "evidence": {
         "type": "readme",
@@ -350,9 +308,7 @@
       "homepage": "https://github.com/bleeeet/TermiPet/releases/latest",
       "stars": 76,
       "language": "Swift",
-      "platforms": [
-        "macOS"
-      ],
+      "platforms": ["macOS"],
       "addedAt": "2026-05-20",
       "evidence": {
         "type": "readme",
@@ -370,9 +326,7 @@
       "homepage": null,
       "stars": 38,
       "language": "Python",
-      "platforms": [
-        "Windows"
-      ],
+      "platforms": ["Windows"],
       "addedAt": "2026-05-20",
       "evidence": {
         "type": "readme",
@@ -390,10 +344,7 @@
       "homepage": "http://aicodingbox.com/",
       "stars": 54,
       "language": "C++",
-      "platforms": [
-        "Windows",
-        "Linux"
-      ],
+      "platforms": ["Windows", "Linux"],
       "addedAt": "2026-05-30",
       "evidence": {
         "type": "code",
@@ -411,10 +362,7 @@
       "homepage": "https://github.com/Jedeiah/agent-critter/releases/latest",
       "stars": 2,
       "language": "Rust",
-      "platforms": [
-        "macOS",
-        "Windows"
-      ],
+      "platforms": ["macOS", "Windows"],
       "addedAt": "2026-06-03",
       "evidence": {
         "type": "code",
@@ -432,10 +380,7 @@
       "homepage": "https://codexpet.xyz/nest/",
       "stars": 13,
       "language": "Swift",
-      "platforms": [
-        "macOS",
-        "Web"
-      ],
+      "platforms": ["macOS", "Web"],
       "addedAt": "2026-06-03",
       "evidence": {
         "type": "code",
@@ -453,11 +398,7 @@
       "homepage": "https://github.com/yr2b/code-dog",
       "stars": 2,
       "language": "JavaScript",
-      "platforms": [
-        "macOS",
-        "Windows",
-        "Linux"
-      ],
+      "platforms": ["macOS", "Windows", "Linux"],
       "addedAt": "2026-06-29",
       "evidence": {
         "type": "readme",
@@ -475,11 +416,7 @@
       "homepage": "https://skales.app",
       "stars": 1101,
       "language": "TypeScript",
-      "platforms": [
-        "macOS",
-        "Windows",
-        "Linux"
-      ],
+      "platforms": ["macOS", "Windows", "Linux"],
       "addedAt": "2026-06-29",
       "evidence": {
         "type": "readme",
@@ -497,11 +434,7 @@
       "homepage": null,
       "stars": 2,
       "language": "TypeScript",
-      "platforms": [
-        "macOS",
-        "Windows",
-        "Linux"
-      ],
+      "platforms": ["macOS", "Windows", "Linux"],
       "addedAt": "2026-06-04",
       "evidence": {
         "type": "readme",
@@ -519,9 +452,7 @@
       "homepage": "https://shmulik-ai-superhero.netlify.app",
       "stars": 0,
       "language": "JavaScript",
-      "platforms": [
-        "Web"
-      ],
+      "platforms": ["Web"],
       "addedAt": "2026-06-04",
       "evidence": {
         "type": "code",
@@ -539,11 +470,7 @@
       "homepage": "https://hermes-agent.nousresearch.com",
       "stars": 206496,
       "language": "Python",
-      "platforms": [
-        "macOS",
-        "Windows",
-        "Linux"
-      ],
+      "platforms": ["macOS", "Windows", "Linux"],
       "addedAt": "2026-07-01",
       "evidence": {
         "type": "code",
@@ -561,9 +488,7 @@
       "homepage": "https://chengbuilds.github.io/PetPhrase/",
       "stars": 9,
       "language": "Rust",
-      "platforms": [
-        "Windows"
-      ],
+      "platforms": ["Windows"],
       "addedAt": "2026-07-17",
       "evidence": {
         "type": "readme",
@@ -581,11 +506,7 @@
       "homepage": "https://github.com/Seeed-Solution/vibe-pet",
       "stars": 38,
       "language": "C",
-      "platforms": [
-        "Windows",
-        "macOS",
-        "Linux"
-      ],
+      "platforms": ["Windows", "macOS", "Linux"],
       "addedAt": "2026-07-17",
       "evidence": {
         "type": "readme",

--- a/src/lib/pet-preview.test.ts
+++ b/src/lib/pet-preview.test.ts
@@ -5,6 +5,7 @@ import {
   petPreviewUrl,
   petPreviewUrlForSource,
 } from "@/lib/pet-preview";
+import { R2_PUBLIC_BASE } from "@/lib/r2-public-url";
 
 const originalFlag = process.env.NEXT_PUBLIC_PETDEX_PET_PREVIEWS_ENABLED;
 
@@ -20,7 +21,7 @@ describe("pet preview artifact helpers", () => {
   it("builds the public preview key and URL", () => {
     expect(petPreviewKey("cai-chao")).toBe("pets/cai-chao/preview.webp");
     expect(petPreviewUrl("cai-chao")).toBe(
-      "https://assets.petdex.dev/pets/cai-chao/preview.webp",
+      `${R2_PUBLIC_BASE}/pets/cai-chao/preview.webp`,
     );
   });
 
@@ -32,7 +33,7 @@ describe("pet preview artifact helpers", () => {
         "cai-chao",
         "https://assets.petdex.dev/pets/cai-chao/spritesheet.webp",
       ),
-    ).toBe("https://assets.petdex.dev/pets/cai-chao/preview.webp");
+    ).toBe(`${R2_PUBLIC_BASE}/pets/cai-chao/preview.webp`);
     expect(
       petPreviewUrlForSource(
         "cai-chao",


### PR DESCRIPTION
Makes `bun run check` and the full mock-env test suite green on main for the first time in a while.

- `packages/petdex-cli`: format fixes in `bin/petdex.ts` + `process.test.ts`, `useImportType`, and typed the spawn-mock `options` instead of `any`
- `src/data/built-with.json`: format
- `src/lib/pet-preview.test.ts`: expectations now build from the exported `R2_PUBLIC_BASE` instead of hardcoding the production asset host, so the suite passes under `.env.mock`'s override (was 2 failing tests on main)

## Validation

- `bun run check`: Checked 519 files, no errors
- `bun test --env-file=.env.mock`: 468 pass, 0 fail
- petdex-cli: `bun run typecheck` + `bun test` green