### PR TITLE
chore(desktop): actually run the native test suite — root aggregator + CI step

### DIFF
--- a/.github/workflows/desktop-native-ci.yml
+++ b/.github/workflows/desktop-native-ci.yml
@@ -136,6 +136,22 @@ jobs:
           "$NATIVE_CLI" build
           ls -lh zig-out/bin/
 
+      - name: Run the test suite
+        # The suite ran on nobody's machine until the root aggregator
+        # existed: `zig build test` collects tests from the root module
+        # file only, so the imported files' tests (agent_hooks' config
+        # merging, hook_runner's payload parsing, installer's URL
+        # checks) compiled green and never executed — and CI had no
+        # test step to notice. Unix legs only for now: the fixture
+        # tests write under /tmp by absolute POSIX path, which Windows
+        # has no equivalent for until the fixtures learn a portable
+        # temp dir.
+        if: matrix.platform != 'windows'
+        working-directory: packages/petdex-desktop-native
+        shell: bash
+        run: |
+          "$NATIVE_CLI" test .
+
       # Compiling proves nothing about whether the app draws: the hook
       # server regression that shipped in this branch compiled fine on
       # every platform. These steps run the binary, exercise the hook

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -2252,3 +2252,17 @@ test "waiting chime fires only on the transition into waiting" {
     try std.testing.expect(!shouldChime(.waiting, .idle));
     try std.testing.expect(!shouldChime(.running, .idle));
 }
+
+test {
+    // `zig build test` only collects tests from the root module FILE,
+    // and imports are analyzed lazily — so without these references
+    // every test in the imported files (18 today, across agent_hooks,
+    // hook_runner and installer) compiled green and never ran. This
+    // block is the standard aggregator: referencing the imports forces
+    // their semantic analysis, which is what registers their tests.
+    _ = agent_hooks;
+    _ = hook_runner;
+    _ = hook_server;
+    _ = installer;
+    _ = plat;
+}


### PR DESCRIPTION
Found while working on #607: `native test` reported success while executing almost nothing.

## Problem

`zig build test` collects tests from the **root module file only**, and imports are analyzed lazily. main.zig has no aggregator, so every test in the imported files — agent_hooks' non-destructive settings.json merging, hook_runner's payload parsing, installer's URL allowlisting, **18 in all** — compiled green and never ran. Easy to prove: the agent_hooks fixture tests write `/tmp/petdex-agenthooks-fixture` as a side effect, and that directory exists on nobody's machine. On top, `desktop-native-ci.yml` builds and exercises the binary but has no test step, so even a working suite had nowhere to fail.

## Fix

- The standard root aggregator block at the bottom of main.zig (`test { _ = agent_hooks; ... }`) — referencing the imports forces their semantic analysis, which is what registers their tests. 19/19 pass locally against the pinned SDK, fixture side effects present.
- A `native test` CI step on the macOS and Linux legs. Windows sits out deliberately: the fixture tests write under `/tmp` by absolute POSIX path, and enabling that leg means teaching the fixtures a portable temp dir first — a separate, mechanical follow-up if you want it.

Relates to #589 (CI-repeatable tests) in spirit; touches only the test seam, zero behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)