### PR TITLE
fix(desktop): get the pid without libc on Linux

### DIFF
--- a/packages/petdex-desktop-native/src/plat.zig
+++ b/packages/petdex-desktop-native/src/plat.zig
@@ -261,9 +261,17 @@ pub fn replaceSymlink(target: []const u8, link: []const u8) bool {
 
 /// Own pid, for the /whoami endpoint. std has no portable accessor in
 /// 0.16, so this is the one genuine per-platform branch in this file.
+///
+/// Linux goes through the raw syscall rather than libc: `std.c.getpid`
+/// is an `extern "c"` declaration, and Linux refuses to compile one
+/// unless the build links libc explicitly. The app binary does, but
+/// `native test` also builds an analysis object that does not, so the
+/// libc path failed the Linux leg of CI while compiling fine on macOS
+/// and Windows. The syscall needs no linkage and returns the same pid.
 pub fn processId() u32 {
     return switch (builtin.os.tag) {
         .windows => std.os.windows.GetCurrentProcessId(),
+        .linux => @intCast(std.os.linux.getpid()),
         else => @intCast(std.c.getpid()),
     };
 }

--- a/packages/petdex-desktop-native/src/plat.zig
+++ b/packages/petdex-desktop-native/src/plat.zig
@@ -351,8 +351,6 @@ pub fn setLaunchAtLogin(enabled: bool) bool {
     return @as(MsgSendErr, @ptrCast(&AppleApp.objc_msgSend))(svc, sel, null);
 }
 
-extern "c" fn kill(pid: c_int, sig: c_int) c_int;
-
 /// Quit the way a menu quit would. SIGTERM rides the hosts'
 /// graceful-shutdown paths (the macOS host turns it into `NSApp
 /// terminate` through a dispatch source, sealing journals on the way
@@ -364,11 +362,18 @@ extern "c" fn kill(pid: c_int, sig: c_int) c_int;
 /// process is `pthread_kill(self)`, which the source never observes
 /// (verified: an external `kill -TERM` quit the app, an in-process
 /// `raise` was silently dropped).
+///
+/// Both branches avoid libc for the same reason `processId` does: the
+/// analysis object `native test` builds does not link it. Linux sends
+/// the signal through the raw syscall, and Windows exits through
+/// `std.process.exit` (`RtlExitUserProcess` underneath) since
+/// `kernel32.ExitProcess` is not declared in Zig 0.16's std.
 pub fn requestQuit() void {
-    if (builtin.os.tag == .windows) {
-        std.os.windows.kernel32.ExitProcess(0);
+    switch (builtin.os.tag) {
+        .windows => std.process.exit(0),
+        .linux => _ = std.os.linux.kill(@intCast(processId()), .TERM),
+        else => _ = std.c.kill(@intCast(processId()), .TERM),
     }
-    _ = kill(@intCast(processId()), 15); // SIGTERM
 }
 
 /// Open a URL or a folder in the desktop's default handler. One


### PR DESCRIPTION
Fixes #622. Main has been red on the Linux leg since #616 landed.

## Problem

`native test` builds an `<app>-analysis` object alongside the test binary to force semantic analysis of `main`. That module does not link libc. `plat.processId` calls `std.c.getpid`, an `extern "c"` declaration that Linux refuses to compile without explicit linkage:

```
std/c.zig:11013:12: error: dependency on libc must be explicitly specified in the build command
pub extern "c" fn getpid() pid_t;
referenced by:
    processId: src/plat.zig:267:31
```

The app binary links libc, so `native build` passes on the same run. macOS and Windows do not require the explicit dependency, so only Linux failed. It stayed invisible until #616 added a test step that runs the analysis object.

The cost is larger than one red check: the failing step skips the ones behind it, which on the Linux leg are the hook-server round trip and the deep-link check. Those are the steps that verify behavior rather than compilation, so the platform that fails loudest is also the one that stops being tested.

## Fix

`std.os.linux.getpid` is the raw syscall. No linkage, same value. Windows and macOS keep their existing branches.

## Verified

Forced analysis of `processId` for `x86_64-linux` with no libc, which is what the analysis object does:

- before: reproduces the CI error above, same stdlib line
- after: compiles

Runtime checked as well, not just compilation: the pid the function returns matches the one the shell sees for the same process. `native test` and `native build` are green on macOS.

## Note

This is the app-side fix, and it unblocks CI today. The SDK-side fix is still worth doing: the analysis module should inherit the app's libc linkage, otherwise the next `std.c` call anywhere in the app reintroduces this. I left that direction in #622.