### PR TITLE
feat(cli): honor CLAUDE_CONFIG_DIR when wiring Claude Code hooks

### DIFF
--- a/packages/petdex-cli/src/hooks/agents.test.ts
+++ b/packages/petdex-cli/src/hooks/agents.test.ts
@@ -9,6 +9,7 @@ import {
   antigravityMcpConfigPath,
   applyCodexHooksFix,
   inspectFeaturesCodexHooks,
+  resolveClaudeConfigDir,
   resolveOpenCodeConfigDir,
   SIDECAR_URL,
 } from "./agents";
@@ -334,6 +335,23 @@ describe("OpenCode hook plugin", () => {
     );
     expect(source).toContain(
       `notify({ state: "failed", duration: 2500, text: "OpenCode hit an error." })`,
+    );
+  });
+});
+
+describe("Claude Code config path resolution", () => {
+  test("prefers CLAUDE_CONFIG_DIR", () => {
+    expect(
+      resolveClaudeConfigDir(
+        { CLAUDE_CONFIG_DIR: "/tmp/claude-work" },
+        "/home/example",
+      ),
+    ).toBe("/tmp/claude-work");
+  });
+
+  test("falls back to ~/.claude", () => {
+    expect(resolveClaudeConfigDir({}, "/home/example")).toBe(
+      "/home/example/.claude",
     );
   });
 });

--- a/packages/petdex-cli/src/hooks/agents.ts
+++ b/packages/petdex-cli/src/hooks/agents.ts
@@ -95,7 +95,26 @@ export type Agent = {
 };
 
 const HOME = homedir();
+const CLAUDE_CONFIG_DIR = resolveClaudeConfigDir();
 const OPENCODE_CONFIG_DIR = resolveOpenCodeConfigDir();
+
+/**
+ * Claude Code keeps everything under ~/.claude unless CLAUDE_CONFIG_DIR
+ * points elsewhere — that env var is how people run several fully
+ * isolated Claude Code installs (separate settings, separate accounts)
+ * on one machine. Honoring it here means
+ * `CLAUDE_CONFIG_DIR=~/.claude-work petdex hooks install` wires the
+ * instance the user actually launches instead of always the default
+ * one; detection, refresh, and uninstall all flow through the same
+ * resolved dir.
+ */
+export function resolveClaudeConfigDir(
+  env: NodeJS.ProcessEnv = process.env,
+  home = HOME,
+): string {
+  if (env.CLAUDE_CONFIG_DIR) return env.CLAUDE_CONFIG_DIR;
+  return path.join(home, ".claude");
+}
 
 export function resolveOpenCodeConfigDir(
   env: NodeJS.ProcessEnv = process.env,
@@ -180,9 +199,9 @@ export const AGENTS: Agent[] = [
   {
     id: "claude-code",
     displayName: "Claude Code",
-    configDir: path.join(HOME, ".claude"),
-    configFile: path.join(HOME, ".claude", "settings.json"),
-    slashCommandPath: path.join(HOME, ".claude", "commands", "petdex.md"),
+    configDir: CLAUDE_CONFIG_DIR,
+    configFile: path.join(CLAUDE_CONFIG_DIR, "settings.json"),
+    slashCommandPath: path.join(CLAUDE_CONFIG_DIR, "commands", "petdex.md"),
     docsUrl: "https://docs.anthropic.com/en/docs/claude-code/hooks",
     hookEntries: [
       { event: "UserPromptSubmit", kind: "user.prompt" },


### PR DESCRIPTION
## Problem

Claude Code supports fully isolated side-by-side installs through `CLAUDE_CONFIG_DIR` — separate settings, separate slash commands, even separate logged-in accounts. The agent registry hardcodes `~/.claude`, so `petdex hooks install` always detects and writes the default instance. If the Claude Code you actually launch runs from a non-default config dir, its `settings.json` never gets the hooks and the pet just sits there; there is no flag or env var to point petdex at the right place.

## Fix

`resolveClaudeConfigDir(env, home)`: prefer `CLAUDE_CONFIG_DIR`, fall back to `~/.claude` — the exact shape of the existing `resolveOpenCodeConfigDir` (which already honors `OPENCODE_CONFIG_DIR` for the same reason). `configDir`, `configFile`, and `slashCommandPath` in the `claude-code` registry entry all derive from the resolved dir, so detection, install, refresh, and uninstall follow the same instance with no other call-site changes.

Wiring more than one instance is just one run per instance:

```bash
petdex hooks install                                    # default ~/.claude
CLAUDE_CONFIG_DIR=~/.claude-work petdex hooks install   # isolated work install
```

All instances then drive the same mascot through the shared sidecar, which already merges hook traffic from multiple agents.

## Verification

- `bun test` in `packages/petdex-cli`: 180 pass, including two new resolution tests mirroring the OpenCode ones
- `bun run build && bun run typecheck` in `packages/petdex-cli`: clean
- `bun run check` at root: clean
- Manual: importing `AGENTS` with `CLAUDE_CONFIG_DIR=/tmp/claude-b` yields `/tmp/claude-b/settings.json` + `/tmp/claude-b/commands/petdex.md`; unset falls back to `~/.claude`
