### PR TITLE
fix(submit): say email addresses are blocked too, not just URLs

### DIFF
--- a/src/lib/url-blocklist.test.ts
+++ b/src/lib/url-blocklist.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { containsUrl } from "@/lib/url-blocklist";
+import { containsUrl, URL_BLOCKED_REASON } from "@/lib/url-blocklist";
 
 describe("containsUrl — pass cases", () => {
   it("passes on plain text without any URL", () => {
@@ -170,5 +170,24 @@ describe("containsUrl — allowlisted legit domains", () => {
     const hit = containsUrl(["description", "join promo.dev for free"]);
     expect(hit).not.toBeNull();
     expect(hit?.pattern).toBe("bare_domain");
+  });
+});
+
+describe("containsUrl — email addresses", () => {
+  it("blocks an email, because the domain in it is what spam harvests", () => {
+    const hit = containsUrl([
+      "description",
+      "A pixel-art companion. Contact haipengzhu33@gmail.com",
+    ]);
+    expect(hit).not.toBeNull();
+    expect(hit?.field).toBe("description");
+  });
+
+  it("says so in the reason, so a submitter can tell what tripped it", () => {
+    // #631: someone put their address in a description to take
+    // suggestions privately, got told "URLs are not allowed", and had no
+    // way to connect that to their own email. The rule was right; the
+    // wording was not.
+    expect(URL_BLOCKED_REASON.toLowerCase()).toContain("email");
   });
 });

--- a/src/lib/url-blocklist.ts
+++ b/src/lib/url-blocklist.ts
@@ -124,5 +124,9 @@ export function containsUrl(
   return null;
 }
 
+// Email addresses trip the bare-domain rule, which is correct (the
+// filter exists to stop contact-harvesting spam) but the old wording
+// only said "URLs", so a submitter reading it did not know their own
+// address was the problem. #631 sat for days on exactly that confusion.
 export const URL_BLOCKED_REASON =
-  "URLs are not allowed in this field. Use the credit URL field for links.";
+  "Links and email addresses are not allowed in this field. Use the credit URL field for links.";


### PR DESCRIPTION
Follow-up to #631.

The bare-domain rule catches email addresses. That is correct behavior: the filter exists to stop contact harvesting, and an address is exactly the payload it is meant to catch. The problem was the message, which only said "URLs are not allowed in this field."

#631 sat for days on that gap. The submitter put their address in a description so people could send suggestions privately, hit `url_in_field`, and had no way to connect that error to their own email. They worked it out themselves in the end.

Their package was fine, incidentally. I ran the `pet.json` from the attached zip through the validator and it came back clean, which is what narrowed it down to something typed into the form rather than carried in the file.

Tests pin both halves: an address still trips the rule, and the reason string names email so the next person can tell what happened.
