### PR TITLE
chore(sdk): move the pin to 5f9f7cfa

### DIFF
--- a/.github/workflows/desktop-native-ci.yml
+++ b/.github/workflows/desktop-native-ci.yml
@@ -105,7 +105,7 @@ jobs:
         env:
           NATIVE_SDK_REMOTE: "https://github.com/Railly/native.git"
           NATIVE_SDK_BRANCH: "feat/floating-window-0.5.3"
-          NATIVE_SDK_REF: "65d4885cb5f76a5d1f33cace56b93a898f7b2cb3"
+          NATIVE_SDK_REF: "5f9f7cfa77f2a16f2dc26e337806d2a4b59a067b"
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           NATIVE_SDK_REMOTE: "https://github.com/Railly/native.git"
           NATIVE_SDK_BRANCH: "feat/floating-window-0.5.3"
-          NATIVE_SDK_REF: "65d4885cb5f76a5d1f33cace56b93a898f7b2cb3"
+          NATIVE_SDK_REF: "5f9f7cfa77f2a16f2dc26e337806d2a4b59a067b"
         # Explicit bash: this job now runs on a Windows runner too, where
         # the default shell is PowerShell and `set -euo pipefail` fails
         # as an unknown parameter before git is ever reached.


### PR DESCRIPTION
Unblocks #614.

`Railly/native#1` landed the Linux Wayland runtime support on 08-02, and I told @ThermalEng on #614 that the pin could move to `5f9f7cfa`. Then I did not move it. Both workflows still pointed at `65d4885`, so #614 has sat CONFLICTING for five days waiting on a one-line change from me.

The distinction matters for him, which is why he asked before rebasing: with the pin here, #614 drops its 1681-line patch file and both `git apply` steps, because the SDK carries that work now. Rebasing against the old pin would have meant redoing the resolution afterwards.

## Verified

Ran main against the new pin before moving it, rather than moving it and hoping CI agreed:

- 68/68 native tests
- `native build` green on macOS and `x86_64-windows -Dcpu=baseline`

Both workflows move together, which `lockfile-check` already enforces. A release built from a different SDK commit than CI tested is untested by construction.
