### PR TITLE
chore(release): desktop 0.4.0, cli 1.0.1

### DIFF
--- a/packages/petdex-cli/package.json
+++ b/packages/petdex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "petdex",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "CLI for Petdex. Install, browse, and submit Codex pets from your terminal.",
   "homepage": "https://petdex.dev",
   "repository": {

--- a/packages/petdex-desktop-native/app.zon
+++ b/packages/petdex-desktop-native/app.zon
@@ -3,7 +3,7 @@
     .name = "petdex-desktop-native",
     .display_name = "Petdex",
     .description = "Petdex desktop pet on Native SDK: no WebView, no Node.",
-    .version = "0.3.1",
+    .version = "0.4.0",
     .icons = .{"assets/icon.png"},
     .platforms = .{ "macos", "windows", "linux" },
     .permissions = .{ "view", "command" },


### PR DESCRIPTION
Version bump ahead of the first release since `desktop-v0.3.1` (2026-07-27). 30 commits behind it.

**Desktop 0.3.1 to 0.4.0.** Three new agents (Kimi Code #634, CodeBuddy #635, OMP #636) on top of the crash fix that makes 0.3.1 unusable on Zen 3 (#621, closing #604 and #618).

**CLI 1.0.0 to 1.0.1.** The Grep bubble losing its pattern to an ASCII quote (#628) and the bubble hook's stdin handling (#583). No API change.

Merging this publishes the CLI: `cli-release.yml` triggers on push to main and compares the version field against npm, so no tag needed for that half.

## Checked before tagging

`-Dcpu=baseline` landed in #621, after the last release, so the release path has never actually run with it. I built the Windows target and disassembled it: **0 AVX instructions, 0 kmovd, 0 vpternlogd**. The AMD crash fix will really ship, rather than being a flag nobody exercised.

Also verified `bun install --frozen-lockfile` is clean, since a stale lockfile broke every cron for two days earlier this week.

68 native tests, 350 web tests.