### PR TITLE
fix(desktop): build release binaries for baseline x86-64

### DIFF
--- a/.github/workflows/desktop-native-ci.yml
+++ b/.github/workflows/desktop-native-ci.yml
@@ -133,7 +133,10 @@ jobs:
         working-directory: packages/petdex-desktop-native
         shell: bash
         run: |
-          "$NATIVE_CLI" build
+          # Match the release build: baseline x86-64, so CI exercises
+          # the same instruction set users actually get. See the note in
+          # desktop-release.yml.
+          "$NATIVE_CLI" build -Dcpu=baseline
           ls -lh zig-out/bin/
 
       - name: Run the test suite

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -94,7 +94,13 @@ jobs:
         working-directory: packages/petdex-desktop-native
         shell: bash
         run: |
-          "$NATIVE_CLI" build
+          # Released binaries must run on every x86-64 CPU, not just the
+          # runner's. Without -Dcpu=baseline Zig targets the host, and
+          # the GitHub runner is new enough to emit AVX-512: the
+          # desktop-v0.3.1 Windows exe carries 862 kmovd and 199
+          # vpternlogd, which no Zen 3 chip decodes. That is the
+          # 0xC000001D illegal-instruction crash in #604 and #618.
+          "$NATIVE_CLI" build -Dcpu=baseline
           ls -lh zig-out/bin/
 
       - name: Stage the binary (Linux)


### PR DESCRIPTION
Fixes #604. Fixes #618.

## Problem

The `desktop-v0.3.1` Windows binary carries AVX-512. Disassembling the published exe (sha `2E734C70...`, the one @kongbaic checksummed) finds 862 `kmovd`, 199 `vpternlogd`, and 1512 AVX-512-only instructions in total. No Zen 3 part decodes those, which is why the app dies at startup with `0xC000001D` before it draws anything.

Two reports, two different AMD CPUs: @sasa-lty in #604 and @kongbaic on a Ryzen 5 5600G in #618.

Zig targets the host CPU unless told otherwise, and the GitHub runner is newer than the machines people install on. The runner's own CPU was leaking into the artifact.

## Fix

`-Dcpu=baseline` on the release build, and the same flag in CI so it exercises the instruction set users actually get.

## Verified

Three builds of the same source, disassembled and compared:

| build | AVX total | AVX-512 only | kmovd | vpternlogd |
| --- | --- | --- | --- | --- |
| shipped v0.3.1 | 67635 | 1512 | 862 | 199 |
| `-Dcpu=x86_64_v4` (control) | 67768 | 1517 | 862 | 199 |
| `-Dcpu=baseline` (this PR) | 0 | 0 | 0 | 0 |

The control reproduces the release almost instruction for instruction, which confirms the mechanism rather than assuming it. Baseline emits zero AVX of any kind.

## Note

I cannot run a Windows binary here, so this is proven at the instruction level, not by launching the app on a Ryzen box. Worth having @sasa-lty or @kongbaic confirm against the next release build.

#614 already applies the same flag for its Linux work. If that lands first, this becomes a no-op for the shared build step and only the CI leg differs.