### PR TITLE
feat(policy): explicit war/militarism category in auto-review, content-policy line on submit

### DIFF
--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -229,7 +229,7 @@
     "title": "Add your pet to Petdex",
     "body": "Share a Codex-compatible animated pet package. Petdex checks the files locally, previews the sprite, and prepares the submission.",
     "createCta": "Don't have a pet yet? Hatch one in Codex",
-    "legalPrefix": "By submitting, you confirm you have rights to the artwork or are creating fan content. Rights holders can request removal via our",
+    "legalPrefix": "By submitting, you confirm you have rights to the artwork or are creating fan content. Content that glorifies war, hate, or militarist symbols is not allowed and will be removed. Rights holders can request removal via our",
     "legalLink": "takedown notice",
     "legalSuffix": ".",
     "form": {

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -229,7 +229,7 @@
     "title": "Agrega tu mascota a Petdex",
     "body": "Comparte un paquete de mascota animada compatible con Codex. Petdex revisa los archivos localmente, previsualiza el sprite y prepara el envío.",
     "createCta": "¿Todavía no tienes una mascota? Créala en Codex",
-    "legalPrefix": "Al enviar, confirmas que tienes derechos sobre la ilustración o que estás creando fan content. Los titulares pueden pedir la eliminación mediante nuestro",
+    "legalPrefix": "Al enviar, confirmas que tienes derechos sobre la ilustración o que estás creando fan content. No se permite contenido que glorifique la guerra, el odio o símbolos militaristas; será eliminado. Los titulares pueden pedir la eliminación mediante nuestro",
     "legalLink": "aviso de retiro",
     "legalSuffix": ".",
     "form": {

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -249,7 +249,7 @@
     "body__fixme": true,
     "createCta": "还没有宠物？去 Codex 里孵化一只",
     "createCta__fixme": true,
-    "legalPrefix": "提交即表示你确认自己拥有该作品的权利，或这是你创作的同人内容。权利人可以通过我们的",
+    "legalPrefix": "提交即表示你确认自己拥有该作品的权利，或这是你创作的同人内容。不允许美化战争、仇恨或军国主义符号的内容，此类内容将被移除。权利人可以通过我们的",
     "legalPrefix__fixme": true,
     "legalLink": "下架通知",
     "legalSuffix": "。",

--- a/src/lib/submission-review-policy.ts
+++ b/src/lib/submission-review-policy.ts
@@ -28,6 +28,13 @@ export const REVIEW_POLICY_CATEGORIES = [
     holdAboveConfidence: 0.35,
   },
   {
+    id: "war_militarism_glorification",
+    label: "War or militarism glorification",
+    description:
+      "Imagery glorifying wars, war crimes, or militarist movements: WWII Axis symbols such as kamikaze (神風) headbands, rising-sun war flags or roundels on wartime military hardware, swastikas or SS runes, or heroic framing of forces tied to invasions or atrocities. Use this category, not self_harm, for kamikaze imagery.",
+    holdAboveConfidence: 0.3,
+  },
+  {
     id: "graphic_violence_gore",
     label: "Graphic violence or gore",
     description: "Graphic injury, gore, torture, mutilation, or shock imagery.",


### PR DESCRIPTION
The automated reviewer caught taki-2's kamikaze imagery in May but
filed it under self_harm at 0.6 confidence, and the manual gate
approved over the hold: the label did not communicate the actual
problem. Name the category explicitly (war_militarism_glorification,
hold above 0.3) and state the rule to submitters in en/es/zh.

Refs #567
