### PR TITLE
fix(cli): make Claude Code hooks work on Windows via exec form

### DIFF
--- a/packages/petdex-cli/bin/petdex.ts
+++ b/packages/petdex-cli/bin/petdex.ts
@@ -1411,7 +1411,30 @@ async function cmdHooks(args: string[]) {
   }
   switch (sub) {
     case "install": {
-      const { installedAgents } = await runHooksInstall();
+      // Non-interactive selection: `--agents claude-code,codex` or
+      // repeated `--agent <id>`. Lets Windows/CI wire hooks without a
+      // TTY (the interactive multiselect blocks on EOF there).
+      const agentFlag = args.find((a) => a.startsWith("--agents="));
+      let agents: string[] | undefined;
+      if (agentFlag) {
+        agents = agentFlag
+          .slice("--agents=".length)
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean);
+      } else {
+        const idx = args.indexOf("--agents");
+        const idx2 = idx === -1 ? args.indexOf("--agent") : idx;
+        if (idx2 !== -1 && args[idx2 + 1]) {
+          agents = args[idx2 + 1]
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean);
+        }
+      }
+      const { installedAgents } = await runHooksInstall(
+        agents ? { agents } : {},
+      );
       // Only emit success when at least one agent was actually written.
       // Cancelled/no-op runs return an empty array; counting those as
       // success makes the dashboard "agents wired up" funnel lie.

--- a/packages/petdex-cli/src/hooks/agents.ts
+++ b/packages/petdex-cli/src/hooks/agents.ts
@@ -202,15 +202,7 @@ export const AGENTS: Agent[] = [
           UserPromptSubmit: [
             {
               hooks: [
-                {
-                  type: "command",
-                  command: bubbleHookCommand(
-                    "claude-code",
-                    "user-prompt",
-                    "jumping",
-                    800,
-                  ),
-                },
+                bubbleHookAction("claude-code", "user-prompt", "jumping", 800),
               ],
             },
           ],
@@ -221,51 +213,24 @@ export const AGENTS: Agent[] = [
             // file compact and removes a maintenance trap (matcher
             // drift between agents.ts and bubble-runner.ts).
             {
-              hooks: [
-                {
-                  type: "command",
-                  command: bubbleHookCommand("claude-code", "pre", "running"),
-                },
-              ],
+              hooks: [bubbleHookAction("claude-code", "pre", "running")],
             },
           ],
           PostToolUse: [
             {
-              hooks: [
-                {
-                  type: "command",
-                  command: bubbleHookCommand("claude-code", "post", "idle"),
-                },
-              ],
+              hooks: [bubbleHookAction("claude-code", "post", "idle")],
             },
           ],
           Notification: [
             {
               hooks: [
-                {
-                  type: "command",
-                  command: bubbleHookCommand(
-                    "claude-code",
-                    "notification",
-                    "waiting",
-                  ),
-                },
+                bubbleHookAction("claude-code", "notification", "waiting"),
               ],
             },
           ],
           Stop: [
             {
-              hooks: [
-                {
-                  type: "command",
-                  command: bubbleHookCommand(
-                    "claude-code",
-                    "stop",
-                    "waving",
-                    1500,
-                  ),
-                },
-              ],
+              hooks: [bubbleHookAction("claude-code", "stop", "waving", 1500)],
             },
           ],
         },
