### PR TITLE
fix(gallery): cycle fallback cards, republish on sprite swap, test both

### DIFF
--- a/src/components/pets/pet-sprite.test.ts
+++ b/src/components/pets/pet-sprite.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "bun:test";
+
+import { resolveSprite } from "./pet-sprite";
+
+const PREVIEW = "https://assets.petdex.dev/pets/curly-dog-lady/preview.webp";
+const ATLAS = "https://assets.petdex.dev/pets/curly-dog-lady/spritesheet.webp";
+
+const base = {
+  preferredSrc: PREVIEW,
+  fallbackSrc: ATLAS,
+  failedSrc: null as string | null,
+  preferredLayout: "row" as const,
+  cycleStates: false,
+};
+
+describe("resolveSprite", () => {
+  it("draws the preview until it fails", () => {
+    const result = resolveSprite(base);
+    expect(result.useFallback).toBe(false);
+    expect(result.src).toBe(PREVIEW);
+    expect(result.layout).toBe("row");
+  });
+
+  it("swaps to the atlas when the preview errors", () => {
+    const result = resolveSprite({ ...base, failedSrc: PREVIEW });
+    expect(result.useFallback).toBe(true);
+    expect(result.src).toBe(ATLAS);
+    expect(result.layout).toBe("atlas");
+  });
+
+  it("cycles states on a fallback card, matching one that never had a preview", () => {
+    const recovered = resolveSprite({ ...base, failedSrc: PREVIEW });
+    const neverHadPreview = resolveSprite({
+      ...base,
+      preferredSrc: ATLAS,
+      fallbackSrc: undefined,
+      preferredLayout: "atlas",
+      cycleStates: true,
+    });
+    expect(recovered.cycleStates).toBe(true);
+    expect(recovered.cycleStates).toBe(neverHadPreview.cycleStates);
+  });
+
+  it("keeps a working preview on its caller's fixed state", () => {
+    expect(resolveSprite(base).cycleStates).toBe(false);
+  });
+
+  it("ignores a stale failure recorded against a different src", () => {
+    const result = resolveSprite({ ...base, failedSrc: "https://old.example" });
+    expect(result.useFallback).toBe(false);
+    expect(result.src).toBe(PREVIEW);
+  });
+
+  it("stays on the preview when no fallback is supplied", () => {
+    const result = resolveSprite({
+      ...base,
+      fallbackSrc: undefined,
+      failedSrc: PREVIEW,
+    });
+    expect(result.useFallback).toBe(false);
+    expect(result.src).toBe(PREVIEW);
+    expect(result.layout).toBe("row");
+  });
+});

