### PR TITLE
docs(cli): link retired commands to desktop settings

### DIFF
--- a/packages/petdex-cli/bin/petdex.ts
+++ b/packages/petdex-cli/bin/petdex.ts
@@ -30,6 +30,8 @@ const DESKTOP_START_REDIRECT =
 const DESKTOP_STOP_REDIRECT = "Quit Petdex from its menu bar icon to stop it.";
 
 const RETIRED_COMMANDS = new Map<string, string>([
+  // Desktop Settings → Agents:
+  // packages/petdex-desktop-native/src/settings_view.zig (`agentsSection`).
   ["init", "The desktop app installs its own agent hooks from Settings."],
   ["up", DESKTOP_START_REDIRECT],
   ["start", DESKTOP_START_REDIRECT],
@@ -39,6 +41,9 @@ const RETIRED_COMMANDS = new Map<string, string>([
   ["toggle", "Toggle the mascot from the Petdex menu bar icon."],
   ["desktop", "The desktop app manages its own lifecycle."],
   ["update", "The desktop app updates itself automatically."],
+  // Desktop Settings → Agents:
+  // packages/petdex-desktop-native/src/settings_view.zig (`agentsSection`).
+  // This view renders agent/hook status and the Install/Update actions.
   ["doctor", "Petdex Settings shows agent and hook status directly."],
   ["hooks", "Install agent hooks from Petdex Settings, one click per agent."],
 ]);


### PR DESCRIPTION
## Summary

- Document that the retired `init`, `doctor`, and `hooks` CLI redirects map to the Desktop Settings → Agents implementation.
- Point maintainers to `packages/petdex-desktop-native/src/settings_view.zig` and `agentsSection` so the CLI guidance stays aligned with the desktop UI.

## Validation

- `bun test`
- `bun run build`
- `bun run typecheck`
- `bun bin/petdex.ts doctor`

## Scope

- No CLI behavior or user-facing text changed.
- I did not change the `update` redirect because desktop self-update is tracked separately in #673.
- I kept the optional grep-based CI guard out of this small documentation patch, pending maintainer preference.

Related to #666