### PR TITLE
[fix] 修复 Bubble Hook 阻塞并安全迁移旧配置

### DIFF
--- a/packages/petdex-cli/src/hooks/bubble-runner.test.ts
+++ b/packages/petdex-cli/src/hooks/bubble-runner.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, utimesSync, writeFileSync } from "node:fs";
+import { PassThrough } from "node:stream";
 
 import {
   clipPreview,
@@ -7,10 +8,39 @@ import {
   eventFromArgs,
   lastAssistantText,
   pruneSessions,
+  readStdin,
   rememberSessionTitle,
   sessionTitle,
   stateForEvent,
 } from "./bubble-runner";
+
+describe("readStdin", () => {
+  test("returns after EOF with the complete payload", async () => {
+    const input = new PassThrough();
+    const reading = readStdin(input);
+    input.end('{"tool_name":"Read"}');
+    await expect(reading).resolves.toBe('{"tool_name":"Read"}');
+  });
+
+  test("returns within the deadline when stdin stays open", async () => {
+    const input = new PassThrough();
+    const start = performance.now();
+    const reading = readStdin(input);
+    input.write('{"tool_name":"Read"}');
+    await expect(reading).resolves.toBe('{"tool_name":"Read"}');
+    expect(performance.now() - start).toBeLessThan(500);
+    input.destroy();
+  });
+
+  test("keeps the first 64KB while continuing to drain oversized input", async () => {
+    const input = new PassThrough();
+    const payload = "x".repeat(96 * 1024);
+    const reading = readStdin(input);
+    input.end(payload);
+    const result = await reading;
+    expect(result).toHaveLength(64 * 1024);
+  });
+});
 
 describe("eventFromArgs - session-level", () => {
   test("stop returns session.end", () => {

--- a/packages/petdex-cli/src/hooks/bubble-runner.test.ts
+++ b/packages/petdex-cli/src/hooks/bubble-runner.test.ts
@@ -159,6 +159,19 @@ describe("readStdin", () => {
     await expect(reading).resolves.toBe(retained);
   });
 
+  test("drops a partial UTF-8 code point at the retained byte boundary", async () => {
+    const input = new PassThrough();
+    const retained = "a".repeat(64 * 1024 - 1);
+    const multibyteCharacter = String.fromCodePoint(0x591a);
+    const reading = readStdin(input);
+
+    input.end(`${retained}${multibyteCharacter}${"x".repeat(64 * 1024)}`);
+
+    const result = await reading;
+    expect(result).toBe(retained);
+    expect(result).not.toContain("\uFFFD");
+  });
+
   test("keeps the hook pipe open when disabled while a host finishes a delayed large payload", async () => {
     const fakeHome = mkdtempSync(join(tmpdir(), "petdex-hook-stdin-"));
     const runtimeDir = join(fakeHome, ".petdex", "runtime");

--- a/packages/petdex-cli/src/hooks/bubble-runner.test.ts
+++ b/packages/petdex-cli/src/hooks/bubble-runner.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, utimesSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { PassThrough } from "node:stream";
+import { fileURLToPath } from "node:url";
 
 import {
   clipPreview,
@@ -14,6 +25,82 @@ import {
   stateForEvent,
 } from "./bubble-runner";
 
+const CLI_PACKAGE_DIR = fileURLToPath(new URL("../..", import.meta.url));
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function waitForClose(child: ReturnType<typeof spawn>): Promise<number | null> {
+  if (child.exitCode !== null) return Promise.resolve(child.exitCode);
+  return new Promise((resolve) => child.once("close", resolve));
+}
+
+function waitForReady(child: ReturnType<typeof spawn>): Promise<void> {
+  const output = child.stdout;
+  if (!output) {
+    return Promise.reject(new Error("hook child stdout is unavailable"));
+  }
+
+  return new Promise((resolve, reject) => {
+    let text = "";
+    const failOnClose = (code: number | null) => {
+      cleanup();
+      reject(new Error(`hook child exited before reading stdin: ${code}`));
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onData = (chunk: string) => {
+      text += chunk;
+      if (!text.includes("ready\n")) return;
+      cleanup();
+      resolve();
+    };
+    const cleanup = () => {
+      output.off("data", onData);
+      child.off("close", failOnClose);
+      child.off("error", onError);
+    };
+
+    output.setEncoding("utf8");
+    output.on("data", onData);
+    child.once("close", failOnClose);
+    child.once("error", onError);
+  });
+}
+
+async function writeDelayedInput(
+  child: ReturnType<typeof spawn>,
+  first: string,
+  rest: string,
+): Promise<void> {
+  const input = child.stdin;
+  if (!input) throw new Error("hook child stdin is unavailable");
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const finish = (error?: Error | null) => {
+      if (settled) return;
+      settled = true;
+      input.off("error", onError);
+      if (error) reject(error);
+      else resolve();
+    };
+    const onError = (error: Error) => finish(error);
+
+    input.once("error", onError);
+    input.write(first, (error) => {
+      if (error) {
+        finish(error);
+        return;
+      }
+      setTimeout(() => input.end(rest, () => finish()), 180);
+    });
+  });
+}
+
 describe("readStdin", () => {
   test("returns after EOF with the complete payload", async () => {
     const input = new PassThrough();
@@ -22,14 +109,22 @@ describe("readStdin", () => {
     await expect(reading).resolves.toBe('{"tool_name":"Read"}');
   });
 
-  test("returns within the deadline when stdin stays open", async () => {
+  test("keeps reading until a delayed hook payload reaches EOF", async () => {
     const input = new PassThrough();
-    const start = performance.now();
-    const reading = readStdin(input);
-    input.write('{"tool_name":"Read"}');
-    await expect(reading).resolves.toBe('{"tool_name":"Read"}');
-    expect(performance.now() - start).toBeLessThan(500);
-    input.destroy();
+    let settled = false;
+    const reading = readStdin(input).then((value) => {
+      settled = true;
+      return value;
+    });
+
+    input.write('{"tool_name":"Read","tool_input":"');
+    await delay(180);
+    expect(settled).toBeFalse();
+
+    input.end('continued"}');
+    await expect(reading).resolves.toBe(
+      '{"tool_name":"Read","tool_input":"continued"}',
+    );
   });
 
   test("keeps the first 64KB while continuing to drain oversized input", async () => {
@@ -39,6 +134,68 @@ describe("readStdin", () => {
     input.end(payload);
     const result = await reading;
     expect(result).toHaveLength(64 * 1024);
+  });
+
+  test("copies the retained prefix out of an oversized source chunk", async () => {
+    const input = new PassThrough();
+    const source = Buffer.alloc(128 * 1024, "a");
+    const reading = readStdin(input);
+
+    input.write(source);
+    source.fill("b", 0, 64 * 1024);
+    input.end();
+
+    await expect(reading).resolves.toBe("a".repeat(64 * 1024));
+  });
+
+  test("caps retained input by bytes when the payload contains UTF-8", async () => {
+    const input = new PassThrough();
+    const retained = `${"\u591a".repeat(21_845)}a`;
+    expect(Buffer.byteLength(retained, "utf8")).toBe(64 * 1024);
+
+    const reading = readStdin(input);
+    input.end(`${retained}${"x".repeat(64 * 1024)}`);
+
+    await expect(reading).resolves.toBe(retained);
+  });
+
+  test("keeps the hook pipe open when disabled while a host finishes a delayed large payload", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "petdex-hook-stdin-"));
+    const runtimeDir = join(fakeHome, ".petdex", "runtime");
+    mkdirSync(runtimeDir, { recursive: true });
+    writeFileSync(join(runtimeDir, "hooks-disabled"), "");
+    const child = spawn(
+      process.execPath,
+      [
+        "-e",
+        'import("./src/hooks/bubble-runner.ts").then(async ({ runBubble }) => { const task = runBubble(["post", "codex"]); process.stdout.write("ready\\n"); await task; })',
+      ],
+      {
+        cwd: CLI_PACKAGE_DIR,
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, HOME: fakeHome },
+      },
+    );
+    let stderr = "";
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk;
+    });
+
+    try {
+      await waitForReady(child);
+      await writeDelayedInput(
+        child,
+        '{"tool_name":"Read","tool_input":"',
+        `${"x".repeat(8 * 1024 * 1024)}"}`,
+      );
+
+      expect(await waitForClose(child)).toBe(0);
+      expect(stderr).toBe("");
+    } finally {
+      if (child.exitCode === null && !child.killed) child.kill();
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/petdex-cli/src/hooks/bubble-runner.test.ts
+++ b/packages/petdex-cli/src/hooks/bubble-runner.test.ts
@@ -186,7 +186,11 @@ describe("readStdin", () => {
       {
         cwd: CLI_PACKAGE_DIR,
         stdio: ["pipe", "pipe", "pipe"],
-        env: { ...process.env, HOME: fakeHome },
+        env: {
+          ...process.env,
+          HOME: fakeHome,
+          USERPROFILE: fakeHome,
+        },
       },
     );
     let stderr = "";

--- a/packages/petdex-cli/src/hooks/bubble-runner.ts
+++ b/packages/petdex-cli/src/hooks/bubble-runner.ts
@@ -4,7 +4,8 @@
  * a human bubble via templates, POSTs to the sidecar.
  *
  * Hot path: this runs 20-50× per active session. We:
- *   - exit fast on killswitch (no token read, no fetch, no parse)
+ *   - bound stdin reads so a hook host that keeps stdin open cannot stall
+ *     the agent indefinitely
  *   - swallow ALL errors silently (a noisy hook stains the agent UI)
  *   - cap stdin reads at 64KB (hooks don't need bigger payloads, and
  *     a runaway upstream shouldn't OOM us)
@@ -31,6 +32,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import type { Readable } from "node:stream";
 
 import { type BubbleEvent, formatBubble } from "./bubble-templates";
 
@@ -174,6 +176,9 @@ function safeSessionId(raw: unknown): string | null {
   if (typeof raw !== "string") return null;
   return /^[a-zA-Z0-9_-]{1,64}$/.test(raw) ? raw : null;
 }
+const STDIN_TIMEOUT_MS = 120;
+
+type HookStdin = Readable & { isTTY?: boolean };
 
 /**
  * Map a hook phase + tool to the sprite state we want.
@@ -203,25 +208,39 @@ export function stateForEvent(
   return null;
 }
 
-async function readStdin(): Promise<string> {
-  // Drain stdin up to STDIN_CAP. Hooks pipe a single JSON payload, so
-  // we don't need streaming semantics — we just need a bounded read.
-  if (process.stdin.isTTY) return "";
+export async function readStdin(
+  input: HookStdin = process.stdin,
+): Promise<string> {
+  // Hooks pipe a single JSON payload. Preserve at most STDIN_CAP bytes for
+  // parsing, but keep draining oversized input until EOF or the deadline so
+  // a writer never sees a broken pipe from our early return.
+  if (input.isTTY) return Promise.resolve("");
   return await new Promise((resolve) => {
     let buf = "";
-    let truncated = false;
-    process.stdin.setEncoding("utf8");
-    process.stdin.on("data", (chunk) => {
-      if (truncated) return;
-      if (buf.length + chunk.length > STDIN_CAP) {
-        buf += chunk.slice(0, STDIN_CAP - buf.length);
-        truncated = true;
-        return;
-      }
-      buf += chunk;
-    });
-    process.stdin.on("end", () => resolve(buf));
-    process.stdin.on("error", () => resolve(buf));
+    let settled = false;
+
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      input.off("data", onData);
+      input.off("end", finish);
+      input.off("error", finish);
+      input.pause();
+      resolve(buf);
+    };
+
+    const onData = (chunk: string) => {
+      if (settled || buf.length >= STDIN_CAP) return;
+      const remaining = STDIN_CAP - buf.length;
+      buf += chunk.slice(0, remaining);
+    };
+
+    const timer = setTimeout(finish, STDIN_TIMEOUT_MS);
+    input.setEncoding("utf8");
+    input.on("data", onData);
+    input.on("end", finish);
+    input.on("error", finish);
   });
 }
 
@@ -359,16 +378,21 @@ async function postJson(
 }
 
 export async function runBubble(args: string[]): Promise<void> {
-  // Killswitch check FIRST — even before stdin drain — so a disabled
-  // state has minimal cost. existsSync is one stat call.
-  if (existsSync(KILLSWITCH_PATH)) return;
+  // Start consuming stdin before checking the killswitch. Hook hosts can
+  // write their payload immediately after spawning us; returning before the
+  // reader attaches turns that write into EPIPE/Broken pipe.
+  const stdinPromise = readStdin();
+  if (existsSync(KILLSWITCH_PATH)) {
+    await stdinPromise;
+    return;
+  }
 
   // The agentSource is also passed as the second arg
   // (`petdex bubble pre claude-code`) so we know it without parsing
   // stdin if stdin is empty (e.g. session.end events from Stop).
   const argSource = args[1] ?? null;
 
-  const stdin = await readStdin();
+  const stdin = await stdinPromise;
   const event = eventFromArgs(args, stdin);
   if (!event) return;
 

--- a/packages/petdex-cli/src/hooks/bubble-runner.ts
+++ b/packages/petdex-cli/src/hooks/bubble-runner.ts
@@ -4,8 +4,8 @@
  * a human bubble via templates, POSTs to the sidecar.
  *
  * Hot path: this runs 20-50× per active session. We:
- *   - bound stdin reads so a hook host that keeps stdin open cannot stall
- *     the agent indefinitely
+ *   - retain a bounded stdin prefix while draining the rest, so oversized
+ *     payloads cannot OOM us or make their writer hit a broken pipe
  *   - swallow ALL errors silently (a noisy hook stains the agent UI)
  *   - cap stdin reads at 64KB (hooks don't need bigger payloads, and
  *     a runaway upstream shouldn't OOM us)
@@ -176,7 +176,6 @@ function safeSessionId(raw: unknown): string | null {
   if (typeof raw !== "string") return null;
   return /^[a-zA-Z0-9_-]{1,64}$/.test(raw) ? raw : null;
 }
-const STDIN_TIMEOUT_MS = 120;
 
 type HookStdin = Readable & { isTTY?: boolean };
 
@@ -212,35 +211,38 @@ export async function readStdin(
   input: HookStdin = process.stdin,
 ): Promise<string> {
   // Hooks pipe a single JSON payload. Preserve at most STDIN_CAP bytes for
-  // parsing, but keep draining oversized input until EOF or the deadline so
-  // a writer never sees a broken pipe from our early return.
+  // parsing, but keep draining until EOF or an input error. Returning early
+  // closes the read end of the pipe and can make a host that is still writing
+  // report EPIPE. The generated agent hook timeout bounds the process itself.
   if (input.isTTY) return Promise.resolve("");
   return await new Promise((resolve) => {
-    let buf = "";
+    const prefix: Buffer[] = [];
+    let prefixBytes = 0;
     let settled = false;
 
     const finish = () => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
       input.off("data", onData);
       input.off("end", finish);
       input.off("error", finish);
-      input.pause();
-      resolve(buf);
+      resolve(Buffer.concat(prefix, prefixBytes).toString("utf8"));
     };
 
-    const onData = (chunk: string) => {
-      if (settled || buf.length >= STDIN_CAP) return;
-      const remaining = STDIN_CAP - buf.length;
-      buf += chunk.slice(0, remaining);
+    const onData = (chunk: Buffer | string) => {
+      if (settled) return;
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      const remaining = STDIN_CAP - prefixBytes;
+      if (remaining <= 0) return;
+      const retained = Buffer.from(bytes.subarray(0, remaining));
+      prefix.push(retained);
+      prefixBytes += retained.length;
     };
 
-    const timer = setTimeout(finish, STDIN_TIMEOUT_MS);
-    input.setEncoding("utf8");
     input.on("data", onData);
     input.on("end", finish);
     input.on("error", finish);
+    input.resume();
   });
 }
 

--- a/packages/petdex-cli/src/hooks/bubble-runner.ts
+++ b/packages/petdex-cli/src/hooks/bubble-runner.ts
@@ -179,6 +179,35 @@ function safeSessionId(raw: unknown): string | null {
 
 type HookStdin = Readable & { isTTY?: boolean };
 
+function requiredUtf8ContinuationBytes(byte: number): number | null {
+  if (byte <= 0x7f) return 0;
+  if (byte >= 0xc2 && byte <= 0xdf) return 1;
+  if (byte >= 0xe0 && byte <= 0xef) return 2;
+  if (byte >= 0xf0 && byte <= 0xf4) return 3;
+  return null;
+}
+
+function completeUtf8PrefixLength(prefix: Buffer): number {
+  let leadIndex = prefix.length - 1;
+  while (leadIndex >= 0 && (prefix[leadIndex] & 0b1100_0000) === 0b1000_0000) {
+    leadIndex -= 1;
+  }
+
+  if (leadIndex < 0) return prefix.length;
+
+  const requiredContinuations = requiredUtf8ContinuationBytes(
+    prefix[leadIndex],
+  );
+  const actualContinuations = prefix.length - leadIndex - 1;
+  if (
+    requiredContinuations !== null &&
+    actualContinuations < requiredContinuations
+  ) {
+    return leadIndex;
+  }
+  return prefix.length;
+}
+
 /**
  * Map a hook phase + tool to the sprite state we want.
  * Mirrors the matchers in agents.ts so the hook command is a single
@@ -226,7 +255,8 @@ export async function readStdin(
       input.off("data", onData);
       input.off("end", finish);
       input.off("error", finish);
-      resolve(Buffer.concat(prefix, prefixBytes).toString("utf8"));
+      const retained = Buffer.concat(prefix, prefixBytes);
+      resolve(retained.toString("utf8", 0, completeUtf8PrefixLength(retained)));
     };
 
     const onData = (chunk: Buffer | string) => {

--- a/packages/petdex-desktop-native/src/agent_hooks.zig
+++ b/packages/petdex-desktop-native/src/agent_hooks.zig
@@ -88,12 +88,13 @@ const claude_events = [_]HookEvent{
     .{ .event = "Stop", .phase = "stop" },
 };
 
-/// Canonical hook command: killswitch first, then the stable symlink;
-/// silent exit when the app (and its symlink) is not installed.
+/// Canonical hook command: pass live payloads to the stable symlink. The
+/// disabled and missing-runner paths still drain stdin before exiting so an
+/// agent host never sees EPIPE while it is writing a hook payload.
 pub fn canonicalCommand(buf: []u8, phase: []const u8, agent: []const u8) ?[]const u8 {
     return std.fmt.bufPrint(
         buf,
-        "[ -f \"$HOME/.petdex/runtime/hooks-disabled\" ] && exit 0; [ -x \"$HOME/.petdex/bin/petdex-hook\" ] && exec \"$HOME/.petdex/bin/petdex-hook\" bubble {s} {s}; exit 0",
+        "if [ -f \"$HOME/.petdex/runtime/hooks-disabled\" ]; then [ -t 0 ] || cat >/dev/null; exit 0; fi; if [ -x \"$HOME/.petdex/bin/petdex-hook\" ]; then exec \"$HOME/.petdex/bin/petdex-hook\" bubble {s} {s}; fi; [ -t 0 ] || cat >/dev/null; exit 0",
         .{ phase, agent },
     ) catch null;
 }
@@ -176,7 +177,7 @@ const HookEvent = struct { event: []const u8, phase: []const u8 };
 pub fn installClaude(allocator: std.mem.Allocator, home: []const u8) bool {
     var path_buf: [512]u8 = undefined;
     const path = claudeSettingsPath(&path_buf, home) orelse return false;
-    return installJsonHooks(allocator, path, &claude_events, "claude-code");
+    return installJsonHooks(allocator, path, &claude_events, "claude-code", 2, false);
 }
 
 /// Gemini rides the exact same settings.json hook shape as Claude,
@@ -190,7 +191,7 @@ const gemini_events = [_]HookEvent{
 pub fn installGemini(allocator: std.mem.Allocator, home: []const u8) bool {
     var path_buf: [512]u8 = undefined;
     const path = std.fmt.bufPrint(&path_buf, "{s}/.gemini/settings.json", .{home}) catch return false;
-    return installJsonHooks(allocator, path, &gemini_events, "gemini");
+    return installJsonHooks(allocator, path, &gemini_events, "gemini", 2000, true);
 }
 
 /// opencode has no hooks: it loads a self-contained JS plugin that
@@ -210,7 +211,14 @@ pub fn installOpencode(allocator: std.mem.Allocator, home: []const u8) bool {
 /// JSON-hook agents (Claude Code, Gemini): std.json Value roundtrip of
 /// settings.json that filters existing petdex entries per event and
 /// appends the canonical one, touching nothing else.
-fn installJsonHooks(allocator: std.mem.Allocator, path: []const u8, events: []const HookEvent, agent: []const u8) bool {
+fn installJsonHooks(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    events: []const HookEvent,
+    agent: []const u8,
+    timeout: i64,
+    enable_hooks_config: bool,
+) bool {
     const existing = readFileAlloc(allocator, path, 1024 * 1024);
     defer if (existing) |e| allocator.free(e);
     backupOnce(allocator, path);
@@ -226,6 +234,8 @@ fn installJsonHooks(allocator: std.mem.Allocator, path: []const u8, events: []co
         }
         break :blk emptyObject(a);
     };
+
+    if (enable_hooks_config and !ensureHooksConfigEnabled(&root, a)) return false;
 
     const hooks_entry = root.object.getOrPut(a, "hooks") catch return false;
     if (!hooks_entry.found_existing or hooks_entry.value_ptr.* != .object) {
@@ -253,6 +263,7 @@ fn installJsonHooks(allocator: std.mem.Allocator, path: []const u8, events: []co
         var hook_obj = std.json.ObjectMap.init(a, &.{}, &.{}) catch return false;
         hook_obj.put(a, "type", .{ .string = "command" }) catch return false;
         hook_obj.put(a, "command", .{ .string = a.dupe(u8, cmd) catch return false }) catch return false;
+        hook_obj.put(a, "timeout", .{ .integer = timeout }) catch return false;
         var inner = std.json.Array.init(a);
         inner.append(.{ .object = hook_obj }) catch return false;
         var entry_obj = std.json.ObjectMap.init(a, &.{}, &.{}) catch return false;
@@ -262,6 +273,15 @@ fn installJsonHooks(allocator: std.mem.Allocator, path: []const u8, events: []co
 
     const serialized = std.json.Stringify.valueAlloc(a, root, .{ .whitespace = .indent_2 }) catch return false;
     return writeFile(path, serialized);
+}
+
+fn ensureHooksConfigEnabled(root: *std.json.Value, allocator: std.mem.Allocator) bool {
+    const config_entry = root.object.getOrPut(allocator, "hooksConfig") catch return false;
+    if (!config_entry.found_existing or config_entry.value_ptr.* != .object) {
+        config_entry.value_ptr.* = .{ .object = std.json.ObjectMap.init(allocator, &.{}, &.{}) catch return false };
+    }
+    config_entry.value_ptr.object.put(allocator, "enabled", .{ .bool = true }) catch return false;
+    return true;
 }
 
 fn entryIsPetdex(entry: std.json.Value) bool {
@@ -306,7 +326,7 @@ pub fn installCodex(allocator: std.mem.Allocator, home: []const u8) bool {
             esc.append(c) catch return false;
         }
         var line_buf: [1024]u8 = undefined;
-        const line = std.fmt.bufPrint(&line_buf, "    \"{s}\": [{{ \"hooks\": [{{ \"type\": \"command\", \"command\": \"{s}\" }}] }}]{s}\n", .{ ev.event, esc.items, if (idx + 1 < codex_events.len) "," else "" }) catch return false;
+        const line = std.fmt.bufPrint(&line_buf, "    \"{s}\": [{{ \"hooks\": [{{ \"type\": \"command\", \"command\": \"{s}\", \"timeout\": 2 }}] }}]{s}\n", .{ ev.event, esc.items, if (idx + 1 < codex_events.len) "," else "" }) catch return false;
         out.appendSlice(line) catch return false;
     }
     out.appendSlice("  }\n}\n") catch return false;
@@ -473,6 +493,7 @@ test "installCodex writes hooks.json and feature flag" {
     defer t.allocator.free(hooks);
     try t.expect(std.mem.indexOf(u8, hooks, "bubble stop codex") != null);
     try t.expect(std.mem.indexOf(u8, hooks, "PermissionRequest") != null);
+    try t.expect(std.mem.indexOf(u8, hooks, "\"timeout\": 2") != null);
     const toml_after = readFileAlloc(t.allocator, toml, 64 * 1024).?;
     defer t.allocator.free(toml_after);
     try t.expect(std.mem.indexOf(u8, toml_after, "hooks = true") != null);
@@ -530,6 +551,21 @@ test "canonical command carries killswitch, symlink, phase and agent" {
     const cmd = canonicalCommand(&buf, "pre", "claude-code").?;
     try t.expect(std.mem.indexOf(u8, cmd, "hooks-disabled") != null);
     try t.expect(std.mem.indexOf(u8, cmd, "petdex-hook\" bubble pre claude-code") != null);
+    try t.expectEqual(@as(usize, 2), std.mem.count(u8, cmd, "cat >/dev/null"));
+}
+
+test "installGemini enables hooks and uses a millisecond timeout" {
+    const home = "/tmp/petdex-agenthooks-gemini-fixture";
+    plat.makeDir(home ++ "/.gemini");
+    var path_buf: [512]u8 = undefined;
+    const config = std.fmt.bufPrint(&path_buf, "{s}/.gemini/settings.json", .{home}) catch unreachable;
+    try t.expect(writeFile(config, "{\"hooksConfig\":{\"keep\":true}}"));
+    try t.expect(installGemini(t.allocator, home));
+    const written = readFileAlloc(t.allocator, config, 64 * 1024).?;
+    defer t.allocator.free(written);
+    try t.expect(std.mem.indexOf(u8, written, "\"timeout\": 2000") != null);
+    try t.expect(std.mem.indexOf(u8, written, "\"enabled\": true") != null);
+    try t.expect(std.mem.indexOf(u8, written, "\"keep\": true") != null);
 }
 
 test "toml feature detection" {

--- a/packages/petdex-desktop-native/src/agent_hooks.zig
+++ b/packages/petdex-desktop-native/src/agent_hooks.zig
@@ -1,13 +1,14 @@
-//! Agent hook detection and installation — the Agents section's engine.
+//! Agent hook detection and installation - the Agents section's engine.
 //!
 //! Detection is read-only and runs at boot and on settings-open: which
 //! agents exist on this machine, and whether their configs carry our
-//! hooks (and which runner generation they point at). Installation
-//! writes the canonical hook command — the stable `petdex-hook`
-//! symlink the app re-aims at itself every boot — and NEVER touches
-//! anything that is not ours: Claude's settings.json is merged through
-//! a std.json Value roundtrip that only filters/appends petdex
-//! entries, and a one-time backup is written beside any file we edit.
+//! hooks (and which runner generation they point at). A separate,
+//! narrow migration updates only recognized legacy Petdex hook entries.
+//! Installation writes the canonical hook command - the stable
+//! `petdex-hook` symlink the app re-aims at itself every boot - and
+//! never touches non-Petdex hook entries. JSON config files are merged
+//! through a std.json Value roundtrip and a one-time backup is written
+//! beside any file we edit.
 
 const std = @import("std");
 const plat = @import("plat.zig");
@@ -88,6 +89,14 @@ const claude_events = [_]HookEvent{
     .{ .event = "Stop", .phase = "stop" },
 };
 
+const codex_events = [_]HookEvent{
+    .{ .event = "UserPromptSubmit", .phase = "user-prompt" },
+    .{ .event = "PreToolUse", .phase = "pre" },
+    .{ .event = "PostToolUse", .phase = "post" },
+    .{ .event = "PermissionRequest", .phase = "notification" },
+    .{ .event = "Stop", .phase = "stop" },
+};
+
 /// Canonical hook command: pass live payloads to the stable symlink. The
 /// disabled and missing-runner paths still drain stdin before exiting so an
 /// agent host never sees EPIPE while it is writing a hook payload.
@@ -101,10 +110,106 @@ pub fn canonicalCommand(buf: []u8, phase: []const u8, agent: []const u8) ?[]cons
 
 // ----------------------------------------------------------- detection
 
-fn classifyConfig(content: []const u8) HookStatus {
-    if (std.mem.indexOf(u8, content, "petdex-hook") != null) return .current;
-    if (std.mem.indexOf(u8, content, "petdex") != null) return .node;
+const ManagedHookGeneration = enum {
+    none,
+    legacy,
+    current,
+};
+
+fn containsCommandPath(command: []const u8, path: []const u8) bool {
+    var offset: usize = 0;
+    while (std.mem.indexOfPos(u8, command, offset, path)) |start| {
+        const end = start + path.len;
+        const has_left_boundary = start == 0 or switch (command[start - 1]) {
+            ' ', '\t', '\r', '\n', '\'', '"', '(', '=', '/', '\\' => true,
+            else => false,
+        };
+        const has_right_boundary = end == command.len or switch (command[end]) {
+            ' ', '\t', '\r', '\n', '\'', '"', ';', ')', '&', '|' => true,
+            else => false,
+        };
+        if (has_left_boundary and has_right_boundary) return true;
+        offset = end;
+    }
+    return false;
+}
+
+fn containsPetdexHomePath(command: []const u8, relative_path: []const u8) bool {
+    const homes = [_][]const u8{
+        "$HOME/.petdex",
+        "${HOME}/.petdex",
+        "$HOME\\.petdex",
+        "${HOME}\\.petdex",
+    };
+    var path_buf: [128]u8 = undefined;
+    for (homes) |home| {
+        const path = std.fmt.bufPrint(&path_buf, "{s}{s}", .{ home, relative_path }) catch continue;
+        if (containsCommandPath(command, path)) return true;
+    }
+    return false;
+}
+
+fn commandGeneration(command: []const u8) ManagedHookGeneration {
+    // Old CLI-generated hooks invoked the persisted Node bundle or posted
+    // directly with the old token-based curl command. Match those exact
+    // ownership markers rather than every incidental mention of Petdex.
+    const has_legacy_bundle = (containsPetdexHomePath(command, "/bin/petdex.js") or
+        containsPetdexHomePath(command, "\\bin\\petdex.js")) and
+        std.mem.indexOf(u8, command, " bubble ") != null;
+    const has_legacy_curl = containsPetdexHomePath(command, "/runtime/update-token") and
+        std.mem.indexOf(u8, command, "X-Petdex-Update-Token") != null and
+        std.mem.indexOf(u8, command, "http://127.0.0.1:7777/state") != null and
+        std.mem.indexOf(u8, command, "curl") != null;
+    if (has_legacy_bundle or has_legacy_curl) return .legacy;
+    if ((containsPetdexHomePath(command, "/bin/petdex-hook") or
+        containsPetdexHomePath(command, "\\bin\\petdex-hook")) and
+        std.mem.indexOf(u8, command, " bubble ") != null) return .current;
     return .none;
+}
+
+fn hookGeneration(hook: std.json.Value) ManagedHookGeneration {
+    if (hook != .object) return .none;
+    const command = hook.object.get("command") orelse return .none;
+    if (command != .string) return .none;
+    return commandGeneration(command.string);
+}
+
+fn entryGeneration(entry: std.json.Value) ManagedHookGeneration {
+    if (entry != .object) return .none;
+    const hooks = entry.object.get("hooks") orelse return .none;
+    if (hooks != .array) return .none;
+    var current = false;
+    for (hooks.array.items) |hook| {
+        switch (hookGeneration(hook)) {
+            .legacy => return .legacy,
+            .current => current = true,
+            .none => {},
+        }
+    }
+    return if (current) .current else .none;
+}
+
+fn classifyConfig(allocator: std.mem.Allocator, content: []const u8) HookStatus {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const root = std.json.parseFromSliceLeaky(std.json.Value, arena.allocator(), content, .{}) catch return .none;
+    if (root != .object) return .none;
+    const hooks = root.object.get("hooks") orelse return .none;
+    if (hooks != .object) return .none;
+
+    var current = false;
+    var events = hooks.object.iterator();
+    while (events.next()) |event| {
+        if (event.value_ptr.* != .array) continue;
+        for (event.value_ptr.array.items) |entry| {
+            switch (entryGeneration(entry)) {
+                .legacy => return .node,
+                .current => current = true,
+                .none => {},
+            }
+        }
+    }
+    return if (current) .current else .none;
 }
 
 const dirExists = plat.dirExists;
@@ -116,13 +221,13 @@ fn readFileAlloc(allocator: std.mem.Allocator, path: []const u8, max: usize) ?[]
 }
 
 /// One-time backup beside the file we are about to edit.
-fn backupOnce(allocator: std.mem.Allocator, path: []const u8) void {
+fn backupOnce(allocator: std.mem.Allocator, path: []const u8) bool {
     var bak_buf: [512]u8 = undefined;
-    const bak = std.fmt.bufPrint(&bak_buf, "{s}.pre-petdex-backup", .{path}) catch return;
-    if (fileExists(bak)) return;
-    const content = readFileAlloc(allocator, path, 1024 * 1024) orelse return;
+    const bak = std.fmt.bufPrint(&bak_buf, "{s}.pre-petdex-backup", .{path}) catch return false;
+    if (fileExists(bak)) return true;
+    const content = readFileAlloc(allocator, path, 1024 * 1024) orelse return !fileExists(path);
     defer allocator.free(content);
-    _ = writeFile(bak, content);
+    return writeFile(bak, content);
 }
 
 pub fn scan(allocator: std.mem.Allocator, home: []const u8) [agent_count]AgentInfo {
@@ -156,7 +261,7 @@ pub fn scan(allocator: std.mem.Allocator, home: []const u8) [agent_count]AgentIn
             if (info.kind == .opencode) {
                 info.status = if (std.mem.eql(u8, std.mem.trim(u8, content, " \n"), std.mem.trim(u8, opencode_plugin, " \n"))) .current else .node;
             } else {
-                info.status = classifyConfig(content);
+                info.status = classifyConfig(allocator, content);
             }
         }
     }
@@ -204,7 +309,7 @@ pub fn installOpencode(allocator: std.mem.Allocator, home: []const u8) bool {
     const dir = std.fmt.bufPrint(&path_buf, "{s}/.config/opencode/plugins", .{home}) catch return false;
     plat.makeDir(dir);
     const path = std.fmt.bufPrint(&path_buf, "{s}/.config/opencode/plugins/petdex.js", .{home}) catch return false;
-    backupOnce(allocator, path);
+    if (!backupOnce(allocator, path)) return false;
     return writeFile(path, opencode_plugin);
 }
 
@@ -221,7 +326,10 @@ fn installJsonHooks(
 ) bool {
     const existing = readFileAlloc(allocator, path, 1024 * 1024);
     defer if (existing) |e| allocator.free(e);
-    backupOnce(allocator, path);
+    // An empty, unreadable, or malformed user config is not a safe
+    // starting point. Refuse to overwrite it so the user can repair the
+    // real problem instead of losing their settings.
+    if (existing == null and fileExists(path)) return false;
 
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
@@ -229,35 +337,38 @@ fn installJsonHooks(
 
     var root: std.json.Value = blk: {
         if (existing) |bytes| {
-            const parsed = std.json.parseFromSliceLeaky(std.json.Value, a, bytes, .{}) catch break :blk emptyObject(a);
-            if (parsed == .object) break :blk parsed;
+            const parsed = std.json.parseFromSliceLeaky(std.json.Value, a, bytes, .{}) catch return false;
+            if (parsed != .object) return false;
+            break :blk parsed;
         }
         break :blk emptyObject(a);
     };
 
+    if (existing != null and !backupOnce(allocator, path)) return false;
+
     if (enable_hooks_config and !ensureHooksConfigEnabled(&root, a)) return false;
 
     const hooks_entry = root.object.getOrPut(a, "hooks") catch return false;
-    if (!hooks_entry.found_existing or hooks_entry.value_ptr.* != .object) {
+    if (!hooks_entry.found_existing) {
         hooks_entry.value_ptr.* = .{ .object = std.json.ObjectMap.init(a, &.{}, &.{}) catch return false };
+    } else if (hooks_entry.value_ptr.* != .object) {
+        return false;
     }
     const hooks_obj = &hooks_entry.value_ptr.object;
 
+    // A legacy install may have written events that no longer belong to
+    // the current event list. Remove only Petdex-owned commands from every
+    // event before appending the canonical entries below.
+    removeManagedHooks(hooks_obj);
+
     for (events) |ev| {
         const arr_entry = hooks_obj.getOrPut(a, ev.event) catch return false;
-        if (!arr_entry.found_existing or arr_entry.value_ptr.* != .array) {
+        if (!arr_entry.found_existing) {
             arr_entry.value_ptr.* = .{ .array = std.json.Array.init(a) };
+        } else if (arr_entry.value_ptr.* != .array) {
+            return false;
         }
         const arr = &arr_entry.value_ptr.array;
-        // Drop any existing petdex entry for this event.
-        var i: usize = 0;
-        while (i < arr.items.len) {
-            if (entryIsPetdex(arr.items[i])) {
-                _ = arr.orderedRemove(i);
-            } else {
-                i += 1;
-            }
-        }
         var cmd_buf: [512]u8 = undefined;
         const cmd = canonicalCommand(&cmd_buf, ev.phase, agent) orelse return false;
         var hook_obj = std.json.ObjectMap.init(a, &.{}, &.{}) catch return false;
@@ -275,95 +386,239 @@ fn installJsonHooks(
     return writeFile(path, serialized);
 }
 
+/// Verify every shape installJsonHooks depends on without changing the file.
+/// Codex uses this before its separate config.toml update so a malformed
+/// hooks.json cannot leave an otherwise unrelated configuration half-updated.
+fn canInstallJsonHooks(allocator: std.mem.Allocator, path: []const u8, events: []const HookEvent) bool {
+    const existing = readFileAlloc(allocator, path, 1024 * 1024);
+    defer if (existing) |bytes| allocator.free(bytes);
+    if (existing == null) return !fileExists(path);
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const root = std.json.parseFromSliceLeaky(std.json.Value, arena.allocator(), existing.?, .{}) catch return false;
+    if (root != .object) return false;
+    const hooks = root.object.get("hooks") orelse return true;
+    if (hooks != .object) return false;
+    for (events) |event| {
+        const entries = hooks.object.get(event.event) orelse continue;
+        if (entries != .array) return false;
+    }
+    return true;
+}
+
 fn ensureHooksConfigEnabled(root: *std.json.Value, allocator: std.mem.Allocator) bool {
     const config_entry = root.object.getOrPut(allocator, "hooksConfig") catch return false;
-    if (!config_entry.found_existing or config_entry.value_ptr.* != .object) {
+    if (!config_entry.found_existing) {
         config_entry.value_ptr.* = .{ .object = std.json.ObjectMap.init(allocator, &.{}, &.{}) catch return false };
+    } else if (config_entry.value_ptr.* != .object) {
+        return false;
     }
     config_entry.value_ptr.object.put(allocator, "enabled", .{ .bool = true }) catch return false;
     return true;
 }
 
 fn entryIsPetdex(entry: std.json.Value) bool {
-    if (entry != .object) return false;
-    const hooks = entry.object.get("hooks") orelse return false;
-    if (hooks != .array) return false;
-    for (hooks.array.items) |h| {
-        if (h != .object) continue;
-        const cmd = h.object.get("command") orelse continue;
-        if (cmd == .string and std.mem.indexOf(u8, cmd.string, "petdex") != null) return true;
-    }
-    return false;
+    return entryGeneration(entry) != .none;
 }
 
-/// Install/refresh Codex hooks: hooks.json is wholly ours (canonical
-/// content), and config.toml gains `hooks = true` under [features]
-/// without disturbing the rest.
+/// Remove Petdex commands in-place without deleting a hook group that also
+/// carries a user-owned command.
+fn stripManagedHooks(entry: *std.json.Value) bool {
+    if (entry.* != .object) return false;
+    const hooks = entry.object.getPtr("hooks") orelse return false;
+    if (hooks.* != .array) return false;
+    var removed = false;
+    var i: usize = 0;
+    while (i < hooks.array.items.len) {
+        if (hookGeneration(hooks.array.items[i]) != .none) {
+            _ = hooks.array.orderedRemove(i);
+            removed = true;
+        } else {
+            i += 1;
+        }
+    }
+    return removed and hooks.array.items.len == 0;
+}
+
+fn removeManagedHooks(hooks_obj: *std.json.ObjectMap) void {
+    var events = hooks_obj.iterator();
+    while (events.next()) |event| {
+        if (event.value_ptr.* != .array) continue;
+        const entries = &event.value_ptr.array;
+        var i: usize = 0;
+        while (i < entries.items.len) {
+            if (stripManagedHooks(&entries.items[i])) {
+                _ = entries.orderedRemove(i);
+            } else {
+                i += 1;
+            }
+        }
+    }
+}
+
+/// Install/refresh Codex hooks, preserving non-Petdex hooks in hooks.json
+/// and enabling the required feature flag in config.toml.
 pub fn installCodex(allocator: std.mem.Allocator, home: []const u8) bool {
-    var path_buf: [512]u8 = undefined;
-    const hooks_path = std.fmt.bufPrint(&path_buf, "{s}/.codex/hooks.json", .{home}) catch return false;
-    backupOnce(allocator, hooks_path);
+    var hooks_path_buf: [512]u8 = undefined;
+    const hooks_path = std.fmt.bufPrint(&hooks_path_buf, "{s}/.codex/hooks.json", .{home}) catch return false;
+    var toml_path_buf: [512]u8 = undefined;
+    const toml_path = std.fmt.bufPrint(&toml_path_buf, "{s}/.codex/config.toml", .{home}) catch return false;
+    const toml = readFileAlloc(allocator, toml_path, 1024 * 1024);
+    defer if (toml) |tm| allocator.free(tm);
+    if (toml) |content| {
+        if (inspectFeatureHooks(content).state == .unsafe) return false;
+    } else if (fileExists(toml_path)) return false;
+
+    // Validate both files before changing either one. Write hooks first so a
+    // later config.toml failure can only leave the new runner disabled, never
+    // keep an enabled legacy runner on the hook hot path.
+    if (!canInstallJsonHooks(allocator, hooks_path, &codex_events)) return false;
+    if (!installJsonHooks(allocator, hooks_path, &codex_events, "codex", 2, false)) return false;
+
+    if (toml) |content| return ensureFeatureHooks(allocator, toml_path, content);
+    return writeFile(toml_path, "[features]\nhooks = true\n");
+}
+
+const FeatureHooksState = enum {
+    enabled,
+    insert_after_features,
+    replace_line,
+    append_features,
+    unsafe,
+};
+
+const FeatureHooksInspection = struct {
+    state: FeatureHooksState,
+    offset: usize = 0,
+    line_end: usize = 0,
+};
+
+fn inspectFeatureHooks(toml: []const u8) FeatureHooksInspection {
+    var line_start: usize = 0;
+    var features_insert_offset: ?usize = null;
+    var current_features = false;
+    var at_root = true;
+    var hook_count: usize = 0;
+    var hook_is_enabled = false;
+    var hook_offset: usize = 0;
+    var hook_line_end: usize = 0;
+    while (line_start <= toml.len) {
+        const relative_end = std.mem.indexOfScalar(u8, toml[line_start..], '\n');
+        const line_end = if (relative_end) |end| line_start + end else toml.len;
+        const line = toml[line_start..line_end];
+        const trimmed = std.mem.trim(u8, line, " \t\r");
+        if (trimmed.len > 0 and trimmed[0] == '[') {
+            const name = sectionName(trimmed) orelse return .{ .state = .unsafe };
+            if (std.mem.startsWith(u8, name, "features.")) return .{ .state = .unsafe };
+            current_features = std.mem.eql(u8, name, "features");
+            at_root = false;
+            if (current_features) {
+                if (features_insert_offset != null) return .{ .state = .unsafe };
+                features_insert_offset = if (relative_end == null) line_end else line_end + 1;
+            }
+        } else if (at_root and isFeaturesNamespaceAssignment(trimmed)) {
+            return .{ .state = .unsafe };
+        } else if (current_features) {
+            switch (hooksAssignment(trimmed)) {
+                .other => {},
+                .unsafe => return .{ .state = .unsafe },
+                .value => |value_with_comment| {
+                    const comment = std.mem.indexOfScalar(u8, value_with_comment, '#') orelse value_with_comment.len;
+                    const value = std.mem.trim(u8, value_with_comment[0..comment], " \t");
+                    const enabled = if (std.mem.eql(u8, value, "true")) true else if (std.mem.eql(u8, value, "false")) false else return .{ .state = .unsafe };
+                    hook_count += 1;
+                    if (hook_count > 1) return .{ .state = .unsafe };
+                    hook_is_enabled = enabled;
+                    hook_offset = line_start;
+                    hook_line_end = line_end;
+                },
+            }
+        }
+        if (relative_end == null) break;
+        line_start = line_end + 1;
+    }
+    if (hook_count == 1) {
+        return if (hook_is_enabled)
+            .{ .state = .enabled }
+        else
+            .{ .state = .replace_line, .offset = hook_offset, .line_end = hook_line_end };
+    }
+    if (features_insert_offset) |offset| return .{ .state = .insert_after_features, .offset = offset };
+    return .{ .state = .append_features };
+}
+
+fn isFeaturesNamespaceAssignment(line: []const u8) bool {
+    if (line.len == 0 or line[0] == '#') return false;
+    const equals = std.mem.indexOfScalar(u8, line, '=') orelse return false;
+    const key = std.mem.trim(u8, line[0..equals], " \t");
+    return std.mem.eql(u8, key, "features") or std.mem.startsWith(u8, key, "features.");
+}
+
+fn sectionName(line: []const u8) ?[]const u8 {
+    if (line.len < 3 or line[0] != '[' or line[1] == '[') return null;
+    const close = std.mem.indexOfScalar(u8, line[1..], ']') orelse return null;
+    const close_index = close + 1;
+    const suffix = std.mem.trim(u8, line[close_index + 1 ..], " \t");
+    if (suffix.len > 0 and suffix[0] != '#') return null;
+    return std.mem.trim(u8, line[1..close_index], " \t");
+}
+
+const HooksAssignment = union(enum) {
+    other,
+    unsafe,
+    value: []const u8,
+};
+
+fn hooksAssignment(line: []const u8) HooksAssignment {
+    if (line.len == 0 or line[0] == '#') return .other;
+    const equals = std.mem.indexOfScalar(u8, line, '=') orelse return .other;
+    const key = std.mem.trim(u8, line[0..equals], " \t");
+    if (!std.mem.eql(u8, key, "hooks")) return .other;
+    const value = std.mem.trim(u8, line[equals + 1 ..], " \t");
+    if (value.len == 0) return .unsafe;
+    return .{ .value = value };
+}
+
+fn ensureFeatureHooks(allocator: std.mem.Allocator, path: []const u8, content: []const u8) bool {
+    const inspection = inspectFeatureHooks(content);
+    if (inspection.state == .enabled) return true;
+    if (inspection.state == .unsafe) return false;
 
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
     const a = arena.allocator();
-
-    var out = std.array_list.Managed(u8).init(a);
-    out.appendSlice("{\n  \"hooks\": {\n") catch return false;
-    const codex_events = [_]struct { event: []const u8, phase: []const u8 }{
-        .{ .event = "UserPromptSubmit", .phase = "user-prompt" },
-        .{ .event = "PreToolUse", .phase = "pre" },
-        .{ .event = "PostToolUse", .phase = "post" },
-        .{ .event = "PermissionRequest", .phase = "notification" },
-        .{ .event = "Stop", .phase = "stop" },
-    };
-    inline for (codex_events, 0..) |ev, idx| {
-        var cmd_buf: [512]u8 = undefined;
-        const cmd = canonicalCommand(&cmd_buf, ev.phase, "codex") orelse return false;
-        var esc = std.array_list.Managed(u8).init(a);
-        for (cmd) |c| {
-            if (c == '"' or c == '\\') esc.append('\\') catch return false;
-            esc.append(c) catch return false;
-        }
-        var line_buf: [1024]u8 = undefined;
-        const line = std.fmt.bufPrint(&line_buf, "    \"{s}\": [{{ \"hooks\": [{{ \"type\": \"command\", \"command\": \"{s}\", \"timeout\": 2 }}] }}]{s}\n", .{ ev.event, esc.items, if (idx + 1 < codex_events.len) "," else "" }) catch return false;
-        out.appendSlice(line) catch return false;
+    var updated = std.array_list.Managed(u8).init(a);
+    switch (inspection.state) {
+        .enabled => unreachable,
+        .unsafe => unreachable,
+        .append_features => {
+            updated.appendSlice(content) catch return false;
+            if (content.len > 0 and content[content.len - 1] != '\n') updated.append('\n') catch return false;
+            updated.appendSlice("\n[features]\nhooks = true\n") catch return false;
+        },
+        .insert_after_features => {
+            updated.appendSlice(content[0..inspection.offset]) catch return false;
+            if (inspection.offset > 0 and content[inspection.offset - 1] != '\n') updated.append('\n') catch return false;
+            updated.appendSlice("hooks = true\n") catch return false;
+            updated.appendSlice(content[inspection.offset..]) catch return false;
+        },
+        .replace_line => {
+            const original = content[inspection.offset..inspection.line_end];
+            const leading_len = original.len - std.mem.trimStart(u8, original, " \t").len;
+            updated.appendSlice(content[0..inspection.offset]) catch return false;
+            updated.appendSlice(original[0..leading_len]) catch return false;
+            updated.appendSlice("hooks = true") catch return false;
+            if (std.mem.indexOfScalar(u8, original, '#')) |comment| {
+                updated.append(' ') catch return false;
+                updated.appendSlice(original[comment..]) catch return false;
+            }
+            updated.appendSlice(content[inspection.line_end..]) catch return false;
+        },
     }
-    out.appendSlice("  }\n}\n") catch return false;
-    if (!writeFile(hooks_path, out.items)) return false;
 
-    // config.toml: ensure [features] hooks = true.
-    const toml_path = std.fmt.bufPrint(&path_buf, "{s}/.codex/config.toml", .{home}) catch return false;
-    const toml = readFileAlloc(allocator, toml_path, 1024 * 1024);
-    defer if (toml) |tm| allocator.free(tm);
-    if (toml) |content| {
-        if (hasFeatureHooks(content)) return true;
-        backupOnce(allocator, toml_path);
-        var new_toml = std.array_list.Managed(u8).init(a);
-        if (std.mem.indexOf(u8, content, "[features]")) |at| {
-            const line_end = std.mem.indexOfScalarPos(u8, content, at, '\n') orelse content.len;
-            new_toml.appendSlice(content[0 .. line_end + 1]) catch return false;
-            new_toml.appendSlice("hooks = true\n") catch return false;
-            if (line_end + 1 < content.len) new_toml.appendSlice(content[line_end + 1 ..]) catch return false;
-        } else {
-            new_toml.appendSlice(content) catch return false;
-            new_toml.appendSlice("\n[features]\nhooks = true\n") catch return false;
-        }
-        return writeFile(toml_path, new_toml.items);
-    }
-    return writeFile(toml_path, "[features]\nhooks = true\n");
-}
-
-fn hasFeatureHooks(toml: []const u8) bool {
-    const at = std.mem.indexOf(u8, toml, "[features]") orelse return false;
-    const section_end = std.mem.indexOfPos(u8, toml, at + 10, "\n[") orelse toml.len;
-    const section = toml[at..section_end];
-    var it = std.mem.tokenizeScalar(u8, section, '\n');
-    while (it.next()) |line| {
-        const trimmed = std.mem.trim(u8, line, " \t");
-        if (std.mem.startsWith(u8, trimmed, "hooks") and std.mem.indexOf(u8, trimmed, "true") != null) return true;
-    }
-    return false;
+    if (!backupOnce(allocator, path)) return false;
+    return writeFile(path, updated.items);
 }
 
 // ------------------------------------------------------------ removal
@@ -376,25 +631,41 @@ fn uninstallJsonHooks(allocator: std.mem.Allocator, path: []const u8) bool {
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
     const a = arena.allocator();
-    const root = std.json.parseFromSliceLeaky(std.json.Value, a, existing, .{}) catch return false;
+    var root = std.json.parseFromSliceLeaky(std.json.Value, a, existing, .{}) catch return false;
     if (root != .object) return false;
-    const hooks_val = root.object.get("hooks") orelse return true;
-    if (hooks_val != .object) return true;
-    var it = hooks_val.object.iterator();
-    while (it.next()) |entry| {
-        if (entry.value_ptr.* != .array) continue;
-        const arr = &entry.value_ptr.array;
-        var i: usize = 0;
-        while (i < arr.items.len) {
-            if (entryIsPetdex(arr.items[i])) {
-                _ = arr.orderedRemove(i);
-            } else {
-                i += 1;
-            }
-        }
-    }
+    const hooks_val = root.object.getPtr("hooks") orelse return true;
+    if (hooks_val.* != .object) return true;
+    removeManagedHooks(&hooks_val.object);
     const serialized = std.json.Stringify.valueAlloc(a, root, .{ .whitespace = .indent_2 }) catch return false;
     return writeFile(path, serialized);
+}
+
+pub const LegacyMigration = struct {
+    migrated: usize = 0,
+    failed: usize = 0,
+};
+
+/// Update only recognized legacy CLI hook commands when the desktop app
+/// starts. This closes the gap for users who upgrade the app but never open
+/// Settings to press Update; unrelated hooks and configurations are left
+/// untouched.
+pub fn migrateLegacyHooks(allocator: std.mem.Allocator, home: []const u8) LegacyMigration {
+    const agents = scan(allocator, home);
+    var result: LegacyMigration = .{};
+    for (agents) |info| {
+        if (info.status != .node) continue;
+        const migrated = switch (info.kind) {
+            .claude_code => installClaude(allocator, home),
+            .codex => installCodex(allocator, home),
+            .gemini => installGemini(allocator, home),
+            // An outdated OpenCode plugin has no subprocess stdin path.
+            // Keep its existing explicit Update action rather than changing
+            // it as part of this bubble-runner migration.
+            .opencode => continue,
+        };
+        if (migrated) result.migrated += 1 else result.failed += 1;
+    }
+    return result;
 }
 
 pub fn uninstall(allocator: std.mem.Allocator, home: []const u8, kind: AgentKind) bool {
@@ -409,11 +680,9 @@ pub fn uninstall(allocator: std.mem.Allocator, home: []const u8, kind: AgentKind
             return uninstallJsonHooks(allocator, path);
         },
         .codex => {
-            // hooks.json is wholly ours; the config.toml feature flag
-            // stays (harmless without the file).
+            // The config.toml feature flag stays harmless without the file.
             const p = std.fmt.bufPrint(&path_buf, "{s}/.codex/hooks.json", .{home}) catch return false;
-            plat.deleteFile(p);
-            return true;
+            return uninstallJsonHooks(allocator, p);
         },
         .opencode => {
             const p = std.fmt.bufPrint(&path_buf, "{s}/.config/opencode/plugins/petdex.js", .{home}) catch return false;
@@ -481,19 +750,29 @@ test "installClaude merges into a real fixture home non-destructively" {
     try t.expect(fileExists(bak));
 }
 
-test "installCodex writes hooks.json and feature flag" {
-    const home = "/tmp/petdex-agenthooks-fixture";
+test "installCodex migrates legacy hooks without dropping a foreign hook" {
+    const home = "/tmp/petdex-agenthooks-codex-fixture";
     plat.makeDir(home ++ "/.codex");
     var pb: [512]u8 = undefined;
     const toml = std.fmt.bufPrint(&pb, "{s}/.codex/config.toml", .{home}) catch unreachable;
     try t.expect(writeFile(toml, "model = \"gpt\"\n[features]\nmemories = true\n"));
+    var hooks_path_buf: [512]u8 = undefined;
+    const hooks_path = std.fmt.bufPrint(&hooks_path_buf, "{s}/.codex/hooks.json", .{home}) catch unreachable;
+    const legacy =
+        \\{"hooks":{"PreToolUse":[
+        \\ {"matcher":"Read","hooks":[{"type":"command","command":"my-own-hook"}]},
+        \\ {"hooks":[{"type":"command","command":"node $HOME/.petdex/bin/petdex.js bubble pre codex"}]}
+        \\]}}
+    ;
+    try t.expect(writeFile(hooks_path, legacy));
     try t.expect(installCodex(t.allocator, home));
-    var pb2: [512]u8 = undefined;
-    const hooks = readFileAlloc(t.allocator, std.fmt.bufPrint(&pb2, "{s}/.codex/hooks.json", .{home}) catch unreachable, 64 * 1024).?;
+    const hooks = readFileAlloc(t.allocator, hooks_path, 64 * 1024).?;
     defer t.allocator.free(hooks);
     try t.expect(std.mem.indexOf(u8, hooks, "bubble stop codex") != null);
     try t.expect(std.mem.indexOf(u8, hooks, "PermissionRequest") != null);
     try t.expect(std.mem.indexOf(u8, hooks, "\"timeout\": 2") != null);
+    try t.expect(std.mem.indexOf(u8, hooks, "my-own-hook") != null);
+    try t.expect(std.mem.indexOf(u8, hooks, "petdex.js") == null);
     const toml_after = readFileAlloc(t.allocator, toml, 64 * 1024).?;
     defer t.allocator.free(toml_after);
     try t.expect(std.mem.indexOf(u8, toml_after, "hooks = true") != null);
@@ -546,6 +825,98 @@ test "CLAUDE_CONFIG_DIR redirects install, scan and uninstall" {
     try t.expectEqual(HookStatus.absent, blank[0].status);
 }
 
+test "installClaude removes only its command from a mixed hook group" {
+    const home = "/tmp/petdex-agenthooks-mixed-group-fixture";
+    plat.makeDir(home ++ "/.claude");
+    var path_buf: [512]u8 = undefined;
+    const config = std.fmt.bufPrint(&path_buf, "{s}/.claude/settings.json", .{home}) catch unreachable;
+    const mixed =
+        \\{"hooks":{"PreToolUse":[{"hooks":[
+        \\ {"type":"command","command":"my-own-hook"},
+        \\ {"type":"command","command":"node $HOME/.petdex/bin/petdex.js bubble pre claude-code"}
+        \\]}]}}
+    ;
+    try t.expect(writeFile(config, mixed));
+    try t.expect(installClaude(t.allocator, home));
+    const after = readFileAlloc(t.allocator, config, 64 * 1024).?;
+    defer t.allocator.free(after);
+    try t.expect(std.mem.indexOf(u8, after, "my-own-hook") != null);
+    try t.expect(std.mem.indexOf(u8, after, "petdex.js") == null);
+    try t.expect(std.mem.indexOf(u8, after, "petdex-hook") != null);
+}
+
+test "migration ignores similarly named user scripts" {
+    const home = "/tmp/petdex-agenthooks-user-script-fixture";
+    plat.makeDir(home ++ "/.claude");
+    var path_buf: [512]u8 = undefined;
+    const config = std.fmt.bufPrint(&path_buf, "{s}/.claude/settings.json", .{home}) catch unreachable;
+    const user_script =
+        \\{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"node $HOME/.petdex/bin/petdex.js-custom bubble pre claude-code"}]}]}}
+    ;
+    try t.expect(writeFile(config, user_script));
+    const migration = migrateLegacyHooks(t.allocator, home);
+    try t.expectEqual(@as(usize, 0), migration.migrated);
+    try t.expectEqual(@as(usize, 0), migration.failed);
+    const after = readFileAlloc(t.allocator, config, 64 * 1024).?;
+    defer t.allocator.free(after);
+    try t.expectEqualStrings(user_script, after);
+}
+
+test "migrateLegacyHooks rewrites recognized legacy configs at startup" {
+    const home = "/tmp/petdex-agenthooks-migrate-fixture";
+    plat.makeDir(home ++ "/.claude");
+    plat.makeDir(home ++ "/.codex");
+    plat.makeDir(home ++ "/.gemini");
+    var claude_path_buf: [512]u8 = undefined;
+    const claude = std.fmt.bufPrint(&claude_path_buf, "{s}/.claude/settings.json", .{home}) catch unreachable;
+    const legacy_claude =
+        \\{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"node $HOME/.petdex/bin/petdex.js bubble pre claude-code"}]}]}}
+    ;
+    try t.expect(writeFile(claude, legacy_claude));
+    var codex_path_buf: [512]u8 = undefined;
+    const codex = std.fmt.bufPrint(&codex_path_buf, "{s}/.codex/hooks.json", .{home}) catch unreachable;
+    const legacy_codex =
+        \\{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"T=\"$(cat $HOME/.petdex/runtime/update-token 2>/dev/null)\"; [ -n \"$T\" ] && curl -s -m 0.3 -X POST http://127.0.0.1:7777/state -H \"X-Petdex-Update-Token: $T\""}]}]}}
+    ;
+    try t.expect(writeFile(codex, legacy_codex));
+    var gemini_path_buf: [512]u8 = undefined;
+    const gemini = std.fmt.bufPrint(&gemini_path_buf, "{s}/.gemini/settings.json", .{home}) catch unreachable;
+    const legacy_gemini =
+        \\{"hooks":{"BeforeTool":[{"hooks":[{"type":"command","command":"node ${HOME}/.petdex/bin/petdex.js bubble pre gemini"}]}]}}
+    ;
+    try t.expect(writeFile(gemini, legacy_gemini));
+
+    const migration = migrateLegacyHooks(t.allocator, home);
+    try t.expectEqual(@as(usize, 3), migration.migrated);
+    try t.expectEqual(@as(usize, 0), migration.failed);
+
+    const claude_after = readFileAlloc(t.allocator, claude, 64 * 1024).?;
+    defer t.allocator.free(claude_after);
+    try t.expect(std.mem.indexOf(u8, claude_after, "petdex.js") == null);
+    try t.expect(std.mem.indexOf(u8, claude_after, "petdex-hook") != null);
+    const codex_after = readFileAlloc(t.allocator, codex, 64 * 1024).?;
+    defer t.allocator.free(codex_after);
+    try t.expect(std.mem.indexOf(u8, codex_after, "update-token") == null);
+    try t.expect(std.mem.indexOf(u8, codex_after, "petdex-hook") != null);
+    const gemini_after = readFileAlloc(t.allocator, gemini, 64 * 1024).?;
+    defer t.allocator.free(gemini_after);
+    try t.expect(std.mem.indexOf(u8, gemini_after, "petdex.js") == null);
+    try t.expect(std.mem.indexOf(u8, gemini_after, "petdex-hook") != null);
+}
+
+test "installJsonHooks refuses malformed configs without overwriting them" {
+    const home = "/tmp/petdex-agenthooks-invalid-json";
+    plat.makeDir(home ++ "/.claude");
+    var path_buf: [512]u8 = undefined;
+    const config = std.fmt.bufPrint(&path_buf, "{s}/.claude/settings.json", .{home}) catch unreachable;
+    const invalid = "{ invalid json";
+    try t.expect(writeFile(config, invalid));
+    try t.expect(!installClaude(t.allocator, home));
+    const after = readFileAlloc(t.allocator, config, 64 * 1024).?;
+    defer t.allocator.free(after);
+    try t.expectEqualStrings(invalid, after);
+}
+
 test "canonical command carries killswitch, symlink, phase and agent" {
     var buf: [512]u8 = undefined;
     const cmd = canonicalCommand(&buf, "pre", "claude-code").?;
@@ -568,9 +939,96 @@ test "installGemini enables hooks and uses a millisecond timeout" {
     try t.expect(std.mem.indexOf(u8, written, "\"keep\": true") != null);
 }
 
-test "toml feature detection" {
-    try t.expect(hasFeatureHooks("[features]\nhooks = true\n"));
-    try t.expect(hasFeatureHooks("[core]\nx=1\n[features]\nmemories = true\nhooks = true\n"));
-    try t.expect(!hasFeatureHooks("[features]\nmemories = true\n[other]\nhooks = true\n"));
-    try t.expect(!hasFeatureHooks("hooks = true\n"));
+test "legacy curl migration requires the complete Petdex command signature" {
+    const command = "T=\"$(cat $HOME/.petdex/runtime/update-token 2>/dev/null)\"; [ -n \"$T\" ] && curl -s -m 0.3 -X POST http://127.0.0.1:7777/state -H \"X-Petdex-Update-Token: $T\"";
+    try t.expectEqual(ManagedHookGeneration.legacy, commandGeneration(command));
+    try t.expectEqual(ManagedHookGeneration.none, commandGeneration("curl -H \"X-Petdex-Update-Token: $T\" http://127.0.0.1:7777/state"));
+    try t.expectEqual(ManagedHookGeneration.none, commandGeneration("cat $HOME/.petdex/runtime/update-token; curl http://127.0.0.1:7777/other -H \"X-Petdex-Update-Token: $T\""));
+}
+
+test "command path detection requires both boundaries" {
+    try t.expectEqual(ManagedHookGeneration.legacy, commandGeneration("node $HOME/.petdex/bin/petdex.js bubble pre codex"));
+    try t.expectEqual(ManagedHookGeneration.legacy, commandGeneration("node ${HOME}/.petdex/bin/petdex.js bubble pre codex"));
+    try t.expectEqual(ManagedHookGeneration.none, commandGeneration("node $HOME/.petdex/bin/petdex.js-custom bubble pre codex"));
+    try t.expectEqual(ManagedHookGeneration.none, commandGeneration("node /tmp/.petdex/bin/petdex.js bubble pre codex"));
+    try t.expectEqual(ManagedHookGeneration.none, commandGeneration("node /tmp/not-petdex/bin/petdex.js bubble pre codex"));
+    try t.expectEqual(ManagedHookGeneration.none, commandGeneration("node $HOME/.petdex/bin/petdex.js status"));
+}
+
+test "codex feature inspection is section-aware and conservative" {
+    try t.expectEqual(FeatureHooksState.enabled, inspectFeatureHooks("[features]\nhooks = true # keep\n").state);
+    try t.expectEqual(FeatureHooksState.replace_line, inspectFeatureHooks("[features]\nhooks = false\n").state);
+    try t.expectEqual(FeatureHooksState.insert_after_features, inspectFeatureHooks("[features]\nmemories = true\n").state);
+    try t.expectEqual(FeatureHooksState.append_features, inspectFeatureHooks("[other]\nhooks = true\n").state);
+    try t.expectEqual(FeatureHooksState.unsafe, inspectFeatureHooks("[features]\nhooks =\n").state);
+    try t.expectEqual(FeatureHooksState.unsafe, inspectFeatureHooks("[features]\nhooks = true\nhooks = false\n").state);
+    try t.expectEqual(FeatureHooksState.unsafe, inspectFeatureHooks("[features]\nhooks = true\n[features]\n").state);
+    try t.expectEqual(FeatureHooksState.unsafe, inspectFeatureHooks("[features\nhooks = true\n").state);
+    try t.expectEqual(FeatureHooksState.unsafe, inspectFeatureHooks("[features.extra]\nvalue = true\n").state);
+    try t.expectEqual(FeatureHooksState.unsafe, inspectFeatureHooks("features.hooks = true\n").state);
+    try t.expectEqual(FeatureHooksState.unsafe, inspectFeatureHooks("features = { hooks = true }\n").state);
+}
+
+test "installCodex replaces a false feature flag without duplicating it" {
+    const home = "/tmp/petdex-agenthooks-codex-false-feature";
+    plat.makeDir(home ++ "/.codex");
+    var path_buf: [512]u8 = undefined;
+    const toml = std.fmt.bufPrint(&path_buf, "{s}/.codex/config.toml", .{home}) catch unreachable;
+    try t.expect(writeFile(toml, "[features]\nhooks = false # previous value\n"));
+    try t.expect(installCodex(t.allocator, home));
+    const after = readFileAlloc(t.allocator, toml, 64 * 1024).?;
+    defer t.allocator.free(after);
+    try t.expectEqual(@as(usize, 1), std.mem.count(u8, after, "hooks ="));
+    try t.expect(std.mem.indexOf(u8, after, "hooks = true # previous value") != null);
+}
+
+test "installCodex does not update hooks when its feature config is unsafe" {
+    const home = "/tmp/petdex-agenthooks-codex-unsafe-feature";
+    plat.makeDir(home ++ "/.codex");
+    var path_buf: [512]u8 = undefined;
+    const toml = std.fmt.bufPrint(&path_buf, "{s}/.codex/config.toml", .{home}) catch unreachable;
+    try t.expect(writeFile(toml, "[features]\nhooks =\n"));
+    var hooks_path_buf: [512]u8 = undefined;
+    const hooks = std.fmt.bufPrint(&hooks_path_buf, "{s}/.codex/hooks.json", .{home}) catch unreachable;
+    const legacy = "{\"hooks\":{\"PreToolUse\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"node $HOME/.petdex/bin/petdex.js bubble pre codex\"}]}]}}";
+    try t.expect(writeFile(hooks, legacy));
+    try t.expect(!installCodex(t.allocator, home));
+    const after = readFileAlloc(t.allocator, hooks, 64 * 1024).?;
+    defer t.allocator.free(after);
+    try t.expectEqualStrings(legacy, after);
+}
+
+test "installCodex does not update its feature config when hooks json is malformed" {
+    const home = "/tmp/petdex-agenthooks-codex-invalid-hooks";
+    plat.makeDir(home ++ "/.codex");
+    var path_buf: [512]u8 = undefined;
+    const toml = std.fmt.bufPrint(&path_buf, "{s}/.codex/config.toml", .{home}) catch unreachable;
+    const toml_before = "[features]\nhooks = false\n";
+    try t.expect(writeFile(toml, toml_before));
+    var hooks_path_buf: [512]u8 = undefined;
+    const hooks = std.fmt.bufPrint(&hooks_path_buf, "{s}/.codex/hooks.json", .{home}) catch unreachable;
+    try t.expect(writeFile(hooks, "{ invalid json"));
+    try t.expect(!installCodex(t.allocator, home));
+    const after = readFileAlloc(t.allocator, toml, 64 * 1024).?;
+    defer t.allocator.free(after);
+    try t.expectEqualStrings(toml_before, after);
+}
+
+test "uninstallCodex preserves foreign hooks in a mixed config" {
+    const home = "/tmp/petdex-agenthooks-codex-uninstall-fixture";
+    plat.makeDir(home ++ "/.codex");
+    var hooks_path_buf: [512]u8 = undefined;
+    const hooks = std.fmt.bufPrint(&hooks_path_buf, "{s}/.codex/hooks.json", .{home}) catch unreachable;
+    const mixed =
+        \\{"hooks":{"PreToolUse":[{"hooks":[
+        \\ {"type":"command","command":"my-own-hook"},
+        \\ {"type":"command","command":"node $HOME/.petdex/bin/petdex.js bubble pre codex"}
+        \\]}]}}
+    ;
+    try t.expect(writeFile(hooks, mixed));
+    try t.expect(uninstall(t.allocator, home, .codex));
+    const after = readFileAlloc(t.allocator, hooks, 64 * 1024).?;
+    defer t.allocator.free(after);
+    try t.expect(std.mem.indexOf(u8, after, "my-own-hook") != null);
+    try t.expect(std.mem.indexOf(u8, after, "petdex.js") == null);
 }

--- a/packages/petdex-desktop-native/src/hook_runner.zig
+++ b/packages/petdex-desktop-native/src/hook_runner.zig
@@ -22,22 +22,27 @@ const title_max = 60;
 const preview_max = 110;
 const transcript_tail_cap = 64 * 1024;
 const session_ttl_secs: i64 = 24 * 60 * 60;
+const post_timeout_ms: u64 = 300;
+const post_poll_ms: u64 = 5;
 
 // ------------------------------------------------------------- entry
 
 /// argv tail after "bubble": [phase, agent?]. Reads stdin, formats,
 /// POSTs bubble + state to the sidecar. Never fails outward.
 pub fn run(phase: []const u8, arg_agent: ?[]const u8, home: []const u8) void {
+    // Always finish consuming the host's payload before any early return.
+    // The host may still be writing after the useful 64 KiB prefix, and
+    // closing the read end early propagates EPIPE/Broken pipe to the agent.
+    var stdin_buf: [stdin_cap]u8 = undefined;
+    const payload = readStdin(&stdin_buf);
+
     var path_buf: [512]u8 = undefined;
     var probe: [1]u8 = undefined;
 
-    // Killswitch first: one stat, minimal cost when disabled.
+    // Killswitch remains a cheap no-op after the mandatory stdin drain.
     if (std.fmt.bufPrint(&path_buf, "{s}/.petdex/runtime/hooks-disabled", .{home})) |ks| {
         if (cReadFile(ks, &probe) != null) return;
     } else |_| {}
-
-    var stdin_buf: [stdin_cap]u8 = undefined;
-    const payload = readStdin(&stdin_buf);
 
     var token_buf: [128]u8 = undefined;
     const token_raw = blk: {
@@ -85,18 +90,31 @@ pub fn run(phase: []const u8, arg_agent: ?[]const u8, home: []const u8) void {
     const busy = isPromptPhase(phase) or std.mem.eql(u8, phase, "pre") or std.mem.eql(u8, phase, "post");
     const state = stateForEvent(phase, jsonString(payload, "tool_name"));
 
+    var posts: [2]PostJob = undefined;
+    var post_count: usize = 0;
     var body_buf: [1024]u8 = undefined;
     if (text.len > 0) {
         const body = if (title.len > 0)
             std.fmt.bufPrint(&body_buf, "{{\"text\":\"{s}\",\"title\":\"{s}\",\"busy\":{},\"agent_source\":\"{s}\"}}", .{ text, title, busy, agent }) catch null
         else
             std.fmt.bufPrint(&body_buf, "{{\"text\":\"{s}\",\"busy\":{},\"agent_source\":\"{s}\"}}", .{ text, busy, agent }) catch null;
-        if (body) |b| postLocalhost("/bubble", b, token);
+        if (body) |b| {
+            if (startPost("/bubble", b, token)) |post| {
+                posts[post_count] = post;
+                post_count += 1;
+            }
+        }
     }
     if (state) |s| {
         const body = std.fmt.bufPrint(&body_buf, "{{\"state\":\"{s}\",\"agent_source\":\"{s}\"}}", .{ s, agent }) catch null;
-        if (body) |b| postLocalhost("/state", b, token);
+        if (body) |b| {
+            if (startPost("/state", b, token)) |post| {
+                posts[post_count] = post;
+                post_count += 1;
+            }
+        }
     }
+    waitForPosts(posts[0..post_count]);
 }
 
 fn isPromptPhase(phase: []const u8) bool {
@@ -414,9 +432,82 @@ fn cWriteFile(path: []const u8, bytes: []const u8) void {
     _ = plat.writeFile(path, bytes);
 }
 
-/// Minimal HTTP POST to the sidecar. Fire, read a token of response,
-/// close. A dead sidecar is connection refused — silent, like today.
-fn postLocalhost(path: []const u8, body: []const u8, token: []const u8) void {
+const PostTask = struct {
+    done: std.atomic.Value(bool) = .init(false),
+    path: [16]u8 = undefined,
+    path_len: usize = 0,
+    body: [1024]u8 = undefined,
+    body_len: usize = 0,
+    token: [128]u8 = undefined,
+    token_len: usize = 0,
+
+    fn run(self: *PostTask) void {
+        postLocalhostBlocking(
+            self.path[0..self.path_len],
+            self.body[0..self.body_len],
+            self.token[0..self.token_len],
+        );
+        self.done.store(true, .release);
+    }
+};
+
+const PostJob = struct {
+    task: *PostTask,
+    thread: std.Thread,
+};
+
+/// Start a localhost POST on a private worker. Every byte is copied into the
+/// task so the worker remains valid even when the hook's stack frame returns.
+fn startPost(path: []const u8, body: []const u8, token: []const u8) ?PostJob {
+    if (path.len > 16 or body.len > 1024 or token.len > 128) return null;
+    const task = std.heap.page_allocator.create(PostTask) catch return null;
+    task.* = .{};
+    @memcpy(task.path[0..path.len], path);
+    task.path_len = path.len;
+    @memcpy(task.body[0..body.len], body);
+    task.body_len = body.len;
+    @memcpy(task.token[0..token.len], token);
+    task.token_len = token.len;
+    const thread = std.Thread.spawn(.{}, PostTask.run, .{task}) catch {
+        std.heap.page_allocator.destroy(task);
+        return null;
+    };
+    return .{ .task = task, .thread = thread };
+}
+
+/// The hook waits for both localhost requests together, never for more than
+/// 300ms. A stalled loopback socket cannot hold an agent session hostage.
+/// Timed-out jobs intentionally retain their small task allocation until the
+/// short-lived runner process exits; freeing it here would race the worker.
+fn waitForPosts(posts: []PostJob) void {
+    if (posts.len == 0) return;
+    const polls = post_timeout_ms / post_poll_ms;
+    var scope = plat.Scope.init();
+    defer scope.deinit();
+    for (0..polls) |_| {
+        var all_done = true;
+        for (posts) |post| {
+            if (!post.task.done.load(.acquire)) {
+                all_done = false;
+                break;
+            }
+        }
+        if (all_done) break;
+        std.Io.sleep(scope.io(), std.Io.Duration.fromMilliseconds(post_poll_ms), .awake) catch {};
+    }
+    for (posts) |*post| {
+        if (post.task.done.load(.acquire)) {
+            post.thread.join();
+            std.heap.page_allocator.destroy(post.task);
+        } else {
+            post.thread.detach();
+        }
+    }
+}
+
+/// Minimal HTTP POST to the sidecar. The caller owns the deadline; this
+/// worker only flushes a small request and never waits for a response.
+fn postLocalhostBlocking(path: []const u8, body: []const u8, token: []const u8) void {
     var scope = plat.Scope.init();
     defer scope.deinit();
     const io = scope.io();
@@ -424,9 +515,9 @@ fn postLocalhost(path: []const u8, body: []const u8, token: []const u8) void {
     // No .timeout here: Zig 0.16 panics on it (netConnectIpPosix and
     // netConnectIpWindows are both "TODO implement ... with timeout"),
     // and a panic in the runner is the one thing this binary must never
-    // do to an agent. The old 300ms SO_RCVTIMEO/SO_SNDTIMEO bound is
-    // therefore gone; the target is loopback, so connect either wins
-    // immediately or fails with connection refused when no app listens.
+    // do to an agent. The caller's worker deadline is the timeout boundary;
+    // the target is loopback, so connect either wins immediately or fails
+    // with connection refused when no app listens.
     var stream = addr.connect(io, .{ .mode = .stream, .protocol = .tcp }) catch return;
     defer stream.close(io);
     var req_buf: [1600]u8 = undefined;
@@ -435,12 +526,6 @@ fn postLocalhost(path: []const u8, body: []const u8, token: []const u8) void {
     var writer = stream.writer(io, &write_buf);
     writer.interface.writeAll(req) catch return;
     writer.interface.flush() catch return;
-    // Drain a token of the reply so the server sees an orderly close;
-    // the runner never inspects it (every failure exits 0 silently).
-    var read_buf: [256]u8 = undefined;
-    var reader = stream.reader(io, &read_buf);
-    var resp: [256]u8 = undefined;
-    _ = reader.interface.readSliceShort(&resp) catch {};
 }
 
 // ------------------------------------------------------------ parity

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -1294,6 +1294,13 @@ fn applyState(model: *Model, state: State, duration_ms: u32, fx: *Effects) void 
 
 pub fn boot(model: *Model, fx: *Effects) void {
     if (env_home) |home| {
+        // Upgrade old CLI-written hooks before any agent starts another
+        // session. The migration recognizes only Petdex-owned legacy
+        // commands and leaves malformed or foreign configs untouched.
+        const migration = agent_hooks.migrateLegacyHooks(boot_allocator, home);
+        if (migration.failed > 0) {
+            std.debug.print("petdex: {d} legacy hook configuration(s) could not be migrated; repair the config and update the affected agent in Settings\n", .{migration.failed});
+        }
         hook_server.start(boot_allocator, home) catch |err| {
             std.debug.print("petdex: hook server failed to start ({s})\n", .{@errorName(err)});
         };

--- a/packages/petdex-desktop-native/src/plat.zig
+++ b/packages/petdex-desktop-native/src/plat.zig
@@ -197,13 +197,43 @@ pub fn readStdin(buf: []u8) []const u8 {
     const io = scope.io();
     var read_buf: [4096]u8 = undefined;
     var reader = std.Io.File.stdin().reader(io, &read_buf);
+    return readCappedAndDrain(&reader.interface, buf);
+}
+
+/// Keep the first `buf.len` bytes but drain the rest of the pipe. Hook
+/// hosts can still be writing a large payload after the useful prefix; an
+/// early close makes their writer see EPIPE/Broken pipe.
+fn readCappedAndDrain(reader: anytype, buf: []u8) []const u8 {
     var total: usize = 0;
-    while (total < buf.len) {
-        const n = reader.interface.readSliceShort(buf[total..]) catch break;
+    var discard: [4096]u8 = undefined;
+    while (true) {
+        const target = if (total < buf.len) buf[total..] else &discard;
+        const n = reader.readSliceShort(target) catch break;
         if (n == 0) break;
-        total += n;
+        if (total < buf.len) total += n;
     }
     return buf[0..total];
+}
+
+test "readCappedAndDrain keeps the cap and consumes the source" {
+    const Source = struct {
+        bytes: []const u8,
+        offset: usize = 0,
+
+        fn readSliceShort(self: *@This(), out: []u8) !usize {
+            if (self.offset >= self.bytes.len) return 0;
+            const n = @min(out.len, self.bytes.len - self.offset);
+            @memcpy(out[0..n], self.bytes[self.offset .. self.offset + n]);
+            self.offset += n;
+            return n;
+        }
+    };
+
+    var source = Source{ .bytes = "0123456789" };
+    var kept: [4]u8 = undefined;
+    const captured = readCappedAndDrain(&source, &kept);
+    try std.testing.expectEqualStrings("0123", captured);
+    try std.testing.expectEqual(source.bytes.len, source.offset);
 }
 
 // ------------------------------------------------------------------ clock


### PR DESCRIPTION
## 概要

关联 #582。

修复 Petdex CLI 与原生 desktop Bubble Hook 在宿主持续写入、大输入、早退及 localhost 无响应场景下可能出现的 `EPIPE` / `Broken pipe` 和长时间阻塞。

同时补齐升级路径：已安装旧版 CLI Hook 的用户启动新版 desktop 后，会自动迁移明确识别的旧 Petdex Hook，不需要手动打开设置页再次更新。

## 根因

- Hook 宿主会向子进程 stdin 写入完整 JSON。若 Hook 在宿主写完前退出、暂停读取或移除监听器，宿主继续写入会收到 `EPIPE` / `Broken pipe`。
- CLI 旧实现曾通过内部定时器提前结束读取；原生 runner 也在读取 stdin 前检查 killswitch 和 token，并在保留 64 KiB 后停止消费剩余输入。
- 原生 localhost 投递等待响应时，接受连接但不返回响应的服务可能拖住 Hook。
- 已升级 desktop 的用户仍可能保留旧 CLI 写入的 Node runner 或 token/curl Hook，因此仅更新运行器无法覆盖实际热路径。
- 旧的 Codex 安装逻辑假设 `hooks.json` 完全由 Petdex 管理，可能覆盖用户自定义 Hook。

## 修复

- CLI runner 仅按字节复制并保留 stdin 前 64 KiB，继续排空剩余输入至 EOF 或输入错误；解码前移除截断边界处不完整的 UTF-8 字节。
- 原生 runner 在 killswitch、token 和事件判断前无条件排空 stdin，仅保留前 64 KiB 供解析。
- shell Hook 在禁用或 runner 缺失时，对非 TTY stdin 执行排空后再退出。
- 原生 `/bubble` 与 `/state` 使用独立 worker 并行投递；不等待 HTTP 响应，localhost 投递阶段共同受约 300ms 等待上限约束。
- Codex 和 Claude Code 写入 `timeout: 2`；Gemini 写入 `timeout: 2000` 并确保 `hooksConfig.enabled: true`。
- desktop 启动时仅识别具有完整 Petdex 所有权特征的旧 Node runner 或 token/curl 命令，并迁移 Claude Code、Codex、Gemini CLI 到当前 `petdex-hook` runner。OpenCode 不走子进程 stdin 路径，保持原有显式更新行为。
- 安装、迁移和卸载均按 Hook 条目合并：保留用户自定义 Hook 和混合 Hook 组，只替换或移除 Petdex 自己的命令。
- JSON 无法安全读取或解析、TOML 结构不明确、重复或使用不支持的嵌套形式时拒绝自动覆盖。Codex 会先预检两份配置，先替换旧 Hook，再启用功能开关；已存在配置在写入前保留一次备份。

## 验证

- `bun test --timeout 60000`：73 通过，0 失败。
- `bun run build && bun run typecheck`。
- `bun run check`。
- 原生测试：`native test` 的 9/9 构建步骤成功。
- 原生 ReleaseFast：`native build` 成功。
- `zig test src/agent_hooks.zig`：17 通过，覆盖旧配置迁移、混合 Hook 保留、误识别拒绝、无效 JSON、Codex TOML 保护和卸载保留。
- 向禁用和缺 token 的原生 Hook 写入 8 MiB stdin，写入端与 Hook 均退出 0。
- `git diff --check`。