### PR TITLE
feat(desktop): serve the latest release as JSON

### DIFF
--- a/src/app/api/desktop/latest-release/route.test.ts
+++ b/src/app/api/desktop/latest-release/route.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "bun:test";
+
+import { buildJsonPayload, versionFromTag } from "./route";
+
+describe("versionFromTag", () => {
+  it("strips the desktop prefix", () => {
+    expect(versionFromTag("desktop-v0.6.0")).toBe("0.6.0");
+    expect(versionFromTag("desktop-v1.10.2")).toBe("1.10.2");
+  });
+
+  it("keeps a prerelease suffix so clients can compare the full string", () => {
+    expect(versionFromTag("desktop-v0.7.0-rc.1")).toBe("0.7.0-rc.1");
+  });
+
+  // A client that receives a guessed version can talk itself into
+  // "up to date" against a tag that never carried one.
+  it("returns null rather than guessing", () => {
+    expect(versionFromTag("cli-v1.2.0")).toBeNull();
+    expect(versionFromTag("desktop-vnightly")).toBeNull();
+    expect(versionFromTag(undefined)).toBeNull();
+  });
+});
+
+describe("buildJsonPayload", () => {
+  const release = {
+    tag_name: "desktop-v0.6.0",
+    html_url:
+      "https://github.com/crafter-station/petdex/releases/tag/desktop-v0.6.0",
+    assets: [
+      {
+        name: "Petdex-arm64.dmg",
+        browser_download_url:
+          "https://github.com/crafter-station/petdex/releases/download/desktop-v0.6.0/Petdex-arm64.dmg",
+      },
+      {
+        name: "petdex-desktop-native-win32-x64.exe",
+        browser_download_url:
+          "https://github.com/crafter-station/petdex/releases/download/desktop-v0.6.0/petdex-desktop-native-win32-x64.exe",
+      },
+    ],
+  };
+
+  it("reports the version and the assets it resolved", () => {
+    const payload = buildJsonPayload(release);
+    expect(payload.version).toBe("0.6.0");
+    expect(payload.tag).toBe("desktop-v0.6.0");
+    expect(payload.assets["darwin-arm64"]).toBe(
+      "https://github.com/crafter-station/petdex/releases/download/desktop-v0.6.0/Petdex-arm64.dmg",
+    );
+    expect(payload.assets["win32-x64"]).toBe(
+      "https://github.com/crafter-station/petdex/releases/download/desktop-v0.6.0/petdex-desktop-native-win32-x64.exe",
+    );
+  });
+
+  it("omits platforms with no asset instead of emitting an empty string", () => {
+    const payload = buildJsonPayload(release);
+    expect(payload.assets["linux-arm64"]).toBeUndefined();
+    expect(Object.values(payload.assets).every((url) => url.length > 0)).toBe(
+      true,
+    );
+  });
+
+  // Same open-redirect guard the redirect path applies. A compromised
+  // or reshaped GitHub response must not hand the desktop app a
+  // download URL off github.com.
+  it("drops assets that are not on the petdex repo", () => {
+    const payload = buildJsonPayload({
+      tag_name: "desktop-v0.6.0",
+      assets: [
+        {
+          name: "Petdex-arm64.dmg",
+          browser_download_url: "https://evil.example.com/Petdex-arm64.dmg",
+        },
+      ],
+    });
+    expect(payload.assets["darwin-arm64"]).toBeUndefined();
+  });
+
+  // Offline must read as "unknown", never as "you are current".
+  it("returns a null version when the release could not be resolved", () => {
+    const payload = buildJsonPayload(null);
+    expect(payload.version).toBeNull();
+    expect(payload.tag).toBeNull();
+    expect(payload.assets).toEqual({});
+    expect(payload.releaseUrl).toBe(
+      "https://github.com/crafter-station/petdex/releases",
+    );
+  });
+});

--- a/src/app/api/desktop/latest-release/route.ts
+++ b/src/app/api/desktop/latest-release/route.ts
@@ -133,12 +133,63 @@ function releasePageUrl(release: GhRelease | null): string {
   return RELEASES_PAGE;
 }
 
