### PR TITLE
fix(upload): align owner edit asset limit

### DIFF
--- a/src/app/api/cli/submit/route.ts
+++ b/src/app/api/cli/submit/route.ts
@@ -11,11 +11,12 @@ import { verifyCliBearer } from "@/lib/cli-auth";
 import { presignPut } from "@/lib/r2";
 import { cliVerifyRatelimit, submitRatelimit } from "@/lib/ratelimit";
 import { deriveSlug } from "@/lib/slug";
+import { PET_ASSET_MAX_BYTES } from "@/lib/upload-limits";
 
 export const runtime = "nodejs";
 
 const MAX_KEY_LEN = 80;
-const MAX_BYTES = 8 * 1024 * 1024;
+const MAX_BYTES = PET_ASSET_MAX_BYTES;
 
 type Body = {
   slugHint?: string;

--- a/src/app/api/r2/presign/route.ts
+++ b/src/app/api/r2/presign/route.ts
@@ -6,6 +6,7 @@ import { isAdmin } from "@/lib/admin";
 import { presignPut } from "@/lib/r2";
 import { presignRatelimit } from "@/lib/ratelimit";
 import { requireSameOrigin } from "@/lib/same-origin";
+import { PET_ASSET_MAX_BYTES } from "@/lib/upload-limits";
 
 export const runtime = "nodejs";
 
@@ -24,7 +25,7 @@ type AskedFile = {
   size: number;
 };
 
-const MAX_BYTES = 8 * 1024 * 1024;
+const MAX_BYTES = PET_ASSET_MAX_BYTES;
 
 export async function POST(req: Request): Promise<Response> {
   const csrf = requireSameOrigin(req);

--- a/src/components/profile/owner-edit-panel.tsx
+++ b/src/components/profile/owner-edit-panel.tsx
@@ -6,6 +6,8 @@ import { useEffect, useRef, useState, useTransition } from "react";
 import { Loader2, Pencil, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 
+import { PET_ASSET_MAX_BYTES } from "@/lib/upload-limits";
+
 type Pending = {
   displayName: string | null;
   description: string | null;
@@ -46,7 +48,7 @@ function readImageDims(file: File): Promise<{ width: number; height: number }> {
   });
 }
 
-const MAX_SPRITE_BYTES = 2 * 1024 * 1024;
+const MAX_SPRITE_BYTES = PET_ASSET_MAX_BYTES;
 const MAX_SPRITE_DIM = 4096;
 
 export function OwnerEditPanel({

--- a/src/components/submit/pet-submit-form.tsx
+++ b/src/components/submit/pet-submit-form.tsx
@@ -18,6 +18,7 @@ import { useTranslations } from "next-intl";
 
 import { petStates } from "@/lib/pet-states";
 import { deriveSlug } from "@/lib/slug";
+import { PET_ASSET_MAX_BYTES } from "@/lib/upload-limits";
 
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -43,7 +44,7 @@ type ParsedPet = {
 // pet is caught before the upload starts rather than after the round
 // trip, and so the message can name the file (#594 reported only the
 // bare error code with no way to tell which of the three was over).
-const MAX_UPLOAD_BYTES = 8 * 1024 * 1024;
+const MAX_UPLOAD_BYTES = PET_ASSET_MAX_BYTES;
 
 const MAX_DISPLAY_NAME_LENGTH = 60;
 const MAX_DESCRIPTION_LENGTH = 500;

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -740,7 +740,7 @@
       "spritesheetHelp": "Replaces the current sprite. Goes to manual review.",
       "metaLabel": "Metadata (pet.json)",
       "metaHelp": "Replaces the current metadata. Goes to manual review.",
-      "fileTooBig": "File exceeds 2 MB",
+      "fileTooBig": "File exceeds 8 MB",
       "invalidImage": "Invalid image file",
       "invalidJson": "Invalid JSON file",
       "autoApproved": "Edit applied",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -740,7 +740,7 @@
       "spritesheetHelp": "Reemplaza el sprite actual. Va a revision manual.",
       "metaLabel": "Metadatos (pet.json)",
       "metaHelp": "Reemplaza los metadatos actuales. Va a revision manual.",
-      "fileTooBig": "El archivo supera los 2 MB",
+      "fileTooBig": "El archivo supera los 8 MB",
       "invalidImage": "Archivo de imagen no valido",
       "invalidJson": "Archivo JSON no valido",
       "autoApproved": "Edicion aplicada",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -918,7 +918,7 @@
       "spritesheetHelp": "替换当前精灵图集 Spritesheet。需要人工审核。",
       "metaLabel": "元数据 pet.json",
       "metaHelp": "替换当前元数据。需要人工审核。",
-      "fileTooBig": "文件超过 2 MB",
+      "fileTooBig": "文件超过 8 MB",
       "invalidImage": "无效的图片文件",
       "invalidJson": "无效的 JSON 文件",
       "autoApproved": "编辑已应用",

--- a/src/lib/submission-review.ts
+++ b/src/lib/submission-review.ts
@@ -39,9 +39,10 @@ import {
   SUBMISSION_SIMILARITY_VISUAL_THRESHOLD,
   SUBMISSION_STRONG_SEMANTIC_CORROBORATION_THRESHOLD,
 } from "@/lib/submission-similarity";
+import { PET_ASSET_MAX_BYTES } from "@/lib/upload-limits";
 import { isAllowedAssetUrl } from "@/lib/url-allowlist";
 
-const MAX_ASSET_BYTES = 8 * 1024 * 1024;
+const MAX_ASSET_BYTES = PET_ASSET_MAX_BYTES;
 const MAX_ZIP_ENTRIES = 80;
 const MAX_ZIP_PET_JSON_SCAN_ENTRIES = 16;
 const MAX_ZIP_PET_JSON_TOTAL_BYTES = MAX_ASSET_BYTES;

--- a/src/lib/upload-limits.test.ts
+++ b/src/lib/upload-limits.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+
+import { PET_ASSET_MAX_BYTES, PET_ASSET_MAX_LABEL } from "@/lib/upload-limits";
+
+import en from "@/i18n/messages/en.json";
+import es from "@/i18n/messages/es.json";
+import zh from "@/i18n/messages/zh.json";
+
+describe("pet asset upload limits", () => {
+  it("keeps owner edit upload copy aligned with the shared pet asset limit", () => {
+    expect(PET_ASSET_MAX_BYTES).toBe(8 * 1024 * 1024);
+    expect(PET_ASSET_MAX_LABEL).toBe("8 MB");
+
+    expect(en.myPets.edit.fileTooBig).toContain(PET_ASSET_MAX_LABEL);
+    expect(es.myPets.edit.fileTooBig).toContain(PET_ASSET_MAX_LABEL);
+    expect(zh.myPets.edit.fileTooBig).toContain(PET_ASSET_MAX_LABEL);
+  });
+});

--- a/src/lib/upload-limits.ts
+++ b/src/lib/upload-limits.ts
@@ -1,0 +1,2 @@
+export const PET_ASSET_MAX_BYTES = 8 * 1024 * 1024;
+export const PET_ASSET_MAX_LABEL = "8 MB";


### PR DESCRIPTION
## Summary

- align the owner edit spritesheet upload cap with the 8 MB submit/review asset limit
- add a shared pet asset upload limit constant used by submit, presign, CLI submit, review, and owner edit paths
- update owner edit file-too-large copy in all locales from 2 MB to 8 MB
- add a regression test to keep the shared limit and owner edit copy aligned

Closes #652

## Validation

- `bun test`
- `bun test src/lib/upload-limits.test.ts src/lib/r2.test.ts`
- `bun test --env-file=.env.mock src/lib/submission-review.test.ts`
- `bun run i18n:check`
- `bun run check`