### PR TITLE
fix(cli): warn when auth config falls back

### DIFF
--- a/packages/petdex-cli/bin/petdex.ts
+++ b/packages/petdex-cli/bin/petdex.ts
@@ -21,6 +21,7 @@ import {
   maybeShowFirstRunNotice,
   setEnabled,
 } from "../src/telemetry.js";
+import { resolveAuthConfig } from "../src/auth-config.js";
 
 // ─── config ────────────────────────────────────────────────────────────────
 const PETDEX_URL = process.env.PETDEX_URL ?? "https://petdex.dev";
@@ -48,64 +49,10 @@ const RETIRED_COMMANDS = new Map<string, string>([
   ["doctor", "Petdex Settings shows agent and hook status directly."],
   ["hooks", "Install agent hooks from Petdex Settings, one click per agent."],
 ]);
-const FALLBACK_ISSUER = "https://clerk.petdex.dev";
-const FALLBACK_CLIENT_ID = "LcThwEayl6KAA1Qm";
-const DEFAULT_SCOPES = ["profile", "email", "openid", "offline_access"];
-
-// Resolve OAuth config in this order:
-// 1. Environment overrides (advanced users, CI)
-// 2. Server-side /api/cli/auth-config (so we can rotate clientId without
-//    forcing every CLI user to reinstall)
-// 3. Hardcoded fallback (works offline / first-run / server down)
-async function resolveAuthConfig(): Promise<{
-  issuer: string;
-  clientId: string;
-  scopes: string[];
-}> {
-  const envIssuer = process.env.CLERK_ISSUER;
-  const envClientId = process.env.CLERK_OAUTH_CLIENT_ID;
-  if (envIssuer && envClientId) {
-    return { issuer: envIssuer, clientId: envClientId, scopes: DEFAULT_SCOPES };
-  }
-
-  try {
-    const res = await fetch(`${PETDEX_URL}/api/cli/auth-config`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    if (res.ok) {
-      const data = (await res.json()) as {
-        issuer?: unknown;
-        clientId?: unknown;
-        scopes?: unknown;
-      };
-      const issuer = typeof data.issuer === "string" ? data.issuer : null;
-      const clientId = typeof data.clientId === "string" ? data.clientId : null;
-      const scopes = Array.isArray(data.scopes)
-        ? data.scopes.filter((s): s is string => typeof s === "string")
-        : null;
-      if (issuer && clientId) {
-        return {
-          issuer: envIssuer ?? issuer,
-          clientId: envClientId ?? clientId,
-          scopes: scopes && scopes.length > 0 ? scopes : DEFAULT_SCOPES,
-        };
-      }
-    }
-  } catch {
-    /* fall through to baked defaults */
-  }
-
-  return {
-    issuer: envIssuer ?? FALLBACK_ISSUER,
-    clientId: envClientId ?? FALLBACK_CLIENT_ID,
-    scopes: DEFAULT_SCOPES,
-  };
-}
-
 let _auth: ClerkCliAuth | null = null;
 async function getAuth(): Promise<ClerkCliAuth> {
   if (_auth) return _auth;
-  const cfg = await resolveAuthConfig();
+  const cfg = await resolveAuthConfig({ petdexUrl: PETDEX_URL });
   _auth = new ClerkCliAuth({
     clientId: cfg.clientId,
     issuer: cfg.issuer,

--- a/packages/petdex-cli/bin/petdex.ts
+++ b/packages/petdex-cli/bin/petdex.ts
@@ -8,6 +8,7 @@ import pc from "picocolors";
 
 import pkg from "../package.json";
 import { isTrustedAssetUrl } from "../src/asset-hosts.js";
+import { resolveAuthConfig } from "../src/auth-config.js";
 import { ClerkCliAuth } from "../src/cli-auth/index.js";
 import {
   parseImageDims,
@@ -21,7 +22,6 @@ import {
   maybeShowFirstRunNotice,
   setEnabled,
 } from "../src/telemetry.js";
-import { resolveAuthConfig } from "../src/auth-config.js";
 
 // ─── config ────────────────────────────────────────────────────────────────
 const PETDEX_URL = process.env.PETDEX_URL ?? "https://petdex.dev";
@@ -50,9 +50,16 @@ const RETIRED_COMMANDS = new Map<string, string>([
   ["hooks", "Install agent hooks from Petdex Settings, one click per agent."],
 ]);
 let _auth: ClerkCliAuth | null = null;
-async function getAuth(): Promise<ClerkCliAuth> {
+async function getAuth({
+  warnOnFallback = true,
+}: {
+  warnOnFallback?: boolean;
+} = {}): Promise<ClerkCliAuth> {
   if (_auth) return _auth;
-  const cfg = await resolveAuthConfig({ petdexUrl: PETDEX_URL });
+  const cfg = await resolveAuthConfig({
+    petdexUrl: PETDEX_URL,
+    warnOnFallback,
+  });
   _auth = new ClerkCliAuth({
     clientId: cfg.clientId,
     issuer: cfg.issuer,
@@ -233,7 +240,7 @@ async function cmdLogin() {
 }
 
 async function cmdLogout() {
-  const auth = await getAuth();
+  const auth = await getAuth({ warnOnFallback: false });
   await auth.logout();
   console.log(`${pc.green("✓ ")}Signed out`);
 }

--- a/packages/petdex-cli/src/auth-config.test.ts
+++ b/packages/petdex-cli/src/auth-config.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, mock, spyOn, test } from "bun:test";
 
 import {
   AUTH_CONFIG_FALLBACK_WARNING,
+  type AuthConfigFetch,
   DEFAULT_SCOPES,
   FALLBACK_CLIENT_ID,
   FALLBACK_ISSUER,
   resolveAuthConfig,
-  type AuthConfigFetch,
 } from "./auth-config.js";
 
 describe("resolveAuthConfig", () => {
@@ -36,14 +36,15 @@ describe("resolveAuthConfig", () => {
   });
 
   test("does not warn when the server returns valid auth config", async () => {
-    const fetchImpl: AuthConfigFetch = mock(async () =>
-      new Response(
-        JSON.stringify({
-          issuer: "https://clerk.example.test",
-          clientId: "client_test",
-          scopes: ["profile", "email"],
-        }),
-      ),
+    const fetchImpl: AuthConfigFetch = mock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            issuer: "https://clerk.example.test",
+            clientId: "client_test",
+            scopes: ["profile", "email"],
+          }),
+        ),
     );
     const stderr = spyOn(console, "error").mockImplementation(() => {});
 
@@ -59,6 +60,31 @@ describe("resolveAuthConfig", () => {
         issuer: "https://clerk.example.test",
         clientId: "client_test",
         scopes: ["profile", "email"],
+      });
+    } finally {
+      stderr.mockRestore();
+    }
+  });
+
+  test("allows local-only callers to suppress the fallback warning", async () => {
+    const fetchImpl: AuthConfigFetch = mock(async () => {
+      throw new Error("offline");
+    });
+    const stderr = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const config = await resolveAuthConfig({
+        petdexUrl: "https://petdex.test",
+        env: {},
+        fetchImpl,
+        warnOnFallback: false,
+      });
+
+      expect(stderr).not.toHaveBeenCalled();
+      expect(config).toEqual({
+        issuer: FALLBACK_ISSUER,
+        clientId: FALLBACK_CLIENT_ID,
+        scopes: DEFAULT_SCOPES,
       });
     } finally {
       stderr.mockRestore();

--- a/packages/petdex-cli/src/auth-config.test.ts
+++ b/packages/petdex-cli/src/auth-config.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, mock, spyOn, test } from "bun:test";
+
+import {
+  AUTH_CONFIG_FALLBACK_WARNING,
+  DEFAULT_SCOPES,
+  FALLBACK_CLIENT_ID,
+  FALLBACK_ISSUER,
+  resolveAuthConfig,
+  type AuthConfigFetch,
+} from "./auth-config.js";
+
+describe("resolveAuthConfig", () => {
+  test("warns on stderr and uses built-in defaults when fetch rejects", async () => {
+    const fetchImpl: AuthConfigFetch = mock(async () => {
+      throw new Error("offline");
+    });
+    const stderr = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const config = await resolveAuthConfig({
+        petdexUrl: "https://petdex.test",
+        env: {},
+        fetchImpl,
+      });
+
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      expect(stderr).toHaveBeenCalledWith(AUTH_CONFIG_FALLBACK_WARNING);
+      expect(config).toEqual({
+        issuer: FALLBACK_ISSUER,
+        clientId: FALLBACK_CLIENT_ID,
+        scopes: DEFAULT_SCOPES,
+      });
+    } finally {
+      stderr.mockRestore();
+    }
+  });
+
+  test("does not warn when the server returns valid auth config", async () => {
+    const fetchImpl: AuthConfigFetch = mock(async () =>
+      new Response(
+        JSON.stringify({
+          issuer: "https://clerk.example.test",
+          clientId: "client_test",
+          scopes: ["profile", "email"],
+        }),
+      ),
+    );
+    const stderr = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const config = await resolveAuthConfig({
+        petdexUrl: "https://petdex.test",
+        env: {},
+        fetchImpl,
+      });
+
+      expect(stderr).not.toHaveBeenCalled();
+      expect(config).toEqual({
+        issuer: "https://clerk.example.test",
+        clientId: "client_test",
+        scopes: ["profile", "email"],
+      });
+    } finally {
+      stderr.mockRestore();
+    }
+  });
+});

--- a/packages/petdex-cli/src/auth-config.ts
+++ b/packages/petdex-cli/src/auth-config.ts
@@ -17,7 +17,7 @@ export const FALLBACK_CLIENT_ID = "LcThwEayl6KAA1Qm";
 export const DEFAULT_SCOPES = ["profile", "email", "openid", "offline_access"];
 
 export const AUTH_CONFIG_FALLBACK_WARNING =
-  "petdex: unable to refresh auth configuration; using built-in defaults.";
+  "petdex: unable to refresh auth configuration; using fallback authentication values.";
 
 // Resolve OAuth config in this order:
 // 1. Environment overrides (advanced users, CI)
@@ -28,10 +28,12 @@ export async function resolveAuthConfig({
   petdexUrl,
   env = process.env,
   fetchImpl = fetch,
+  warnOnFallback = true,
 }: {
   petdexUrl: string;
   env?: NodeJS.ProcessEnv;
   fetchImpl?: AuthConfigFetch;
+  warnOnFallback?: boolean;
 }): Promise<AuthConfig> {
   const envIssuer = env.CLERK_ISSUER;
   const envClientId = env.CLERK_OAUTH_CLIENT_ID;
@@ -58,7 +60,9 @@ export async function resolveAuthConfig({
       const issuer = typeof data.issuer === "string" ? data.issuer : null;
       const clientId = typeof data.clientId === "string" ? data.clientId : null;
       const scopes = Array.isArray(data.scopes)
-        ? data.scopes.filter((scope): scope is string => typeof scope === "string")
+        ? data.scopes.filter(
+            (scope): scope is string => typeof scope === "string",
+          )
         : null;
 
       if (issuer && clientId) {
@@ -73,7 +77,7 @@ export async function resolveAuthConfig({
     // Fall through to the built-in defaults.
   }
 
-  console.error(AUTH_CONFIG_FALLBACK_WARNING);
+  if (warnOnFallback) console.error(AUTH_CONFIG_FALLBACK_WARNING);
   return {
     issuer: envIssuer ?? FALLBACK_ISSUER,
     clientId: envClientId ?? FALLBACK_CLIENT_ID,

--- a/packages/petdex-cli/src/auth-config.ts
+++ b/packages/petdex-cli/src/auth-config.ts
@@ -1,0 +1,82 @@
+export type AuthConfig = {
+  issuer: string;
+  clientId: string;
+  scopes: string[];
+};
+
+export type AuthConfigFetch = (
+  url: string,
+  init?: { signal?: AbortSignal },
+) => Promise<{
+  ok: boolean;
+  json(): Promise<unknown>;
+}>;
+
+export const FALLBACK_ISSUER = "https://clerk.petdex.dev";
+export const FALLBACK_CLIENT_ID = "LcThwEayl6KAA1Qm";
+export const DEFAULT_SCOPES = ["profile", "email", "openid", "offline_access"];
+
+export const AUTH_CONFIG_FALLBACK_WARNING =
+  "petdex: unable to refresh auth configuration; using built-in defaults.";
+
+// Resolve OAuth config in this order:
+// 1. Environment overrides (advanced users, CI)
+// 2. Server-side /api/cli/auth-config (so we can rotate clientId without
+//    forcing every CLI user to reinstall)
+// 3. Hardcoded fallback (works offline / first-run / server down)
+export async function resolveAuthConfig({
+  petdexUrl,
+  env = process.env,
+  fetchImpl = fetch,
+}: {
+  petdexUrl: string;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: AuthConfigFetch;
+}): Promise<AuthConfig> {
+  const envIssuer = env.CLERK_ISSUER;
+  const envClientId = env.CLERK_OAUTH_CLIENT_ID;
+
+  if (envIssuer && envClientId) {
+    return {
+      issuer: envIssuer,
+      clientId: envClientId,
+      scopes: DEFAULT_SCOPES,
+    };
+  }
+
+  try {
+    const res = await fetchImpl(`${petdexUrl}/api/cli/auth-config`, {
+      signal: AbortSignal.timeout(3000),
+    });
+
+    if (res.ok) {
+      const data = (await res.json()) as {
+        issuer?: unknown;
+        clientId?: unknown;
+        scopes?: unknown;
+      };
+      const issuer = typeof data.issuer === "string" ? data.issuer : null;
+      const clientId = typeof data.clientId === "string" ? data.clientId : null;
+      const scopes = Array.isArray(data.scopes)
+        ? data.scopes.filter((scope): scope is string => typeof scope === "string")
+        : null;
+
+      if (issuer && clientId) {
+        return {
+          issuer: envIssuer ?? issuer,
+          clientId: envClientId ?? clientId,
+          scopes: scopes && scopes.length > 0 ? scopes : DEFAULT_SCOPES,
+        };
+      }
+    }
+  } catch {
+    // Fall through to the built-in defaults.
+  }
+
+  console.error(AUTH_CONFIG_FALLBACK_WARNING);
+  return {
+    issuer: envIssuer ?? FALLBACK_ISSUER,
+    clientId: envClientId ?? FALLBACK_CLIENT_ID,
+    scopes: DEFAULT_SCOPES,
+  };
+}


### PR DESCRIPTION
## Summary

- Extract auth configuration resolution into a testable helper.
- Emit a concise stderr warning when the remote auth configuration cannot be used and the CLI falls back to built-in defaults.
- Add regression coverage for a rejected fetch and the unchanged successful path.

## Validation

- `bun test src/auth-config.test.ts`
- `bun run build`
- `bun run typecheck`

Closes #665