### PR TITLE
chore(release): petdex CLI 1.2.2, desktop 0.7.0

### DIFF
--- a/packages/petdex-cli/package.json
+++ b/packages/petdex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "petdex",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "CLI for Petdex. Install, browse, and submit Codex pets from your terminal.",
   "keywords": [
     "petdex",

--- a/packages/petdex-desktop-native/app.zon
+++ b/packages/petdex-desktop-native/app.zon
@@ -3,7 +3,7 @@
     .name = "petdex-desktop-native",
     .display_name = "Petdex",
     .description = "Petdex desktop pet on Native SDK: no WebView, no Node.",
-    .version = "0.6.0",
+    .version = "0.7.0",
     .icons = .{"assets/icon.png"},
     .platforms = .{ "macos", "windows", "linux" },
     .permissions = .{ "view", "command" },


### PR DESCRIPTION
## Summary

- release petdex CLI 1.2.2
- release Petdex desktop 0.7.0 with the production-ready Herdr integration

## Validation

- CLI build, typecheck, 97 tests
- npm publish dry-run
- native desktop 192 tests
- Biome and i18n checks

After merge, the CLI trusted-publishing workflow will publish npm and create cli-v1.2.2. The desktop tag will be cut only after main is green.