--- a/src/components/pets/pet-sprite.tsx
+++ b/src/components/pets/pet-sprite.tsx
@@ -44,6 +44,38 @@ type PetSpriteProps = {
 
 const ATLAS_SHEET_WIDTH = 1536;
 
+/**
+ * Which sprite to draw, and how, once the preview's success or failure is
+ * known. Pure so it can be tested without a DOM: the component owns the
+ * probe and the state, this owns the decision.
+ */
+export function resolveSprite({
+  preferredSrc,
+  fallbackSrc,
+  failedSrc,
+  preferredLayout,
+  cycleStates,
+}: {
+  preferredSrc: string;
+  fallbackSrc?: string;
+  failedSrc: string | null;
+  preferredLayout: PetSpriteLayout;
+  cycleStates: boolean;
+}) {
+  const useFallback = fallbackSrc != null && failedSrc === preferredSrc;
+  return {
+    useFallback,
+    src: useFallback ? fallbackSrc : preferredSrc,
+    layout: useFallback ? ("atlas" as const) : preferredLayout,
+    // Callers decide `cycleStates` from whether a preview URL exists, before
+    // anyone knows the preview will 404 (pet-gallery.tsx passes
+    // `cycleStates={!previewSrc}`). A card that falls back is in the same
+    // position as one that never had a preview, so it cycles too — otherwise
+    // recovered cards all freeze on `idle` while their neighbours vary.
+    cycleStates: cycleStates || useFallback,
+  };
+}
+
 function PetSpriteImpl({
   src: preferredSrc,
   state = "idle",
@@ -51,13 +83,17 @@ function PetSpriteImpl({
   label,
   className = "",
   layout: preferredLayout = "atlas",
-  cycleStates = false,
+  cycleStates: preferredCycleStates = false,
   fallbackSrc,
 }: PetSpriteProps) {
   const [failedSrc, setFailedSrc] = useState<string | null>(null);
-  const useFallback = fallbackSrc != null && failedSrc === preferredSrc;
-  const src = useFallback ? fallbackSrc : preferredSrc;
-  const layout = useFallback ? "atlas" : preferredLayout;
+  const { useFallback, src, layout, cycleStates } = resolveSprite({
+    preferredSrc,
+    fallbackSrc,
+    failedSrc,
+    preferredLayout,
+    cycleStates: preferredCycleStates,
+  });
 
   const fixedAnimation =
     petStates.find((item) => item.id === state) ?? petStates[0];

--- a/src/lib/submission-decisions.test.ts
+++ b/src/lib/submission-decisions.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 
-import { submissionOwnerNotificationHref } from "@/lib/submission-decisions";
+import {
+  planPublicArtifacts,
+  submissionOwnerNotificationHref,
+} from "@/lib/submission-decisions";
 
 describe("submissionOwnerNotificationHref", () => {
   it("links approved submissions to the public pet page", () => {
@@ -19,5 +22,54 @@ describe("submissionOwnerNotificationHref", () => {
         status: "rejected",
       }),
     ).toBe("/my-pets");
+  });
+});
+
+describe("planPublicArtifacts", () => {
+  const base = {
+    action: "edit" as const,
+    wasApproved: true,
+    isApproved: true,
+    slugChanged: false,
+    spritesheetChanged: false,
+  };
+
+  it("republishes when the sprite is swapped under the same slug", () => {
+    const plan = planPublicArtifacts({ ...base, spritesheetChanged: true });
+    expect(plan.republish).toBe(true);
+    // The keys did not move, so nothing is orphaned.
+    expect(plan.deleteOld).toBe(false);
+  });
+
+  it("republishes and clears the old keys on a rename", () => {
+    const plan = planPublicArtifacts({ ...base, slugChanged: true });
+    expect(plan.republish).toBe(true);
+    expect(plan.deleteOld).toBe(true);
+  });
+
+  it("leaves artifacts alone when an edit changes neither", () => {
+    const plan = planPublicArtifacts(base);
+    expect(plan.republish).toBe(false);
+    expect(plan.deleteOld).toBe(false);
+  });
+
+  it("deletes without republishing when a pet stops being approved", () => {
+    const plan = planPublicArtifacts({
+      ...base,
+      action: "reject",
+      isApproved: false,
+    });
+    expect(plan.republish).toBe(false);
+    expect(plan.deleteOld).toBe(true);
+  });
+
+  it("publishes nothing for a pet that was never approved", () => {
+    const plan = planPublicArtifacts({
+      ...base,
+      wasApproved: false,
+      spritesheetChanged: true,
+    });
+    expect(plan.republish).toBe(false);
+    expect(plan.deleteOld).toBe(false);
   });
 });

--- a/src/lib/submission-decisions.ts
+++ b/src/lib/submission-decisions.ts
@@ -41,6 +41,34 @@ export function submissionOwnerNotificationHref(input: {
   return "/my-pets";
 }
 
+/**
+ * Whether an admin action leaves the pet's public artifacts (preview,
+ * thumb, stickers) stale, and whether the old slug's copies should go.
+ *
+ * Republishing used to key on a rename alone. Artifacts are derived from
+ * the spritesheet, so approving new art under the same slug left the old
+ * ones live until the 6-hourly backfill happened to notice, which is long
+ * enough for a profile card and its detail page to show different sprites
+ * (#590). Deletion still keys on the slug, because that is the only case
+ * where the old keys are orphaned.
+ */
+export function planPublicArtifacts(input: {
+  action: SubmissionAdminAction;
+  wasApproved: boolean;
+  isApproved: boolean;
+  slugChanged: boolean;
+  spritesheetChanged: boolean;
+}): { republish: boolean; deleteOld: boolean } {
+  return {
+    republish:
+      input.action === "edit" &&
+      input.wasApproved &&
+      input.isApproved &&
+      (input.slugChanged || input.spritesheetChanged),
+    deleteOld: input.wasApproved && (!input.isApproved || input.slugChanged),
+  };
+}
+
 export async function applySubmissionAction(
   id: string,
   body: SubmissionActionInput,
@@ -115,6 +143,10 @@ export async function applySubmissionAction(
     columns: {
       slug: true,
       status: true,
+      // Read to decide whether public artifacts are stale: a sprite swap
+      // that keeps the same slug still invalidates preview, thumb and
+      // stickers, and the slug comparison alone would miss it (#590).
+      spritesheetUrl: true,
     },
     where: eq(schema.submittedPets.id, id),
   });
@@ -136,20 +168,17 @@ export async function applySubmissionAction(
   if (body.action === "approve" && !options.skipSideEffects) {
     row = await runPostApprovalEffects(row, actor, db);
   }
-  if (
-    body.action === "edit" &&
-    current.status === "approved" &&
-    row.status === "approved" &&
-    current.slug !== row.slug &&
-    !options.skipSideEffects
-  ) {
+  const artifactPlan = planPublicArtifacts({
+    action: body.action,
+    wasApproved: current.status === "approved",
+    isApproved: row.status === "approved",
+    slugChanged: current.slug !== row.slug,
+    spritesheetChanged: current.spritesheetUrl !== row.spritesheetUrl,
+  });
+  if (artifactPlan.republish && !options.skipSideEffects) {
     await publishApprovedPublicArtifacts(row, actor);
   }
-  if (
-    current.status === "approved" &&
-    (row.status !== "approved" || current.slug !== row.slug) &&
-    !options.skipSideEffects
-  ) {
+  if (artifactPlan.deleteOld && !options.skipSideEffects) {
     await deletePetPublicArtifacts(current.slug, actor);
   }
 


### PR DESCRIPTION
Closes #588. Closes #589. Closes #590.

The three follow-ups #587 left open, plus the test that covers two of them. #563 is closed separately: the reconcile now reports `existing 4347, pending 0, thumbs/stickers missing 0` against production.

## #588: fallback cards froze on idle

The caller sets `cycleStates={!previewSrc}` in `pet-gallery.tsx`, deciding before anyone knows whether the preview will 404. A card whose preview failed then rendered a fixed `idle` while cards that never had a preview cycled through hashed states, so recovered cards stood out as a frozen block.

`resolveSprite` derives it now: a card that fell back is in the same position as one that never had a preview, so it cycles too.

## #590: sprite swaps kept a stale preview

Public artifacts republished only when the slug changed. Approving new art under the same slug left the old `preview.webp`, thumb and stickers live until the 6-hourly backfill happened to notice, which is long enough for a profile card and its detail page to show different sprites.

`planPublicArtifacts` republishes when the spritesheet changes as well. Deletion still keys on the slug alone, since a rename is the only case where the old keys are orphaned. `current` now reads `spritesheetUrl` to make the comparison possible.

## #589: neither path had a test

The repo has no component-test harness and no testing-library, so rather than add that whole chain for one assertion, both decisions moved into pure functions that the existing `bun test` setup can exercise directly. The component still owns the probe and the `useState`; the functions own the decision.

Both were proved red before being fixed, per the force-red rule in #589:

- reverting the `cycleStates` derivation fails `cycles states on a fallback card`
- reverting the atlas swap entirely fails two tests, including the #579 regression
- restoring the slug-only condition fails `republishes when the sprite is swapped under the same slug`

## Verification

348 tests pass, up from 337. `biome check` clean. `tsc --noEmit` reports the same 25 pre-existing errors as main, all in test files where `bun:test` types are out of step.