### PR TITLE
fix(desktop): grep bubbles lose their pattern to an ASCII quote

### DIFF
--- a/packages/petdex-cli/src/hooks/bubble-templates.test.ts
+++ b/packages/petdex-cli/src/hooks/bubble-templates.test.ts
@@ -144,7 +144,29 @@ describe("formatBubble - grep + glob", () => {
         toolName: "Grep",
         toolInput: { pattern: "TODO" },
       }),
-    ).toBe('Searching "TODO"');
+    ).toBe("Searching “TODO”");
+  });
+
+  test("no template renders an ASCII quote", () => {
+    // The in-app runner embeds this text raw into the sidecar POST body
+    // and hook_server reads it back with a scanner that decodes nothing,
+    // so a `"` or a `\` anywhere in a template truncates the bubble.
+    for (const toolName of ["Grep", "Glob", "Read", "Bash", "WebFetch"]) {
+      for (const phase of ["running", "done"] as const) {
+        const text = formatBubble({
+          kind: "tool",
+          phase,
+          toolName,
+          toolInput: {
+            pattern: "TODO",
+            file_path: "a.ts",
+            url: "https://x.dev",
+          },
+        });
+        expect(text).not.toContain('"');
+        expect(text).not.toContain("\\");
+      }
+    }
   });
 
   test("Glob done with pattern", () => {

--- a/packages/petdex-cli/src/hooks/bubble-templates.ts
+++ b/packages/petdex-cli/src/hooks/bubble-templates.ts
@@ -110,9 +110,11 @@ export function formatBubble(event: BubbleEvent): string {
     case "grep": {
       const pattern = fieldFrom(toolInput, "pattern");
       if (pattern) {
+        // Curly quotes keep this in parity with the in-app runner, where
+        // an ASCII `"` truncates the bubble on the way to the sidecar.
         return past
-          ? `Searched "${clip(pattern, 28)}"`
-          : `Searching "${clip(pattern, 28)}"`;
+          ? `Searched “${clip(pattern, 28)}”`
+          : `Searching “${clip(pattern, 28)}”`;
       }
       return past ? "Searched files" : "Searching files";
     }

--- a/packages/petdex-desktop-native/src/assets/opencode-plugin.js
+++ b/packages/petdex-desktop-native/src/assets/opencode-plugin.js
@@ -73,7 +73,10 @@ function formatTool(toolName, toolInput, phase) {
     }
     case "grep": {
       const pattern = fieldFrom(toolInput, "pattern");
-      return pattern ? (past ? "Searched \"" + clip(pattern, 28) + "\"" : "Searching \"" + clip(pattern, 28) + "\"") : past ? "Searched files" : "Searching files";
+      // Curly quotes: JSON.stringify escapes an ASCII `"` correctly, but
+      // the sidecar reads the body back with a scanner that stops at the
+      // backslash, so the pattern never reaches the bubble.
+      return pattern ? (past ? "Searched “" + clip(pattern, 28) + "”" : "Searching “" + clip(pattern, 28) + "”") : past ? "Searched files" : "Searching files";
     }
     case "glob": {
       const pattern = fieldFrom(toolInput, "pattern");

--- a/packages/petdex-desktop-native/src/hook_runner.zig
+++ b/packages/petdex-desktop-native/src/hook_runner.zig
@@ -180,7 +180,13 @@ pub fn formatBubble(phase: []const u8, payload: []const u8, out: []u8) ?[]const 
         return if (done) "Ran command" else "Running command";
     }
     if (asciiEqlLower(tool, "grep")) {
-        if (jsonString(payload, "pattern")) |p| return fmt3(out, if (done) "Searched \"" else "Searching \"", clipRaw(p, 28), "\"");
+        // Curly quotes, not ASCII ones: the bubble text is embedded raw
+        // into the POST body and read back out by hook_server's scanner,
+        // and neither step decodes escapes. A bare `"` closed the JSON
+        // string early and the pattern never reached the bubble; an
+        // escaped `\"` fares no better, since the reader stops at the
+        // backslash too.
+        if (jsonString(payload, "pattern")) |p| return fmt3(out, if (done) "Searched “" else "Searching “", clipRaw(p, 28), "”");
         return if (done) "Searched files" else "Searching files";
     }
     if (asciiEqlLower(tool, "glob")) {
@@ -557,6 +563,42 @@ test "unknown tool falls through to generic" {
     var out: [256]u8 = undefined;
     const payload = "{\"tool_name\":\"mcp__custom__thing\"}";
     try t.expectEqualStrings("Calling mcp__custom__thing", formatBubble("pre", payload, &out).?);
+}
+
+test "grep quotes the pattern without ASCII quotes" {
+    var out: [256]u8 = undefined;
+    const payload = "{\"tool_name\":\"Grep\",\"tool_input\":{\"pattern\":\"TODO\"}}";
+    try t.expectEqualStrings("Searching “TODO”", formatBubble("pre", payload, &out).?);
+    try t.expectEqualStrings("Searched “TODO”", formatBubble("post", payload, &out).?);
+}
+
+test "every template survives the body round trip" {
+    // The bug this pins: a bubble goes out as raw bytes interpolated into
+    // the POST body and comes back through hook_server's scanner, which
+    // stops at the first `"` OR `\` and decodes neither. A template that
+    // renders either one loses everything after it, silently — the ASCII
+    // quotes Grep used to wrap its pattern in dropped the pattern.
+    const payloads = [_][]const u8{
+        "{\"tool_name\":\"Grep\",\"tool_input\":{\"pattern\":\"TODO\"}}",
+        "{\"tool_name\":\"Glob\",\"tool_input\":{\"pattern\":\"*.zig\"}}",
+        "{\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"/a/b/server.ts\"}}",
+        "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git status\"}}",
+        "{\"tool_name\":\"WebFetch\",\"tool_input\":{\"url\":\"https://petdex.dev/x\"}}",
+        "{\"tool_name\":\"Agent\",\"tool_input\":{\"description\":\"review hooks\"}}",
+    };
+    for (payloads) |payload| {
+        for ([_][]const u8{ "pre", "post" }) |phase| {
+            var out: [256]u8 = undefined;
+            const text = formatBubble(phase, payload, &out) orelse continue;
+            var body_buf: [1024]u8 = undefined;
+            const body = try std.fmt.bufPrint(
+                &body_buf,
+                "{{\"text\":\"{s}\",\"busy\":true,\"agent_source\":\"claude-code\"}}",
+                .{text},
+            );
+            try t.expectEqualStrings(text, jsonString(body, "text").?);
+        }
+    }
 }
 
 test "session phases render fixed strings" {


### PR DESCRIPTION
Every Grep bubble renders as a bare `Searching ` — the pattern never makes it to the screen. This has been true on every agent since the in-binary runner landed, and it reproduces on a stock install:

```
$ echo '{"tool_name":"Grep","tool_input":{"pattern":"petdex"}}' \
    | ~/.petdex/bin/petdex-hook bubble pre claude-code
$ curl -s localhost:7777/bubble
{"text":"Searching ", ...}          # want: Searching “petdex”
```

## Why

`hook_runner.run` interpolates the bubble text raw into the POST body:

```zig
bufPrint(&body_buf, "{{\"text\":\"{s}\",\"busy\":{},\"agent_source\":\"{s}\"}}", .{ text, busy, agent })
```

and `hook_server.jsonString` reads it back with a scanner that stops at the first `"` **or** `\` and decodes neither:

```zig
while (i < body.len and body[i] != '"' and body[i] != '\\') i += 1;
```

Every other template honors that contract — payload-derived slices come out of the same scanner, so they carry no bare quote and no stray backslash. Grep is the one template that adds ASCII quotes of its own, which closes the JSON string early and drops the rest.

Escaping to `\"` does not fix it. I checked against the running sidecar:

| body sent | text read back |
| --- | --- |
| `{"text":"Searching "TODO""}` | `Searching ` |
| `{"text":"Searching \"TODO\""}` | `Searching ` |
| `{"text":"Searching “TODO”"}` | `Searching “TODO”` ✅ |

So the fix is curly quotes — plain bytes that survive both steps, the same way `Thinking…` and `Waiting for you…` already do.

## Scope

- **`hook_runner.zig`** — the actual user-visible fix.
- **`assets/opencode-plugin.js`** — same template. It serializes with `JSON.stringify`, so its body is well-formed, but the reader still stops at the backslash and the bubble truncates identically. `scan()` compares the installed plugin against the embedded copy byte-for-byte, so existing installs will surface as *Plugin outdated* and **Update** refreshes them.
- **`bubble-templates.ts`** — the parity source the Zig port is kept against. Moved in step even though the CLI no longer dispatches `bubble`, so the two do not drift.

Deliberately not touched: `jsonString` itself. Teaching it to decode escapes is a change to the parser every hook payload and every runtime mirror file goes through — a much larger blast radius than this bug warrants.

## Tests

A Grep case on each side, plus a round-trip test that pushes every template through the real body format string and back through `hook_server`'s reader:

```zig
const body = try std.fmt.bufPrint(&body_buf, "{{\"text\":\"{s}\",...}}", .{text});
try t.expectEqualStrings(text, jsonString(body, "text").?);
```

Both new tests fail against the old templates and pass against the new ones — I reverted the templates to confirm the assertions have teeth, not just green.

```
$ zig test hook_runner.zig     # 0.16.0
All 11 tests passed.
$ bun test                     # packages/petdex-cli
74 pass, 0 fail
```

`agent_hooks.zig` (18), `installer.zig` (5) and `plat.zig` (1) also still pass. Verified end to end against a live `Petdex.app` 0.3.1 sidecar on macOS 26.3 (arm64).
