### PR TITLE
fix(desktop): close activity bubble with pet

### DIFF
--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -1806,7 +1806,11 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             model.settings_open = true;
         },
         .settings_closed => model.settings_open = false,
-        .close_pet => fx.closeWindow("main"),
+        .close_pet => {
+            clearBubble(model);
+            fx.closeWindow("bubble");
+            fx.closeWindow("main");
+        },
         .select_pet => |index| {
             if (index >= catalog_mod.catalog_len) return;
             // `index == active_pet` is a no-op only once a sheet is up.

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -1806,11 +1806,7 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             model.settings_open = true;
         },
         .settings_closed => model.settings_open = false,
-        .close_pet => {
-            clearBubble(model);
-            fx.closeWindow("bubble");
-            fx.closeWindow("main");
-        },
+        .close_pet => closePet(model, fx),
         .select_pet => |index| {
             if (index >= catalog_mod.catalog_len) return;
             // `index == active_pet` is a no-op only once a sheet is up.
@@ -2920,6 +2916,13 @@ fn clearBubble(model: *Model) void {
     model.bubbles_len = 0;
     model.bubble_expires_at_ms = @splat(-1);
     hook_server.mailbox.clearBubbles();
+}
+
+const close_pet_window_labels = [_][]const u8{ "bubble", "main" };
+
+fn closePet(model: *Model, fx: *Effects) void {
+    clearBubble(model);
+    for (close_pet_window_labels) |label| fx.closeWindow(label);
 }
 
 /// Index of the most recently updated bubble in `drained`.
@@ -4925,6 +4928,21 @@ test "clearing a bubble also cancels its lifetime" {
     try std.testing.expectEqual(@as(usize, 0), model.bubbles_len);
     try std.testing.expect(!bubbleActive(&model));
     try std.testing.expectEqual(@as(i64, -1), model.bubble_expires_at_ms[0]);
+}
+
+test "closing the pet clears its bubble and closes both windows" {
+    var model: Model = .{};
+    testPushBubble(&model, "alpha", "x", true, 1234);
+    var fx = Effects.init(std.testing.allocator);
+    defer fx.deinit();
+
+    closePet(&model, &fx);
+
+    try std.testing.expectEqual(@as(usize, 0), model.bubbles_len);
+    try std.testing.expectEqual(@as(u32, close_pet_window_labels.len), fx.windowActionState().close_count);
+    try std.testing.expectEqualStrings("bubble", close_pet_window_labels[0]);
+    try std.testing.expectEqualStrings("main", close_pet_window_labels[1]);
+    try std.testing.expectEqualStrings("main", fx.windowActionState().lastLabel());
 }
 
 test "two conversations stack and grow the window vertically" {


### PR DESCRIPTION
Closes #683

## Problem
`Close Pet` closed the main pet window but left the independently rendered activity bubble window visible.

## Fix
- Clear the in-memory bubble state when handling `Close Pet`.
- Explicitly close the `bubble` window before closing the `main` window.
- Keep the tray process alive; `Quit Petdex` remains the full process exit action.

## Validation
- Built and tested against the latest `upstream/main` (`0fefb4f`).
- Native test suite: `124/124` passed.
- Manually verified that `Close Pet` removes both the pet and activity bubble while the tray process remains available.