### PR TITLE
feat: move display settings into site header

### DIFF
--- a/src/components/auth/user-dropdown-content.tsx
+++ b/src/components/auth/user-dropdown-content.tsx
@@ -16,8 +16,6 @@ import { useLocale, useTranslations } from "next-intl";
 
 import { withLocale } from "@/lib/locale-routing";
 
-import { LocaleSwitcher } from "@/components/brand/locale-switcher";
-import { ThemeToggle } from "@/components/brand/theme-toggle";
 import {
   DropdownMenuGroup,
   DropdownMenuItem,
@@ -127,18 +125,6 @@ export function UserDropdownContent({
           </span>
           <ExternalLink className="size-3.5 text-muted-4" />
         </DropdownMenuItem>
-      </DropdownMenuGroup>
-
-      <DropdownMenuSeparator />
-
-      <DropdownMenuGroup>
-        <DropdownMenuLabel className="px-3 pt-1 pb-1.5 font-mono text-[10px] tracking-[0.18em] text-muted-3 uppercase">
-          {t("settings")}
-        </DropdownMenuLabel>
-        <div className="flex items-center gap-2 px-2 pb-1">
-          <ThemeToggle />
-          <LocaleSwitcher />
-        </div>
       </DropdownMenuGroup>
 
       <DropdownMenuSeparator />

--- a/src/components/brand/theme-toggle.tsx
+++ b/src/components/brand/theme-toggle.tsx
@@ -2,44 +2,33 @@
 
 import { useEffect, useState } from "react";
 
-import { Monitor, Moon, Sun } from "lucide-react";
+import { Moon, Sun } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useTheme } from "next-themes";
 
-// Cycles light -> dark -> system. Icon-only because it sits next to
-// the bell + UserButton in the header and we don't want to widen
-// that cluster. Renders a sun placeholder until mounted to avoid the
-// hydration flash next-themes warns about.
+// Toggles light <-> dark. Renders a sun placeholder until mounted to
+// avoid the hydration flash next-themes warns about.
 export function ThemeToggle({ className }: { className?: string }) {
   const t = useTranslations("theme");
-  const { theme, setTheme, resolvedTheme } = useTheme();
+  const { theme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    setMounted(true);
+    // `system` was supported before the theme control became binary.
+    // Preserve explicit light/dark choices and migrate only that legacy value.
+    if (theme === "system") setTheme("light");
+  }, [setTheme, theme]);
 
   function next() {
-    if (theme === "system") setTheme("light");
-    else if (theme === "light") setTheme("dark");
-    else setTheme("system");
+    setTheme(theme === "dark" ? "light" : "dark");
   }
 
   // Pre-mount: render the icon that matches the SSR background
   // (light) so the layout doesn't shift.
-  const showDark = mounted && resolvedTheme === "dark";
-  const Icon = !mounted
-    ? Sun
-    : theme === "system"
-      ? Monitor
-      : showDark
-        ? Moon
-        : Sun;
-
-  const label = !mounted
-    ? t("toggle")
-    : theme === "system"
-      ? t("system", { resolvedTheme: resolvedTheme ?? "light" })
-      : theme === "dark"
-        ? t("dark")
-        : t("light");
+  const showDark = mounted && theme === "dark";
+  const Icon = showDark ? Moon : Sun;
+  const label = !mounted ? t("toggle") : showDark ? t("dark") : t("light");
 
   return (
     <button

--- a/src/components/layout/theme-providers.tsx
+++ b/src/components/layout/theme-providers.tsx
@@ -8,8 +8,8 @@ export function AppProviders({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider
       attribute="class"
-      defaultTheme="system"
-      enableSystem
+      defaultTheme="light"
+      enableSystem={false}
       disableTransitionOnChange
     >
       <AuthIntentProvider>{children}</AuthIntentProvider>

--- a/src/components/site-header/index.tsx
+++ b/src/components/site-header/index.tsx
@@ -3,7 +3,9 @@ import { getLocale, getTranslations } from "next-intl/server";
 import { withLocale } from "@/lib/locale-routing";
 
 import { AuthBadge } from "@/components/auth/auth-badge";
+import { LocaleSwitcher } from "@/components/brand/locale-switcher";
 import { PetdexLogo } from "@/components/brand/petdex-logo";
+import { ThemeToggle } from "@/components/brand/theme-toggle";
 import { DesktopNav } from "@/components/site-header/desktop-nav";
 import { GithubLink } from "@/components/site-header/github-link";
 import { MobileNav } from "@/components/site-header/mobile-nav";
@@ -50,6 +52,14 @@ export async function SiteHeader({ hideSubmitCta = false }: SiteHeaderProps) {
         </div>
 
         <div className="flex shrink-0 items-center gap-2">
+          <div className="hidden items-center gap-2 xl:flex">
+            <ThemeToggle />
+            <LocaleSwitcher />
+          </div>
+          <span
+            aria-hidden="true"
+            className="mx-1 hidden h-5 w-px bg-border-base xl:block"
+          />
           <GithubLink item={nav.githubItem} />
           {hideSubmitCta ? null : (
             <SubmitLink

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -80,10 +80,9 @@
   },
   "theme": {
     "toggle": "Toggle theme",
-    "system": "System ({resolvedTheme})",
     "dark": "Dark",
     "light": "Light",
-    "ariaLabel": "Theme: {label}. Click to cycle.",
+    "ariaLabel": "Theme: {label}. Click to switch.",
     "title": "Theme: {label}"
   },
   "footer": {

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -80,7 +80,6 @@
   },
   "theme": {
     "toggle": "Cambiar tema",
-    "system": "Sistema ({resolvedTheme})",
     "dark": "Oscuro",
     "light": "Claro",
     "ariaLabel": "Tema: {label}. Haz clic para alternar.",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -83,7 +83,6 @@
   },
   "theme": {
     "toggle": "切换主题",
-    "system": "跟随系统（{resolvedTheme}）",
     "dark": "深色",
     "light": "浅色",
     "ariaLabel": "主题：{label}。点击切换。",


### PR DESCRIPTION
## Summary

- surface the theme and language controls directly in the desktop site header
- simplify theme selection to light and dark, default new users to light, and migrate the legacy system preference to light
- remove the duplicate settings section from the signed-in user menu while keeping the controls in the mobile navigation menu

## Validation

- `bunx biome check` on the seven changed files
- `bun run i18n:check`
- `TELEMETRY_RATELIMIT_SECRET=petdex-build-check-secret bun --env-file=.env.mock run build`
- visually verified the header and theme switch at 1440px and the mobile menu at 390px

## Note

The repository-wide `bun run check` remains blocked by a pre-existing import-order finding in `packages/petdex-cli/bin/petdex.ts`; the changed files pass the focused Biome check.