### PR TITLE
fix(download): offer the Intel build, and unbreak bun dev

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -171,6 +171,13 @@ const publicHtmlCacheSources = [
 const mockRoot = path.resolve(__dirname, "src/lib/mock");
 
 const nextConfig: NextConfig = {
+  experimental: {
+    // TypeScript 7 dropped the compiler API Next reads for its dev-time
+    // type checking, so `bun dev` crashed on boot after the 6-to-7 bump
+    // in #580. This is the escape hatch Next's own error names: it drives
+    // `tsc` as a CLI instead of importing its API.
+    useTypeScriptCli: true,
+  },
   // Hide the framework banner on every response.
   poweredByHeader: false,
   images: {

--- a/src/components/download/download-hero.tsx
+++ b/src/components/download/download-hero.tsx
@@ -22,10 +22,18 @@ const ASSET = {
   "win32-x64": "/api/desktop/latest-release?asset=win32-x64",
 } as const;
 
-type Build = { key: keyof typeof ASSET; os: "macos" | "windows" | "linux" };
+type Build = {
+  key: keyof typeof ASSET;
+  os: "macos" | "windows" | "linux";
+  /// Shown in parentheses after the OS name. Only macOS ships two
+  /// architectures, and the row lists both, so without this they would
+  /// read as the same link twice.
+  hint?: string;
+};
 
 const BUILDS: Build[] = [
-  { key: "darwin-arm64", os: "macos" },
+  { key: "darwin-arm64", os: "macos", hint: "Apple Silicon" },
+  { key: "darwin-x64", os: "macos", hint: "Intel" },
   { key: "win32-x64", os: "windows" },
   { key: "linux-x64", os: "linux" },
 ];
@@ -35,6 +43,7 @@ function primaryBuild(platform: Platform, arch: MacArch): Build | null {
     return {
       key: arch === "intel" ? "darwin-x64" : "darwin-arm64",
       os: "macos",
+      hint: arch === "intel" ? "Intel" : "Apple Silicon",
     };
   }
   if (platform === "windows") return { key: "win32-x64", os: "windows" };
@@ -56,7 +65,10 @@ export function DownloadHero() {
   const platform = usePlatform();
   const arch = useMacArch();
   const primary = primaryBuild(platform, arch);
-  const others = BUILDS.filter((b) => b.os !== primary?.os);
+  // Filter by build, not by OS: a Mac visitor has already been handed
+  // one architecture, and hiding the other one leaves an Intel user
+  // whose arch we failed to detect with nowhere to go.
+  const others = BUILDS.filter((b) => b.key !== primary?.key);
 
   return (
     <section className="mx-auto flex w-full max-w-xl flex-col items-center px-5 pt-16 pb-20 text-center md:pt-24">
@@ -94,6 +106,10 @@ export function DownloadHero() {
             >
               <ArrowDownToLine className="size-[18px]" />
               {t(`for.${primary.os}`)}
+              {/* Name the architecture on the primary button too. It is
+                  detected, not chosen, so saying which one it picked is
+                  what lets someone notice it guessed wrong. */}
+              {primary.hint ? ` (${primary.hint})` : ""}
             </a>
             <p className="font-mono text-xs text-muted-3">{t("freeNote")}</p>
           </>
@@ -114,6 +130,7 @@ export function DownloadHero() {
               className="underline decoration-border-strong underline-offset-4 transition hover:text-foreground"
             >
               {t(`for.${b.os}`)}
+              {b.hint ? ` (${b.hint})` : ""}
             </a>
           ))}
         </div>


### PR DESCRIPTION
Two things, both found by trying to actually look at the page rather than reading the code.

## The Intel build was shipped but unreachable

The download row filtered by OS, so a Mac visitor was handed one architecture and had no way to reach the other. An Intel user whose arch we failed to detect (Safari without WebGL hints falls back to arm64) had nowhere to go, which defeats the point of shipping the Intel build in the first place (#609).

It filters by build now, and both macOS entries carry an architecture hint in parentheses.

The primary button names its architecture too. It is detected, not chosen, so saying which one it picked is what lets someone notice the guess was wrong and grab the other.

## `bun dev` has been broken since #580

TypeScript 7 dropped the compiler API Next reads for dev-time type checking, so the dev server crashed on boot:

```
TypeScript 7.0.2 does not provide the compiler API required by Next.js.
```

`next.config.ts` now sets `experimental.useTypeScriptCli`, the escape hatch Next's own error message names. It drives `tsc` as a CLI instead of importing its API.

This regression is mine. I verified #580 with `tsc --noEmit` and `bun test`, both of which pass, and never started the dev server, which is the one place it breaks. Confirmed against `main` before fixing so this is not something I introduced in this branch.

## Verified

Screenshot from a running dev server: the primary button reads **Download for macOS (Apple Silicon)**, with **Download for macOS (Intel)** alongside Windows and Linux.

350 web tests, `i18n:check` in sync. The hints are literal strings rather than translation keys, matching how `download-cta.tsx` already renders the same two labels.