@@ -573,6 +538,48 @@ export const AGENTS: Agent[] = [
  * Both branches share the killswitch + token-gate envelope of the
  * original curlCommand, so agent UIs stay clean.
  */
+/**
+ * Build a single hook action object for one phase.
+ *
+ * POSIX (macOS/Linux): emit the shell snippet from bubbleHookCommand —
+ * the shell checks the killswitch, prefers the persisted node binary,
+ * and falls back to raw curl when that binary is missing.
+ *
+ * Windows: there is no guaranteed POSIX shell. Claude Code runs hooks
+ * through Git Bash when it is installed but PowerShell otherwise, and the
+ * POSIX snippet ("[ -f ... ]; if [ -x ... ]; then ...; fi", "$HOME") is
+ * not portable across both. Instead we use Claude Code's "exec form"
+ * ({ command, args }), which runs node directly with NO shell involved.
+ * stdin is still piped, so runBubble drains the hook payload exactly as on
+ * POSIX, and the killswitch is honored inside runBubble itself
+ * (bubble-runner.ts checks hooks-disabled before doing any work). The only
+ * behavior dropped on Windows is the curl fallback for a missing persisted
+ * binary, which cannot happen right after `init` persists it.
+ */
+function bubbleHookAction(
+  agentId: Agent["id"],
+  phase: string,
+  fallbackState: PetState,
+  fallbackDuration?: number,
+): Record<string, unknown> {
+  if (process.platform === "win32") {
+    return {
+      type: "command",
+      command: "node",
+      args: [
+        path.join(HOME, ".petdex", "bin", "petdex.js"),
+        "bubble",
+        phase,
+        agentId,
+      ],
+    };
+  }
+  return {
+    type: "command",
+    command: bubbleHookCommand(agentId, phase, fallbackState, fallbackDuration),
+  };
+}
+
 function bubbleHookCommand(
   agentId: Agent["id"],
   phase: string,

--- a/packages/petdex-cli/src/hooks/install.ts
+++ b/packages/petdex-cli/src/hooks/install.ts
@@ -63,7 +63,9 @@ export type HooksInstallResult = {
   installedAgents: string[];
 };
 
-export async function runInstall(): Promise<HooksInstallResult> {
+export async function runInstall(
+  opts: { agents?: string[] } = {},
+): Promise<HooksInstallResult> {
   p.intro(pc.bgMagenta(pc.white(" petdex hooks install ")));
 
   // Snapshot the running petdex binary to a known path so hooks can
@@ -99,16 +101,34 @@ export async function runInstall(): Promise<HooksInstallResult> {
     console.log(`   ${badge} ${pc.bold(agent.displayName)}  ${label}`);
   }
 
-  const selected = await p.multiselect<string>({
-    message: "Which agents should drive the mascot?",
-    options: detections.map(({ agent, installed }) => ({
-      value: agent.id,
-      label: agent.displayName,
-      hint: installed ? "installed" : "not installed yet",
-    })),
-    initialValues: detections.filter((d) => d.installed).map((d) => d.agent.id),
-    required: false,
-  });
+  // Non-interactive path: when caller passes an explicit agent list
+  // (e.g. `petdex hooks install --agents claude-code`), skip the
+  // multiselect entirely. Required on Windows/CI where there is no TTY
+  // and @clack/prompts would block on EOF. Unknown ids are dropped with
+  // a warning rather than failing the whole run.
+  let selected: string[] | symbol;
+  if (opts.agents && opts.agents.length > 0) {
+    const known = new Set<string>(AGENTS.map((a) => a.id));
+    const valid = opts.agents.filter((id) => known.has(id));
+    const unknown = opts.agents.filter((id) => !known.has(id));
+    if (unknown.length > 0) {
+      p.log.warn(`Ignoring unknown agent id(s): ${unknown.join(", ")}`);
+    }
+    selected = valid;
+  } else {
+    selected = await p.multiselect<string>({
+      message: "Which agents should drive the mascot?",
+      options: detections.map(({ agent, installed }) => ({
+        value: agent.id,
+        label: agent.displayName,
+        hint: installed ? "installed" : "not installed yet",
+      })),
+      initialValues: detections
+        .filter((d) => d.installed)
+        .map((d) => d.agent.id),
+      required: false,
+    });
+  }
 
   if (p.isCancel(selected) || selected.length === 0) {
     p.cancel("No agents selected. Bye.");


### PR DESCRIPTION
## Problem

On Windows, `petdex init` / `petdex hooks install` wires up Claude Code but the hooks don't work.

`bubbleHookCommand()` (in `src/hooks/agents.ts`) emits a **POSIX shell** snippet that gets written verbatim into `~/.claude/settings.json`:

```sh
[ -f "$HOME/.petdex/runtime/hooks-disabled" ] && exit 0; if [ -x "$HOME/.petdex/bin/petdex.js" ]...; then node ...; else curl ...; fi
```

Per the [Claude Code hooks docs](https://code.claude.com/docs/en/hooks.md), on Windows a `"type": "command"` hook runs through **Git Bash** when Git for Windows is installed, but falls back to **PowerShell** otherwise. `[ -f ]`, `if [ -x ]; then…fi`, and `$HOME` aren't portable across both, so hooks error out.

## Fix

Add `bubbleHookAction()`. On `win32` it emits Claude Code's **exec form** instead of a shell string:

```jsonc
{ "type": "command", "command": "node",
  "args": ["C:\Users\<you>\.petdex\bin\petdex.js", "bubble", "pre", "claude-code"] }
```

Exec form runs `node` directly with **no shell involved**, so there's nothing to be POSIX/PowerShell-incompatible. This is safe because:

- **stdin is still piped** → `runBubble` drains the hook payload exactly as before.
- **the killswitch still works** → `runBubble` already checks `hooks-disabled` first (`bubble-runner.ts`), so the shell-level check was redundant.
- **the path is native** → `path.join(homedir(), ...)`.

POSIX platforms keep the existing shell snippet unchanged. Scoped to the `claude-code` agent only; other agents are untouched.

The one behavior dropped on Windows is the raw-`curl` fallback for a missing persisted binary — which can't happen immediately after `init` persists it.

## Also: non-interactive install

Added a `--agents <id[,id]>` flag to `petdex hooks install`:

```bash
petdex hooks install --agents claude-code
```

The interactive `@clack` multiselect blocks on EOF in a non-TTY (Windows terminals, CI), so there was no way to wire hooks headlessly. The flag skips the prompt; the interactive path is unchanged when the flag is absent.

## Testing

- `bun run build && bun run typecheck` — clean
- `bunx biome check` on changed files — clean
- Installed on Windows 11 (Claude Code): desktop `win32-x64` binary launches, `hooks install --agents claude-code` writes exec-form hooks, and firing each hook returns exit 0. Verified the pet state transitions end-to-end (`jumping` → `waving`) with the sidecar logging `source=claude-code`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)