### PR TITLE
feat(desktop): add safe update discovery

### DIFF
--- a/packages/petdex-desktop-native/app.zon
+++ b/packages/petdex-desktop-native/app.zon
@@ -3,7 +3,7 @@
     .name = "petdex-desktop-native",
     .display_name = "Petdex",
     .description = "Petdex desktop pet on Native SDK: no WebView, no Node.",
-    .version = "0.7.0",
+    .version = "0.8.0",
     .icons = .{"assets/icon.png"},
     .platforms = .{ "macos", "windows", "linux" },
     .permissions = .{ "view", "command" },

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -128,12 +128,13 @@ pub const Msg = union(enum) {
     toggle_update_checks,
     update_response: native_sdk.EffectResponse,
     homebrew_done: native_sdk.EffectExit,
+    homebrew_timeout: native_sdk.EffectTimer,
     download_update,
     copy_brew_command,
     brew_command_copied: native_sdk.EffectClipboardResult,
     noop,
 
-    pub const view_unbound = .{ "frame_tick", "poll_tick", "physics_tick", "frame_clock", "cycle_state", "native_drag_watchdog", "chime_done", "quit_app", "toggle_focus_mode", "shuffle_pet", "remote_line", "remote_done", "remote_backoff", "update_boot_check", "update_response", "homebrew_done", "brew_command_copied" };
+    pub const view_unbound = .{ "frame_tick", "poll_tick", "physics_tick", "frame_clock", "cycle_state", "native_drag_watchdog", "chime_done", "quit_app", "toggle_focus_mode", "shuffle_pet", "remote_line", "remote_done", "remote_backoff", "update_boot_check", "update_response", "homebrew_done", "homebrew_timeout", "brew_command_copied" };
 };
 
 pub const Model = struct {
@@ -298,6 +299,8 @@ pub const Model = struct {
     latest_version_len: usize = 0,
     last_update_check_ms: i64 = 0,
     install_source: updates.InstallSource = .unknown,
+    update_cancel_pending: bool = false,
+    update_restart_after_cancel: bool = false,
     brew_command_copied: bool = false,
     agents_prompted: bool = false,
     codex_trust_note: bool = false,
@@ -763,9 +766,12 @@ const update_fetch_key: u64 = 30;
 const homebrew_check_key: u64 = 31;
 const brew_clipboard_key: u64 = 32;
 const update_boot_timer_key: u64 = 33;
+const homebrew_timeout_timer_key: u64 = 34;
 const update_boot_delay_ms: u32 = 5000;
 const update_background_interval_ms: i64 = 24 * 60 * 60 * 1000;
 const update_settings_interval_ms: i64 = 5 * 60 * 1000;
+const update_failure_retry_ms: u64 = 60 * 60 * 1000;
+const homebrew_timeout_ms: u64 = 8000;
 
 fn updateCachePhase(model: *Model) void {
     if (model.latest_version_len == 0) {
@@ -780,8 +786,33 @@ fn updateCheckStale(last_check_ms: i64, now_ms: i64, interval_ms: i64) bool {
     return last_check_ms <= 0 or now_ms < last_check_ms or now_ms - last_check_ms >= interval_ms;
 }
 
+fn updateCheckDelay(last_check_ms: i64, now_ms: i64) u64 {
+    if (updateCheckStale(last_check_ms, now_ms, update_background_interval_ms)) return update_boot_delay_ms;
+    return @intCast(update_background_interval_ms - (now_ms - last_check_ms));
+}
+
+fn armNextUpdateCheck(model: *const Model, fx: *Effects) void {
+    if (!model.update_checks_enabled) return;
+    fx.startTimer(.{
+        .key = update_boot_timer_key,
+        .interval_ms = updateCheckDelay(model.last_update_check_ms, fx.wallMs()),
+        .mode = .one_shot,
+        .on_fire = Effects.timerMsg(.update_boot_check),
+    });
+}
+
+fn armUpdateRetry(model: *const Model, fx: *Effects) void {
+    if (!model.update_checks_enabled) return;
+    fx.startTimer(.{
+        .key = update_boot_timer_key,
+        .interval_ms = update_failure_retry_ms,
+        .mode = .one_shot,
+        .on_fire = Effects.timerMsg(.update_boot_check),
+    });
+}
+
 fn startUpdateCheck(model: *Model, manual: bool, fx: *Effects) void {
-    if (model.update_phase == .checking) return;
+    if (model.update_phase == .checking or model.update_cancel_pending) return;
     model.update_manual = manual;
     model.update_phase = .checking;
     fx.fetch(.{
@@ -802,7 +833,7 @@ fn finishUpdateFailure(model: *Model) void {
 }
 
 fn startHomebrewCheck(model: *Model, fx: *Effects) void {
-    if (builtin.target.os.tag != .macos or model.install_source != .unknown) return;
+    if (builtin.target.os.tag != .macos or model.install_source == .checking or model.install_source == .homebrew) return;
     const brew = if (plat.fileExists("/opt/homebrew/bin/brew"))
         "/opt/homebrew/bin/brew"
     else if (plat.fileExists("/usr/local/bin/brew"))
@@ -817,6 +848,12 @@ fn startHomebrewCheck(model: *Model, fx: *Effects) void {
         .argv = &.{ brew, "list", "--cask", "petdex" },
         .output = .collect,
         .on_exit = Effects.exitMsg(.homebrew_done),
+    });
+    fx.startTimer(.{
+        .key = homebrew_timeout_timer_key,
+        .interval_ms = homebrew_timeout_ms,
+        .mode = .one_shot,
+        .on_fire = Effects.timerMsg(.homebrew_timeout),
     });
 }
 
@@ -1773,14 +1810,7 @@ pub fn boot(model: *Model, fx: *Effects) void {
     @memcpy(model.latest_version[0..initial_latest_version_len], initial_latest_version[0..initial_latest_version_len]);
     model.latest_version_len = initial_latest_version_len;
     updateCachePhase(model);
-    if (model.update_checks_enabled and updateCheckStale(model.last_update_check_ms, fx.wallMs(), update_background_interval_ms)) {
-        fx.startTimer(.{
-            .key = update_boot_timer_key,
-            .interval_ms = update_boot_delay_ms,
-            .mode = .one_shot,
-            .on_fire = Effects.timerMsg(.update_boot_check),
-        });
-    }
+    armNextUpdateCheck(model, fx);
     model.launch_at_login = plat.launchAtLoginEnabled();
     // Applied via the main queue, so the flip lands as soon as the
     // host's runloop spins up; a Regular-policy Dock icon may blink in
@@ -2028,46 +2058,78 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
         .check_updates => startUpdateCheck(model, true, fx),
         .toggle_update_checks => {
             model.update_checks_enabled = !model.update_checks_enabled;
-            if (!model.update_checks_enabled and model.update_phase == .checking) {
-                model.update_manual = false;
-                fx.cancel(update_fetch_key);
-                updateCachePhase(model);
-            } else if (model.update_checks_enabled and updateCheckStale(model.last_update_check_ms, fx.wallMs(), update_background_interval_ms)) {
+            if (!model.update_checks_enabled) {
+                fx.cancelTimer(update_boot_timer_key);
+                if (model.update_phase == .checking and !model.update_manual) {
+                    model.update_cancel_pending = true;
+                    model.update_restart_after_cancel = false;
+                    fx.cancel(update_fetch_key);
+                    updateCachePhase(model);
+                }
+            } else if (model.update_cancel_pending) {
+                model.update_restart_after_cancel = true;
+            } else if (updateCheckStale(model.last_update_check_ms, fx.wallMs(), update_background_interval_ms)) {
                 startUpdateCheck(model, false, fx);
+            } else {
+                armNextUpdateCheck(model, fx);
             }
             saveSettings(model);
         },
         .update_response => |response| {
-            model.last_update_check_ms = fx.wallMs();
+            if (model.update_cancel_pending) {
+                const restart = model.update_restart_after_cancel and model.update_checks_enabled;
+                model.update_cancel_pending = false;
+                model.update_restart_after_cancel = false;
+                model.update_manual = false;
+                updateCachePhase(model);
+                if (restart) startUpdateCheck(model, false, fx);
+                saveSettings(model);
+                return;
+            }
             if (response.outcome != .ok or response.status != 200 or response.truncated) {
                 finishUpdateFailure(model);
+                armUpdateRetry(model, fx);
                 saveSettings(model);
                 return;
             }
             var parsed = updates.parseLatest(boot_allocator, response.body) orelse {
                 finishUpdateFailure(model);
+                armUpdateRetry(model, fx);
                 saveSettings(model);
                 return;
             };
             defer parsed.deinit();
             const version = parsed.value.version orelse {
                 finishUpdateFailure(model);
+                armUpdateRetry(model, fx);
                 saveSettings(model);
                 return;
             };
             if (version.len > model.latest_version.len) {
                 finishUpdateFailure(model);
+                armUpdateRetry(model, fx);
                 saveSettings(model);
                 return;
             }
             @memcpy(model.latest_version[0..version.len], version);
             model.latest_version_len = version.len;
+            model.last_update_check_ms = fx.wallMs();
             model.update_phase = if (updates.isNewer(version, updates.current_version)) .available else .current;
             model.update_manual = false;
+            armNextUpdateCheck(model, fx);
             saveSettings(model);
         },
         .homebrew_done => |exit| {
-            model.install_source = if (exit.reason == .exited and exit.code == 0) .homebrew else .direct;
+            fx.cancelTimer(homebrew_timeout_timer_key);
+            if (model.install_source == .checking) {
+                model.install_source = if (exit.reason == .exited and exit.code == 0) .homebrew else .direct;
+            }
+        },
+        .homebrew_timeout => |timer| {
+            if (timer.outcome == .fired and model.install_source == .checking) {
+                model.install_source = .direct;
+                fx.cancel(homebrew_check_key);
+            }
         },
         .download_update => plat.openExternal(updates.downloadUrl()),
         .copy_brew_command => {
@@ -4232,6 +4294,27 @@ test "empty-state copy fits the pet window" {
     while (it.next()) |line| {
         try std.testing.expect(line.len <= 14);
     }
+}
+
+test "update checks stay daily across a long-lived process" {
+    try std.testing.expectEqual(@as(u64, update_boot_delay_ms), updateCheckDelay(0, 1000));
+    try std.testing.expectEqual(@as(u64, update_boot_delay_ms), updateCheckDelay(2000, 1000));
+    try std.testing.expectEqual(@as(u64, 23 * 60 * 60 * 1000), updateCheckDelay(1000, 1000 + 60 * 60 * 1000));
+    try std.testing.expectEqual(@as(u64, update_boot_delay_ms), updateCheckDelay(1000, 1000 + update_background_interval_ms));
+}
+
+test "cached update versions restore the correct phase" {
+    var model: Model = .{};
+    updateCachePhase(&model);
+    try std.testing.expectEqual(updates.Phase.idle, model.update_phase);
+    @memcpy(model.latest_version[0.."0.9.0".len], "0.9.0");
+    model.latest_version_len = "0.9.0".len;
+    updateCachePhase(&model);
+    try std.testing.expectEqual(updates.Phase.available, model.update_phase);
+    @memcpy(model.latest_version[0.."0.8.0".len], "0.8.0");
+    model.latest_version_len = "0.8.0".len;
+    updateCachePhase(&model);
+    try std.testing.expectEqual(updates.Phase.current, model.update_phase);
 }
 
 test "bubble text default is its own value, not the range floor" {

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -27,6 +27,7 @@ const remote_ssh = @import("remote_ssh.zig");
 const remote_writeback = @import("remote_writeback.zig");
 const remote_runtime = @import("remote_runtime.zig");
 const herdr_status = @import("herdr_status.zig");
+pub const updates = @import("updates.zig");
 
 pub const panic = std.debug.FullPanic(native_sdk.debug.capturePanic);
 
@@ -122,9 +123,17 @@ pub const Msg = union(enum) {
     remote_line: native_sdk.EffectLine,
     remote_done: native_sdk.EffectExit,
     remote_backoff: native_sdk.EffectTimer,
+    update_boot_check: native_sdk.EffectTimer,
+    check_updates,
+    toggle_update_checks,
+    update_response: native_sdk.EffectResponse,
+    homebrew_done: native_sdk.EffectExit,
+    download_update,
+    copy_brew_command,
+    brew_command_copied: native_sdk.EffectClipboardResult,
     noop,
 
-    pub const view_unbound = .{ "frame_tick", "poll_tick", "physics_tick", "frame_clock", "cycle_state", "native_drag_watchdog", "chime_done", "quit_app", "toggle_focus_mode", "shuffle_pet", "remote_line", "remote_done", "remote_backoff" };
+    pub const view_unbound = .{ "frame_tick", "poll_tick", "physics_tick", "frame_clock", "cycle_state", "native_drag_watchdog", "chime_done", "quit_app", "toggle_focus_mode", "shuffle_pet", "remote_line", "remote_done", "remote_backoff", "update_boot_check", "update_response", "homebrew_done", "brew_command_copied" };
 };
 
 pub const Model = struct {
@@ -282,6 +291,14 @@ pub const Model = struct {
         .{ .kind = .hermes },
     },
     herdr_status: herdr_status.Status = .absent,
+    update_checks_enabled: bool = true,
+    update_phase: updates.Phase = .idle,
+    update_manual: bool = false,
+    latest_version: [32]u8 = @splat(0),
+    latest_version_len: usize = 0,
+    last_update_check_ms: i64 = 0,
+    install_source: updates.InstallSource = .unknown,
+    brew_command_copied: bool = false,
     agents_prompted: bool = false,
     codex_trust_note: bool = false,
     pet_filter: [48]u8 = @splat(0),
@@ -742,6 +759,66 @@ pub const Effects = native_sdk.Effects(Msg);
 const frame_timer_key: u64 = 1;
 const native_drag_watchdog_key: u64 = 4;
 const native_drag_watchdog_ms: u32 = 5000;
+const update_fetch_key: u64 = 30;
+const homebrew_check_key: u64 = 31;
+const brew_clipboard_key: u64 = 32;
+const update_boot_timer_key: u64 = 33;
+const update_boot_delay_ms: u32 = 5000;
+const update_background_interval_ms: i64 = 24 * 60 * 60 * 1000;
+const update_settings_interval_ms: i64 = 5 * 60 * 1000;
+
+fn updateCachePhase(model: *Model) void {
+    if (model.latest_version_len == 0) {
+        model.update_phase = .idle;
+        return;
+    }
+    const latest = model.latest_version[0..model.latest_version_len];
+    model.update_phase = if (updates.isNewer(latest, updates.current_version)) .available else .current;
+}
+
+fn updateCheckStale(last_check_ms: i64, now_ms: i64, interval_ms: i64) bool {
+    return last_check_ms <= 0 or now_ms < last_check_ms or now_ms - last_check_ms >= interval_ms;
+}
+
+fn startUpdateCheck(model: *Model, manual: bool, fx: *Effects) void {
+    if (model.update_phase == .checking) return;
+    model.update_manual = manual;
+    model.update_phase = .checking;
+    fx.fetch(.{
+        .key = update_fetch_key,
+        .url = updates.endpoint,
+        .timeout_ms = 8000,
+        .on_response = Effects.responseMsg(.update_response),
+    });
+}
+
+fn finishUpdateFailure(model: *Model) void {
+    if (model.update_manual) {
+        model.update_phase = .failed;
+    } else {
+        updateCachePhase(model);
+    }
+    model.update_manual = false;
+}
+
+fn startHomebrewCheck(model: *Model, fx: *Effects) void {
+    if (builtin.target.os.tag != .macos or model.install_source != .unknown) return;
+    const brew = if (plat.fileExists("/opt/homebrew/bin/brew"))
+        "/opt/homebrew/bin/brew"
+    else if (plat.fileExists("/usr/local/bin/brew"))
+        "/usr/local/bin/brew"
+    else {
+        model.install_source = .direct;
+        return;
+    };
+    model.install_source = .checking;
+    fx.spawn(.{
+        .key = homebrew_check_key,
+        .argv = &.{ brew, "list", "--cask", "petdex" },
+        .output = .collect,
+        .on_exit = Effects.exitMsg(.homebrew_done),
+    });
+}
 
 fn armFrameTimer(model: *const Model, fx: *Effects) void {
     const def = stateDef(model.state);
@@ -914,7 +991,7 @@ fn saveSettings(model: *const Model) void {
     // drops the whole save): keep room for the configurable bubble
     // fields, rotation state, a long slug, and negative coordinates.
     // Grown with every key added; `font_path` alone can escape to 1024.
-    var buf: [1792]u8 = undefined;
+    var buf: [2304]u8 = undefined;
     const active = if (model.active_pet < catalog_mod.catalog_len) catalog[model.active_pet].slice() else "";
     // The position keys only exist once the window has been fitted and
     // read: a save fired on the very first frame would otherwise
@@ -928,7 +1005,8 @@ fn saveSettings(model: *const Model) void {
     var escaped_font_buf: [1024]u8 = undefined;
     const font_path = std.mem.trim(u8, model.font_path[0..model.font_path_len], " \t\r\n");
     const escaped_font = jsonEscapeString(font_path, &escaped_font_buf) orelse return;
-    const json = std.fmt.bufPrint(&buf, "{{\"active_pet\":\"{s}\",\"scale\":{d:.2},\"bubbles\":{},\"bubbles_per_conversation\":{},\"waiting_sound\":{},\"bubble_text\":{d:.1},\"bubble_lifetime\":{d:.0},\"bubble_columns\":{},\"bubble_answer_lines\":{},\"font_path\":\"{s}\",\"hide_dock\":{},\"rotate_pets\":{},\"rotation_day\":{d}{s},\"agents_prompted\":{}}}", .{ active, model.scale, model.bubbles_enabled, model.bubbles_per_conversation, model.waiting_sound, model.bubble_text_px, model.bubble_lifetime_secs, model.bubble_columns, model.bubble_answer_lines, escaped_font, model.hide_dock, model.rotate_pets, model.rotation_day, pos, model.agents_prompted }) catch return;
+    const latest = model.latest_version[0..model.latest_version_len];
+    const json = std.fmt.bufPrint(&buf, "{{\"active_pet\":\"{s}\",\"scale\":{d:.2},\"bubbles\":{},\"bubbles_per_conversation\":{},\"waiting_sound\":{},\"bubble_text\":{d:.1},\"bubble_lifetime\":{d:.0},\"bubble_columns\":{},\"bubble_answer_lines\":{},\"font_path\":\"{s}\",\"hide_dock\":{},\"rotate_pets\":{},\"rotation_day\":{d},\"update_checks\":{},\"last_update_check_ms\":{d},\"latest_desktop_version\":\"{s}\"{s},\"agents_prompted\":{}}}", .{ active, model.scale, model.bubbles_enabled, model.bubbles_per_conversation, model.waiting_sound, model.bubble_text_px, model.bubble_lifetime_secs, model.bubble_columns, model.bubble_answer_lines, escaped_font, model.hide_dock, model.rotate_pets, model.rotation_day, model.update_checks_enabled, model.last_update_check_ms, latest, pos, model.agents_prompted }) catch return;
     cWriteFile(path, json);
 }
 
@@ -1078,6 +1156,10 @@ var initial_hide_dock: bool = false;
 var initial_rotate_pets: bool = false;
 var initial_rotation_day: u32 = 0;
 var initial_agents_prompted: bool = false;
+var initial_update_checks: bool = true;
+var initial_last_update_check_ms: i64 = 0;
+var initial_latest_version: [32]u8 = @splat(0);
+var initial_latest_version_len: usize = 0;
 /// Persisted pet window origin; null on first run (or a settings file
 /// from before positions were saved), which keeps the platform's
 /// default placement. Off-screen values from an unplugged monitor are
@@ -1351,7 +1433,7 @@ fn resolveInitialPet(io: std.Io, allocator: std.mem.Allocator, environ_map: *std
     if (catalog_mod.catalog_len == 0) return error.NoPetInstalled;
 
     var wanted: []const u8 = "";
-    var settings_buf: [512]u8 = undefined;
+    var settings_buf: [3072]u8 = undefined;
     var path_buf: [512]u8 = undefined;
     if (env_wanted_pet) |w| {
         wanted = w;
@@ -1415,6 +1497,18 @@ fn resolveInitialPet(io: std.Io, allocator: std.mem.Allocator, environ_map: *std
             }
             if (hook_server.jsonNumberPub(json, "rotation_day")) |v| {
                 if (v >= 0) initial_rotation_day = @intFromFloat(v);
+            }
+            if (std.mem.indexOf(u8, json, "\"update_checks\":false") != null) {
+                initial_update_checks = false;
+            }
+            if (hook_server.jsonNumberPub(json, "last_update_check_ms")) |v| {
+                if (v >= 0) initial_last_update_check_ms = @intFromFloat(v);
+            }
+            if (hook_server.jsonStringPub(json, "latest_desktop_version")) |version| {
+                if (version.len <= initial_latest_version.len and updates.isValidVersion(version)) {
+                    @memcpy(initial_latest_version[0..version.len], version);
+                    initial_latest_version_len = version.len;
+                }
             }
         }
     }
@@ -1674,6 +1768,19 @@ pub fn boot(model: *Model, fx: *Effects) void {
     model.hide_dock = initial_hide_dock;
     model.rotate_pets = initial_rotate_pets;
     model.rotation_day = initial_rotation_day;
+    model.update_checks_enabled = initial_update_checks;
+    model.last_update_check_ms = initial_last_update_check_ms;
+    @memcpy(model.latest_version[0..initial_latest_version_len], initial_latest_version[0..initial_latest_version_len]);
+    model.latest_version_len = initial_latest_version_len;
+    updateCachePhase(model);
+    if (model.update_checks_enabled and updateCheckStale(model.last_update_check_ms, fx.wallMs(), update_background_interval_ms)) {
+        fx.startTimer(.{
+            .key = update_boot_timer_key,
+            .interval_ms = update_boot_delay_ms,
+            .mode = .one_shot,
+            .on_fire = Effects.timerMsg(.update_boot_check),
+        });
+    }
     model.launch_at_login = plat.launchAtLoginEnabled();
     // Applied via the main queue, so the flip lands as soon as the
     // host's runloop spins up; a Regular-policy Dock icon may blink in
@@ -1900,6 +2007,10 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
                 model.agents = agent_hooks.scan(boot_allocator, home);
                 model.herdr_status = herdr_status.detect(boot_allocator, home);
             }
+            startHomebrewCheck(model, fx);
+            if (model.update_checks_enabled and updateCheckStale(model.last_update_check_ms, fx.wallMs(), update_settings_interval_ms)) {
+                startUpdateCheck(model, false, fx);
+            }
             loadAgentsAtlas(model.dark, fx);
             if (model.settings_open) {
                 // Already open, likely buried behind other windows:
@@ -1911,6 +2022,63 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             model.settings_open = true;
         },
         .settings_closed => model.settings_open = false,
+        .update_boot_check => |timer| {
+            if (timer.outcome == .fired and model.update_checks_enabled) startUpdateCheck(model, false, fx);
+        },
+        .check_updates => startUpdateCheck(model, true, fx),
+        .toggle_update_checks => {
+            model.update_checks_enabled = !model.update_checks_enabled;
+            if (!model.update_checks_enabled and model.update_phase == .checking) {
+                model.update_manual = false;
+                fx.cancel(update_fetch_key);
+                updateCachePhase(model);
+            } else if (model.update_checks_enabled and updateCheckStale(model.last_update_check_ms, fx.wallMs(), update_background_interval_ms)) {
+                startUpdateCheck(model, false, fx);
+            }
+            saveSettings(model);
+        },
+        .update_response => |response| {
+            model.last_update_check_ms = fx.wallMs();
+            if (response.outcome != .ok or response.status != 200 or response.truncated) {
+                finishUpdateFailure(model);
+                saveSettings(model);
+                return;
+            }
+            var parsed = updates.parseLatest(boot_allocator, response.body) orelse {
+                finishUpdateFailure(model);
+                saveSettings(model);
+                return;
+            };
+            defer parsed.deinit();
+            const version = parsed.value.version orelse {
+                finishUpdateFailure(model);
+                saveSettings(model);
+                return;
+            };
+            if (version.len > model.latest_version.len) {
+                finishUpdateFailure(model);
+                saveSettings(model);
+                return;
+            }
+            @memcpy(model.latest_version[0..version.len], version);
+            model.latest_version_len = version.len;
+            model.update_phase = if (updates.isNewer(version, updates.current_version)) .available else .current;
+            model.update_manual = false;
+            saveSettings(model);
+        },
+        .homebrew_done => |exit| {
+            model.install_source = if (exit.reason == .exited and exit.code == 0) .homebrew else .direct;
+        },
+        .download_update => plat.openExternal(updates.downloadUrl()),
+        .copy_brew_command => {
+            model.brew_command_copied = false;
+            fx.writeClipboard(.{
+                .key = brew_clipboard_key,
+                .text = updates.brew_command,
+                .on_result = Effects.clipboardMsg(.brew_command_copied),
+            });
+        },
+        .brew_command_copied => |result| model.brew_command_copied = result.outcome == .ok,
         .close_pet => closePet(model, fx),
         .select_pet => |index| {
             if (index >= catalog_mod.catalog_len) return;

--- a/packages/petdex-desktop-native/src/settings_view.zig
+++ b/packages/petdex-desktop-native/src/settings_view.zig
@@ -271,7 +271,7 @@ fn updatesSection(ui: *AppUi, model: *const Model) AppUi.Node {
         else
             ui.button(.{ .variant = .primary, .on_press = .download_update }, "Download update")
     else
-        ui.button(.{ .variant = .secondary, .on_press = .check_updates, .disabled = model.update_phase == .checking }, "Check now");
+        ui.button(.{ .variant = .secondary, .on_press = .check_updates, .disabled = model.update_phase == .checking or model.update_cancel_pending }, "Check now");
     const warning_title = if (builtin.os.tag == .macos and model.install_source == .homebrew)
         "Homebrew manages updates"
     else

--- a/packages/petdex-desktop-native/src/settings_view.zig
+++ b/packages/petdex-desktop-native/src/settings_view.zig
@@ -254,6 +254,70 @@ fn remoteSection(ui: *AppUi, model: *const Model) AppUi.Node {
     return ui.column(.{ .gap = 12 }, .{ heading, hint, list });
 }
 
+var update_status_buf: [96]u8 = undefined;
+
+fn updatesSection(ui: *AppUi, model: *const Model) AppUi.Node {
+    const latest = model.latest_version[0..model.latest_version_len];
+    const version_status = switch (model.update_phase) {
+        .idle => std.fmt.bufPrint(&update_status_buf, "{s} · Not checked yet", .{app.updates.current_version}) catch app.updates.current_version,
+        .checking => std.fmt.bufPrint(&update_status_buf, "{s} · Checking…", .{app.updates.current_version}) catch app.updates.current_version,
+        .current => std.fmt.bufPrint(&update_status_buf, "{s} · Up to date", .{app.updates.current_version}) catch app.updates.current_version,
+        .available => std.fmt.bufPrint(&update_status_buf, "{s} installed · {s} available", .{ app.updates.current_version, latest }) catch app.updates.current_version,
+        .failed => std.fmt.bufPrint(&update_status_buf, "{s} · Check failed", .{app.updates.current_version}) catch app.updates.current_version,
+    };
+    const version_action = if (model.update_phase == .available)
+        if (model.install_source == .homebrew)
+            ui.button(.{ .variant = .primary, .on_press = .copy_brew_command }, if (model.brew_command_copied) "Copied" else "Copy brew upgrade command")
+        else
+            ui.button(.{ .variant = .primary, .on_press = .download_update }, "Download update")
+    else
+        ui.button(.{ .variant = .secondary, .on_press = .check_updates, .disabled = model.update_phase == .checking }, "Check now");
+    const warning_title = if (builtin.os.tag == .macos and model.install_source == .homebrew)
+        "Homebrew manages updates"
+    else
+        "Updates stay manual";
+    const warning_copy = if (builtin.os.tag == .macos)
+        if (model.install_source == .homebrew)
+            "Petdex never runs Brew for you. Update with brew upgrade --cask petdex."
+        else
+            "Petdex never replaces itself. Homebrew users should install the petdex cask first."
+    else
+        "Petdex can download a release, but never replaces itself automatically.";
+    var warning = ui.el(.panel, .{ .padding = 12, .style_tokens = .{ .radius = .md } }, .{
+        ui.column(.{ .gap = 4 }, .{
+            ui.text(.{}, warning_title),
+            mutedParagraph(ui, warning_copy),
+        }),
+    });
+    warning.widget.style.background = if (model.dark) canvas.Color.rgb8(48, 38, 22) else canvas.Color.rgb8(255, 246, 214);
+    return ui.column(.{ .gap = 12 }, .{
+        ui.text(.{ .size = .lg }, "Updates"),
+        ui.el(.panel, .{ .style_tokens = .{ .background = .surface, .radius = .md } }, .{
+            ui.row(.{ .padding = 12, .cross = .center, .gap = 12 }, .{
+                ui.column(.{ .grow = 1 }, .{
+                    ui.text(.{}, "Current version"),
+                    mutedParagraph(ui, version_status),
+                }),
+                version_action,
+            }),
+        }),
+        ui.el(.panel, .{ .style_tokens = .{ .background = .surface, .radius = .md } }, .{
+            ui.row(.{ .padding = 12, .cross = .center, .gap = 12 }, .{
+                ui.column(.{ .grow = 1 }, .{
+                    ui.text(.{}, "Check automatically"),
+                    mutedParagraph(ui, "Quietly checks once per day"),
+                }),
+                ui.el(.switch_control, .{
+                    .selected = model.update_checks_enabled,
+                    .on_toggle = .toggle_update_checks,
+                    .semantics = .{ .label = "Check for updates automatically" },
+                }, .{}),
+            }),
+        }),
+        warning,
+    });
+}
+
 pub fn settingsView(ui: *AppUi, model: *const Model, icons: IconAtlas, thumbs: ThumbAtlas) AppUi.Node {
     var rows: [max_catalog]AppUi.Node = undefined;
     var shown: usize = 0;
@@ -516,6 +580,8 @@ pub fn settingsView(ui: *AppUi, model: *const Model, icons: IconAtlas, thumbs: T
                 ui.button(.{ .on_press = .open_pets_folder }, "Open folder"),
             }),
         }),
+        ui.el(.stack, .{ .height = 10 }, .{}),
+        updatesSection(ui, model),
         // Trailing spacer: the column's own bottom padding is not part
         // of the scroll extent, so the last card needs explicit air.
         ui.el(.stack, .{ .height = 8 }, .{}),

--- a/packages/petdex-desktop-native/src/updates.zig
+++ b/packages/petdex-desktop-native/src/updates.zig
@@ -1,0 +1,104 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub const endpoint = "https://petdex.crafter.run/api/desktop/latest-release?format=json";
+pub const release_page = "https://github.com/crafter-station/petdex/releases";
+pub const brew_command = "brew upgrade --cask petdex";
+pub const current_version = "0.8.0";
+
+pub const Phase = enum { idle, checking, current, available, failed };
+pub const InstallSource = enum { unknown, checking, direct, homebrew };
+
+pub const Latest = struct {
+    version: ?[]const u8 = null,
+};
+
+fn manifestVersion(source: []const u8) ?[]const u8 {
+    const prefix = ".version = \"";
+    const start = (std.mem.indexOf(u8, source, prefix) orelse return null) + prefix.len;
+    const end = std.mem.indexOfPos(u8, source, start, "\"") orelse return null;
+    const value = source[start..end];
+    return if (parseVersion(value) == null) null else value;
+}
+
+pub fn parseLatest(allocator: std.mem.Allocator, body: []const u8) ?std.json.Parsed(Latest) {
+    const parsed = std.json.parseFromSlice(Latest, allocator, body, .{ .ignore_unknown_fields = true }) catch return null;
+    if (parsed.value.version) |version| {
+        if (parseVersion(version) == null) {
+            parsed.deinit();
+            return null;
+        }
+    }
+    return parsed;
+}
+
+const Version = struct { major: u32, minor: u32, patch: u32 };
+
+fn parseVersion(value: []const u8) ?Version {
+    var parts = std.mem.splitScalar(u8, value, '.');
+    const major_text = parts.next() orelse return null;
+    const minor_text = parts.next() orelse return null;
+    const patch_text = parts.next() orelse return null;
+    if (parts.next() != null or major_text.len == 0 or minor_text.len == 0 or patch_text.len == 0) return null;
+    for (value) |byte| if (byte != '.' and !std.ascii.isDigit(byte)) return null;
+    return .{
+        .major = std.fmt.parseInt(u32, major_text, 10) catch return null,
+        .minor = std.fmt.parseInt(u32, minor_text, 10) catch return null,
+        .patch = std.fmt.parseInt(u32, patch_text, 10) catch return null,
+    };
+}
+
+pub fn isValidVersion(value: []const u8) bool {
+    return parseVersion(value) != null;
+}
+
+pub fn isNewer(latest: []const u8, current: []const u8) bool {
+    const a = parseVersion(latest) orelse return false;
+    const b = parseVersion(current) orelse return false;
+    if (a.major != b.major) return a.major > b.major;
+    if (a.minor != b.minor) return a.minor > b.minor;
+    return a.patch > b.patch;
+}
+
+pub fn downloadUrl() []const u8 {
+    return switch (builtin.os.tag) {
+        .macos => switch (builtin.cpu.arch) {
+            .aarch64 => "https://petdex.crafter.run/api/desktop/latest-release?asset=darwin-arm64",
+            .x86_64 => "https://petdex.crafter.run/api/desktop/latest-release?asset=darwin-x64",
+            else => release_page,
+        },
+        .windows => "https://petdex.crafter.run/api/desktop/latest-release?asset=win32-x64",
+        .linux => switch (builtin.cpu.arch) {
+            .aarch64 => "https://petdex.crafter.run/api/desktop/latest-release?asset=linux-arm64",
+            .x86_64 => "https://petdex.crafter.run/api/desktop/latest-release?asset=linux-x64",
+            else => release_page,
+        },
+        else => release_page,
+    };
+}
+
+test "current version comes from app.zon" {
+    var source_buf: [4096]u8 = undefined;
+    const source = @import("plat.zig").readFile("app.zon", &source_buf).?;
+    try std.testing.expectEqualStrings(manifestVersion(source).?, current_version);
+}
+
+test "semantic versions compare numerically" {
+    try std.testing.expect(isNewer("0.10.0", "0.9.9"));
+    try std.testing.expect(isNewer("1.0.0", "0.99.99"));
+    try std.testing.expect(!isNewer("0.7.0", "0.7.0"));
+    try std.testing.expect(!isNewer("0.6.9", "0.7.0"));
+    try std.testing.expect(!isNewer("0.8.0-beta.1", "0.7.0"));
+}
+
+test "latest release payload accepts null and valid versions" {
+    var parsed = parseLatest(std.testing.allocator, "{\"version\":\"0.8.0\",\"tag\":\"desktop-v0.8.0\"}").?;
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("0.8.0", parsed.value.version.?);
+
+    var unknown = parseLatest(std.testing.allocator, "{\"version\":null}").?;
+    defer unknown.deinit();
+    try std.testing.expectEqual(@as(?[]const u8, null), unknown.value.version);
+
+    try std.testing.expect(parseLatest(std.testing.allocator, "{\"version\":\"next\"}") == null);
+}

--- a/packages/petdex-desktop-native/src/updates.zig
+++ b/packages/petdex-desktop-native/src/updates.zig
@@ -89,6 +89,9 @@ test "semantic versions compare numerically" {
     try std.testing.expect(!isNewer("0.7.0", "0.7.0"));
     try std.testing.expect(!isNewer("0.6.9", "0.7.0"));
     try std.testing.expect(!isNewer("0.8.0-beta.1", "0.7.0"));
+    try std.testing.expect(parseVersion("v0.8.0") == null);
+    try std.testing.expect(parseVersion("0.8.0.1") == null);
+    try std.testing.expect(parseVersion("4294967296.0.0") == null);
 }
 
 test "latest release payload accepts null and valid versions" {


### PR DESCRIPTION
## Summary

- add quiet daily desktop update discovery with a manual check
- keep installation explicit and detect Homebrew-managed installs on macOS
- surface the current version and update status inside Settings
- harden long-lived scheduling, cancellation races, retries, and Brew probe timeouts
- bump the native desktop app to 0.8.0

## Verification

- head SHA: 17bb84b2270e84c72bcb0dfe6ba0daa8e9ebb463
- bun run check
- bun run i18n:check
- bun test: 418/418
- pinned Native SDK: 197/197
- ReleaseFast automation build
- native Settings screenshot verified
- latest-SHA OpenCode gate: NO ACTIONABLE FINDINGS
- GitHub native matrix green on macOS, Linux, and Windows

Closes #693
Refs #679