### PR TITLE
chore(release): petdex cli 1.2.0, desktop 0.6.0

### DIFF
--- a/packages/petdex-cli/package.json
+++ b/packages/petdex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "petdex",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "CLI for Petdex. Install, browse, and submit Codex pets from your terminal.",
   "keywords": [
     "petdex",

--- a/packages/petdex-desktop-native/app.zon
+++ b/packages/petdex-desktop-native/app.zon
@@ -3,7 +3,7 @@
     .name = "petdex-desktop-native",
     .display_name = "Petdex",
     .description = "Petdex desktop pet on Native SDK: no WebView, no Node.",
-    .version = "0.5.0",
+    .version = "0.6.0",
     .icons = .{"assets/icon.png"},
     .platforms = .{ "macos", "windows", "linux" },
     .permissions = .{ "view", "command" },


### PR DESCRIPTION
Version bump for everything merged on 2026-08-08. Nine commits landed since `cli-v1.1.0` and `desktop-v0.5.0`, and neither package has shipped them.

## CLI 1.1.0 → 1.2.0

Minor, because #658 adds a feature to the submit path.

- #658 sprite atlas version travels through `pet.json` on submit
- #668 `start`/`stop`/`restart` redirect to their canonical retired-command message
- #671 hook runner and bubble template changes

Merging this triggers the npm publish: `cli-release.yml` fires on a push to main that touches `packages/petdex-cli/package.json`.

## Desktop 0.5.0 → 0.6.0

Minor, two user-visible features.

- #656 clicking the pet focuses the terminal that produced the bubble, and `fullscreen_overlay` puts the pet above other apps in full screen
- #667, #662 bubble clearance and cross-display anchoring
- #670 Linux Wayland transparency and overlays
- #671 hook server connection caps and timeouts, plus the macOS headerpad fix that kept a signed bundle from crashing on its first GPU frame

The desktop release is not automatic. After this merges it needs a `desktop-v0.6.0` tag, and the macOS bundle has to be signed and notarized from a workstation with `scripts/sign-macos.sh` since CI has no macOS leg on purpose.

## Testing

- `bun test` in packages/petdex-cli: 84/84
- `native test`: 120/120 against the pinned SDK (c0b10d02)
- `native validate app.zon`: valid