+// `desktop-v0.6.0` → `0.6.0`. The tag is the only place the version
+// lives, so a tag that does not carry one yields null rather than a
+// guess: a client comparing against a made-up version is worse than a
+// client that learns nothing this poll.
+export function versionFromTag(tag: string | undefined): string | null {
+  if (typeof tag !== "string" || !tag.startsWith(DESKTOP_TAG_PREFIX)) {
+    return null;
+  }
+  const version = tag.slice(DESKTOP_TAG_PREFIX.length);
+  return /^\d+\.\d+\.\d+/.test(version) ? version : null;
+}
+
+export type LatestReleasePayload = {
+  version: string | null;
+  tag: string | null;
+  releaseUrl: string;
+  assets: Record<string, string>;
+};
+
+// The shape old clients keep calling forever, so it stays additive:
+// fields may be added, never removed or retyped. `version` is null when
+// GitHub is unreachable, which the client must read as "do not know"
+// rather than "up to date".
+export function buildJsonPayload(
+  release: GhRelease | null,
+): LatestReleasePayload {
+  const assets: Record<string, string> = {};
+  if (release) {
+    for (const platform of Object.keys(PLATFORM_ASSET_PATTERNS)) {
+      const hit = pickAssetForPlatform(release, platform);
+      if (hit?.browser_download_url) {
+        assets[platform] = hit.browser_download_url;
+      }
+    }
+  }
+  return {
+    version: versionFromTag(release?.tag_name),
+    tag: release?.tag_name ?? null,
+    releaseUrl: releasePageUrl(release),
+    assets,
+  };
+}
+
 /**
  * GET /api/desktop/latest-release
  *
  * Default behavior: 307 to the latest desktop-v* release page on
  * GitHub. This is the "show me where the desktop app lives" UX —
  * the user lands on a page they can browse.
+ *
+ * `?format=json`: returns the latest version, its tag, the release
+ * page, and the per-platform asset URLs instead of redirecting. This is
+ * what the desktop app polls to learn it is behind (#673); it carries no
+ * version of its own at runtime today, so this endpoint is the other
+ * half of that check. Old installs call this shape forever, so treat it
+ * as additive-only. `version` is null when GitHub cannot be reached,
+ * which means "unknown", not "up to date".
  *
  * `?asset=darwin-arm64` (or any future platform suffix): 307 directly
  * to the platform-specific binary asset's download URL. The browser
@@ -152,11 +203,26 @@ function releasePageUrl(release: GhRelease | null): string {
  */
 export async function GET(req: NextRequest): Promise<Response> {
   const asset = req.nextUrl.searchParams.get("asset");
+  const format = req.nextUrl.searchParams.get("format");
   let release: GhRelease | null = null;
   try {
     release = await findLatestDesktopRelease();
   } catch {
     // fall through with release=null → fallback page
+  }
+
+  // Checked before `asset` so a client can ask for both without the
+  // redirect winning and turning a version check into a file download.
+  if (format === "json") {
+    return NextResponse.json(buildJsonPayload(release), {
+      // A desktop client polls this on its own schedule and must never
+      // be told it is current by a stale edge copy after a release.
+      // Same 5 minutes as the page cache, explicit because JSON is
+      // consumed by long-lived installs rather than one browser click.
+      headers: {
+        "Cache-Control": "public, max-age=300, stale-while-revalidate=300",
+      },
+    });
   }
 
   if (asset) {


### PR DESCRIPTION
Prerequisite for slice 1 of #673. The desktop app cannot learn a newer build exists: it carries no version at runtime, and this endpoint only redirected, so there was nothing to compare against.

Adds `?format=json` returning the version, tag, release page and per-platform asset URLs. It reuses the existing release lookup and the same `github.com/crafter-station/petdex` prefix guard the redirect path applies, so a reshaped GitHub response cannot hand the app an off-repo download URL.

`version` is `null` when GitHub cannot be reached. Clients must read that as unknown, never as up to date. Old installs will call this shape forever, so it is additive only.

Verified against a running server: `?format=json` returns 0.6.0 with 4 platforms, and both existing consumers still 307 as before. 403 tests pass, tsc and biome clean.

Does not close #673. Slices 1 to 3 still need the app side, and the opt-in vs always-on decision is still open.