### PR TITLE
refactor(desktop): pack agent logos into one image slot

### DIFF
--- a/docs/agent-adapters-research.md
+++ b/docs/agent-adapters-research.md
@@ -1,0 +1,175 @@
+# Agent adapter research: OpenClaw, Kimi Code, CodeBuddy, OMP
+
+Research for #289, #290, #291 and #559. No adapter code shipped yet; this
+decides which are worth building and in what order.
+
+Everything below was verified against upstream docs and live registries on
+2026-08-02. Claims that could not be sourced are marked as such.
+
+## Verdicts
+
+| Issue | Agent | Verdict | Failure event | Config format |
+| --- | --- | --- | --- | --- |
+| #290 | Kimi Code | Build it | `PostToolUseFailure`, distinct | TOML |
+| #291 | CodeBuddy | Build it | field on `PostToolUse` | JSON |
+| #559 | OMP | Build it | `isError` on `tool_result` | TS extension |
+| #289 | OpenClaw | Decline | none | JSON |
+
+Three of the four are viable. OpenClaw is not, for a structural reason
+rather than a missing feature.
+
+## Why OpenClaw does not fit
+
+OpenClaw is real and very much alive (github.com/openclaw/openclaw, pushed
+the same day this was written). It has a hook system, JSON config at
+`~/.openclaw/openclaw.json`, and four discovery roots.
+
+The problem is what its events describe. The documented set covers
+commands, sessions, the gateway lifecycle, and messages:
+`command:new`, `session:compact:before`, `gateway:startup`,
+`message:received`, and so on. There is no tool-level event anywhere in it.
+No tool name appears in any payload, and nothing fires when a tool
+succeeds or fails.
+
+Petdex's entire model is tool-driven. `PreToolUse` gives `running` and
+`review`, `PostToolUse` gives `idle`, a failure gives `failed`. Without
+tool events we could drive `jumping` on a new command and `waving` on
+shutdown, and the pet would sit idle through all the work in between.
+
+There is a second reason worth stating plainly: OpenClaw is a gateway that
+orchestrates Claude Code, Codex and OpenCode as backends. It is not a peer
+to them. A user running OpenClaw is already running one of the agents
+Petdex supports, and the pet already reacts to that agent directly.
+Integrating the orchestrator would double-count the same work.
+
+## The three that work
+
+### Kimi Code (#290)
+
+The closest to what Petdex already knows how to do.
+
+- Config: `~/.kimi-code/config.toml`, overridable with `KIMI_CODE_HOME`
+- Hooks: a `[[hooks]]` array inside `config.toml`, with `event`,
+  `matcher`, `command`, `timeout`
+- Events include `PreToolUse`, `PostToolUse`, `PostToolUseFailure`,
+  `UserPromptSubmit`, `SessionStart`, `SessionEnd`, `Notification`
+- Payload arrives as JSON on stdin with `hook_event_name`, `session_id`,
+  `cwd`, `tool_name`, `tool_input`
+
+`PostToolUseFailure` is a distinct event, exactly like Qoder's, so the
+`failed` sprite row lights up for free.
+
+Two things to encode. There is a deprecated predecessor, `kimi-cli`, whose
+config lives at `~/.kimi/config.toml`; build against the new root and treat
+the old one as a legacy fallback at most. And `UserPromptSubmit` delivers
+`prompt` as a `ContentPart[]` array rather than a string
+(MoonshotAI/kimi-code#917), so the text has to be joined out of it. The
+docs are misleading on that point.
+
+### CodeBuddy (#291)
+
+Tencent's CLI, derived from Claude Code rather than compatible with it.
+
+- Config: `~/.codebuddy/settings.json`, plus project and project-local
+  variants
+- Hooks: `hooks.<EventName>` with matcher and command arrays, the same
+  shape as Claude's
+- Core events overlap Claude almost exactly: `PreToolUse`, `PostToolUse`,
+  `UserPromptSubmit`, `Stop`, `SubagentStop`, `SessionStart`,
+  `SessionEnd`, `Notification`, `PreCompact`
+- Payload carries `session_id`, `transcript_path`, `cwd`,
+  `permission_mode`, `hook_event_name`, plus `tool_name` and `tool_input`
+
+It recognizes `${CLAUDE_PLUGIN_ROOT}` and reads `.claude-plugin/` for
+plugin interop, but it does not read Claude's `settings.json`, so pointing
+the existing adapter at a different directory is not enough.
+
+Failure detection is the weak spot: there is no distinct failure event, so
+it has to be inferred from the `tool_response` field on `PostToolUse`.
+
+It also declares 27+ events, but only the core set has documented payload
+schemas. Wire against the core and leave the rest alone.
+
+### OMP (#559)
+
+The most interesting of the three, and the most different.
+
+OMP has no shell-command-per-event mechanism. Its docs call the legacy hook
+subsystem legacy and point at an extension API instead: an in-process
+TypeScript module that default-exports `(pi: ExtensionAPI) => void`. So
+this adapter is a TS extension we ship, not a config file we edit.
+
+- Events: `session_start`, `input`, `tool_call`, `tool_result`,
+  `tool_approval_requested`, `tool_approval_resolved`, `agent_end`,
+  `session_shutdown`, all confirmed against `docs/extensions.md`
+- `tool_result` carries `isError`, set true on failure before the error is
+  rethrown, which is our `failed` row
+- `pi.registerCommand` exists and is documented, so the `/petdex` command
+  the issue asks for is achievable
+
+Config discovery is the hard part and cannot assume one path. Three
+variables stack: `PI_CODING_AGENT_DIR` relocates the whole agent base, the
+default is `~/.omp/agent/`, named profiles live at
+`~/.omp/profiles/<name>/agent/`, and there is a project-local
+`<project>/.omp/settings.json`.
+
+A third-party bridge exists (ZeR020/omp-hooks) that reimplements Claude's
+`settings.json` hooks on top of OMP events. We do not need it, and its own
+README says to write a native extension when you only target OMP.
+
+Before writing the payload parser, pull
+`src/extensibility/extensions/types.ts` and `docs/extension-loading.md`
+from the repo. The markdown docs describe behavior rather than exhaustive
+field lists, and guessing field names is how this goes wrong.
+
+## The blocker that comes first
+
+None of these can ship until the icon registry has room.
+
+`src/runtime/canvas_limits.zig:105` in the SDK sets
+`max_registered_canvas_images = 16`, and slots are runtime-wide. Petdex
+already uses 1 for the spritesheet, 9/10/11/15/16 for agent icons, 13 for
+the avatar and 14 for the bubble tail. Slot 16 went to Qoder in #629, so
+a sixth agent has nowhere to put its icon.
+
+Three ways out:
+
+1. Atlas the agent icons into one image, indexed by x-offset, the way
+   `thumb_atlas_id` already packs pet thumbnails. Frees four slots
+   immediately and scales to any number of agents. Icons are 40px, so
+   even sixteen of them make a 640x40 strip, far inside the 512x512 and
+   1MB per-image ceilings.
+2. Raise the cap in the SDK. We own that fork and just merged into it, so
+   it is available, but it is a runtime-wide limit and this is a
+   Petdex-specific packing problem.
+3. Register only the agents actually installed. Most machines have one or
+   two. Correct in spirit, but it adds churn to a path that runs once and
+   still breaks for someone with six agents installed.
+
+Option 1 is the one to take. It is local to Petdex, follows a pattern
+already in the file, and removes the ceiling rather than raising it.
+
+## Cost
+
+Measured against Qoder (`b8f274b`, PR #629), the most recent adapter:
+13 files, +730/-28. Of the 448 lines in `agent_hooks.zig`, 121 mention
+Qoder. So roughly 180 lines are plumbing and the rest was understanding
+the agent.
+
+That ratio matters for scoping. The mechanical part is small and the
+compiler enforces it: `AgentKind` is an exhaustive enum with six switches
+over it, so a missing case is a build error rather than a silent gap. The
+expensive part is the reverse engineering, and this document is most of
+it.
+
+Kimi and CodeBuddy should land close to the Qoder number. OMP will cost
+more, because it is a TypeScript extension rather than a config edit and
+the config discovery has three variables.
+
+## Order
+
+1. Atlas the agent icons. Blocks everything else.
+2. Kimi Code. Closest to the existing pattern, distinct failure event.
+3. CodeBuddy. Same shape, minus clean failure detection.
+4. OMP. Different mechanism, needs the type files read first.
+5. Close #289 with the reason above.

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -1081,12 +1081,29 @@ var initial_pet_y: ?f64 = null;
 // assets/agents/, re-registered only when the agent changes.
 const avatar_image_id: u64 = 13;
 const tail_image_id: u64 = 14;
-// The registry caps at 16 slots and 16 is the last one free, so both Qoder
-// builds share it — they ship the same artwork anyway.
-const agent_icon_ids = [agent_hooks.agent_count]u64{ 9, 10, 11, 15, 16 };
+// One slot for every agent logo, packed side by side and read back with
+// `image_src` (the thumbnail atlas above does the same). Previously each
+// agent held its own registry id, which ran the app into the SDK's
+// 16-slot ceiling (canvas_limits.max_registered_canvas_images): ids
+// 1/9/10/11/13/14/15/16 were spoken for and Qoder took the last one, so
+// a sixth agent had nowhere to register. Packing removes the ceiling
+// instead of raising it — sixteen 40px logos are a 640x40 strip, far
+// inside the 512x512 and 1MiB per-image bounds.
+const agent_icon_atlas_id: u64 = 9;
 const agent_icon_px: usize = 40;
 var agents_icons_ready: bool = false;
 var agents_icons_dark: bool = false;
+var agent_icon_pixels: []u8 = &.{};
+
+/// Where agent `index`'s logo sits in the packed strip.
+fn agentIconRect(index: usize) geometry.RectF {
+    return geometry.RectF.init(
+        @as(f32, @floatFromInt(index * agent_icon_px)),
+        0,
+        @as(f32, @floatFromInt(agent_icon_px)),
+        @as(f32, @floatFromInt(agent_icon_px)),
+    );
+}
 
 /// Agent logo bytes, compiled in. The runtime decodes them through the
 /// platform codec (CGImageSource, gdk-pixbuf, WIC), so these need no
@@ -1103,13 +1120,52 @@ const agent_art = [agent_hooks.agent_count]AgentArt{
 };
 const agent_fallback_art: []const u8 = @embedFile("assets/agents/fallback.png");
 
-/// Register the four settings agent logos, one registry slot each,
-/// themed like the bubble avatar and refreshed on appearance flips.
+/// Pack every settings agent logo into one registry slot, themed like the
+/// bubble avatar and rebuilt on appearance flips. Each logo decodes
+/// through the platform codec (the same path `registerImageBytes` takes
+/// internally) and is copied into its own cell of the strip.
+///
+/// A logo that fails to decode leaves its cell transparent rather than
+/// aborting the strip, so one bad asset costs one icon instead of all of
+/// them. The row is only registered if at least one cell landed.
 fn loadAgentsAtlas(dark: bool, fx: *Effects) void {
     if (agents_icons_ready and agents_icons_dark == dark) return;
-    for (agent_art, 0..) |art, cell| {
-        _ = fx.registerImageBytes(agent_icon_ids[cell], if (dark) art.dark else art.light) catch continue;
+    const services = fx.services orelse return;
+
+    const atlas_w = agent_art.len * agent_icon_px;
+    if (agent_icon_pixels.len == 0) {
+        agent_icon_pixels = boot_allocator.alloc(u8, atlas_w * agent_icon_px * 4) catch return;
     }
+    @memset(agent_icon_pixels, 0);
+
+    // Decoding happens into a scratch buffer sized for one logo at the
+    // per-image ceiling, reused across cells so the pack costs one
+    // allocation rather than one per agent.
+    const scratch = boot_allocator.alloc(u8, 512 * 512 * 4) catch return;
+    defer boot_allocator.free(scratch);
+
+    const atlas_row_len = atlas_w * 4;
+    var packed_any = false;
+    for (agent_art, 0..) |art, cell| {
+        const decoded = services.decodeImage(if (dark) art.dark else art.light, scratch) catch continue;
+        if (decoded.width == 0 or decoded.height == 0) continue;
+        // Nearest-neighbour into the cell: the logos ship at 40px and the
+        // view draws them at 24, so the scale here is identity in practice
+        // and the sampling only matters if an asset is authored off-size.
+        for (0..agent_icon_px) |y| {
+            const src_y = y * decoded.height / agent_icon_px;
+            for (0..agent_icon_px) |x| {
+                const src_x = x * decoded.width / agent_icon_px;
+                const src_off = (src_y * decoded.width + src_x) * 4;
+                const dst_off = y * atlas_row_len + (cell * agent_icon_px + x) * 4;
+                @memcpy(agent_icon_pixels[dst_off..][0..4], decoded.rgba8[src_off..][0..4]);
+            }
+        }
+        packed_any = true;
+    }
+    if (!packed_any) return;
+
+    fx.registerImage(agent_icon_atlas_id, atlas_w, agent_icon_px, agent_icon_pixels) catch return;
     agents_icons_dark = dark;
     agents_icons_ready = true;
 }
@@ -2417,9 +2473,10 @@ fn agentsSection(ui: *AppUi, model: *const Model) AppUi.Node {
         var logo = ui.image(.{
             .width = 24,
             .height = 24,
-            .image = if (agents_icons_ready) agent_icon_ids[@intFromEnum(info.kind)] else 0,
+            .image = if (agents_icons_ready) agent_icon_atlas_id else 0,
             .semantics = .{ .label = info.kind.displayName() },
         });
+        logo.widget.image_src = agentIconRect(@intFromEnum(info.kind));
         logo.widget.image_fit = .contain;
         rows[count] = ui.el(.panel, .{
             .padding = 12,
@@ -2937,6 +2994,35 @@ pub fn main(init: std.process.Init) !void {
             .navigation = .{ .allowed_origins = &.{ "zero://inline", "zero://app" } },
         },
     }, init);
+}
+
+test "every agent gets its own cell in the icon strip" {
+    // One slot holds them all, so a wrong offset silently draws the
+    // neighbouring agent's logo rather than failing to register.
+    for (0..agent_hooks.agent_count) |i| {
+        const rect = agentIconRect(i);
+        try std.testing.expectEqual(@as(f32, @floatFromInt(i * agent_icon_px)), rect.x);
+        try std.testing.expectEqual(@as(f32, 0), rect.y);
+        try std.testing.expectEqual(@as(f32, agent_icon_px), rect.width);
+        try std.testing.expectEqual(@as(f32, agent_icon_px), rect.height);
+    }
+    // Cells abut with no overlap: agent N ends exactly where N+1 begins.
+    if (agent_hooks.agent_count >= 2) {
+        const first = agentIconRect(0);
+        const second = agentIconRect(1);
+        try std.testing.expectEqual(first.x + first.width, second.x);
+    }
+    // The packed strip stays inside the SDK's per-image bounds, which is
+    // the ceiling this atlas exists to avoid running into again.
+    const atlas_w = agent_hooks.agent_count * agent_icon_px;
+    try std.testing.expect(atlas_w * agent_icon_px * 4 <= 1024 * 1024);
+    try std.testing.expect(atlas_w <= 512 * 512);
+}
+
+test "one image slot covers every agent" {
+    // agent_art is what loadAgentsAtlas walks, so a new AgentKind without
+    // artwork would pack short and leave the last agent blank.
+    try std.testing.expectEqual(agent_hooks.agent_count, agent_art.len);
 }
 
 test "waiting escalation pings once, only while still waiting" {


### PR DESCRIPTION
Unblocks #290, #291 and #559. Nothing user-facing changes.

## Why

The SDK's image registry holds 16 slots runtime-wide (`canvas_limits.max_registered_canvas_images`). Petdex had spoken for 1 (spritesheet), 9/10/11/15/16 (agent logos), 12 (thumbnail atlas), 13 (avatar) and 14 (bubble tail). Qoder took the last free id in #629, which I flagged when merging it: the next agent has nowhere to register.

Three adapters are queued behind that, so it had to be solved before any of them.

## What

The logos now share one slot as a horizontal strip, read back per agent with `image_src`. The thumbnail atlas two functions away already works this way, so this follows a pattern in the file rather than inventing one.

Sixteen 40px logos come to 640x40, well inside the 512x512 and 1MiB per-image bounds. That removes the ceiling instead of raising it, and frees four slots on the way.

I considered raising the cap in the SDK (we own that fork) and rejected it: this is a Petdex packing problem, not a platform limit, and the cap is runtime-wide for every app.

A logo that fails to decode leaves its cell transparent rather than aborting the strip, and the row only registers if at least one cell landed, so one bad asset costs one icon instead of all five.

## Verified

Screenshot with all five agents present, taken from a scratch $HOME with config roots for each. Claude Code, Codex, Gemini, opencode and Qoder each render their own logo in the Agents panel, none shifted a cell. An off-by-one here would draw the neighbour's logo rather than fail loudly, so this needed eyes on it, not just a green build.

Tests cover what the screenshot cannot repeat in CI: per-agent offsets, cells abutting without overlap, the strip staying inside the per-image bounds, and `agent_art` covering every `AgentKind` so a new agent without artwork fails the build instead of packing short.

57/57 tests, `native build` green on macOS and `x86_64-windows -Dcpu=baseline`.

## Also included

`docs/agent-adapters-research.md`, the research behind the three remaining adapter issues. Short version: Kimi Code, CodeBuddy and OMP are all viable and being built; OpenClaw was closed in #289 because it has no tool-level events at all and is a gateway that orchestrates the agents Petdex already supports.