### PR TITLE
fix(cli): add the slug-to-id route petdex edit needs

### DIFF
--- a/src/app/api/pets/[slug]/route.ts
+++ b/src/app/api/pets/[slug]/route.ts
@@ -1,0 +1,68 @@
+// Slug to internal id, for the CLI's edit flow.
+//
+// `petdex edit <slug>` resolves the slug here before it can ask
+// /api/cli/edit-presign for upload slots, because that route keys on the
+// internal id. The route never existed (#606): only sub-resources under
+// [slug] did, so every edit died at "not found or you do not own it"
+// before a single byte was uploaded.
+//
+// Ownership is enforced here, not just disclosed: the lookup is scoped to
+// the bearer's own pets, so this cannot be used to enumerate ids for pets
+// the caller does not own. That matches /api/cli/edit-presign, which
+// re-checks ownership anyway; this is defense in depth, not the only gate.
+
+import { NextResponse } from "next/server";
+
+import { and, eq } from "drizzle-orm";
+
+import { verifyCliBearer } from "@/lib/cli-auth";
+import { db, schema } from "@/lib/db/client";
+import { cliVerifyRatelimit } from "@/lib/ratelimit";
+
+export const runtime = "nodejs";
+
+function clientIp(req: Request): string {
+  const xff = req.headers.get("x-forwarded-for") ?? "";
+  return xff.split(",")[0]?.trim() || "anon";
+}
+
+export async function GET(
+  req: Request,
+  ctx: { params: Promise<{ slug: string }> },
+): Promise<Response> {
+  const limit = await cliVerifyRatelimit.limit(clientIp(req));
+  if (!limit.success) {
+    return NextResponse.json({ error: "rate_limited" }, { status: 429 });
+  }
+
+  const principal = await verifyCliBearer(req.headers.get("authorization"));
+  if (!principal) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const { slug: raw } = await ctx.params;
+  const slug = typeof raw === "string" ? raw.trim() : "";
+  if (!slug) {
+    return NextResponse.json({ error: "missing_slug" }, { status: 400 });
+  }
+
+  const row = await db.query.submittedPets.findFirst({
+    where: and(
+      eq(schema.submittedPets.slug, slug),
+      eq(schema.submittedPets.ownerId, principal.userId),
+    ),
+    columns: { id: true, slug: true, status: true, displayName: true },
+  });
+  // Not-found and not-yours answer the same way on purpose: a distinct
+  // 403 would confirm a slug exists and belongs to someone else.
+  if (!row) {
+    return NextResponse.json({ error: "pet_not_found" }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    id: row.id,
+    slug: row.slug,
+    status: row.status,
+    displayName: row.displayName,
+  });
+}


### PR DESCRIPTION
Closes #606. Thanks @MisonL for a report that named the missing file and the exact route.

## The bug

`petdex edit <slug>` resolves the slug through `GET /api/pets/<slug>` before it can ask `/api/cli/edit-presign` for upload slots, because that route keys on the internal id.

The route never existed. Only sub-resources under `[slug]` did (`metrics`, `like`, `thumb`, and friends). So every edit died at *"not found or you do not own it"* before uploading a byte.

Confirmed against production before writing anything:

```
GET /api/pets/doraemon          -> 404
GET /api/pets/doraemon/metrics  -> 200
```

A missing route, not a broken one.

## The second half of the report

The issue also flags the owner routes under `/api/my-pets` as a blocker, since they read a Clerk browser session while the CLI carries an OAuth bearer.

That is accurate but does not apply to this flow: the CLI never calls those routes. It goes to `/api/cli/edit-presign`, which answers `401` in production, meaning it is deployed and gated correctly. So one blocker, not two.

## Ownership

Enforced in the lookup rather than disclosed after it. The query is scoped to `ownerId = principal.userId`, and a pet owned by someone else answers `404`, not `403`, so this cannot be used to confirm which slugs exist or to enumerate ids. `/api/cli/edit-presign` re-checks ownership anyway; this is defense in depth, not the only gate.

## Verified

Running, not just compiling:

- unauthenticated `GET /api/pets/doraemon` now answers **401** instead of 404
- `GET /api/pets/doraemon/metrics` still answers **200**, so the new route does not shadow the sub-resources
- `tsc --noEmit` 0 errors, `bun run build` exits 0 with `ƒ /api/pets/[slug]` in the route table
- 350 tests

No test added: this repo has no harness for API routes, and standing one up for a single handler belongs in its own change rather than smuggled into a fix.
