### PR TITLE
feat(desktop): focus originating terminal and support fullscreen overlays

### DIFF
--- a/packages/petdex-desktop-native/app.zon
+++ b/packages/petdex-desktop-native/app.zon
@@ -34,6 +34,7 @@
                 .resizable = false,
                 .titlebar = "chromeless",
                 .floating = true,
+                .fullscreen_overlay = true,
                 .transparent = true,
                 .restore_state = false,
                 .restore_policy = "center_on_primary",

--- a/packages/petdex-desktop-native/src/assets/opencode-plugin.js
+++ b/packages/petdex-desktop-native/src/assets/opencode-plugin.js
@@ -36,6 +36,15 @@ function clip(text, max = 40) {
   return text.length <= max ? text : text.slice(0, max - 1) + "…";
 }
 
+function originMetadata() {
+  const sourceApp = process.env.TERM_PROGRAM;
+  if (sourceApp !== "Apple_Terminal" && sourceApp !== "vscode") return {};
+  return {
+    source_app: sourceApp,
+    source_cwd: process.cwd(),
+  };
+}
+
 function canonicalToolKind(toolName) {
   const lower = String(toolName || "").toLowerCase();
   if (lower === "read") return "read";
@@ -137,7 +146,9 @@ async function notify({ state, duration, text, title, busy }) {
     duration != null
       ? { state, duration, agent_source: "opencode" }
       : { state, agent_source: "opencode" };
-  const bubbleBody = { text, agent_source: "opencode" };
+  const metadata = originMetadata();
+  Object.assign(stateBody, metadata);
+  const bubbleBody = { text, agent_source: "opencode", ...metadata };
   if (title) bubbleBody.title = title;
   if (busy !== undefined) bubbleBody.busy = busy;
   await Promise.all([

--- a/packages/petdex-desktop-native/src/hook_runner.zig
+++ b/packages/petdex-desktop-native/src/hook_runner.zig
@@ -29,7 +29,7 @@ const post_poll_ms: u64 = 5;
 
 /// argv tail after "bubble": [phase, agent?]. Reads stdin, formats,
 /// POSTs bubble + state to the sidecar. Never fails outward.
-pub fn run(phase: []const u8, arg_agent: ?[]const u8, home: []const u8) void {
+pub fn run(phase: []const u8, arg_agent: ?[]const u8, origin_app: plat.OriginApplication, source_cwd_raw: ?[]const u8, home: []const u8) void {
     // Always finish consuming the host's payload before any early return.
     // The host may still be writing after the useful 64 KiB prefix, and
     // closing the read end early propagates EPIPE/Broken pipe to the agent.
@@ -53,6 +53,10 @@ pub fn run(phase: []const u8, arg_agent: ?[]const u8, home: []const u8) void {
     if (token.len == 0) return;
 
     const agent = jsonString(payload, "agent_source") orelse (arg_agent orelse "");
+    const source_app = origin_app.wireName();
+    var tty_buf: [64]u8 = undefined;
+    const source_tty = if (origin_app == .terminal) (plat.controllingTty(&tty_buf) orelse "") else "";
+    const source_cwd = plat.safeSourceCwd(source_cwd_raw) orelse "";
     const session_id = safeSessionId(jsonString(payload, "session_id"));
 
     // Session title: user-prompt seeds it, every event attaches it.
@@ -97,7 +101,7 @@ pub fn run(phase: []const u8, arg_agent: ?[]const u8, home: []const u8) void {
     var post_count: usize = 0;
     var body_buf: [1024]u8 = undefined;
     if (text.len > 0) {
-        const body = bubbleBody(&body_buf, text, title, busy, agent, session_id);
+        const body = bubbleBodyWithMetadata(&body_buf, text, title, busy, agent, session_id, source_app, source_tty, source_cwd);
         if (body) |b| {
             if (startPost("/bubble", b, token)) |post| {
                 posts[post_count] = post;
@@ -144,6 +148,10 @@ fn isToolFailurePhase(phase: []const u8) bool {
 /// precisely how session_id got parsed, used for titles, and then left out of
 /// the POST that needed it.
 pub fn bubbleBody(out: []u8, text: []const u8, title: []const u8, busy: bool, agent: []const u8, session_id: ?[]const u8) ?[]const u8 {
+    return bubbleBodyWithMetadata(out, text, title, busy, agent, session_id, "", "", "");
+}
+
+fn bubbleBodyWithMetadata(out: []u8, text: []const u8, title: []const u8, busy: bool, agent: []const u8, session_id: ?[]const u8, source_app: []const u8, source_tty: []const u8, source_cwd: []const u8) ?[]const u8 {
     var title_buf: [256]u8 = undefined;
     const title_part: []const u8 = if (title.len > 0)
         (std.fmt.bufPrint(&title_buf, ",\"title\":\"{s}\"", .{title}) catch return null)
@@ -154,7 +162,12 @@ pub fn bubbleBody(out: []u8, text: []const u8, title: []const u8, busy: bool, ag
         (std.fmt.bufPrint(&session_buf, ",\"session_id\":\"{s}\"", .{sid}) catch return null)
     else
         "";
-    return std.fmt.bufPrint(out, "{{\"text\":\"{s}\"{s},\"busy\":{},\"agent_source\":\"{s}\"{s}}}", .{ text, title_part, busy, agent, session_part }) catch null;
+    var metadata_buf: [704]u8 = undefined;
+    const metadata = if (source_app.len > 0 or source_tty.len > 0 or source_cwd.len > 0)
+        (std.fmt.bufPrint(&metadata_buf, ",\"source_app\":\"{s}\",\"source_tty\":\"{s}\",\"source_cwd\":\"{s}\"", .{ source_app, source_tty, source_cwd }) catch return null)
+    else
+        "";
+    return std.fmt.bufPrint(out, "{{\"text\":\"{s}\"{s},\"busy\":{},\"agent_source\":\"{s}\"{s}{s}}}", .{ text, title_part, busy, agent, session_part, metadata }) catch null;
 }
 
 /// The /state request body. Extracted and pure for one reason: `run()` reaches

--- a/packages/petdex-desktop-native/src/hook_server.zig
+++ b/packages/petdex-desktop-native/src/hook_server.zig
@@ -50,11 +50,22 @@ pub const Bubble = struct {
     /// path), which is what keeps single-bubble behaviour identical.
     session: [64]u8 = @splat(0),
     session_len: usize = 0,
+    origin_app: plat.OriginApplication = .none,
+    source_tty: [64]u8 = @splat(0),
+    source_tty_len: usize = 0,
+    source_cwd: [512]u8 = @splat(0),
+    source_cwd_len: usize = 0,
     busy: bool = false,
     counter: u64 = 0,
 
     pub fn sessionSlice(self: *const Bubble) []const u8 {
         return self.session[0..self.session_len];
+    }
+    pub fn ttySlice(self: *const Bubble) []const u8 {
+        return self.source_tty[0..self.source_tty_len];
+    }
+    pub fn cwdSlice(self: *const Bubble) []const u8 {
+        return self.source_cwd[0..self.source_cwd_len];
     }
 };
 
@@ -128,6 +139,10 @@ pub const Mailbox = struct {
     /// full the least recently updated entry is evicted: an abandoned
     /// session must not hold a slot against a live one.
     pub fn setBubble(self: *Mailbox, session: []const u8, text: []const u8, agent: []const u8, title: []const u8, busy: bool) u64 {
+        return self.setBubbleWithMetadata(session, text, agent, title, .none, "", "", busy);
+    }
+
+    pub fn setBubbleWithMetadata(self: *Mailbox, session: []const u8, text: []const u8, agent: []const u8, title: []const u8, origin_app: plat.OriginApplication, source_tty: []const u8, source_cwd: []const u8, busy: bool) u64 {
         self.mutex.lock();
         defer self.mutex.unlock();
 
@@ -160,6 +175,13 @@ pub const Mailbox = struct {
         const tn = @min(title.len, slot.title.len);
         @memcpy(slot.title[0..tn], title[0..tn]);
         slot.title_len = tn;
+        slot.origin_app = origin_app;
+        const tty_n = @min(source_tty.len, slot.source_tty.len);
+        @memcpy(slot.source_tty[0..tty_n], source_tty[0..tty_n]);
+        slot.source_tty_len = tty_n;
+        const cwd_n = @min(source_cwd.len, slot.source_cwd.len);
+        @memcpy(slot.source_cwd[0..cwd_n], source_cwd[0..cwd_n]);
+        slot.source_cwd_len = cwd_n;
         slot.busy = busy;
 
         self.bubble_counter += 1;
@@ -418,12 +440,15 @@ fn route(server: *Server, conn: *Conn, method: []const u8, path: []const u8, hea
         const capped = text[0..@min(text.len, 200)];
         const agent = jsonString(body, "agent_source") orelse "";
         const title = jsonString(body, "title") orelse "";
+        const origin_app = plat.OriginApplication.fromTermProgram(jsonString(body, "source_app"));
+        const source_tty = plat.safeSourceTty(jsonString(body, "source_tty")) orelse "";
+        const source_cwd = plat.safeSourceCwd(jsonString(body, "source_cwd")) orelse "";
         const busy = std.mem.indexOf(u8, body, "\"busy\":true") != null;
         // No session_id means an agent that predates per-conversation
         // bubbles (or the MCP path, which has no session): the empty key
         // is one shared slot, so those callers keep the old behaviour.
         const session = jsonString(body, "session_id") orelse "";
-        const counter = mailbox.setBubble(session[0..@min(session.len, 64)], capped, agent[0..@min(agent.len, 24)], title[0..@min(title.len, 96)], busy);
+        const counter = mailbox.setBubbleWithMetadata(session[0..@min(session.len, 64)], capped, agent[0..@min(agent.len, 24)], title[0..@min(title.len, 96)], origin_app, source_tty, source_cwd, busy);
         mirrorBubble(server, capped, counter, title[0..@min(title.len, 96)], agent[0..@min(agent.len, 24)], busy) catch {};
         const out = std.fmt.bufPrint(&scratch, "{{\"ok\":true,\"counter\":{d}}}", .{counter}) catch return;
         return respond(conn, 200, out);

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -1541,7 +1541,7 @@ pub fn boot(model: *Model, fx: *Effects) void {
     // host's runloop spins up; a Regular-policy Dock icon may blink in
     // for the first frames of a hidden-dock boot, which beats holding
     // the setting hostage to an SDK boot hook that does not exist yet.
-    if (model.hide_dock) plat.setDockIconHidden(true);
+    plat.setDockIconHidden(model.hide_dock, true);
     if (env_home) |home| model.agents = agent_hooks.scan(boot_allocator, home);
 
     // First point where the platform codec is reachable: `init_fx` runs
@@ -1866,7 +1866,7 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
         },
         .toggle_hide_dock => {
             model.hide_dock = !model.hide_dock;
-            plat.setDockIconHidden(model.hide_dock);
+            plat.setDockIconHidden(model.hide_dock, true);
             saveSettings(model);
         },
         .toggle_launch_at_login => {
@@ -2049,6 +2049,9 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
                 // canned (#557's "pet" interaction).
                 if (isTap(now - model.press_ms, read.x - model.press_x, read.y - model.press_y)) {
                     model.sample_len = 0;
+                    if (newestBubble(model)) |bubble| {
+                        _ = plat.activateOriginApplication(bubble.origin_app, bubble.ttySlice(), bubble.cwdSlice());
+                    }
                     model.pat_flip = !model.pat_flip;
                     applyState(model, if (model.pat_flip) .jumping else .waving, pat_react_ms, fx);
                     return;
@@ -3331,6 +3334,7 @@ fn petdexWindows(model: *const Model, scratch: *PetdexApp.WindowsScratch) []cons
             .resizable = false,
             .titlebar = .chromeless,
             .floating = true,
+            .fullscreen_overlay = true,
             .transparent = true,
             .click_through = true,
         };
@@ -3365,8 +3369,6 @@ fn petdexWindowView(ui: *PetdexApp.Ui, model: *const Model, window_label: []cons
         .cell_h = @floatFromInt(thumb_h),
     });
 }
-
-
 
 /// Keep `~/.petdex/bin/petdex-hook` pointing at the running binary so
 /// agent hooks survive app updates: the hooks reference the stable
@@ -3476,7 +3478,8 @@ pub fn main(init: std.process.Init) !void {
         if (std.mem.eql(u8, cmd, "bubble")) {
             const phase = args_it.next() orelse return;
             const agent: ?[]const u8 = args_it.next();
-            hook_runner.run(phase, agent, env_home orelse return);
+            const origin_app = plat.OriginApplication.fromTermProgram(init.environ_map.get("TERM_PROGRAM"));
+            hook_runner.run(phase, agent, origin_app, init.environ_map.get("PWD"), env_home orelse return);
             return;
         }
     }

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -55,6 +55,7 @@ const shell_windows = [_]native_sdk.ShellWindow{.{
     .restore_state = false,
     .titlebar = .chromeless,
     .floating = true,
+    .fullscreen_overlay = true,
     .transparent = true,
     .views = &shell_views,
 }};
@@ -1541,7 +1542,7 @@ pub fn boot(model: *Model, fx: *Effects) void {
     // host's runloop spins up; a Regular-policy Dock icon may blink in
     // for the first frames of a hidden-dock boot, which beats holding
     // the setting hostage to an SDK boot hook that does not exist yet.
-    plat.setDockIconHidden(model.hide_dock, true);
+    plat.setDockIconHidden(model.hide_dock);
     if (env_home) |home| model.agents = agent_hooks.scan(boot_allocator, home);
 
     // First point where the platform codec is reachable: `init_fx` runs
@@ -1866,7 +1867,7 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
         },
         .toggle_hide_dock => {
             model.hide_dock = !model.hide_dock;
-            plat.setDockIconHidden(model.hide_dock, true);
+            plat.setDockIconHidden(model.hide_dock);
             saveSettings(model);
         },
         .toggle_launch_at_login => {
@@ -2791,7 +2792,11 @@ fn updateBubbleStack(model: *Model, cursor_x: f64, cursor_y: f64, now_ms: i64, f
 /// stack is empty.
 fn newestBubble(model: *const Model) ?*const hook_server.Bubble {
     if (model.bubbles_len == 0) return null;
-    return &model.bubbles[model.bubbles_len - 1];
+    var newest = &model.bubbles[0];
+    for (model.bubbles[1..model.bubbles_len]) |*bubble| {
+        if (bubble.counter > newest.counter) newest = bubble;
+    }
+    return newest;
 }
 
 fn clearBubble(model: *Model) void {
@@ -4574,6 +4579,15 @@ test "two conversations stack and grow the window vertically" {
     // budget, they do not sit side by side.
     try std.testing.expectEqual(one_wide, bubbleWindowWidth(&model));
     try std.testing.expectEqualStrings("beta", newestBubble(&model).?.sessionSlice());
+}
+
+test "newest bubble follows counter rather than array position" {
+    var model: Model = .{};
+    testPushBubble(&model, "older", "older text", true, -1);
+    testPushBubble(&model, "newer", "newer text", true, -1);
+    model.bubbles[0].counter = 9;
+    model.bubbles[1].counter = 4;
+    try std.testing.expectEqualStrings("older", newestBubble(&model).?.sessionSlice());
 }
 
 test "an empty stack still reserves one card of window height" {

--- a/packages/petdex-desktop-native/src/plat.zig
+++ b/packages/petdex-desktop-native/src/plat.zig
@@ -341,14 +341,11 @@ const terminal_focus_script =
     \\on run argv
     \\  set targetTTY to item 1 of argv
     \\  tell application "Terminal"
-    \\    set allTabs to every tab of every window
-    \\    set windowIndex to 0
-    \\    repeat with tabsInWindow in allTabs
-    \\      set windowIndex to windowIndex + 1
-    \\      repeat with targetTab in tabsInWindow
+    \\    repeat with targetWindow in every window
+    \\      repeat with targetTab in tabs of targetWindow
     \\        if (tty of targetTab) is targetTTY then
     \\          set selected of targetTab to true
-    \\          set frontmost of window windowIndex to true
+    \\          set index of targetWindow to 1
     \\          activate
     \\          return
     \\        end if

--- a/packages/petdex-desktop-native/src/plat.zig
+++ b/packages/petdex-desktop-native/src/plat.zig
@@ -462,12 +462,9 @@ const AppleApp = if (builtin.os.tag == .macos) struct {
 /// `.accessory` vs `.regular`). Windows still open and focus in
 /// accessory mode; the app just leaves the Dock and app switcher.
 /// No-op on other platforms.
-pub fn setDockIconHidden(hidden: bool, fullscreen_overlay: bool) void {
+pub fn setDockIconHidden(hidden: bool) void {
     if (builtin.os.tag != .macos) return;
-    // A fullscreen companion must remain accessory even when the user
-    // leaves Hide Dock icon disabled. This keeps the SDK's launch policy
-    // and the runtime toggle from fighting each other.
-    const ctx: ?*anyopaque = if (hidden or fullscreen_overlay) @ptrFromInt(1) else null;
+    const ctx: ?*anyopaque = if (hidden) @ptrFromInt(1) else null;
     AppleApp.dispatch_async_f(&AppleApp._dispatch_main_q, ctx, AppleApp.applyPolicy);
 }
 

--- a/packages/petdex-desktop-native/src/plat.zig
+++ b/packages/petdex-desktop-native/src/plat.zig
@@ -306,6 +306,118 @@ pub fn processId() u32 {
     };
 }
 
+/// GUI application that owns the terminal hosting the latest agent event.
+/// Hook metadata is allowlisted and never becomes an arbitrary bundle id.
+pub const OriginApplication = enum(u8) {
+    none,
+    terminal,
+    vscode,
+
+    pub fn fromTermProgram(value: ?[]const u8) OriginApplication {
+        const name = value orelse return .none;
+        if (std.mem.eql(u8, name, "Apple_Terminal")) return .terminal;
+        if (std.mem.eql(u8, name, "vscode")) return .vscode;
+        return .none;
+    }
+
+    pub fn wireName(self: OriginApplication) []const u8 {
+        return switch (self) {
+            .none => "",
+            .terminal => "Apple_Terminal",
+            .vscode => "vscode",
+        };
+    }
+
+    fn bundleIdentifier(self: OriginApplication) ?[]const u8 {
+        return switch (self) {
+            .none => null,
+            .terminal => "com.apple.Terminal",
+            .vscode => "com.microsoft.VSCode",
+        };
+    }
+};
+
+const terminal_focus_script =
+    \\on run argv
+    \\  set targetTTY to item 1 of argv
+    \\  tell application "Terminal"
+    \\    set allTabs to every tab of every window
+    \\    set windowIndex to 0
+    \\    repeat with tabsInWindow in allTabs
+    \\      set windowIndex to windowIndex + 1
+    \\      repeat with targetTab in tabsInWindow
+    \\        if (tty of targetTab) is targetTTY then
+    \\          set selected of targetTab to true
+    \\          set frontmost of window windowIndex to true
+    \\          activate
+    \\          return
+    \\        end if
+    \\      end repeat
+    \\    end repeat
+    \\  end tell
+    \\  error "Petdex could not find the source TTY" number 1
+    \\end run
+;
+
+const mac_c = struct {
+    extern "c" fn open(path: [*:0]const u8, flags: c_int, ...) c_int;
+    extern "c" fn close(fd: c_int) c_int;
+    extern "c" fn ttyname_r(fd: c_int, buf: [*]u8, len: usize) c_int;
+};
+
+pub fn controllingTty(buf: []u8) ?[]const u8 {
+    if (comptime builtin.os.tag != .macos) return null;
+    const fd = mac_c.open("/dev/tty", 0);
+    if (fd < 0) return null;
+    defer _ = mac_c.close(fd);
+    if (mac_c.ttyname_r(fd, buf.ptr, buf.len) != 0) return null;
+    const end = std.mem.indexOfScalar(u8, buf, 0) orelse return null;
+    return safeSourceTty(buf[0..end]);
+}
+
+pub fn safeSourceTty(value: ?[]const u8) ?[]const u8 {
+    const tty = value orelse return null;
+    if (tty.len <= "/dev/tty".len or tty.len > 63) return null;
+    if (!std.mem.startsWith(u8, tty, "/dev/tty")) return null;
+    for (tty["/dev/tty".len..]) |ch| {
+        if (!std.ascii.isAlphanumeric(ch)) return null;
+    }
+    return tty;
+}
+
+pub fn safeSourceCwd(value: ?[]const u8) ?[]const u8 {
+    const cwd = value orelse return null;
+    if (cwd.len == 0 or cwd.len > 511 or cwd[0] != '/') return null;
+    if (!std.unicode.utf8ValidateSlice(cwd)) return null;
+    for (cwd) |ch| {
+        if (ch < 0x20 or ch == '"' or ch == '\\') return null;
+    }
+    return cwd;
+}
+
+fn spawnAndWait(argv: []const []const u8) bool {
+    var scope = Scope.init();
+    defer scope.deinit();
+    const io = scope.io();
+    var child = std.process.spawn(io, .{ .argv = argv, .stdin = .ignore, .stdout = .ignore, .stderr = .ignore }) catch return false;
+    return switch (child.wait(io) catch return false) {
+        .exited => |code| code == 0,
+        else => false,
+    };
+}
+
+pub fn activateOriginApplication(origin: OriginApplication, source_tty: []const u8, source_cwd: []const u8) bool {
+    if (builtin.os.tag != .macos) return false;
+    _ = source_cwd;
+    if (origin == .terminal) {
+        if (safeSourceTty(source_tty)) |tty| {
+            if (spawnAndWait(&.{ "/usr/bin/osascript", "-e", terminal_focus_script, tty })) return true;
+        }
+    }
+    const bundle_id = origin.bundleIdentifier() orelse return false;
+    return spawnAndWait(&.{ "/usr/bin/open", "-b", bundle_id });
+}
+
 // ------------------------------------------------------- app presence
 
 /// The objc-runtime and libdispatch surface needed to flip the Dock
@@ -353,9 +465,12 @@ const AppleApp = if (builtin.os.tag == .macos) struct {
 /// `.accessory` vs `.regular`). Windows still open and focus in
 /// accessory mode; the app just leaves the Dock and app switcher.
 /// No-op on other platforms.
-pub fn setDockIconHidden(hidden: bool) void {
+pub fn setDockIconHidden(hidden: bool, fullscreen_overlay: bool) void {
     if (builtin.os.tag != .macos) return;
-    const ctx: ?*anyopaque = if (hidden) @ptrFromInt(1) else null;
+    // A fullscreen companion must remain accessory even when the user
+    // leaves Hide Dock icon disabled. This keeps the SDK's launch policy
+    // and the runtime toggle from fighting each other.
+    const ctx: ?*anyopaque = if (hidden or fullscreen_overlay) @ptrFromInt(1) else null;
     AppleApp.dispatch_async_f(&AppleApp._dispatch_main_q, ctx, AppleApp.applyPolicy);
 }
 


### PR DESCRIPTION
## Summary

Fixes #596 and #603.

- keep the pet and bubble together across macOS Spaces and fullscreen apps
- add an explicit fullscreen overlay opt-in for the Petdex windows
- record the originating terminal metadata for supported hook events
- clicking the pet focuses the originating Apple Terminal tab by TTY, or activates VS Code
- keep the activation-policy decision consistent with `hide_dock` and fullscreen overlay mode

## Dependency

This uses the new Native SDK window option from [Railly/native#2](https://github.com/Railly/native/pull/2).

## Validation

- focused Native app test: 68/68 passed
- built and packaged the macOS app locally
- manually verified fullscreen visibility and VS Code activation on a second display

The source application list is intentionally allowlisted to Apple Terminal and VS Code for this first version.