### PR TITLE
fix(cli): redirect retired start/stop/restart aliases

### DIFF
--- a/packages/petdex-cli/bin/petdex.test.ts
+++ b/packages/petdex-cli/bin/petdex.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+
+function runCli(command: string): { exitCode: number; stderr: string } {
+  const result = Bun.spawnSync({
+    cmd: [process.execPath, import.meta.dir + "/petdex.ts", command],
+    env: { ...process.env, NO_COLOR: "1" },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  return {
+    exitCode: result.exitCode,
+    stderr: result.stderr.toString(),
+  };
+}
+
+function normalizeCommand(output: string, command: string): string {
+  return output.replace(`petdex ${command}`, "petdex <command>");
+}
+
+describe("retired command aliases", () => {
+  test.each([
+    ["start", "up"],
+    ["restart", "up"],
+    ["stop", "down"],
+  ])("%s shows the same redirect as %s", (alias, canonical) => {
+    const actual = runCli(alias);
+    const expected = runCli(canonical);
+
+    expect(actual.exitCode).toBe(0);
+    expect(actual.stderr).not.toContain("Unknown command");
+    expect(normalizeCommand(actual.stderr, alias)).toBe(
+      normalizeCommand(expected.stderr, canonical),
+    );
+  });
+});

--- a/packages/petdex-cli/bin/petdex.ts
+++ b/packages/petdex-cli/bin/petdex.ts
@@ -25,10 +25,17 @@ const DOWNLOAD_URL = `${PETDEX_URL.replace(/\/+$/, "")}/download`;
 // replaces it, so the user learns where the capability went instead of
 // hunting for a flag that no longer exists. Declared here, above the
 // top-level main() call, so the lookup is not in the temporal dead zone.
+const DESKTOP_START_REDIRECT =
+  "The desktop app runs on its own. Launch Petdex from Applications.";
+const DESKTOP_STOP_REDIRECT = "Quit Petdex from its menu bar icon to stop it.";
+
 const RETIRED_COMMANDS = new Map<string, string>([
   ["init", "The desktop app installs its own agent hooks from Settings."],
-  ["up", "The desktop app runs on its own. Launch Petdex from Applications."],
-  ["down", "Quit Petdex from its menu bar icon to stop it."],
+  ["up", DESKTOP_START_REDIRECT],
+  ["start", DESKTOP_START_REDIRECT],
+  ["restart", DESKTOP_START_REDIRECT],
+  ["down", DESKTOP_STOP_REDIRECT],
+  ["stop", DESKTOP_STOP_REDIRECT],
   ["toggle", "Toggle the mascot from the Petdex menu bar icon."],
   ["desktop", "The desktop app manages its own lifecycle."],
   ["update", "The desktop app updates itself automatically."],


### PR DESCRIPTION
## Summary

- Redirect start and restart using the existing up message.
- Redirect stop using the existing down message.
- Keep install unchanged because it remains an active catalog command.
- Add regression tests comparing each alias with its canonical redirect.

Fixes #663.

## Testing

- bun test bin/petdex.test.ts
- bun run typecheck
- CLI production build

All checks pass.