### PR TITLE
chore(release): petdex cli 1.2.1

### DIFF
--- a/packages/petdex-cli/package.json
+++ b/packages/petdex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "petdex",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "CLI for Petdex. Install, browse, and submit Codex pets from your terminal.",
   "keywords": [
     "petdex",


### PR DESCRIPTION
## Summary

- release the CLI fallback warning from #688 as petdex 1.2.1

## Validation

- 97 CLI tests
- typecheck
- build and binary version check
- npm publish dry-run
- exact-SHA review: no actionable findings