### PR TITLE
fix(submit): say which file is too large, and check before uploading

### DIFF
--- a/src/app/api/r2/presign/route.ts
+++ b/src/app/api/r2/presign/route.ts
@@ -71,8 +71,24 @@ export async function POST(req: Request): Promise<Response> {
       );
     }
     if (typeof f.size !== "number" || f.size <= 0 || f.size > MAX_BYTES) {
+      // Name the file and both numbers. The bare code sent someone to
+      // #594 with a 1536x2288 sprite, the canonical size, and no way to
+      // tell which of the three uploads was over or by how much — the
+      // zip is sent alongside the sprite and a webp barely compresses,
+      // so it is usually the zip that trips this, not the art.
+      const mb = (n: number) => `${(n / (1024 * 1024)).toFixed(1)} MB`;
+      const size = typeof f.size === "number" ? f.size : 0;
       return NextResponse.json(
-        { error: "file_too_large", maxBytes: MAX_BYTES },
+        {
+          error: "file_too_large",
+          maxBytes: MAX_BYTES,
+          role: f.role,
+          size,
+          message:
+            size > 0
+              ? `Your ${f.role} is ${mb(size)}, over the ${mb(MAX_BYTES)} limit.`
+              : `Your ${f.role} has no readable size.`,
+        },
         { status: 400 },
       );
     }

--- a/src/components/submit/pet-submit-form.tsx
+++ b/src/components/submit/pet-submit-form.tsx
@@ -39,6 +39,12 @@ type ParsedPet = {
   source: "folder" | "zip" | "spritesheet";
 };
 
+// Mirrors MAX_BYTES in /api/r2/presign. Checked here too so an oversized
+// pet is caught before the upload starts rather than after the round
+// trip, and so the message can name the file (#594 reported only the
+// bare error code with no way to tell which of the three was over).
+const MAX_UPLOAD_BYTES = 8 * 1024 * 1024;
+
 const MAX_DISPLAY_NAME_LENGTH = 60;
 const MAX_DESCRIPTION_LENGTH = 500;
 
@@ -399,6 +405,22 @@ export function PetSubmitForm() {
       `${deriveSlug(parsed.petId, displayName)}-pet.json`,
       { type: "application/json" },
     );
+
+    const oversized = (
+      [
+        ["zip", zipFile.size],
+        ["sprite", spriteFile.size],
+      ] as const
+    ).find(([, size]) => size > MAX_UPLOAD_BYTES);
+    if (oversized) {
+      const [role, size] = oversized;
+      const mb = (n: number) => `${(n / (1024 * 1024)).toFixed(1)} MB`;
+      const message = `Your ${role} is ${mb(size)}, over the ${mb(MAX_UPLOAD_BYTES)} limit.`;
+      uploadErrorRef.current = message;
+      setUploadError(message);
+      setSubmission({ kind: "error", message });
+      return;
+    }
 
     setSubmission({ kind: "uploading", step: "uploading" });
     setUploadError(null);


### PR DESCRIPTION
Addresses #594.

@totem-pole hit `file_too_large` on a 1536x2288 sprite, which is the canonical size. The error gave a bare code and a `maxBytes` number and nothing else, so there was no way to tell which of the three uploads was over, or by how much.

## Why that is worse than it sounds

Three files go up per submission: `zip`, `sprite`, `petjson`. A spritesheet is already webp, so zipping it compresses nothing and the zip lands at roughly the sprite's size. I measured a catalog pet: 1.84 MB sprite, 1.84 MB zip.

So whichever file trips the limit, the submitter sees the same opaque code and reasonably concludes their art is too big. It usually is not.

## What changed

The API names the role and both numbers:

```
Your zip is 9.0 MB, over the 8.0 MB limit.
```

And the form checks the same limit locally before starting, so an oversized pet fails immediately instead of after uploading and being rejected.

**The 8MB limit itself does not change.** Real sprites in the catalog run 2.3 to 2.6 MB, so this is about the message, not the ceiling.

## What I could not verify

#594 never attached its zip, so I could not reproduce the submitter's exact file or confirm what actually went over. This fixes the reporting gap the issue exposes rather than a confirmed oversized upload.

If the real problem turns out to be that a legitimate pet cannot fit in 8MB, that is a different change and needs the file to argue about.

## Verified

- the message strings, against the same branch the route runs
- `tsc --noEmit` 0 errors, `bun run build` compiles, 350 tests
