### PR TITLE
chore(sdk): move the pin to c0b10d02

### DIFF
--- a/.github/workflows/desktop-native-ci.yml
+++ b/.github/workflows/desktop-native-ci.yml
@@ -105,7 +105,7 @@ jobs:
         env:
           NATIVE_SDK_REMOTE: "https://github.com/Railly/native.git"
           NATIVE_SDK_BRANCH: "feat/floating-window-0.5.3"
-          NATIVE_SDK_REF: "5f9f7cfa77f2a16f2dc26e337806d2a4b59a067b"
+          NATIVE_SDK_REF: "c0b10d027efa490fc99a3bc7f1cf88b015999d45"
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           NATIVE_SDK_REMOTE: "https://github.com/Railly/native.git"
           NATIVE_SDK_BRANCH: "feat/floating-window-0.5.3"
-          NATIVE_SDK_REF: "5f9f7cfa77f2a16f2dc26e337806d2a4b59a067b"
+          NATIVE_SDK_REF: "c0b10d027efa490fc99a3bc7f1cf88b015999d45"
         # Explicit bash: this job now runs on a Windows runner too, where
         # the default shell is PowerShell and `set -euo pipefail` fails
         # as an unknown parameter before git is ever reached.


### PR DESCRIPTION
Moves both desktop workflows to the Native SDK commit that carries the explicit fullscreen overlay option (Railly/native#2).

The two pins move together because `SDK pins agree` requires it: CI and release drifted apart once already, which made a green CI say nothing about the shipped binary.

Unblocks #656, which needs `fullscreen_overlay` to exist in the SDK.

## Testing

- Native SDK built at c0b10d02 (ReleaseFast).
- `native test` in packages/petdex-desktop-native against that SDK: 107/107 passed, same tally as the previous pin.