### PR TITLE
feat(desktop): define canonical session events

### DIFF
--- a/packages/petdex-desktop-native/integrations/dsh/package.test.ts
+++ b/packages/petdex-desktop-native/integrations/dsh/package.test.ts
@@ -11,6 +11,10 @@ const packagedFiles = [
   "src/normalize.js",
 ];
 
+function normalizeNewlines(value: string) {
+  return value.replaceAll("\r\n", "\n");
+}
+
 function tar(...args: string[]) {
   const result = Bun.spawnSync(["tar", ...args], {
     cwd: root,
@@ -18,7 +22,10 @@ function tar(...args: string[]) {
     stderr: "pipe",
   });
   expect(result.exitCode).toBe(0);
-  return result.stdout.toString();
+  // bsdtar follows the host text convention for listings and git may check
+  // source fixtures out with CRLF on Windows. The archive contract is textual
+  // content, not a platform-specific newline encoding.
+  return normalizeNewlines(result.stdout.toString());
 }
 
 describe("embedded DSH plugin archive", () => {
@@ -34,7 +41,7 @@ describe("embedded DSH plugin archive", () => {
   for (const file of packagedFiles) {
     test(`keeps ${file} in sync with source`, async () => {
       const packed = tar("-xOzf", archive, `package/${file}`);
-      const source = await Bun.file(join(root, file)).text();
+      const source = normalizeNewlines(await Bun.file(join(root, file)).text());
       expect(packed).toBe(source);
     });
   }

--- a/packages/petdex-desktop-native/src/agent_hooks.zig
+++ b/packages/petdex-desktop-native/src/agent_hooks.zig
@@ -233,24 +233,37 @@ fn qoderStatus(allocator: std.mem.Allocator, home: []const u8) HookStatus {
 
 /// The five Claude-shaped hook events the bubble pipeline rides.
 const claude_events = [_]HookEvent{
-    .{ .event = "UserPromptSubmit", .phase = "user-prompt" },
-    .{ .event = "PreToolUse", .phase = "pre" },
-    .{ .event = "PostToolUse", .phase = "post" },
-    .{ .event = "Notification", .phase = "notification" },
-    .{ .event = "Stop", .phase = "stop" },
-};
-
-/// The Claude five plus PostToolUseFailure, the one event no other wired agent
-/// reports — it is what lights the `failed` sprite row. The two Post* events are
-/// mutually exclusive per tool call (coreToolHookTriggers.ts:288 gates
-/// PostToolUse on `!toolResult.error`), so no trailing `idle` stomps it.
-const qoder_events = [_]HookEvent{
+    .{ .event = "SessionStart", .phase = "session-start" },
     .{ .event = "UserPromptSubmit", .phase = "user-prompt" },
     .{ .event = "PreToolUse", .phase = "pre" },
     .{ .event = "PostToolUse", .phase = "post" },
     .{ .event = "PostToolUseFailure", .phase = "tool-failure" },
+    .{ .event = "PermissionRequest", .phase = "approval-request" },
     .{ .event = "Notification", .phase = "notification" },
+    .{ .event = "SubagentStart", .phase = "subagent-start" },
+    .{ .event = "SubagentStop", .phase = "subagent-stop" },
+    .{ .event = "StopFailure", .phase = "tool-failure" },
     .{ .event = "Stop", .phase = "stop" },
+    .{ .event = "SessionEnd", .phase = "session-end" },
+};
+
+/// Qoder exposes the same full lifecycle shape as Claude, including explicit
+/// permission, failure, and subagent events. Keeping those event names intact
+/// lets the shared normalizer correlate input and child sessions without
+/// guessing from prose in a tool result.
+const qoder_events = [_]HookEvent{
+    .{ .event = "SessionStart", .phase = "session-start" },
+    .{ .event = "UserPromptSubmit", .phase = "user-prompt" },
+    .{ .event = "PreToolUse", .phase = "pre" },
+    .{ .event = "PostToolUse", .phase = "post" },
+    .{ .event = "PostToolUseFailure", .phase = "tool-failure" },
+    .{ .event = "PermissionRequest", .phase = "approval-request" },
+    .{ .event = "Notification", .phase = "notification" },
+    .{ .event = "SubagentStart", .phase = "subagent-start" },
+    .{ .event = "SubagentStop", .phase = "subagent-stop" },
+    .{ .event = "StopFailure", .phase = "tool-failure" },
+    .{ .event = "Stop", .phase = "stop" },
+    .{ .event = "SessionEnd", .phase = "session-end" },
 };
 
 const codex_events = [_]HookEvent{
@@ -656,8 +669,14 @@ fn uninstallQoder(allocator: std.mem.Allocator, home: []const u8) bool {
 /// Gemini rides the exact same settings.json hook shape as Claude,
 /// with its own event names.
 const gemini_events = [_]HookEvent{
+    .{ .event = "SessionStart", .phase = "session-start" },
+    .{ .event = "BeforeAgent", .phase = "user-prompt" },
+    .{ .event = "BeforeModel", .phase = "pre-llm" },
     .{ .event = "BeforeTool", .phase = "pre" },
     .{ .event = "AfterTool", .phase = "post" },
+    .{ .event = "AfterModel", .phase = "assistant" },
+    .{ .event = "AfterAgent", .phase = "assistant" },
+    .{ .event = "Notification", .phase = "notification" },
     .{ .event = "SessionEnd", .phase = "stop" },
 };
 
@@ -720,23 +739,22 @@ pub fn installOmp(allocator: std.mem.Allocator, home: []const u8) bool {
 /// shape but never Claude's own file, so it needs its own row instead of
 /// a second config root on the Claude one.
 ///
-/// It declares 27+ events, of which only the Claude-shaped core has
-/// documented payload schemas. Wiring the long tail (Elicitation,
-/// TeammateIdle, WorktreeCreate, and friends) would mean guessing at
-/// field names, so this stays on the documented set.
-///
-/// No tool-failure event: unlike Kimi and Qoder, a failed call surfaces
-/// as the `tool_response` field on PostToolUse. Reading that would mean
-/// pattern-matching prose to decide what "failed" looks like, and a pet
-/// that flashes `failed` on a successful grep is worse than one that
-/// never flashes it at all. So `failed` stays dark here until CodeBuddy
-/// grows a distinct event, and `post` reports plain `idle`.
+/// CodeBuddy exposes the Claude-shaped documented lifecycle, including
+/// explicit failure, permission, and subagent events. The unrelated long tail
+/// remains deliberately unwired because it has no stable payload contract.
 const codebuddy_events = [_]HookEvent{
+    .{ .event = "SessionStart", .phase = "session-start" },
     .{ .event = "UserPromptSubmit", .phase = "user-prompt" },
     .{ .event = "PreToolUse", .phase = "pre" },
     .{ .event = "PostToolUse", .phase = "post" },
+    .{ .event = "PostToolUseFailure", .phase = "tool-failure" },
+    .{ .event = "PermissionRequest", .phase = "approval-request" },
     .{ .event = "Notification", .phase = "notification" },
+    .{ .event = "SubagentStart", .phase = "subagent-start" },
+    .{ .event = "SubagentStop", .phase = "subagent-stop" },
+    .{ .event = "StopFailure", .phase = "tool-failure" },
     .{ .event = "Stop", .phase = "stop" },
+    .{ .event = "SessionEnd", .phase = "session-end" },
 };
 
 pub fn installCodeBuddy(allocator: std.mem.Allocator, home: []const u8) bool {
@@ -760,12 +778,18 @@ pub fn installCodeBuddy(allocator: std.mem.Allocator, home: []const u8) bool {
 /// success), so the `failed` sprite row lights up the same way Qoder's
 /// does, with no trailing `idle` to stomp it.
 const kimi_events = [_]HookEvent{
+    .{ .event = "SessionStart", .phase = "session-start" },
     .{ .event = "UserPromptSubmit", .phase = "user-prompt" },
     .{ .event = "PreToolUse", .phase = "pre" },
     .{ .event = "PostToolUse", .phase = "post" },
     .{ .event = "PostToolUseFailure", .phase = "tool-failure" },
+    .{ .event = "PermissionRequest", .phase = "approval-request" },
     .{ .event = "Notification", .phase = "notification" },
+    .{ .event = "SubagentStart", .phase = "subagent-start" },
+    .{ .event = "SubagentStop", .phase = "subagent-stop" },
+    .{ .event = "StopFailure", .phase = "tool-failure" },
     .{ .event = "Stop", .phase = "stop" },
+    .{ .event = "SessionEnd", .phase = "session-end" },
 };
 
 /// `$KIMI_CODE_HOME/config.toml` when the variable is set and non-empty,
@@ -2173,6 +2197,14 @@ fn expectedCanonicalHookTextOccurrences() usize {
     return if (builtin.os.tag == .windows) 2 else 1;
 }
 
+fn hookPhaseCount(events: []const HookEvent, phase: []const u8) usize {
+    var count: usize = 0;
+    for (events) |event| {
+        if (std.mem.eql(u8, event.phase, phase)) count += 1;
+    }
+    return count;
+}
+
 test "claude merge preserves foreign keys and hooks, replaces petdex entries" {
     // Build a fixture settings.json with a user hook and an old petdex
     // node hook, run the merge logic pieces on it via Value.
@@ -2302,7 +2334,7 @@ test "CLAUDE_CONFIG_DIR redirects install, scan and uninstall" {
     try t.expectEqual(HookStatus.absent, blank[0].status);
 }
 
-test "installQoder writes six events and stays out of the rest of the config" {
+test "installQoder writes its documented lifecycle and preserves the rest of the config" {
     const home = ".zig-cache/petdex-qoder-fixture";
     plat.makeDir(home ++ "/.qoder");
     const fixture =
@@ -2317,8 +2349,20 @@ test "installQoder writes six events and stays out of the rest of the config" {
     const merged = readFileAlloc(t.allocator, cfg, 1024 * 1024).?;
     defer t.allocator.free(merged);
 
-    // All six events, including the one no other agent reports.
-    for ([_][]const u8{ "UserPromptSubmit", "PreToolUse", "PostToolUse", "PostToolUseFailure", "Notification", "Stop" }) |event| {
+    for ([_][]const u8{
+        "SessionStart",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "PermissionRequest",
+        "Notification",
+        "SubagentStart",
+        "SubagentStop",
+        "StopFailure",
+        "Stop",
+        "SessionEnd",
+    }) |event| {
         try t.expect(std.mem.indexOf(u8, merged, event) != null);
     }
     try t.expect(std.mem.indexOf(u8, merged, "bubble tool-failure qoder") != null);
@@ -2336,7 +2380,10 @@ test "installQoder writes six events and stays out of the rest of the config" {
     const merged2 = readFileAlloc(t.allocator, cfg, 1024 * 1024).?;
     defer t.allocator.free(merged2);
     try t.expectEqual(expectedCanonicalHookTextOccurrences(), std.mem.count(u8, merged2, "bubble pre qoder"));
-    try t.expectEqual(expectedCanonicalHookTextOccurrences(), std.mem.count(u8, merged2, "bubble tool-failure qoder"));
+    try t.expectEqual(
+        expectedCanonicalHookTextOccurrences() * hookPhaseCount(&qoder_events, "tool-failure"),
+        std.mem.count(u8, merged2, "bubble tool-failure qoder"),
+    );
 
     const bak = std.fmt.bufPrint(&pb, "{s}/.qoder/settings.json.pre-petdex-backup", .{home}) catch unreachable;
     try t.expect(fileExists(bak));
@@ -2985,23 +3032,26 @@ test "codebuddy merges into its own config and leaves Claude's alone" {
     try t.expect(std.mem.indexOf(u8, cleared, "my-own-hook") != null);
 }
 
-test "codebuddy wires only events with documented payloads" {
-    // It declares 27+ events; the long tail has no documented schema, so
-    // guessing at field names is how an adapter starts reading garbage.
-    for (codebuddy_events) |ev| {
-        const documented = std.mem.eql(u8, ev.event, "UserPromptSubmit") or
-            std.mem.eql(u8, ev.event, "PreToolUse") or
-            std.mem.eql(u8, ev.event, "PostToolUse") or
-            std.mem.eql(u8, ev.event, "Notification") or
-            std.mem.eql(u8, ev.event, "Stop");
-        try t.expect(documented);
-    }
-    // No tool-failure phase: CodeBuddy reports failure as a field on
-    // PostToolUse rather than its own event, and inferring it from prose
-    // would light `failed` on healthy calls. Deliberate, not an omission.
-    for (codebuddy_events) |ev| {
-        try t.expect(!std.mem.eql(u8, ev.phase, "tool-failure"));
-    }
+test "codebuddy wires the documented lifecycle without guessing at unrelated events" {
+    const expected = [_][]const u8{
+        "SessionStart",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "PermissionRequest",
+        "Notification",
+        "SubagentStart",
+        "SubagentStop",
+        "StopFailure",
+        "Stop",
+        "SessionEnd",
+    };
+    try t.expectEqual(expected.len, codebuddy_events.len);
+    for (expected, codebuddy_events) |event, hook| try t.expectEqualStrings(event, hook.event);
+    try t.expectEqual(@as(usize, 2), hookPhaseCount(&codebuddy_events, "tool-failure"));
+    try t.expectEqual(@as(usize, 1), hookPhaseCount(&codebuddy_events, "subagent-start"));
+    try t.expectEqual(@as(usize, 1), hookPhaseCount(&codebuddy_events, "subagent-stop"));
 }
 
 test "omp install writes the extension where OMP discovers it" {

--- a/packages/petdex-desktop-native/src/assets/omp-extension.ts
+++ b/packages/petdex-desktop-native/src/assets/omp-extension.ts
@@ -10,7 +10,14 @@
 // Each pi.on handler below maps one OMP event to one mascot state; edit
 // the state strings there to change what the pet does.
 
-import { existsSync } from "node:fs";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+} from "node:fs";
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -21,6 +28,46 @@ const RUNTIME_DIR = join(homedir(), ".petdex", "runtime");
 const TOKEN_PATH = join(RUNTIME_DIR, "update-token");
 const KILLSWITCH_PATH = join(RUNTIME_DIR, "hooks-disabled");
 const AGENT_SOURCE = "omp";
+const JOURNAL_DIR = join(RUNTIME_DIR, "session-journal");
+const JOURNAL_LIMIT = 4 * 1024 * 1024;
+
+function journalStem(
+  value: string | null | undefined,
+  fallback: string,
+): string {
+  const safe = String(value || fallback).replace(/[^a-zA-Z0-9_.-]/g, "_");
+  return safe.slice(0, 96) || fallback;
+}
+
+function appendJournal(body: Record<string, unknown>): void {
+  if (
+    typeof body.text !== "string" ||
+    body.text.length === 0 ||
+    typeof body.conversation_key !== "string"
+  )
+    return;
+  try {
+    mkdirSync(JOURNAL_DIR, { recursive: true, mode: 0o700 });
+    const path = join(
+      JOURNAL_DIR,
+      `${journalStem(String(body.agent_source ?? ""), "agent")}-${journalStem(body.conversation_key, "unkeyed")}.jsonl`,
+    );
+    const record = `${JSON.stringify({ journal_version: 1, event: body })}\n`;
+    if (
+      existsSync(path) &&
+      statSync(path).size + Buffer.byteLength(record) > JOURNAL_LIMIT
+    ) {
+      const previous = `${path}.1`;
+      try {
+        unlinkSync(previous);
+      } catch {}
+      renameSync(path, previous);
+    }
+    appendFileSync(path, record, { encoding: "utf8", mode: 0o600 });
+  } catch {
+    // Recovery is best-effort and must never stall the in-process extension.
+  }
+}
 
 // Read-only tools read as thinking rather than working, matching how the
 // other adapters split `review` from `running`.
@@ -64,6 +111,11 @@ type Notify = {
   title?: string;
   busy?: boolean;
   sessionId?: string | null;
+  status?: "idle" | "running" | "needs_input" | "completed" | "failed";
+  messageKind?: "status" | "prompt" | "tool" | "lifecycle";
+  eventKind?: string;
+  requestId?: string;
+  resolvesRequestId?: string;
 };
 
 type ExtensionContext = {
@@ -96,12 +148,15 @@ async function notify({
   title,
   busy,
   sessionId,
+  status,
+  messageKind,
+  eventKind,
+  requestId,
+  resolvesRequestId,
 }: Notify): Promise<void> {
   // Killswitch first, before the token read, so the disabled state costs
   // one existsSync and nothing else.
   if (existsSync(KILLSWITCH_PATH)) return;
-  const token = await readToken();
-  if (!token) return; // Hook server offline or missing; silently no-op.
   const stateBody: Record<string, unknown> =
     duration != null
       ? { state, duration, agent_source: AGENT_SOURCE }
@@ -113,9 +168,24 @@ async function notify({
   if (sessionId) {
     stateBody.session_id = sessionId;
     bubbleBody.session_id = sessionId;
+    bubbleBody.conversation_key = sessionId;
+    bubbleBody.source_session_id = sessionId;
+    bubbleBody.session_kind = "primary";
   }
-  if (title) bubbleBody.title = title;
+  if (title) {
+    bubbleBody.title = title;
+    bubbleBody.title_source = "prompt";
+  }
   if (busy !== undefined) bubbleBody.busy = busy;
+  if (status) bubbleBody.status = status;
+  if (messageKind) bubbleBody.message_kind = messageKind;
+  if (eventKind) bubbleBody.event_kind = eventKind;
+  if (requestId) bubbleBody.request_id = requestId;
+  if (resolvesRequestId) bubbleBody.resolves_request_id = resolvesRequestId;
+  bubbleBody.feed_source = "hook";
+  if (text) appendJournal(bubbleBody);
+  const token = await readToken();
+  if (!token) return; // Journal survives while the desktop is offline.
   await Promise.all([
     postJson(HOOK_SERVER_URL, stateBody, token),
     text
@@ -208,6 +278,8 @@ export default function petdex(pi: ExtensionAPI): void {
       state: "jumping",
       duration: 1200,
       busy: false,
+      status: "running",
+      eventKind: "session-start",
       sessionId: sessionIdFor(ctx),
     });
   }) as never);
@@ -221,6 +293,8 @@ export default function petdex(pi: ExtensionAPI): void {
       state: "jumping",
       duration: 900,
       busy: false,
+      status: "running",
+      eventKind: "user-prompt",
       sessionId,
     });
   }) as never);
@@ -233,6 +307,9 @@ export default function petdex(pi: ExtensionAPI): void {
       text: describeTool(name, event?.input ?? {}, false),
       title: titleFor(sessionId),
       busy: true,
+      status: "running",
+      messageKind: "tool",
+      eventKind: "tool-progress",
       sessionId,
     });
   }) as never);
@@ -249,6 +326,9 @@ export default function petdex(pi: ExtensionAPI): void {
         text: `${describeTool(event?.toolName ?? "", event?.input ?? {}, true)} failed`,
         title: titleFor(sessionId),
         busy: false,
+        status: "failed",
+        messageKind: "tool",
+        eventKind: "tool-failure",
         sessionId,
       });
       return;
@@ -258,6 +338,9 @@ export default function petdex(pi: ExtensionAPI): void {
       text: describeTool(event?.toolName ?? "", event?.input ?? {}, true),
       title: titleFor(sessionId),
       busy: true,
+      status: "running",
+      messageKind: "tool",
+      eventKind: "tool-progress",
       sessionId,
     });
   }) as never);
@@ -269,6 +352,9 @@ export default function petdex(pi: ExtensionAPI): void {
       text: "Waiting on you.",
       title: titleFor(sessionId),
       busy: false,
+      status: "needs_input",
+      messageKind: "prompt",
+      eventKind: "approval-request",
       sessionId,
     });
   }) as never);
@@ -281,6 +367,9 @@ export default function petdex(pi: ExtensionAPI): void {
       text: "Done.",
       title: titleFor(sessionId),
       busy: false,
+      status: "completed",
+      messageKind: "lifecycle",
+      eventKind: "session-end",
       sessionId,
     });
   }) as never);

--- a/packages/petdex-desktop-native/src/assets/opencode-plugin.js
+++ b/packages/petdex-desktop-native/src/assets/opencode-plugin.js
@@ -2,16 +2,42 @@
 // Forwards OpenCode lifecycle events to the petdex desktop mascot via HTTP.
 // Edit STATE_MAP below to customize which state each event triggers.
 
-import { existsSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, unlinkSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
 const HOOK_SERVER_URL = "http://127.0.0.1:7777/state";
 const HOOK_SERVER_BUBBLE_URL = "http://127.0.0.1:7777/bubble";
+const HOOK_SERVER_TITLE_URL = "http://127.0.0.1:7777/bubble/title";
 const RUNTIME_DIR = join(homedir(), ".petdex", "runtime");
 const TOKEN_PATH = join(RUNTIME_DIR, "update-token");
 const KILLSWITCH_PATH = join(RUNTIME_DIR, "hooks-disabled");
+const REMOTE_HOST_PATH = join(RUNTIME_DIR, "remote-host");
+const JOURNAL_DIR = join(RUNTIME_DIR, "session-journal");
+const JOURNAL_LIMIT = 4 * 1024 * 1024;
+
+function journalStem(value, fallback) {
+  const safe = String(value || fallback).replace(/[^a-zA-Z0-9_.-]/g, "_");
+  return safe.slice(0, 96) || fallback;
+}
+
+function appendJournal(body) {
+  if (!body?.text || !body?.conversation_key) return;
+  try {
+    mkdirSync(JOURNAL_DIR, { recursive: true, mode: 0o700 });
+    const path = join(JOURNAL_DIR, `${journalStem(body.agent_source, "agent")}-${journalStem(body.conversation_key, "unkeyed")}.jsonl`);
+    const record = JSON.stringify({ journal_version: 1, event: body }) + "\n";
+    if (existsSync(path) && statSync(path).size + Buffer.byteLength(record) > JOURNAL_LIMIT) {
+      const previous = path + ".1";
+      try { unlinkSync(previous); } catch {}
+      renameSync(path, previous);
+    }
+    appendFileSync(path, record, { encoding: "utf8", mode: 0o600 });
+  } catch {
+    // Recovery is best-effort and must never stain the agent process.
+  }
+}
 
 async function readToken() {
   try {
@@ -38,11 +64,15 @@ function clip(text, max = 40) {
 
 function originMetadata() {
   const sourceApp = process.env.TERM_PROGRAM;
-  if (sourceApp !== "Apple_Terminal" && sourceApp !== "vscode") return {};
-  return {
-    source_app: sourceApp,
-    source_cwd: process.cwd(),
-  };
+  const metadata =
+    sourceApp === "Apple_Terminal" || sourceApp === "vscode"
+      ? { source_app: sourceApp, source_cwd: process.cwd() }
+      : { source_cwd: process.cwd() };
+  try {
+    const hostname = readFileSync(REMOTE_HOST_PATH, "utf8").trim().slice(0, 64);
+    if (hostname) return { ...metadata, hostname, remote: true };
+  } catch {}
+  return metadata;
 }
 
 function canonicalToolKind(toolName) {
@@ -128,17 +158,12 @@ async function postJson(url, body, token) {
   }
 }
 
-async function notify({ state, duration, text, title, busy, sessionId }) {
+async function notify({ state, duration, text, title, busy, sessionId, status, messageKind = "tool" }) {
   // Killswitch: users toggle this with /petdex inside their agent
   // (or 'petdex hooks toggle' from a shell). Bail before the token
   // read so the disabled state has zero filesystem cost beyond the
   // existsSync.
   if (existsSync(KILLSWITCH_PATH)) return;
-  // Token gate defends against drive-by no-cors POSTs from any site
-  // the user visits. The token rotates per desktop session and lives
-  // at mode 0600, so only this user can read it.
-  const token = await readToken();
-  if (!token) return; // Hook server offline or missing; silently no-op.
   // Stamp agent_source so the hook server can route per-pet when we
   // ship multi-mascot. Today the field is recorded for telemetry
   // but doesn't affect routing.
@@ -152,9 +177,23 @@ async function notify({ state, duration, text, title, busy, sessionId }) {
   if (sessionId) {
     stateBody.session_id = sessionId;
     bubbleBody.session_id = sessionId;
+    bubbleBody.conversation_key = sessionId;
+    bubbleBody.source_session_id = sessionId;
+    bubbleBody.session_kind = "primary";
   }
-  if (title) bubbleBody.title = title;
+  if (title) {
+    bubbleBody.title = title;
+    bubbleBody.title_source = "server";
+  }
   if (busy !== undefined) bubbleBody.busy = busy;
+  if (status) bubbleBody.status = status;
+  bubbleBody.message_kind = messageKind;
+  bubbleBody.feed_source = "hook";
+  appendJournal(bubbleBody);
+  // Journal first: an event remains recoverable when the desktop is closed.
+  // The rotating token still gates all loopback HTTP writes.
+  const token = await readToken();
+  if (!token) return;
   await Promise.all([
     postJson(HOOK_SERVER_URL, stateBody, token),
     text ? postJson(HOOK_SERVER_BUBBLE_URL, bubbleBody, token) : Promise.resolve(),
@@ -166,18 +205,35 @@ async function notify({ state, duration, text, title, busy, sessionId }) {
 // us opencode's own LLM-generated session titles for the bubble.
 const PetdexPlugin = async ({ client }) => {
   const titleCache = new Map();
+  const clippedTitle = (title) =>
+    typeof title === "string" && title.trim().length > 0
+      ? (title.trim().length > 60 ? title.trim().slice(0, 59) + "\u2026" : title.trim())
+      : null;
   async function sessionTitle(sessionID) {
     if (!sessionID || !client) return titleCache.get(sessionID) || null;
     try {
       const res = await client.session.get({ path: { id: sessionID } });
-      const title = res?.data?.title;
-      if (typeof title === "string" && title.length > 0) {
-        titleCache.set(sessionID, title.length > 60 ? title.slice(0, 59) + "\u2026" : title);
-      }
+      const title = clippedTitle(res?.data?.title);
+      if (title) titleCache.set(sessionID, title);
     } catch {
       // Hook-server silence: a missing title never stains the agent.
     }
     return titleCache.get(sessionID) || null;
+  }
+  async function syncServerTitle(sessionID, rawTitle) {
+    const title = clippedTitle(rawTitle);
+    if (!sessionID || !title) return;
+    titleCache.set(sessionID, title);
+    if (existsSync(KILLSWITCH_PATH)) return;
+    const token = await readToken();
+    if (!token) return;
+    await postJson(HOOK_SERVER_TITLE_URL, {
+      session_id: sessionID,
+      conversation_key: sessionID,
+      title,
+      agent_source: "opencode",
+      ...originMetadata(),
+    }, token);
   }
   return {
     "tool.execute.before": async (input, output) => notify({
@@ -186,6 +242,8 @@ const PetdexPlugin = async ({ client }) => {
       title: await sessionTitle(input.sessionID),
       busy: true,
       sessionId: input.sessionID,
+      status: "running",
+      messageKind: "tool",
     }),
     "tool.execute.after": async (input) => notify({
       state: "idle",
@@ -193,11 +251,16 @@ const PetdexPlugin = async ({ client }) => {
       title: await sessionTitle(input.sessionID),
       busy: true,
       sessionId: input.sessionID,
+      status: "running",
+      messageKind: "tool",
     }),
     event: async ({ event }) => {
-      const sessionId = event?.properties?.sessionID;
+      const info = event?.properties?.info;
+      const sessionId = event?.properties?.sessionID ?? info?.id;
       if (typeof sessionId !== "string" || sessionId.length === 0) return;
-      if (event.type === "session.idle") {
+      if (event.type === "session.updated" || event.type === "session.created") {
+        await syncServerTitle(sessionId, info?.title);
+      } else if (event.type === "session.idle") {
         await notify({
           state: "waving",
           duration: 1500,
@@ -205,6 +268,8 @@ const PetdexPlugin = async ({ client }) => {
           title: await sessionTitle(sessionId),
           busy: false,
           sessionId,
+          status: "completed",
+          messageKind: "lifecycle",
         });
       } else if (event.type === "session.error") {
         await notify({
@@ -214,6 +279,8 @@ const PetdexPlugin = async ({ client }) => {
           title: await sessionTitle(sessionId),
           busy: false,
           sessionId,
+          status: "failed",
+          messageKind: "lifecycle",
         });
       }
     },

--- a/packages/petdex-desktop-native/src/hook_runner.zig
+++ b/packages/petdex-desktop-native/src/hook_runner.zig
@@ -18,12 +18,15 @@ const plat = @import("plat.zig");
 const jsonString = hook_server.jsonStringPub;
 
 const stdin_cap = 64 * 1024;
-const title_max = 60;
-const preview_max = 110;
-const transcript_tail_cap = 64 * 1024;
+const title_max = hook_server.bubble_title_capacity;
+const preview_max = 960;
+const transcript_tail_cap = 256 * 1024;
+const post_body_capacity = 8 * 1024;
 const session_ttl_secs: i64 = 24 * 60 * 60;
 const post_timeout_ms: u64 = 300;
 const post_poll_ms: u64 = 5;
+const journal_version: u8 = 1;
+const journal_rotate_bytes: u64 = 4 * 1024 * 1024;
 
 // ------------------------------------------------------------- entry
 
@@ -44,6 +47,105 @@ pub fn run(phase: []const u8, arg_agent: ?[]const u8, origin_app: plat.OriginApp
         if (cReadFile(ks, &probe) != null) return;
     } else |_| {}
 
+    const agent = jsonString(payload, "agent_source") orelse (arg_agent orelse "");
+    const effective_origin: plat.OriginApplication = if (origin_app == .none and std.ascii.eqlIgnoreCase(agent, "codex")) .codex else origin_app;
+    const source_app = effective_origin.wireName();
+    var tty_buf: [64]u8 = undefined;
+    const source_tty = if (effective_origin == .terminal) (plat.controllingTty(&tty_buf) orelse "") else "";
+    const source_cwd = plat.safeSourceCwd(source_cwd_raw) orelse "";
+    const herdr_pane = plat.safeHerdrPaneId(herdr_pane_raw) orelse "";
+    var session_hash_buf: [64]u8 = undefined;
+    const session_id = payloadSessionId(phase, payload, &session_hash_buf);
+    const session_context = payloadSessionContext(agent, phase, payload, session_id);
+    const turn_id = safeSessionId(firstJsonString(payload, &.{ "turn_id", "turnId" }));
+    var hostname_buf: [64]u8 = undefined;
+    const hostname = plat.hostName(&hostname_buf) orelse "local";
+
+    // Session title precedence: the agent/server's generated title wins and
+    // may change at any time; the first user prompt is only a fallback. Every
+    // event re-resolves the authoritative source so delayed auto-titles and
+    // server-side renames flow into an already visible bubble.
+    var sessions_buf: [512]u8 = undefined;
+    const sessions_dir = std.fmt.bufPrint(&sessions_buf, "{s}/.petdex/runtime/sessions", .{home}) catch return;
+    if (session_id) |sid| {
+        var server_title_buf: [256]u8 = undefined;
+        if (authoritativeTitle(agent, home, sid, payload, &server_title_buf)) |server_title| {
+            rememberTitle(sessions_dir, sid, server_title, .server, true);
+        } else if (isPromptPhase(phase)) {
+            if (promptTitle(payload)) |prompt| rememberTitle(sessions_dir, sid, prompt, .prompt, false);
+        }
+    }
+    var title_buf: [256]u8 = undefined;
+    var title_source: hook_server.TitleSource = .unknown;
+    const title: []const u8 = if (session_id) |sid| blk: {
+        const record = readTitle(sessions_dir, sid, &title_buf) orelse break :blk "";
+        title_source = record.source;
+        break :blk record.text;
+    } else "";
+
+    var text_buf: [preview_max]u8 = undefined;
+    var text = formatBubble(phase, payload, &text_buf) orelse "";
+
+    var preview_buf: [512]u8 = undefined;
+    var tail_buf: [transcript_tail_cap]u8 = undefined;
+    if (isStopPhase(phase)) {
+        // Close-of-turn preview: Codex ships last_assistant_message in
+        // the payload; Claude Code needs the bounded transcript tail.
+        const written: ?[]const u8 = jsonString(payload, "last_assistant_message") orelse blk: {
+            const tp = jsonString(payload, "transcript_path") orelse break :blk null;
+            const tail = cReadTail(tp, &tail_buf) orelse break :blk null;
+            break :blk lastAssistantFromTail(tail);
+        };
+        if (written) |w| {
+            if (clipEscaped(w, preview_max, &preview_buf)) |p| {
+                if (p.len > 0) text = p;
+            }
+        }
+        pruneSessions(sessions_dir);
+    }
+
+    // A failed tool does not end the turn — the agent reacts to the error and
+    // keeps working — so the bubble keeps its spinner, same as `post`.
+    const tool_name = jsonString(payload, "tool_name");
+    const notification_kind = firstJsonString(payload, &.{ "notification_type", "notification_kind" }) orelse "";
+    const status = statusForEvent(phase, tool_name, notification_kind);
+    const busy = status == .running;
+    const state = stateForEventWithNotification(phase, tool_name, notification_kind);
+
+    // First lower the provider payload into the canonical event and persist it.
+    // The journal deliberately precedes the update-token/HTTP path, allowing a
+    // task that ran while Petdex was closed to be recovered on next launch.
+    var bubble_body_buf: [post_body_capacity]u8 = undefined;
+    var bubble_body: ?[]const u8 = null;
+    if (text.len > 0 and shouldPostBubble(agent, phase)) {
+        const correlation_id = firstJsonString(payload, &.{ "request_id", "tool_use_id", "message_id", "event_id", "call_id", "turn_id", "turnId" });
+        const is_request = status == .needs_input;
+        const is_response = std.mem.eql(u8, phase, "approval-response") or
+            (std.mem.eql(u8, phase, "post") and tool_name != null and asciiEqlLower(tool_name.?, "clarify"));
+        bubble_body = bubbleBodyWithMetadata(&bubble_body_buf, text, title, busy, agent, .{
+            .session_id = session_id,
+            .conversation_key = session_context.conversationKey(),
+            .parent_session_id = session_context.parentSession(),
+            .session_kind = session_context.kind,
+            .subagent_label = session_context.labelSlice(),
+            .source_app = source_app,
+            .source_tty = source_tty,
+            .source_cwd = source_cwd,
+            .herdr_pane = herdr_pane,
+            .hostname = hostname,
+            .turn_id = turn_id,
+            .message_id = correlation_id,
+            .event_kind = phase,
+            .request_id = if (is_request) correlation_id else null,
+            .resolves_request_id = if (is_response) correlation_id else null,
+            .notification_kind = notification_kind,
+            .message_kind = messageKindForEvent(phase, payload, notification_kind),
+            .title_source = title_source,
+            .status = status,
+        });
+        if (bubble_body) |body| appendJournalEvent(home, agent, session_context.conversationKey(), body);
+    }
+
     var token_buf: [128]u8 = undefined;
     const token_raw = blk: {
         const tp = std.fmt.bufPrint(&path_buf, "{s}/.petdex/runtime/update-token", .{home}) catch break :blk null;
@@ -52,74 +154,18 @@ pub fn run(phase: []const u8, arg_agent: ?[]const u8, origin_app: plat.OriginApp
     const token = std.mem.trim(u8, token_raw, " \t\r\n");
     if (token.len == 0) return;
 
-    const agent = jsonString(payload, "agent_source") orelse (arg_agent orelse "");
-    const source_app = origin_app.wireName();
-    var tty_buf: [64]u8 = undefined;
-    const source_tty = if (origin_app == .terminal) (plat.controllingTty(&tty_buf) orelse "") else "";
-    const source_cwd = plat.safeSourceCwd(source_cwd_raw) orelse "";
-    const herdr_pane = plat.safeHerdrPaneId(herdr_pane_raw) orelse "";
-    var session_hash_buf: [64]u8 = undefined;
-    const session_id = payloadSessionId(payload, &session_hash_buf);
-
-    // Session title: user-prompt seeds it, every event attaches it.
-    var sessions_buf: [512]u8 = undefined;
-    const sessions_dir = std.fmt.bufPrint(&sessions_buf, "{s}/.petdex/runtime/sessions", .{home}) catch return;
-    if (session_id) |sid| {
-        if (isPromptPhase(phase)) {
-            if (jsonString(payload, "prompt") orelse jsonString(payload, "user_message")) |prompt| rememberTitle(sessions_dir, sid, prompt);
-        }
-    }
-    var title_buf: [256]u8 = undefined;
-    const title: []const u8 = jsonString(payload, "petdex_session_title") orelse if (session_id) |sid| (readTitle(sessions_dir, sid, &title_buf) orelse "") else "";
-
-    var text_buf: [256]u8 = undefined;
-    var text = formatBubble(phase, payload, &text_buf) orelse "";
-
-    var preview_buf: [512]u8 = undefined;
-    var tail_buf: [transcript_tail_cap]u8 = undefined;
-    if (isStopPhase(phase) or isAssistantPhase(phase) or isSubagentStopPhase(phase)) {
-        // Close-of-turn preview: Codex ships last_assistant_message in
-        // the payload; Claude Code needs the bounded transcript tail.
-        const written: ?[]const u8 = if (isAssistantPhase(phase))
-            jsonString(payload, "assistant_response")
-        else if (isSubagentStopPhase(phase))
-            jsonString(payload, "child_summary")
-        else
-            jsonString(payload, "last_assistant_message") orelse blk: {
-                const tp = jsonString(payload, "transcript_path") orelse break :blk null;
-                const tail = cReadTail(tp, &tail_buf) orelse break :blk null;
-                break :blk lastAssistantFromTail(tail);
-            };
-        if (written) |w| {
-            if (clipEscaped(w, preview_max, &preview_buf)) |p| {
-                if (p.len > 0) text = p;
-            }
-        }
-        if (!isSubagentStopPhase(phase)) pruneSessions(sessions_dir);
-    }
-
-    // A failed tool does not end the turn — the agent reacts to the error and
-    // keeps working — so the bubble keeps its spinner, same as `post`.
-    const busy = isPromptPhase(phase) or std.mem.eql(u8, phase, "pre") or
-        std.mem.eql(u8, phase, "post") or isToolFailurePhase(phase) or
-        std.mem.eql(u8, phase, "approval-response") or std.mem.eql(u8, phase, "subagent-start");
-    const state = stateForEvent(phase, jsonString(payload, "tool_name"));
-
     var posts: [2]PostJob = undefined;
     var post_count: usize = 0;
-    var body_buf: [1536]u8 = undefined;
-    if (text.len > 0) {
-        const body = bubbleBodyWithMetadata(&body_buf, text, title, busy, agent, session_id, source_app, source_tty, source_cwd, herdr_pane);
-        if (body) |b| {
-            if (startPost("/bubble", b, token)) |post| {
-                posts[post_count] = post;
-                post_count += 1;
-            }
+    if (bubble_body) |body| {
+        if (startPost("/bubble", body, token)) |post| {
+            posts[post_count] = post;
+            post_count += 1;
         }
     }
     if (state) |s| {
+        var state_body_buf: [post_body_capacity]u8 = undefined;
         const duration_ms: u32 = if (isToolFailurePhase(phase)) failed_duration_ms else 0;
-        const body = stateBody(&body_buf, s, duration_ms, agent);
+        const body = stateBody(&state_body_buf, s, duration_ms, agent);
         if (body) |b| {
             if (startPost("/state", b, token)) |post| {
                 posts[post_count] = post;
@@ -130,6 +176,46 @@ pub fn run(phase: []const u8, arg_agent: ?[]const u8, origin_app: plat.OriginApp
     waitForPosts(posts[0..post_count]);
 }
 
+fn journalSafeStem(out: []u8, raw: []const u8, fallback: []const u8) []const u8 {
+    const source = if (raw.len > 0) raw else fallback;
+    var written: usize = 0;
+    for (source) |byte| {
+        if (written == out.len) break;
+        out[written] = if (std.ascii.isAlphanumeric(byte) or byte == '-' or byte == '_' or byte == '.') byte else '_';
+        written += 1;
+    }
+    return out[0..written];
+}
+
+fn appendJournalEvent(home: []const u8, agent: []const u8, conversation: ?[]const u8, body: []const u8) void {
+    var dir_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const dir = std.fmt.bufPrint(&dir_buf, "{s}/.petdex/runtime/session-journal", .{home}) catch return;
+    if (!plat.makeDirMode(dir, 0o700)) return;
+
+    var agent_buf: [32]u8 = undefined;
+    var conversation_buf: [96]u8 = undefined;
+    const agent_stem = journalSafeStem(&agent_buf, agent, "agent");
+    const conversation_stem = journalSafeStem(&conversation_buf, conversation orelse "", "unkeyed");
+    var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "{s}/{s}-{s}.jsonl", .{ dir, agent_stem, conversation_stem }) catch return;
+
+    var record_buf: [post_body_capacity + 64]u8 = undefined;
+    const record = std.fmt.bufPrint(&record_buf, "{{\"journal_version\":{d},\"event\":{s}}}\n", .{ journal_version, body }) catch return;
+    _ = plat.appendFileModeRotating(path, record, 0o600, journal_rotate_bytes);
+}
+
+/// Local Codex rollouts contain the same user-visible `agent_message` and
+/// `agent_reasoning` feed rendered by Codex Pet. Pre/post tool hooks still
+/// drive mascot state, but must not replace that feed with lower-level
+/// summaries such as "Ran rg". Other agents (and the remote shell adapter)
+/// continue using hook text because no local rollout is available for them.
+fn shouldPostBubble(agent: []const u8, phase: []const u8) bool {
+    if (!std.ascii.eqlIgnoreCase(agent, "codex")) return true;
+    return !(std.mem.eql(u8, phase, "pre") or
+        std.mem.eql(u8, phase, "post") or
+        isToolFailurePhase(phase));
+}
+
 fn isPromptPhase(phase: []const u8) bool {
     return std.mem.eql(u8, phase, "user-prompt") or std.mem.eql(u8, phase, "session-start");
 }
@@ -138,16 +224,61 @@ fn isStopPhase(phase: []const u8) bool {
     return std.mem.eql(u8, phase, "stop") or std.mem.eql(u8, phase, "session-end");
 }
 
-fn isAssistantPhase(phase: []const u8) bool {
-    return std.mem.eql(u8, phase, "assistant");
-}
-
-fn isSubagentStopPhase(phase: []const u8) bool {
-    return std.mem.eql(u8, phase, "subagent-stop");
-}
-
 fn isToolFailurePhase(phase: []const u8) bool {
     return std.mem.eql(u8, phase, "tool-failure");
+}
+
+fn notificationNeedsInput(kind: []const u8) bool {
+    return std.mem.eql(u8, kind, "permission_prompt") or
+        std.mem.eql(u8, kind, "elicitation_dialog") or
+        std.mem.eql(u8, kind, "elicitation_url_dialog") or
+        std.mem.eql(u8, kind, "agent_needs_input");
+}
+
+fn notificationCompletes(kind: []const u8) bool {
+    return std.mem.eql(u8, kind, "idle_prompt") or std.mem.eql(u8, kind, "agent_completed");
+}
+
+fn statusForEvent(phase: []const u8, tool_name: ?[]const u8, notification_kind: []const u8) hook_server.SessionStatus {
+    if (std.mem.eql(u8, phase, "approval-request")) return .needs_input;
+    if (std.mem.eql(u8, phase, "notification")) {
+        if (notificationNeedsInput(notification_kind)) return .needs_input;
+        if (notificationCompletes(notification_kind)) return .completed;
+        return .idle;
+    }
+    // `waiting` remains a sprite/state compatibility phase only. It is not a
+    // correlated request and therefore cannot make the session orange.
+    if (std.mem.eql(u8, phase, "waiting")) return .idle;
+    if (std.mem.eql(u8, phase, "pre") and tool_name != null and asciiEqlLower(tool_name.?, "clarify")) return .needs_input;
+    if (isToolFailurePhase(phase)) return .failed;
+    if (isStopPhase(phase) or std.mem.eql(u8, phase, "assistant")) return .completed;
+    if (isPromptPhase(phase) or
+        std.mem.eql(u8, phase, "pre") or
+        std.mem.eql(u8, phase, "post") or
+        std.mem.eql(u8, phase, "pre-llm") or
+        std.mem.eql(u8, phase, "approval-response") or
+        std.mem.eql(u8, phase, "subagent-start") or
+        std.mem.eql(u8, phase, "subagent-stop")) return .running;
+    return .idle;
+}
+
+fn messageKindForEvent(phase: []const u8, payload: []const u8, notification_kind: []const u8) hook_server.MessageKind {
+    if (std.mem.eql(u8, phase, "assistant")) return .assistant;
+    // Hermes emits `subagent_stop` on the parent's hook stream, but includes
+    // the child's concise result in `child_summary`. Preserve that one
+    // user-facing summary in the nested branch rather than demoting it to
+    // lifecycle noise (or replacing the parent's primary message).
+    if (std.mem.eql(u8, phase, "subagent-stop") and
+        firstJsonString(payload, &.{ "child_summary", "subagent_summary" }) != null)
+        return .assistant;
+    if (std.mem.eql(u8, phase, "pre") or std.mem.eql(u8, phase, "post") or isToolFailurePhase(phase)) return .tool;
+    if (std.mem.eql(u8, phase, "approval-request") or
+        (std.mem.eql(u8, phase, "notification") and notificationNeedsInput(notification_kind))) return .prompt;
+    if (isStopPhase(phase) or
+        std.mem.eql(u8, phase, "subagent-start") or
+        std.mem.eql(u8, phase, "subagent-stop")) return .lifecycle;
+    if (isPromptPhase(phase)) return .prompt;
+    return .status;
 }
 
 /// The /bubble request body, extracted and pure for the same reason stateBody
@@ -164,26 +295,62 @@ fn isToolFailurePhase(phase: []const u8) bool {
 /// precisely how session_id got parsed, used for titles, and then left out of
 /// the POST that needed it.
 pub fn bubbleBody(out: []u8, text: []const u8, title: []const u8, busy: bool, agent: []const u8, session_id: ?[]const u8) ?[]const u8 {
-    return bubbleBodyWithMetadata(out, text, title, busy, agent, session_id, "", "", "", "");
+    return bubbleBodyWithMetadata(out, text, title, busy, agent, .{ .session_id = session_id });
 }
 
-fn bubbleBodyWithMetadata(out: []u8, text: []const u8, title: []const u8, busy: bool, agent: []const u8, session_id: ?[]const u8, source_app: []const u8, source_tty: []const u8, source_cwd: []const u8, herdr_pane: []const u8) ?[]const u8 {
+const BubbleWireContext = struct {
+    session_id: ?[]const u8 = null,
+    conversation_key: ?[]const u8 = null,
+    parent_session_id: ?[]const u8 = null,
+    session_kind: hook_server.SessionKind = .primary,
+    subagent_label: []const u8 = "",
+    source_app: []const u8 = "",
+    source_tty: []const u8 = "",
+    source_cwd: []const u8 = "",
+    herdr_pane: []const u8 = "",
+    hostname: []const u8 = "",
+    turn_id: ?[]const u8 = null,
+    message_id: ?[]const u8 = null,
+    event_kind: []const u8 = "",
+    request_id: ?[]const u8 = null,
+    resolves_request_id: ?[]const u8 = null,
+    notification_kind: []const u8 = "",
+    message_kind: hook_server.MessageKind = .status,
+    title_source: hook_server.TitleSource = .unknown,
+    status: hook_server.SessionStatus = .idle,
+};
+
+fn bubbleBodyWithMetadata(out: []u8, text: []const u8, title: []const u8, busy: bool, agent: []const u8, context: BubbleWireContext) ?[]const u8 {
     var title_buf: [256]u8 = undefined;
     const title_part: []const u8 = if (title.len > 0)
         (std.fmt.bufPrint(&title_buf, ",\"title\":\"{s}\"", .{title}) catch return null)
     else
         "";
     var session_buf: [96]u8 = undefined;
-    const session_part: []const u8 = if (session_id) |sid|
+    const session_part: []const u8 = if (context.session_id) |sid|
         (std.fmt.bufPrint(&session_buf, ",\"session_id\":\"{s}\"", .{sid}) catch return null)
     else
         "";
-    var metadata_buf: [800]u8 = undefined;
-    const metadata = if (source_app.len > 0 or source_tty.len > 0 or source_cwd.len > 0 or herdr_pane.len > 0)
-        (std.fmt.bufPrint(&metadata_buf, ",\"source_app\":\"{s}\",\"source_tty\":\"{s}\",\"source_cwd\":\"{s}\",\"herdr_pane_id\":\"{s}\"", .{ source_app, source_tty, source_cwd, herdr_pane }) catch return null)
+    var context_buf: [2048]u8 = undefined;
+    const conversation = context.conversation_key orelse "";
+    const parent = context.parent_session_id orelse "";
+    const turn = context.turn_id orelse "";
+    const message_id = context.message_id orelse "";
+    const request_id = context.request_id orelse "";
+    const resolves_request_id = context.resolves_request_id orelse "";
+    const session_kind = if (context.session_kind == .subagent) "subagent" else "primary";
+    const has_canonical_context = conversation.len > 0 or parent.len > 0 or
+        context.session_kind == .subagent or context.subagent_label.len > 0 or
+        context.source_app.len > 0 or context.source_tty.len > 0 or
+        context.source_cwd.len > 0 or context.herdr_pane.len > 0 or context.hostname.len > 0 or turn.len > 0 or
+        message_id.len > 0 or context.event_kind.len > 0 or request_id.len > 0 or
+        resolves_request_id.len > 0 or context.notification_kind.len > 0 or context.message_kind != .status or
+        context.title_source != .unknown or context.status != .idle;
+    const context_part: []const u8 = if (has_canonical_context)
+        (std.fmt.bufPrint(&context_buf, ",\"conversation_key\":\"{s}\",\"source_session_id\":\"{s}\",\"parent_session_id\":\"{s}\",\"session_kind\":\"{s}\",\"subagent_label\":\"{s}\",\"source_app\":\"{s}\",\"source_tty\":\"{s}\",\"source_cwd\":\"{s}\",\"herdr_pane_id\":\"{s}\",\"hostname\":\"{s}\",\"turn_id\":\"{s}\",\"message_id\":\"{s}\",\"event_kind\":\"{s}\",\"request_id\":\"{s}\",\"resolves_request_id\":\"{s}\",\"notification_kind\":\"{s}\",\"message_kind\":\"{s}\",\"title_source\":\"{s}\",\"feed_source\":\"hook\",\"status\":\"{s}\"", .{ conversation, context.session_id orelse "", parent, session_kind, context.subagent_label, context.source_app, context.source_tty, context.source_cwd, context.herdr_pane, context.hostname, turn, message_id, context.event_kind, request_id, resolves_request_id, context.notification_kind, @tagName(context.message_kind), @tagName(context.title_source), context.status.wireName() }) catch return null)
     else
         "";
-    return std.fmt.bufPrint(out, "{{\"text\":\"{s}\"{s},\"busy\":{},\"agent_source\":\"{s}\"{s}{s}}}", .{ text, title_part, busy, agent, session_part, metadata }) catch null;
+    return std.fmt.bufPrint(out, "{{\"text\":\"{s}\"{s},\"busy\":{},\"agent_source\":\"{s}\"{s}{s}}}", .{ text, title_part, busy, agent, session_part, context_part }) catch null;
 }
 
 /// The /state request body. Extracted and pure for one reason: `run()` reaches
@@ -211,22 +378,27 @@ pub fn stateBody(out: []u8, state: []const u8, duration_ms: u32, agent: []const 
 pub const failed_duration_ms: u32 = 1220;
 
 /// Port of stateForEvent: phase + tool → sprite state.
-pub fn stateForEvent(phase: []const u8, tool_name: ?[]const u8) ?[]const u8 {
+fn stateForEventWithNotification(phase: []const u8, tool_name: ?[]const u8, notification_kind: []const u8) ?[]const u8 {
     if (std.mem.eql(u8, phase, "pre")) {
         if (tool_name) |name| {
+            if (asciiEqlLower(name, "clarify")) return "waiting";
             if (asciiEqlLower(name, "read") or asciiEqlLower(name, "grep") or asciiEqlLower(name, "glob")) return "review";
         }
         return "running";
     }
-    if (std.mem.eql(u8, phase, "post")) return "idle";
+    if (std.mem.eql(u8, phase, "post") or std.mem.eql(u8, phase, "approval-response")) return "running";
     if (isToolFailurePhase(phase)) return "failed";
-    if (isStopPhase(phase)) return "waving";
-    if (isAssistantPhase(phase)) return "waving";
+    if (isStopPhase(phase) or std.mem.eql(u8, phase, "assistant")) return "waving";
     if (isPromptPhase(phase)) return "jumping";
-    if (std.mem.eql(u8, phase, "waiting") or std.mem.eql(u8, phase, "notification") or std.mem.eql(u8, phase, "approval-request")) return "waiting";
-    if (std.mem.eql(u8, phase, "approval-response") or std.mem.eql(u8, phase, "subagent-start")) return "running";
-    if (isSubagentStopPhase(phase)) return "idle";
+    if (std.mem.eql(u8, phase, "approval-request") or
+        (std.mem.eql(u8, phase, "notification") and notificationNeedsInput(notification_kind))) return "waiting";
+    if (std.mem.eql(u8, phase, "waiting")) return null;
+    if (std.mem.eql(u8, phase, "pre-llm") or std.mem.eql(u8, phase, "subagent-start") or std.mem.eql(u8, phase, "subagent-stop")) return "running";
     return null;
+}
+
+pub fn stateForEvent(phase: []const u8, tool_name: ?[]const u8) ?[]const u8 {
+    return stateForEventWithNotification(phase, tool_name, "");
 }
 
 // ---------------------------------------------------------- templates
@@ -236,13 +408,47 @@ pub fn stateForEvent(phase: []const u8, tool_name: ?[]const u8) ?[]const u8 {
 /// re-embedded into the POST body).
 pub fn formatBubble(phase: []const u8, payload: []const u8, out: []u8) ?[]const u8 {
     if (isPromptPhase(phase)) return "Thinking…";
-    if (isStopPhase(phase)) return "Done.";
-    if (isAssistantPhase(phase)) return "Done.";
-    if (std.mem.eql(u8, phase, "waiting") or std.mem.eql(u8, phase, "notification")) return "Waiting for you…";
-    if (std.mem.eql(u8, phase, "approval-request")) return "Waiting for approval…";
-    if (std.mem.eql(u8, phase, "approval-response")) return "Approval received";
-    if (std.mem.eql(u8, phase, "subagent-start")) return "Subagent working…";
-    if (isSubagentStopPhase(phase)) return "Subagent done";
+    // Hermes lifecycle callbacks report the parent as `session_id` and the
+    // worker separately as `child_session_id`. The start event is activity
+    // noise, while stop's summary is the one meaningful child message worth
+    // keeping beneath the parent card.
+    if (isSubagentLifecycle(phase, payload)) {
+        if (std.mem.eql(u8, phase, "subagent-stop")) {
+            if (firstJsonString(payload, &.{ "child_summary", "subagent_summary" })) |summary| {
+                return clipEscaped(summary, preview_max, out);
+            }
+        }
+        return null;
+    }
+    if (std.mem.eql(u8, phase, "assistant")) {
+        const response = firstJsonString(payload, &.{ "assistant_response", "last_assistant_message", "message", "response" }) orelse return "Done.";
+        return clipEscaped(response, preview_max, out);
+    }
+    if (isStopPhase(phase)) {
+        if (firstJsonString(payload, &.{ "last_assistant_message", "assistant_response" })) |response| {
+            return clipEscaped(response, preview_max, out);
+        }
+        return "Done.";
+    }
+    if (std.mem.eql(u8, phase, "notification")) {
+        const kind = firstJsonString(payload, &.{ "notification_type", "notification_kind" }) orelse "";
+        if (!notificationNeedsInput(kind)) {
+            if (notificationCompletes(kind)) return "Done.";
+            return null;
+        }
+        if (firstJsonString(payload, &.{ "question", "prompt", "message", "reason" })) |question| {
+            return clipEscaped(question, preview_max, out);
+        }
+        return "Waiting for you…";
+    }
+    if (std.mem.eql(u8, phase, "approval-request")) {
+        if (firstJsonString(payload, &.{ "question", "prompt", "message", "reason" })) |question| {
+            return clipEscaped(question, preview_max, out);
+        }
+        return "Waiting for you…";
+    }
+    if (std.mem.eql(u8, phase, "waiting")) return null;
+    if (std.mem.eql(u8, phase, "approval-response")) return "Continuing…";
     // Tool name only, never the payload's `error` string. jsonString stops at
     // the first `"` or `\` and decodes neither, and error text routinely carries
     // both; tool_name is a controlled identifier from the agent's own registry.
@@ -256,6 +462,14 @@ pub fn formatBubble(phase: []const u8, payload: []const u8, out: []u8) ?[]const 
     if (!running and !done) return null;
 
     const tool = jsonString(payload, "tool_name") orelse "tool";
+
+    if (asciiEqlLower(tool, "clarify")) {
+        if (done) return "Continuing…";
+        if (firstJsonString(payload, &.{ "question", "prompt", "message" })) |question| {
+            return clipEscaped(question, preview_max, out);
+        }
+        return "Waiting for you…";
+    }
 
     if (asciiEqlLower(tool, "read")) {
         if (pathField(payload)) |p| return fmt2(out, if (done) "Read " else "Reading ", clipBase(p, 40));
@@ -413,15 +627,24 @@ fn asciiEqlLower(text: []const u8, lower: []const u8) bool {
 
 // ------------------------------------------------------ session titles
 
-fn safeSessionId(raw: ?[]const u8) ?[]const u8 {
-    const sid = raw orelse return null;
-    if (sid.len == 0 or sid.len > 64) return null;
-    for (sid) |c| {
-        if (!(std.ascii.isAlphanumeric(c) or c == '-' or c == '_')) return null;
+const TitleSource = hook_server.TitleSource;
+
+const TitleRecord = struct {
+    text: []const u8,
+    source: TitleSource,
+};
+
+fn firstJsonString(payload: []const u8, keys: []const []const u8) ?[]const u8 {
+    for (keys) |key| {
+        if (jsonString(payload, key)) |value| {
+            if (std.mem.trim(u8, value, " \t\r\n").len > 0) return value;
+        }
     }
-    return sid;
+    return null;
 }
 
+/// Agent APIs do not agree on the conversation identifier spelling. Keep the
+/// aliases here, rather than teaching the mailbox about each harness.
 fn normalizedConversationKey(raw: ?[]const u8, hash_buf: *[64]u8) ?[]const u8 {
     const value = raw orelse return null;
     if (safeSessionId(value)) |safe| return safe;
@@ -432,26 +655,216 @@ fn normalizedConversationKey(raw: ?[]const u8, hash_buf: *[64]u8) ?[]const u8 {
     return hash_buf;
 }
 
-fn payloadSessionId(payload: []const u8, hash_buf: *[64]u8) ?[]const u8 {
-    if (jsonString(payload, "petdex_conversation_key")) |key| return normalizedConversationKey(key, hash_buf);
-    if (safeSessionId(jsonString(payload, "session_id"))) |session| return session;
-    if (jsonString(payload, "session_key")) |key| return normalizedConversationKey(key, hash_buf);
-    return safeSessionId(jsonString(payload, "parent_session_id"));
+fn payloadSessionId(phase: []const u8, payload: []const u8, hash_buf: *[64]u8) ?[]const u8 {
+    // Hermes's `subagent_start` / `subagent_stop` shell-hook payload places
+    // the parent in `session_id`, with the real worker id in
+    // `child_session_id`. Select the child before the generic aliases so the
+    // lifecycle event cannot overwrite the parent as a second primary feed.
+    if (isSubagentLifecycle(phase, payload)) {
+        if (safeSessionId(firstJsonString(payload, &.{ "child_session_id", "childSessionId" }))) |child| return child;
+    }
+    if (firstJsonString(payload, &.{ "petdex_conversation_key", "conversation_key" })) |key|
+        return normalizedConversationKey(key, hash_buf);
+    if (safeSessionId(firstJsonString(payload, &.{
+        "session_id",
+        "sessionId",
+        "sessionID",
+        "thread_id",
+        "conversation_id",
+    }))) |session| return session;
+    if (firstJsonString(payload, &.{"session_key"})) |key|
+        return normalizedConversationKey(key, hash_buf);
+    return safeSessionId(firstJsonString(payload, &.{ "parent_session_id", "parentSessionId" }));
 }
 
-fn rememberTitle(dir: []const u8, session_id: []const u8, prompt: []const u8) void {
+fn subagentLifecycleParent(payload: []const u8) ?[]const u8 {
+    return safeSessionId(firstJsonString(payload, &.{
+        "parent_session_id",
+        "parentSessionId",
+        // Hermes's shell-hook serializer maps parent_session_id into its
+        // top-level session_id field, so retain that documented fallback.
+        "session_id",
+        "sessionId",
+        "sessionID",
+    }));
+}
+
+fn isSubagentLifecycle(phase: []const u8, payload: []const u8) bool {
+    if (!(std.mem.eql(u8, phase, "subagent-start") or std.mem.eql(u8, phase, "subagent-stop"))) return false;
+    const child = safeSessionId(firstJsonString(payload, &.{ "child_session_id", "childSessionId" })) orelse return false;
+    const parent = subagentLifecycleParent(payload) orelse return true;
+    return !std.mem.eql(u8, child, parent);
+}
+
+const SessionContext = struct {
+    conversation_key: ?[]const u8 = null,
+    parent_session_id: ?[]const u8 = null,
+    label: []const u8 = "",
+    kind: hook_server.SessionKind = .primary,
+
+    fn conversationKey(self: SessionContext) ?[]const u8 {
+        return self.conversation_key;
+    }
+
+    fn parentSession(self: SessionContext) ?[]const u8 {
+        return self.parent_session_id;
+    }
+
+    fn labelSlice(self: SessionContext) []const u8 {
+        return self.label;
+    }
+};
+
+fn safeWireScalar(raw: ?[]const u8, max: usize) ?[]const u8 {
+    const value = raw orelse return null;
+    if (value.len == 0 or value.len > max) return null;
+    for (value) |c| {
+        if (c < 0x20 or c == '"' or c == '\\') return null;
+    }
+    return value;
+}
+
+/// Petdesk's Hermes adapters resolve continuation/subagent ancestry against
+/// state.db and attach the stable top-level key. Other harnesses can provide
+/// the same namespaced fields, while legacy payloads fall back to session_id.
+fn sourceMarksSubagent(raw: []const u8) bool {
+    // Source names are not a stable enum across Hermes surfaces. Exact
+    // delegate markers remain the authoritative path, but accept its known
+    // spelling variants and tool-only workers as a conservative fallback.
+    const names = [_][]const u8{
+        "subagent", "sub-agent", "sub_agent",  "child",      "worker",
+        "delegate", "delegated", "delegation", "background", "tool",
+    };
+    for (names) |name| {
+        if (std.ascii.eqlIgnoreCase(raw, name)) return true;
+    }
+    return false;
+}
+
+fn payloadSessionContext(agent: []const u8, phase: []const u8, payload: []const u8, session_id: ?[]const u8) SessionContext {
+    _ = agent;
+    const explicit_conversation = safeWireScalar(firstJsonString(payload, &.{
+        "petdex_conversation_key",
+        "conversation_key",
+        "session_key",
+    }), hook_server.bubble_session_capacity);
+    const explicit_parent = safeWireScalar(firstJsonString(payload, &.{
+        "petdex_parent_session_id",
+        "parent_session_id",
+        "parentSessionId",
+    }), hook_server.bubble_session_capacity);
+    const lifecycle_child = isSubagentLifecycle(phase, payload);
+    const parent = explicit_parent orelse if (lifecycle_child)
+        safeWireScalar(subagentLifecycleParent(payload), hook_server.bubble_session_capacity)
+    else
+        null;
+    const raw_kind = firstJsonString(payload, &.{ "petdex_session_kind", "session_kind", "source" });
+    const is_subagent = if (raw_kind) |kind|
+        (sourceMarksSubagent(kind) or lifecycle_child)
+    else
+        lifecycle_child;
+    const label = safeWireScalar(firstJsonString(payload, &.{
+        "petdex_subagent_label",
+        "subagent_label",
+        "child_role",
+        "subagent_role",
+        "display_name",
+    }), 48) orelse "";
+    const canonical = explicit_conversation orelse if (is_subagent) parent orelse session_id else session_id;
+    return .{
+        .conversation_key = canonical,
+        .parent_session_id = parent,
+        .label = label,
+        .kind = if (is_subagent) .subagent else .primary,
+    };
+}
+
+/// Prompt-shaped agents use `prompt`; Hermes' pre_llm_call uses
+/// `user_message`. The remaining aliases cover the Claude-derived harnesses
+/// without accepting a generic nested `text` field from tool input.
+fn promptTitle(payload: []const u8) ?[]const u8 {
+    return firstJsonString(payload, &.{ "prompt", "user_message", "userPrompt", "input" });
+}
+
+/// Latest matching entry wins because Codex appends another row when its
+/// server-generated thread title changes. Walking backward also makes a rename
+/// visible without confusing it with the initial "New chat"/prompt title.
+fn codexIndexTitleFromTail(tail: []const u8, session_id: []const u8, out: *[256]u8) ?[]const u8 {
+    var end = tail.len;
+    while (end > 0) {
+        const start = if (std.mem.lastIndexOfScalar(u8, tail[0..end], '\n')) |i| i + 1 else 0;
+        const line = std.mem.trim(u8, tail[start..end], " \t\r\n");
+        end = if (start == 0) 0 else start - 1;
+        if (line.len == 0) continue;
+        const id = jsonString(line, "id") orelse continue;
+        if (!std.mem.eql(u8, id, session_id)) continue;
+        const generated = jsonString(line, "thread_name") orelse continue;
+        return clipEscaped(generated, title_max, out);
+    }
+    return null;
+}
+
+fn codexServerTitle(home: []const u8, session_id: []const u8, out: *[256]u8) ?[]const u8 {
+    var path_buf: [512]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "{s}/.codex/session_index.jsonl", .{home}) catch return null;
+    // The current session can be renamed long after its original index row,
+    // and a busy installation may append enough unrelated rows to push that
+    // session beyond a small tail. Read the bounded catalog and walk backward;
+    // 4 MiB covers many years of the compact append-only index.
+    const index = plat.readFileAlloc(std.heap.page_allocator, path, 4 * 1024 * 1024) orelse return null;
+    defer std.heap.page_allocator.free(index);
+    return codexIndexTitleFromTail(index, session_id, out);
+}
+
+/// Resolve a title maintained outside the hook payload. The app polls this at
+/// a low frequency for visible local sessions so a manual/server rename also
+/// updates while the agent is idle and emitting no lifecycle events.
+pub fn storedServerTitle(agent: []const u8, home: []const u8, session_id: []const u8, out: *[256]u8) ?[]const u8 {
+    if (std.ascii.eqlIgnoreCase(agent, "codex")) return codexServerTitle(home, session_id, out);
+    return null;
+}
+
+fn authoritativeTitle(agent: []const u8, home: []const u8, session_id: []const u8, payload: []const u8, out: *[256]u8) ?[]const u8 {
+    // Petdesk-owned adapters use a namespaced field, so nested tool arguments
+    // named `title` can never masquerade as a conversation rename.
+    if (firstJsonString(payload, &.{ "petdex_session_title", "session_title", "thread_name" })) |title| {
+        return clipEscaped(title, title_max, out);
+    }
+    if (storedServerTitle(agent, home, session_id, out)) |title| return title;
+    return null;
+}
+
+fn safeSessionId(raw: ?[]const u8) ?[]const u8 {
+    const sid = raw orelse return null;
+    if (sid.len == 0 or sid.len > 64) return null;
+    for (sid) |c| {
+        if (!(std.ascii.isAlphanumeric(c) or c == '-' or c == '_')) return null;
+    }
+    return sid;
+}
+
+fn rememberTitle(dir: []const u8, session_id: []const u8, value: []const u8, source: TitleSource, replace: bool) void {
     plat.makeDir(dir);
     var title_buf: [256]u8 = undefined;
-    const title = clipEscaped(prompt, title_max, &title_buf) orelse return;
+    const title = clipEscaped(value, title_max, &title_buf) orelse return;
     if (title.len == 0) return;
+    if (!replace) {
+        var existing_buf: [256]u8 = undefined;
+        if (readTitle(dir, session_id, &existing_buf) != null) return;
+    }
     var path_buf: [512]u8 = undefined;
     const path = std.fmt.bufPrint(&path_buf, "{s}/{s}.json", .{ dir, session_id }) catch return;
     var json_buf: [512]u8 = undefined;
-    const json = std.fmt.bufPrint(&json_buf, "{{\"title\":\"{s}\",\"at\":{d}}}", .{ title, plat.nowSeconds() }) catch return;
+    const source_name = switch (source) {
+        .prompt => "prompt",
+        .server => "server",
+        .unknown => "unknown",
+    };
+    const json = std.fmt.bufPrint(&json_buf, "{{\"title\":\"{s}\",\"source\":\"{s}\",\"at\":{d}}}", .{ title, source_name, plat.nowSeconds() }) catch return;
     cWriteFile(path, json);
 }
 
-fn readTitle(dir: []const u8, session_id: []const u8, buf: *[256]u8) ?[]const u8 {
+fn readTitle(dir: []const u8, session_id: []const u8, buf: *[256]u8) ?TitleRecord {
     var path_buf: [512]u8 = undefined;
     const path = std.fmt.bufPrint(&path_buf, "{s}/{s}.json", .{ dir, session_id }) catch return null;
     var file_buf: [512]u8 = undefined;
@@ -459,7 +872,12 @@ fn readTitle(dir: []const u8, session_id: []const u8, buf: *[256]u8) ?[]const u8
     const title = jsonString(json, "title") orelse return null;
     if (title.len == 0 or title.len > buf.len) return null;
     @memcpy(buf[0..title.len], title);
-    return buf[0..title.len];
+    const source: TitleSource = if (jsonString(json, "source")) |name|
+        (if (std.mem.eql(u8, name, "server")) .server else .prompt)
+    else
+        // Files written by older Petdesk builds only contain title + stamp.
+        .prompt;
+    return .{ .text = buf[0..title.len], .source = source };
 }
 
 const PruneCtx = struct {
@@ -519,6 +937,212 @@ pub fn lastAssistantFromTail(tail: []const u8) ?[]const u8 {
     return null;
 }
 
+/// User-visible Codex activity recovered from a rollout tail. Codex writes the
+/// same `agent_reasoning` summaries and `agent_message` text consumed by its
+/// own UI into the JSONL rollout. Hidden reasoning items are deliberately not
+/// considered here.
+pub const CodexActivityKind = enum { status, reasoning, assistant, prompt };
+
+pub const CodexActivity = struct {
+    text: [preview_max]u8 = @splat(0),
+    text_len: usize = 0,
+    turn: [64]u8 = @splat(0),
+    turn_len: usize = 0,
+    request_id: [hook_server.bubble_message_id_capacity]u8 = @splat(0),
+    request_id_len: usize = 0,
+    resolves_request_id: [hook_server.bubble_message_id_capacity]u8 = @splat(0),
+    resolves_request_id_len: usize = 0,
+    busy: bool = false,
+    kind: CodexActivityKind = .status,
+    status: hook_server.SessionStatus = .idle,
+
+    pub fn textSlice(self: *const CodexActivity) []const u8 {
+        return self.text[0..self.text_len];
+    }
+
+    pub fn turnSlice(self: *const CodexActivity) []const u8 {
+        return self.turn[0..self.turn_len];
+    }
+
+    pub fn requestIdSlice(self: *const CodexActivity) []const u8 {
+        return self.request_id[0..self.request_id_len];
+    }
+
+    pub fn resolvesRequestIdSlice(self: *const CodexActivity) []const u8 {
+        return self.resolves_request_id[0..self.resolves_request_id_len];
+    }
+};
+
+fn inputCall(line: []const u8) bool {
+    if (std.mem.indexOf(u8, line, "\"type\":\"response_item\"") == null) return false;
+    if (std.mem.indexOf(u8, line, "\"name\":\"request_user_input\"") != null) return true;
+    if (std.mem.indexOf(u8, line, "\\\"sandbox_permissions\\\":\\\"require_escalated\\\"") != null) return true;
+    return std.mem.indexOf(u8, line, "\"type\":\"permission_request\"") != null or
+        std.mem.indexOf(u8, line, "\"type\":\"approval_request\"") != null or
+        std.mem.indexOf(u8, line, "\"type\":\"request_permissions\"") != null;
+}
+
+fn escapedArgument(line: []const u8, marker: []const u8, out: []u8) ?[]const u8 {
+    const at = std.mem.indexOf(u8, line, marker) orelse return null;
+    const start = at + marker.len;
+    var end = start;
+    while (end + 1 < line.len) : (end += 1) {
+        if (line[end] == '\\' and line[end + 1] == '"') break;
+    }
+    if (end <= start) return null;
+    return clipEscaped(line[start..end], preview_max, out);
+}
+
+fn inputPrompt(line: []const u8, out: []u8) ?[]const u8 {
+    const markers = [_][]const u8{
+        "\\\"question\\\":\\\"",
+        "\\\"justification\\\":\\\"",
+        "\\\"prompt\\\":\\\"",
+        "\\\"reason\\\":\\\"",
+    };
+    for (markers) |marker| {
+        if (escapedArgument(line, marker, out)) |value| {
+            if (value.len > 0) return value;
+        }
+    }
+    return null;
+}
+
+fn pendingCallIndex(pending: *const [8]?[]const u8, count: usize, call_id: []const u8) ?usize {
+    for (pending[0..count], 0..) |candidate, index| {
+        if (candidate) |value| {
+            if (std.mem.eql(u8, value, call_id)) return index;
+        }
+    }
+    return null;
+}
+
+pub fn codexActivityFromTail(tail: []const u8) ?CodexActivity {
+    var display: ?[]const u8 = null;
+    var kind: CodexActivityKind = .status;
+    var lifecycle_found = false;
+    var status: hook_server.SessionStatus = .idle;
+    var turn: []const u8 = "";
+    var pending: [8]?[]const u8 = @splat(null);
+    var pending_count: usize = 0;
+    var resolved_call_id: []const u8 = "";
+    var prompt_buf: [preview_max]u8 = undefined;
+
+    var lines = std.mem.splitScalar(u8, tail, '\n');
+    while (lines.next()) |raw_line| {
+        const line = std.mem.trim(u8, raw_line, " \t\r\n");
+        if (line.len == 0) continue;
+
+        if (std.mem.indexOf(u8, line, "\"type\":\"task_started\"") != null) {
+            lifecycle_found = true;
+            status = .running;
+            turn = jsonString(line, "turn_id") orelse "";
+            display = null;
+            kind = .status;
+            pending_count = 0;
+            continue;
+        }
+        if (std.mem.indexOf(u8, line, "\"type\":\"task_complete\"") != null) {
+            lifecycle_found = true;
+            status = .completed;
+            turn = jsonString(line, "turn_id") orelse "";
+            pending_count = 0;
+            if (jsonString(line, "last_agent_message")) |message| {
+                if (std.mem.trim(u8, message, " ").len > 0) {
+                    display = message;
+                    kind = .assistant;
+                }
+            }
+            continue;
+        }
+        if (std.mem.indexOf(u8, line, "\"type\":\"turn_aborted\"") != null or
+            std.mem.indexOf(u8, line, "\"type\":\"task_failed\"") != null)
+        {
+            lifecycle_found = true;
+            status = .failed;
+            turn = jsonString(line, "turn_id") orelse turn;
+            pending_count = 0;
+            display = if (jsonString(line, "reason")) |reason|
+                (if (std.ascii.eqlIgnoreCase(reason, "interrupted")) "Interrupted." else "Session failed.")
+            else
+                "Session failed.";
+            kind = .status;
+            continue;
+        }
+
+        if (inputCall(line)) {
+            const call_id = jsonString(line, "call_id") orelse "input-request";
+            if (pendingCallIndex(&pending, pending_count, call_id) == null and pending_count < pending.len) {
+                pending[pending_count] = call_id;
+                pending_count += 1;
+            }
+            status = .needs_input;
+            display = inputPrompt(line, &prompt_buf) orelse "Waiting for you…";
+            kind = .prompt;
+            continue;
+        }
+        if (std.mem.indexOf(u8, line, "\"type\":\"function_call_output\"") != null) {
+            if (jsonString(line, "call_id")) |call_id| {
+                if (pendingCallIndex(&pending, pending_count, call_id)) |index| {
+                    resolved_call_id = call_id;
+                    std.mem.copyForwards(?[]const u8, pending[index .. pending_count - 1], pending[index + 1 .. pending_count]);
+                    pending_count -= 1;
+                    pending[pending_count] = null;
+                    if (pending_count == 0) {
+                        status = .running;
+                        display = "Thinking…";
+                        kind = .status;
+                    }
+                }
+            }
+            continue;
+        }
+
+        if (std.mem.indexOf(u8, line, "\"type\":\"agent_message\"") != null) {
+            if (jsonString(line, "message")) |message| {
+                if (std.mem.trim(u8, message, " ").len > 0) {
+                    display = message;
+                    kind = .assistant;
+                }
+            }
+        } else if (std.mem.indexOf(u8, line, "\"type\":\"agent_reasoning\"") != null) {
+            if (jsonString(line, "text")) |reasoning| {
+                if (kind != .assistant and std.mem.trim(u8, reasoning, " ").len > 0) {
+                    display = reasoning;
+                    kind = .reasoning;
+                }
+            }
+        }
+    }
+
+    // A single long Codex turn can exceed the bounded rollout tail, pushing
+    // its task_started record out while fresh visible commentary remains in
+    // range. No current task_complete can precede that commentary, so this is
+    // still an active turn. Treat it as busy instead of dropping the feed and
+    // letting a tool hook become the last writer.
+    if (!lifecycle_found) {
+        if (display == null) return null;
+        if (status == .idle) status = .running;
+    }
+    if (pending_count > 0) status = .needs_input;
+    var activity: CodexActivity = .{ .busy = status == .running, .kind = kind, .status = status };
+    const raw = display orelse if (status == .running) "Thinking…" else "Done.";
+    const clipped = clipEscaped(raw, preview_max, &activity.text) orelse return null;
+    activity.text_len = clipped.len;
+    const turn_len = @min(turn.len, activity.turn.len);
+    @memcpy(activity.turn[0..turn_len], turn[0..turn_len]);
+    activity.turn_len = turn_len;
+    if (pending_count > 0) {
+        const request_id = pending[pending_count - 1].?;
+        activity.request_id_len = @min(request_id.len, activity.request_id.len);
+        @memcpy(activity.request_id[0..activity.request_id_len], request_id[0..activity.request_id_len]);
+    } else if (resolved_call_id.len > 0) {
+        activity.resolves_request_id_len = @min(resolved_call_id.len, activity.resolves_request_id.len);
+        @memcpy(activity.resolves_request_id[0..activity.resolves_request_id_len], resolved_call_id[0..activity.resolves_request_id_len]);
+    }
+    return activity;
+}
+
 /// First {"type":"text","text":"..."} value in the line (raw escaped
 /// bytes; the caller re-embeds or flattens them).
 fn firstTextPart(line: []const u8) ?[]const u8 {
@@ -558,7 +1182,7 @@ const PostTask = struct {
     done: std.atomic.Value(bool) = .init(false),
     path: [16]u8 = undefined,
     path_len: usize = 0,
-    body: [1024]u8 = undefined,
+    body: [post_body_capacity]u8 = undefined,
     body_len: usize = 0,
     token: [128]u8 = undefined,
     token_len: usize = 0,
@@ -581,7 +1205,7 @@ const PostJob = struct {
 /// Start a localhost POST on a private worker. Every byte is copied into the
 /// task so the worker remains valid even when the hook's stack frame returns.
 fn startPost(path: []const u8, body: []const u8, token: []const u8) ?PostJob {
-    if (path.len > 16 or body.len > 1024 or token.len > 128) return null;
+    if (path.len > 16 or body.len > post_body_capacity or token.len > 128) return null;
     const task = std.heap.page_allocator.create(PostTask) catch return null;
     task.* = .{};
     @memcpy(task.path[0..path.len], path);
@@ -642,7 +1266,7 @@ fn postLocalhostBlocking(path: []const u8, body: []const u8, token: []const u8) 
     // with connection refused when no app listens.
     var stream = addr.connect(io, .{ .mode = .stream, .protocol = .tcp }) catch return;
     defer stream.close(io);
-    var req_buf: [1600]u8 = undefined;
+    var req_buf: [post_body_capacity + 768]u8 = undefined;
     const req = std.fmt.bufPrint(&req_buf, "POST {s} HTTP/1.1\r\nhost: 127.0.0.1\r\nx-petdex-update-token: {s}\r\ncontent-type: application/json\r\ncontent-length: {d}\r\nconnection: close\r\n\r\n{s}", .{ path, token, body.len, body }) catch return;
     var write_buf: [64]u8 = undefined;
     var writer = stream.writer(io, &write_buf);
@@ -721,43 +1345,32 @@ test "session phases render fixed strings" {
     var out: [256]u8 = undefined;
     try t.expectEqualStrings("Thinking…", formatBubble("user-prompt", "", &out).?);
     try t.expectEqualStrings("Done.", formatBubble("stop", "", &out).?);
-    try t.expectEqualStrings("Waiting for you…", formatBubble("notification", "", &out).?);
+    try t.expect(formatBubble("notification", "", &out) == null);
+    try t.expectEqualStrings("Waiting for you…", formatBubble("notification", "{\"notification_type\":\"permission_prompt\"}", &out).?);
 }
 
-test "Hermes lifecycle phases render bubbles and states" {
-    var out: [256]u8 = undefined;
-    try t.expectEqualStrings("Done.", formatBubble("assistant", "{}", &out).?);
-    try t.expectEqualStrings("Waiting for approval…", formatBubble("approval-request", "{}", &out).?);
-    try t.expectEqualStrings("Approval received", formatBubble("approval-response", "{}", &out).?);
-    try t.expectEqualStrings("Subagent working…", formatBubble("subagent-start", "{}", &out).?);
-    try t.expectEqualStrings("Subagent done", formatBubble("subagent-stop", "{}", &out).?);
-    try t.expectEqualStrings("waving", stateForEvent("assistant", null).?);
-    try t.expectEqualStrings("waiting", stateForEvent("approval-request", null).?);
-    try t.expectEqualStrings("running", stateForEvent("approval-response", null).?);
-    try t.expectEqualStrings("running", stateForEvent("subagent-start", null).?);
-    try t.expectEqualStrings("idle", stateForEvent("subagent-stop", null).?);
-}
-
-test "Hermes metadata chooses canonical conversation identity" {
-    var hash_buf: [64]u8 = undefined;
-    try t.expectEqualStrings(
-        "stable-session",
-        payloadSessionId("{\"session_id\":\"raw-session\",\"petdex_conversation_key\":\"stable-session\"}", &hash_buf).?,
-    );
-    try t.expectEqualStrings("approval-session", payloadSessionId("{\"session_key\":\"approval-session\"}", &hash_buf).?);
-    const gateway = payloadSessionId("{\"session_key\":\"agent:main:telegram:dm:123\"}", &hash_buf).?;
-    try t.expectEqual(@as(usize, 64), gateway.len);
-    try t.expect(std.mem.indexOfScalar(u8, gateway, ':') == null);
-}
-
-test "state mapping mirrors the TS runner" {
+test "state mapping keeps post-tool work active until the turn completes" {
     try t.expectEqualStrings("review", stateForEvent("pre", "Read").?);
     try t.expectEqualStrings("running", stateForEvent("pre", "Bash").?);
-    try t.expectEqualStrings("idle", stateForEvent("post", null).?);
+    try t.expectEqualStrings("running", stateForEvent("post", null).?);
     try t.expectEqualStrings("waving", stateForEvent("stop", null).?);
     try t.expectEqualStrings("jumping", stateForEvent("user-prompt", null).?);
-    try t.expectEqualStrings("waiting", stateForEvent("notification", null).?);
+    try t.expect(stateForEvent("notification", null) == null);
+    try t.expectEqualStrings("waiting", stateForEventWithNotification("notification", null, "agent_needs_input").?);
     try t.expectEqualStrings("failed", stateForEvent("tool-failure", "Bash").?);
+}
+
+test "Claude notification types follow the documented attention table" {
+    for ([_][]const u8{ "permission_prompt", "elicitation_dialog", "elicitation_url_dialog", "agent_needs_input" }) |kind| {
+        try t.expectEqual(hook_server.SessionStatus.needs_input, statusForEvent("notification", null, kind));
+        try t.expectEqualStrings("waiting", stateForEventWithNotification("notification", null, kind).?);
+    }
+    for ([_][]const u8{ "idle_prompt", "agent_completed" }) |kind|
+        try t.expectEqual(hook_server.SessionStatus.completed, statusForEvent("notification", null, kind));
+    for ([_][]const u8{ "auth_success", "elicitation_complete", "elicitation_response", "future_type" }) |kind| {
+        try t.expectEqual(hook_server.SessionStatus.idle, statusForEvent("notification", null, kind));
+        try t.expect(stateForEventWithNotification("notification", null, kind) == null);
+    }
 }
 
 test "tool-failure bubble names the tool and never the error text" {
@@ -820,9 +1433,102 @@ test "bubbleBody carries session_id, and omits it when there is none" {
 }
 
 test "bubble metadata carries the exact Herdr pane id" {
-    var buf: [1024]u8 = undefined;
-    const body = bubbleBodyWithMetadata(&buf, "Needs approval", "Fix auth", false, "cursor", "session-1", "ghostty", "", "/repo", "w1:p5").?;
+    var buf: [2048]u8 = undefined;
+    const body = bubbleBodyWithMetadata(&buf, "Needs approval", "Fix auth", false, "cursor", .{
+        .session_id = "session-1",
+        .source_app = "ghostty",
+        .source_cwd = "/repo",
+        .herdr_pane = "w1:p5",
+    }).?;
     try t.expectEqualStrings("w1:p5", hook_server.jsonStringPub(body, "herdr_pane_id").?);
+}
+
+test "bubble metadata carries hostname turn and a safe Codex origin" {
+    var buf: [2048]u8 = undefined;
+    const body = bubbleBodyWithMetadata(
+        &buf,
+        "Running tests",
+        "Revamp bubbles",
+        true,
+        "codex",
+        .{
+            .session_id = "thread-7",
+            .conversation_key = "thread-7",
+            .source_app = "codex",
+            .source_tty = "/dev/ttys003",
+            .source_cwd = "/work/petdex",
+            .hostname = "shakib-mac",
+            .turn_id = "turn-9",
+            .status = .running,
+        },
+    ).?;
+    try t.expectEqualStrings("shakib-mac", jsonString(body, "hostname").?);
+    try t.expectEqualStrings("turn-9", jsonString(body, "turn_id").?);
+    try t.expectEqualStrings("codex", jsonString(body, "source_app").?);
+    try t.expectEqualStrings("thread-7", jsonString(body, "session_id").?);
+}
+
+test "supported harness session and prompt aliases resolve consistently" {
+    var hash_buf: [64]u8 = undefined;
+    try t.expectEqualStrings("claude-1", payloadSessionId("pre", "{\"session_id\":\"claude-1\"}", &hash_buf).?);
+    try t.expectEqualStrings("omp-2", payloadSessionId("pre", "{\"sessionId\":\"omp-2\"}", &hash_buf).?);
+    try t.expectEqualStrings("open-3", payloadSessionId("pre", "{\"sessionID\":\"open-3\"}", &hash_buf).?);
+    try t.expectEqualStrings("codex-4", payloadSessionId("pre", "{\"thread_id\":\"codex-4\"}", &hash_buf).?);
+    try t.expectEqualStrings("hermes-5", payloadSessionId("pre", "{\"conversation_id\":\"hermes-5\"}", &hash_buf).?);
+    try t.expectEqualStrings("Fix the hooks", promptTitle("{\"prompt\":\"Fix the hooks\"}").?);
+    try t.expectEqualStrings("Sync Hermes", promptTitle("{\"user_message\":\"Sync Hermes\"}").?);
+}
+
+test "Hermes subagent lifecycle binds the child summary to its parent" {
+    const payload =
+        "{\"session_id\":\"parent-session\",\"extra\":{\"child_session_id\":\"worker-session\",\"child_role\":\"researcher\",\"child_summary\":\"Found the compatibility shim.\"}}";
+    var hash_buf: [64]u8 = undefined;
+    const child = payloadSessionId("subagent-stop", payload, &hash_buf).?;
+    try t.expectEqualStrings("worker-session", child);
+    const context = payloadSessionContext("hermes", "subagent-stop", payload, child);
+    try t.expectEqual(hook_server.SessionKind.subagent, context.kind);
+    try t.expectEqualStrings("parent-session", context.conversationKey().?);
+    try t.expectEqualStrings("parent-session", context.parentSession().?);
+    try t.expectEqualStrings("researcher", context.labelSlice());
+    try t.expectEqual(hook_server.MessageKind.assistant, messageKindForEvent("subagent-stop", payload, ""));
+    var rendered: [256]u8 = undefined;
+    try t.expectEqualStrings("Found the compatibility shim.", formatBubble("subagent-stop", payload, &rendered).?);
+    try t.expect(formatBubble("subagent-start", payload, &rendered) == null);
+}
+
+test "known Hermes worker source spellings remain children while continuations stay primary" {
+    const worker_payload = "{\"session_id\":\"worker\",\"parent_session_id\":\"root\",\"source\":\"delegated\"}";
+    const worker = payloadSessionContext("hermes", "assistant", worker_payload, "worker");
+    try t.expectEqual(hook_server.SessionKind.subagent, worker.kind);
+    try t.expectEqualStrings("root", worker.conversationKey().?);
+
+    // Parent linkage alone is intentionally insufficient: Hermes uses the
+    // same relation for compression and branch continuations.
+    const continuation_payload = "{\"session_id\":\"tip\",\"parent_session_id\":\"root\",\"source\":\"tui\"}";
+    const continuation = payloadSessionContext("hermes", "assistant", continuation_payload, "tip");
+    try t.expectEqual(hook_server.SessionKind.primary, continuation.kind);
+    try t.expectEqualStrings("tip", continuation.conversationKey().?);
+}
+
+test "Codex title index chooses the newest server-side rename" {
+    const index =
+        "{\"id\":\"other\",\"thread_name\":\"Other chat\"}\n" ++
+        "{\"id\":\"thread-7\",\"thread_name\":\"Initial prompt title\"}\n" ++
+        "{\"id\":\"thread-7\",\"thread_name\":\"Renamed by server\"}\n";
+    var out: [256]u8 = undefined;
+    try t.expectEqualStrings("Renamed by server", codexIndexTitleFromTail(index, "thread-7", &out).?);
+    try t.expect(codexIndexTitleFromTail(index, "missing", &out) == null);
+}
+
+test "namespaced adapter title wins without reading nested tool title" {
+    const payload =
+        "{\"tool_input\":{\"title\":\"Document heading\"}," ++
+        "\"petdex_session_title\":\"Hermes server title\"}";
+    var out: [256]u8 = undefined;
+    try t.expectEqualStrings(
+        "Hermes server title",
+        authoritativeTitle("hermes", "/missing", "session-1", payload, &out).?,
+    );
 }
 
 test "two runner sessions reach the mailbox as two bubbles" {
@@ -885,6 +1591,95 @@ test "transcript tail takes the newest assistant text" {
         "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"name\":\"Bash\"},{\"type\":\"text\",\"text\":\"Listo, el fix quedo\\npusheado.\"}]}}\n" ++
         "{\"type\":\"system\",\"subtype\":\"hook\"}\n";
     try t.expectEqualStrings("Listo, el fix quedo\\npusheado.", lastAssistantFromTail(tail).?);
+}
+
+test "Codex rollout activity follows visible reasoning during an active turn" {
+    const tail =
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_started\",\"turn_id\":\"turn-1\"}}\n" ++
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_reasoning\",\"text\":\"Inspecting the session index\"}}\n";
+    const activity = codexActivityFromTail(tail).?;
+    try std.testing.expect(activity.busy);
+    try std.testing.expectEqual(hook_server.SessionStatus.running, activity.status);
+    try std.testing.expectEqual(CodexActivityKind.reasoning, activity.kind);
+    try std.testing.expectEqualStrings("Inspecting the session index", activity.textSlice());
+    try std.testing.expectEqualStrings("turn-1", activity.turnSlice());
+}
+
+test "Codex assistant prose outranks later intermediate reasoning in the turn" {
+    const tail =
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_started\",\"turn_id\":\"turn-prose\"}}\n" ++
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_message\",\"message\":\"Here is the useful answer.\"}}\n" ++
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_reasoning\",\"text\":\"Checking one more detail\"}}\n";
+    const activity = codexActivityFromTail(tail).?;
+    try std.testing.expectEqual(CodexActivityKind.assistant, activity.kind);
+    try std.testing.expectEqualStrings("Here is the useful answer.", activity.textSlice());
+}
+
+test "Codex completed activity uses the final app-visible message" {
+    const tail =
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_started\",\"turn_id\":\"turn-2\"}}\n" ++
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_reasoning\",\"text\":\"Working\"}}\n" ++
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_complete\",\"turn_id\":\"turn-2\",\"last_agent_message\":\"Finished with details\"}}\n";
+    const activity = codexActivityFromTail(tail).?;
+    try std.testing.expect(!activity.busy);
+    try std.testing.expectEqual(hook_server.SessionStatus.completed, activity.status);
+    try std.testing.expectEqual(CodexActivityKind.assistant, activity.kind);
+    try std.testing.expectEqualStrings("Finished with details", activity.textSlice());
+}
+
+test "Codex aborted activity remains a terminal failure cue" {
+    const tail =
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_started\",\"turn_id\":\"turn-stop\"}}\n" ++
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"turn_aborted\",\"turn_id\":\"turn-stop\",\"reason\":\"interrupted\"}}\n";
+    const activity = codexActivityFromTail(tail).?;
+    try std.testing.expect(!activity.busy);
+    try std.testing.expectEqual(hook_server.SessionStatus.failed, activity.status);
+    try std.testing.expectEqualStrings("Interrupted.", activity.textSlice());
+}
+
+test "Codex unmatched input call exposes the question until its response" {
+    const waiting_tail =
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_started\",\"turn_id\":\"turn-input\"}}\n" ++
+        "{\"type\":\"response_item\",\"payload\":{\"type\":\"function_call\",\"name\":\"request_user_input\",\"arguments\":\"{\\\"questions\\\":[{\\\"question\\\":\\\"Which host should I use?\\\"}]}\",\"call_id\":\"call-input\"}}\n";
+    const waiting = codexActivityFromTail(waiting_tail).?;
+    try std.testing.expectEqual(hook_server.SessionStatus.needs_input, waiting.status);
+    try std.testing.expectEqual(CodexActivityKind.prompt, waiting.kind);
+    try std.testing.expectEqualStrings("Which host should I use?", waiting.textSlice());
+
+    const resumed_tail = waiting_tail ++
+        "{\"type\":\"response_item\",\"payload\":{\"type\":\"function_call_output\",\"call_id\":\"call-input\",\"output\":\"inframework\"}}\n";
+    const resumed = codexActivityFromTail(resumed_tail).?;
+    try std.testing.expectEqual(hook_server.SessionStatus.running, resumed.status);
+    try std.testing.expectEqualStrings("Thinking…", resumed.textSlice());
+}
+
+test "Codex escalation call is user-input-required until tool output" {
+    const tail =
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_started\",\"turn_id\":\"turn-approval\"}}\n" ++
+        "{\"type\":\"response_item\",\"payload\":{\"type\":\"function_call\",\"name\":\"exec_command\",\"arguments\":\"{\\\"sandbox_permissions\\\":\\\"require_escalated\\\",\\\"justification\\\":\\\"Allow launching Petdesk?\\\"}\",\"call_id\":\"call-approval\"}}\n";
+    const activity = codexActivityFromTail(tail).?;
+    try std.testing.expectEqual(hook_server.SessionStatus.needs_input, activity.status);
+    try std.testing.expectEqualStrings("Allow launching Petdesk?", activity.textSlice());
+}
+
+test "Codex truncated active tail keeps the latest app-visible commentary" {
+    const tail =
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_message\",\"message\":\"I’m matching the Codex Pet feed\"}}\n" ++
+        "{\"type\":\"response_item\",\"payload\":{\"type\":\"custom_tool_call\",\"name\":\"exec_command\"}}\n" ++
+        "{\"type\":\"response_item\",\"payload\":{\"type\":\"custom_tool_call_output\",\"output\":\"done\"}}\n";
+    const activity = codexActivityFromTail(tail).?;
+    try std.testing.expect(activity.busy);
+    try std.testing.expectEqual(CodexActivityKind.assistant, activity.kind);
+    try std.testing.expectEqualStrings("I’m matching the Codex Pet feed", activity.textSlice());
+}
+
+test "local Codex tool hooks update mascot state without replacing feed" {
+    try std.testing.expect(!shouldPostBubble("codex", "pre"));
+    try std.testing.expect(!shouldPostBubble("CODEX", "post"));
+    try std.testing.expect(!shouldPostBubble("codex", "tool-failure"));
+    try std.testing.expect(shouldPostBubble("codex", "user-prompt"));
+    try std.testing.expect(shouldPostBubble("codex", "stop"));
+    try std.testing.expect(shouldPostBubble("hermes", "post"));
 }
 
 test "clipEscaped flattens escapes and collapses spaces" {

--- a/packages/petdex-desktop-native/src/hook_server.zig
+++ b/packages/petdex-desktop-native/src/hook_server.zig
@@ -1,6 +1,6 @@
 //! In-process replacement for the Node sidecar's HTTP surface on
 //! 127.0.0.1:7777. Same contract the hooks already speak: token-gated
-//! POST /state and /bubble (header x-petdex-update-token, token file
+//! POST /state, /bubble and /bubble/title (header x-petdex-update-token, token file
 //! at ~/.petdex/runtime/update-token mode 0600, regenerated per
 //! session), shared 30/s rate limit, and the read endpoints /health,
 //! /whoami, /state, /bubble, /init-status. /update endpoints answer
@@ -20,18 +20,143 @@ const builtin = @import("builtin");
 const plat = @import("plat.zig");
 const dsh_integration = @import("dsh_integration.zig");
 
-/// One connection, plus the Io that owns it. Everything downstream of
-/// accept() needs both, and passing them as a pair keeps the response
-/// helpers' signatures as flat as the old bare fd was.
+/// One connection with the persistent buffered writer used for its response.
+/// The request is pre-read under one absolute deadline before routing.
 const Conn = struct {
-    stream: std.Io.net.Stream,
     io: std.Io,
+    writer: *std.Io.Writer,
 };
 
 pub const max_pending = 50;
 const max_active_connections: u32 = 64;
 const max_request_bytes: usize = 8192;
-const connection_timeout_ms: i64 = 5_000;
+const connection_read_timeout_ms: u64 = 2_000;
+pub const bubble_text_capacity: usize = 4096;
+pub const bubble_title_capacity: usize = 256;
+pub const bubble_session_capacity: usize = 96;
+pub const bubble_message_id_capacity: usize = 96;
+pub const bubble_child_message_capacity: usize = 512;
+pub const max_child_messages: usize = 8;
+pub const max_pending_inputs: usize = 4;
+
+pub const SessionStatus = enum(u8) {
+    idle,
+    running,
+    needs_input,
+    completed,
+    failed,
+
+    pub fn fromWire(raw: []const u8) ?SessionStatus {
+        if (std.mem.eql(u8, raw, "idle")) return .idle;
+        if (std.mem.eql(u8, raw, "running")) return .running;
+        if (std.mem.eql(u8, raw, "needs_input")) return .needs_input;
+        if (std.mem.eql(u8, raw, "completed")) return .completed;
+        if (std.mem.eql(u8, raw, "failed")) return .failed;
+        return null;
+    }
+
+    pub fn wireName(self: SessionStatus) []const u8 {
+        return switch (self) {
+            .idle => "idle",
+            .running => "running",
+            .needs_input => "needs_input",
+            .completed => "completed",
+            .failed => "failed",
+        };
+    }
+};
+
+pub const SessionKind = enum(u8) {
+    primary,
+    subagent,
+
+    fn fromWire(raw: []const u8) SessionKind {
+        return if (std.mem.eql(u8, raw, "subagent")) .subagent else .primary;
+    }
+};
+
+pub const MessageKind = enum(u8) {
+    status,
+    reasoning,
+    assistant,
+    tool,
+    lifecycle,
+    prompt,
+
+    fn fromWire(raw: []const u8) MessageKind {
+        if (std.mem.eql(u8, raw, "reasoning")) return .reasoning;
+        if (std.mem.eql(u8, raw, "assistant")) return .assistant;
+        if (std.mem.eql(u8, raw, "tool")) return .tool;
+        if (std.mem.eql(u8, raw, "lifecycle")) return .lifecycle;
+        if (std.mem.eql(u8, raw, "prompt")) return .prompt;
+        return .status;
+    }
+};
+
+pub const TitleSource = enum(u8) {
+    unknown,
+    prompt,
+    server,
+
+    fn fromWire(raw: []const u8) TitleSource {
+        if (std.mem.eql(u8, raw, "server")) return .server;
+        if (std.mem.eql(u8, raw, "prompt")) return .prompt;
+        return .unknown;
+    }
+};
+
+pub const FeedSource = enum(u8) {
+    hook,
+    journal,
+    native_store,
+    local_api,
+
+    fn fromWire(raw: []const u8) FeedSource {
+        if (std.mem.eql(u8, raw, "journal")) return .journal;
+        if (std.mem.eql(u8, raw, "native_store") or
+            std.mem.eql(u8, raw, "rollout") or
+            std.mem.eql(u8, raw, "hermes_state")) return .native_store;
+        if (std.mem.eql(u8, raw, "local_api")) return .local_api;
+        return .hook;
+    }
+
+    fn rank(self: FeedSource) u8 {
+        return switch (self) {
+            .journal => 1,
+            .native_store => 2,
+            .local_api => 3,
+            .hook => 4,
+        };
+    }
+};
+
+pub const ChildMessage = struct {
+    text: [bubble_child_message_capacity]u8 = @splat(0),
+    text_len: usize = 0,
+    label: [48]u8 = @splat(0),
+    label_len: usize = 0,
+    source_session: [bubble_session_capacity]u8 = @splat(0),
+    source_session_len: usize = 0,
+    message_id: [bubble_message_id_capacity]u8 = @splat(0),
+    message_id_len: usize = 0,
+    counter: u64 = 0,
+
+    pub fn textSlice(self: *const ChildMessage) []const u8 {
+        return self.text[0..self.text_len];
+    }
+
+    pub fn labelSlice(self: *const ChildMessage) []const u8 {
+        return self.label[0..self.label_len];
+    }
+
+    pub fn sourceSessionSlice(self: *const ChildMessage) []const u8 {
+        return self.source_session[0..self.source_session_len];
+    }
+
+    pub fn messageIdSlice(self: *const ChildMessage) []const u8 {
+        return self.message_id[0..self.message_id_len];
+    }
+};
 
 pub const StateEvent = struct {
     state: [16]u8 = @splat(0),
@@ -44,17 +169,40 @@ pub const StateEvent = struct {
 };
 
 pub const Bubble = struct {
-    text: [200]u8 = @splat(0),
+    text: [bubble_text_capacity]u8 = @splat(0),
     text_len: usize = 0,
-    title: [96]u8 = @splat(0),
+    title: [bubble_title_capacity]u8 = @splat(0),
     title_len: usize = 0,
     agent: [24]u8 = @splat(0),
     agent_len: usize = 0,
     /// Which conversation this bubble belongs to. Empty is the sentinel
     /// key an agent without a session_id lands on (older CLI, the MCP
     /// path), which is what keeps single-bubble behaviour identical.
-    session: [64]u8 = @splat(0),
+    session: [bubble_session_capacity]u8 = @splat(0),
     session_len: usize = 0,
+    /// Raw provider session that emitted the current primary update. The
+    /// `session` field above is the stable canonical conversation key.
+    source_session: [bubble_session_capacity]u8 = @splat(0),
+    source_session_len: usize = 0,
+    parent_session: [bubble_session_capacity]u8 = @splat(0),
+    parent_session_len: usize = 0,
+    session_kind: SessionKind = .primary,
+    status: SessionStatus = .idle,
+    message_kind: MessageKind = .status,
+    title_source: TitleSource = .unknown,
+    feed_source: FeedSource = .hook,
+    message_id: [bubble_message_id_capacity]u8 = @splat(0),
+    message_id_len: usize = 0,
+    pending_input_ids: [max_pending_inputs][bubble_message_id_capacity]u8 = @splat(@splat(0)),
+    pending_input_id_lens: [max_pending_inputs]usize = @splat(0),
+    pending_input_ids_len: usize = 0,
+    /// Providers that cannot supply a correlation id get one bounded pending
+    /// request per conversation. Unlike keyed requests, definitive resumed
+    /// work may safely clear this fallback.
+    pending_unkeyed_input: bool = false,
+    completed_at_ms: i64 = 0,
+    child_messages: [max_child_messages]ChildMessage = @splat(.{}),
+    child_messages_len: usize = 0,
     origin_app: plat.OriginApplication = .none,
     source_tty: [64]u8 = @splat(0),
     source_tty_len: usize = 0,
@@ -62,7 +210,26 @@ pub const Bubble = struct {
     source_cwd_len: usize = 0,
     herdr_pane: [64]u8 = @splat(0),
     herdr_pane_len: usize = 0,
+    /// Machine that owns the agent process. Local hooks report the Mac's
+    /// hostname; SSH hooks report the remote host, so the header never has
+    /// to infer locality from a filesystem path.
+    hostname: [64]u8 = @splat(0),
+    hostname_len: usize = 0,
+    /// Active agent turn. Codex requires both thread + turn ids for a safe
+    /// interrupt/steer request; other agents leave this empty.
+    turn: [64]u8 = @splat(0),
+    turn_len: usize = 0,
+    remote: bool = false,
     busy: bool = false,
+    /// Last distinct running event accepted for this conversation. This is
+    /// intentionally separate from `counter`: repeated transport heartbeats
+    /// must not keep an abandoned card visually active forever.
+    last_meaningful_activity_ms: i64 = 0,
+    last_activity_fingerprint: u64 = 0,
+    /// Set after the desktop has quieted a running card. An identical running
+    /// snapshot must not immediately restart its animation; a meaningful
+    /// event below clears this flag.
+    stale_running_suppressed: bool = false,
     counter: u64 = 0,
 
     pub fn sessionSlice(self: *const Bubble) []const u8 {
@@ -77,11 +244,255 @@ pub const Bubble = struct {
     pub fn herdrPaneSlice(self: *const Bubble) []const u8 {
         return self.herdr_pane[0..self.herdr_pane_len];
     }
+    pub fn hostnameSlice(self: *const Bubble) []const u8 {
+        return self.hostname[0..self.hostname_len];
+    }
+    pub fn turnSlice(self: *const Bubble) []const u8 {
+        return self.turn[0..self.turn_len];
+    }
+    pub fn sourceSessionSlice(self: *const Bubble) []const u8 {
+        return self.source_session[0..self.source_session_len];
+    }
+    pub fn parentSessionSlice(self: *const Bubble) []const u8 {
+        return self.parent_session[0..self.parent_session_len];
+    }
+    pub fn messageIdSlice(self: *const Bubble) []const u8 {
+        return self.message_id[0..self.message_id_len];
+    }
 };
 
 /// How many conversations can narrate at once. Fixed because the
 /// mailbox holds them inline: no allocator runs on the hook hot path.
 pub const max_bubbles = 8;
+
+/// Provider-neutral update accepted by the mailbox. The HTTP route and
+/// in-process rollout reconcilers both lower their event shapes into this one
+/// record, so canonical identity and message precedence cannot drift by feed.
+pub const BubbleUpdate = struct {
+    conversation_key: []const u8 = "",
+    source_session: []const u8 = "",
+    parent_session: []const u8 = "",
+    text: []const u8 = "",
+    agent: []const u8 = "",
+    title: []const u8 = "",
+    origin_app: plat.OriginApplication = .none,
+    source_tty: []const u8 = "",
+    source_cwd: []const u8 = "",
+    herdr_pane: []const u8 = "",
+    hostname: []const u8 = "",
+    turn: []const u8 = "",
+    message_id: []const u8 = "",
+    event_kind: []const u8 = "",
+    request_id: []const u8 = "",
+    resolves_request_id: []const u8 = "",
+    notification_kind: []const u8 = "",
+    subagent_label: []const u8 = "",
+    remote: bool = false,
+    busy: bool = false,
+    status: ?SessionStatus = null,
+    session_kind: SessionKind = .primary,
+    message_kind: MessageKind = .status,
+    title_source: TitleSource = .unknown,
+    feed_source: FeedSource = .hook,
+};
+
+fn copyField(destination: []u8, source: []const u8) usize {
+    const count = @min(destination.len, source.len);
+    @memset(destination, 0);
+    @memcpy(destination[0..count], source[0..count]);
+    return count;
+}
+
+fn identityMatches(bubble: *const Bubble, update: BubbleUpdate) bool {
+    if (!std.mem.eql(u8, bubble.sessionSlice(), update.conversation_key)) return false;
+    // Empty is the compatibility slot used by pre-session integrations.
+    if (update.conversation_key.len == 0) return true;
+    if (bubble.remote != update.remote) return false;
+    if (!std.ascii.eqlIgnoreCase(bubble.agent[0..bubble.agent_len], update.agent)) return false;
+    if (!update.remote) return true;
+    return std.ascii.eqlIgnoreCase(bubble.hostnameSlice(), update.hostname);
+}
+
+/// Match a provisional card opened under a raw child id before its provider
+/// had persisted canonical ancestry. Once that same raw id is authoritatively
+/// identified as a subagent, the provisional card must disappear rather than
+/// survive beside its parent until normal expiry.
+fn sourceSessionIdentityMatches(bubble: *const Bubble, update: BubbleUpdate) bool {
+    if (update.source_session.len == 0 or
+        std.mem.eql(u8, update.source_session, update.conversation_key) or
+        !std.mem.eql(u8, bubble.sessionSlice(), update.source_session)) return false;
+    if (bubble.remote != update.remote) return false;
+    if (!std.ascii.eqlIgnoreCase(bubble.agent[0..bubble.agent_len], update.agent)) return false;
+    if (!update.remote) return true;
+    return std.ascii.eqlIgnoreCase(bubble.hostnameSlice(), update.hostname);
+}
+
+fn shouldReplaceMessage(bubble: *const Bubble, update: BubbleUpdate) bool {
+    if (std.mem.trim(u8, update.text, " \t\r\n").len == 0) return false;
+    if (bubble.text_len == 0) return true;
+    if (update.status == .failed) return true;
+    if (update.message_kind == .assistant or update.message_kind == .prompt) return true;
+    if (update.status == .needs_input) return true;
+    if (update.turn.len > 0 and !std.mem.eql(u8, bubble.turnSlice(), update.turn)) return true;
+    // Once user-visible assistant prose exists for this turn, lower-level
+    // reasoning, tools and lifecycle summaries may update state but not the
+    // feed text. This is the Codex Pet/Petdesk parity invariant.
+    if (bubble.message_kind == .assistant) return false;
+    if (update.message_kind == .reasoning) return true;
+    if (update.message_kind == .tool and bubble.message_kind != .reasoning) return true;
+    return bubble.message_kind == .status or bubble.message_kind == .lifecycle;
+}
+
+fn childMessageMatches(message: *const ChildMessage, update: BubbleUpdate) bool {
+    if (update.message_id.len > 0 and message.message_id_len > 0)
+        return std.mem.eql(u8, message.messageIdSlice(), update.message_id);
+    return std.mem.eql(u8, message.sourceSessionSlice(), update.source_session) and
+        std.mem.eql(u8, message.textSlice(), update.text);
+}
+
+fn childMessageEquivalent(message: *const ChildMessage, update: BubbleUpdate) bool {
+    return std.mem.eql(u8, message.textSlice(), update.text) and
+        std.mem.eql(u8, message.labelSlice(), if (update.subagent_label.len > 0) update.subagent_label else "Subagent") and
+        std.mem.eql(u8, message.sourceSessionSlice(), update.source_session) and
+        std.mem.eql(u8, message.messageIdSlice(), update.message_id);
+}
+
+/// A provider may poll/replay a `running` status for minutes without any new
+/// assistant work. Only an event with a distinct, user-relevant token is
+/// allowed to refresh a card's activity lease.
+fn runningActivityFingerprint(update: BubbleUpdate) u64 {
+    if (update.message_id.len == 0 and update.turn.len == 0 and update.text.len == 0 and update.event_kind.len == 0)
+        return 0;
+    var hash: u64 = 1469598103934665603;
+    const mix = struct {
+        fn apply(current: *u64, value: []const u8) void {
+            for (value) |byte| current.* = (current.* ^ byte) *% 1099511628211;
+            current.* = (current.* ^ 0xff) *% 1099511628211;
+        }
+    }.apply;
+    mix(&hash, update.message_id);
+    mix(&hash, update.turn);
+    mix(&hash, update.event_kind);
+    mix(&hash, update.text);
+    return hash;
+}
+
+fn bubblePresentationEquivalent(before: Bubble, after: Bubble) bool {
+    var left = before;
+    var right = after;
+    // These fields govern feed freshness and ordering, not visible card
+    // content. Comparing them would turn an otherwise identical heartbeat
+    // into a redraw.
+    left.counter = 0;
+    right.counter = 0;
+    left.last_meaningful_activity_ms = 0;
+    right.last_meaningful_activity_ms = 0;
+    left.last_activity_fingerprint = 0;
+    right.last_activity_fingerprint = 0;
+    return std.meta.eql(left, right);
+}
+
+fn pendingInputKey(update: BubbleUpdate) []const u8 {
+    if (update.request_id.len > 0) return update.request_id;
+    return update.message_id;
+}
+
+fn pendingInputIndex(bubble: *const Bubble, key: []const u8) ?usize {
+    if (key.len == 0) return null;
+    for (0..bubble.pending_input_ids_len) |index| {
+        if (std.mem.eql(u8, bubble.pending_input_ids[index][0..bubble.pending_input_id_lens[index]], key)) return index;
+    }
+    return null;
+}
+
+fn clearPendingInputs(bubble: *Bubble) void {
+    bubble.pending_input_ids_len = 0;
+    bubble.pending_unkeyed_input = false;
+    @memset(&bubble.pending_input_ids, @splat(0));
+    @memset(&bubble.pending_input_id_lens, 0);
+}
+
+fn notificationNeedsInput(kind: []const u8) bool {
+    return std.mem.eql(u8, kind, "permission_prompt") or
+        std.mem.eql(u8, kind, "elicitation_dialog") or
+        std.mem.eql(u8, kind, "elicitation_url_dialog") or
+        std.mem.eql(u8, kind, "agent_needs_input");
+}
+
+fn notificationCompletes(kind: []const u8) bool {
+    return std.mem.eql(u8, kind, "idle_prompt") or
+        std.mem.eql(u8, kind, "agent_completed");
+}
+
+fn normalizedProposedStatus(update: BubbleUpdate) SessionStatus {
+    const proposed = update.status orelse if (update.busy) SessionStatus.running else SessionStatus.idle;
+    // Claude-shaped Notification hooks are deliberately closed over the
+    // documented notification_type values. Unknown or authentication-only
+    // notifications must never manufacture an orange card.
+    if (std.mem.eql(u8, update.event_kind, "notification")) {
+        if (notificationNeedsInput(update.notification_kind)) return .needs_input;
+        if (notificationCompletes(update.notification_kind)) return .completed;
+        return if (update.busy) .running else .idle;
+    }
+    // `waiting` is a mascot phase used by older integrations, not evidence of
+    // an outstanding user request. Explicit approval/question event kinds and
+    // legacy callers without event_kind retain their intended status.
+    if (std.mem.eql(u8, update.event_kind, "waiting"))
+        return if (update.busy) .running else .idle;
+    return proposed;
+}
+
+fn isDefinitiveResume(update: BubbleUpdate) bool {
+    if (std.mem.eql(u8, update.event_kind, "user-prompt") or
+        std.mem.eql(u8, update.event_kind, "new-turn") or
+        std.mem.eql(u8, update.event_kind, "assistant") or
+        std.mem.eql(u8, update.event_kind, "approval-response")) return true;
+    return update.message_kind == .assistant or update.message_kind == .reasoning or
+        update.message_kind == .tool or
+        (update.turn.len > 0);
+}
+
+fn removePendingInput(bubble: *Bubble, index: usize) void {
+    if (index >= bubble.pending_input_ids_len) return;
+    std.mem.copyForwards([bubble_message_id_capacity]u8, bubble.pending_input_ids[index .. bubble.pending_input_ids_len - 1], bubble.pending_input_ids[index + 1 .. bubble.pending_input_ids_len]);
+    std.mem.copyForwards(usize, bubble.pending_input_id_lens[index .. bubble.pending_input_ids_len - 1], bubble.pending_input_id_lens[index + 1 .. bubble.pending_input_ids_len]);
+    bubble.pending_input_ids_len -= 1;
+    bubble.pending_input_ids[bubble.pending_input_ids_len] = @splat(0);
+    bubble.pending_input_id_lens[bubble.pending_input_ids_len] = 0;
+}
+
+fn reconcileStatus(bubble: *Bubble, update: BubbleUpdate, proposed: SessionStatus) SessionStatus {
+    const key = pendingInputKey(update);
+    switch (proposed) {
+        .failed, .completed, .idle => clearPendingInputs(bubble),
+        .needs_input => {
+            if (key.len > 0 and pendingInputIndex(bubble, key) == null) {
+                if (bubble.pending_input_ids_len == max_pending_inputs) removePendingInput(bubble, 0);
+                const index = bubble.pending_input_ids_len;
+                bubble.pending_input_id_lens[index] = copyField(&bubble.pending_input_ids[index], key);
+                bubble.pending_input_ids_len += 1;
+            } else if (key.len == 0) {
+                bubble.pending_unkeyed_input = true;
+            }
+        },
+        .running => {
+            const resolving_key = if (update.resolves_request_id.len > 0) update.resolves_request_id else "";
+            if (pendingInputIndex(bubble, resolving_key)) |index| {
+                removePendingInput(bubble, index);
+            }
+            if (bubble.pending_unkeyed_input and isDefinitiveResume(update))
+                bubble.pending_unkeyed_input = false;
+            // A genuinely new turn invalidates even keyed requests from the
+            // previous turn. Ordinary tool/assistant progress only resolves
+            // the bounded unkeyed fallback.
+            if (std.mem.eql(u8, update.event_kind, "user-prompt") or
+                std.mem.eql(u8, update.event_kind, "new-turn")) clearPendingInputs(bubble);
+        },
+    }
+    if (proposed == .failed) return .failed;
+    if (bubble.pending_input_ids_len > 0 or bubble.pending_unkeyed_input) return .needs_input;
+    return proposed;
+}
 
 /// Shared mailbox between the server thread (producer) and the app's
 /// poll timer (consumer). Everything behind one mutex; operations are
@@ -115,9 +526,21 @@ const BlockingMutex = struct {
 };
 
 pub const Mailbox = struct {
+    /// In-process diagnostic counters for duplicate/stale feed behavior.
+    /// They deliberately stay with each mailbox instance and are not emitted
+    /// as telemetry.
+    pub const BubbleRenderDebugCounters = struct {
+        suppressed_duplicates: u64 = 0,
+        stale_transitions: u64 = 0,
+    };
+
     mutex: SpinMutex = .{},
     pending: [max_pending]StateEvent = @splat(.{}),
     pending_len: usize = 0,
+    /// Last semantic sprite state accepted by the queue.  It intentionally
+    /// survives a drain: providers commonly emit the same `running` state for
+    /// every tool heartbeat, and re-enqueuing it after each poll would restart
+    /// the pet animation forever without conveying new user-visible state.
     last_enqueued: StateEvent = .{},
     /// One live bubble per conversation, keyed by session id. Slots
     /// below bubbles_len are occupied; the array is compacted on evict
@@ -129,14 +552,17 @@ pub const Mailbox = struct {
     /// its LRU stamp: the smallest one is the least recently updated.
     bubble_counter: u64 = 0,
     state_counter: u64 = 0,
+    bubble_render_debug: BubbleRenderDebugCounters = .{},
 
     pub const EnqueueResult = struct {
         queued: bool,
         counter: u64,
     };
 
-    /// Coalesce + append, sidecar semantics: consecutive identical
-    /// states collapse. Returns whether the event was queued.
+    /// Coalesce + append, sidecar semantics: identical steady states collapse
+    /// even after the consumer drains them.  A different state (or duration)
+    /// remains an explicit transition, so completion, failure, and the next
+    /// task still reach the mascot immediately.
     pub fn enqueue(self: *Mailbox, event: StateEvent) bool {
         return self.enqueueWithCounter(event).queued;
     }
@@ -144,10 +570,8 @@ pub const Mailbox = struct {
     pub fn enqueueWithCounter(self: *Mailbox, event: StateEvent) EnqueueResult {
         self.mutex.lock();
         defer self.mutex.unlock();
-        if (self.pending_len > 0 or self.last_enqueued.state_len > 0) {
-            if (std.mem.eql(u8, self.last_enqueued.slice(), event.slice())) {
-                return .{ .queued = false, .counter = self.state_counter };
-            }
+        if (self.last_enqueued.state_len > 0 and stateEventEquivalent(self.last_enqueued, event)) {
+            return .{ .queued = false, .counter = self.state_counter };
         }
         if (self.pending_len >= max_pending) {
             return .{ .queued = false, .counter = self.state_counter };
@@ -162,14 +586,17 @@ pub const Mailbox = struct {
     pub fn pop(self: *Mailbox) ?StateEvent {
         self.mutex.lock();
         defer self.mutex.unlock();
-        if (self.pending_len == 0) {
-            self.last_enqueued = .{};
-            return null;
-        }
+        if (self.pending_len == 0) return null;
         const head = self.pending[0];
         std.mem.copyForwards(StateEvent, self.pending[0 .. self.pending_len - 1], self.pending[1..self.pending_len]);
         self.pending_len -= 1;
         return head;
+    }
+
+    pub fn bubbleRenderDebugCounters(self: *Mailbox) BubbleRenderDebugCounters {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        return self.bubble_render_debug;
     }
 
     /// Update the bubble for `session`, or open a slot for it. A repeat
@@ -182,54 +609,275 @@ pub const Mailbox = struct {
     }
 
     pub fn setBubbleWithMetadata(self: *Mailbox, session: []const u8, text: []const u8, agent: []const u8, title: []const u8, origin_app: plat.OriginApplication, source_tty: []const u8, source_cwd: []const u8, herdr_pane: []const u8, busy: bool) u64 {
+        return self.applyBubbleUpdate(.{
+            .conversation_key = session,
+            .source_session = session,
+            .text = text,
+            .agent = agent,
+            .title = title,
+            .origin_app = origin_app,
+            .source_tty = source_tty,
+            .source_cwd = source_cwd,
+            .herdr_pane = herdr_pane,
+            .busy = busy,
+            .status = if (busy) .running else .idle,
+        });
+    }
+
+    pub fn setBubbleWithContext(self: *Mailbox, session: []const u8, text: []const u8, agent: []const u8, title: []const u8, origin_app: plat.OriginApplication, source_tty: []const u8, source_cwd: []const u8, hostname: []const u8, turn: []const u8, remote: bool, busy: bool) u64 {
+        return self.applyBubbleUpdate(.{
+            .conversation_key = session,
+            .source_session = session,
+            .text = text,
+            .agent = agent,
+            .title = title,
+            .origin_app = origin_app,
+            .source_tty = source_tty,
+            .source_cwd = source_cwd,
+            .hostname = hostname,
+            .turn = turn,
+            .remote = remote,
+            .busy = busy,
+            .status = if (busy) .running else .idle,
+        });
+    }
+
+    pub fn applyBubbleUpdate(self: *Mailbox, update_raw: BubbleUpdate) u64 {
+        var conversation_hash: [64]u8 = undefined;
+        var source_hash: [64]u8 = undefined;
+        var parent_hash: [64]u8 = undefined;
+        var update = update_raw;
+        update.conversation_key = normalizeBubbleSession(update_raw.conversation_key, &conversation_hash) orelse "";
+        update.source_session = normalizeBubbleSession(update_raw.source_session, &source_hash) orelse "";
+        update.parent_session = normalizeBubbleSession(update_raw.parent_session, &parent_hash) orelse "";
         self.mutex.lock();
         defer self.mutex.unlock();
 
-        const slot = blk: {
-            for (self.bubbles[0..self.bubbles_len]) |*b| {
-                if (std.mem.eql(u8, b.sessionSlice(), session)) break :blk b;
+        // Hermes can emit a child's first tool event before state.db contains
+        // `_delegate_from`. Older adapters therefore opened a raw child card,
+        // then correctly classified later events without ever retracting that
+        // provisional card. An authoritative child update owns the cleanup.
+        if (update.session_kind == .subagent) {
+            var index: usize = 0;
+            while (index < self.bubbles_len) : (index += 1) {
+                if (!sourceSessionIdentityMatches(&self.bubbles[index], update)) continue;
+                if (index + 1 < self.bubbles_len)
+                    std.mem.copyForwards(Bubble, self.bubbles[index .. self.bubbles_len - 1], self.bubbles[index + 1 .. self.bubbles_len]);
+                self.bubbles_len -= 1;
+                self.bubbles[self.bubbles_len] = .{};
+                self.bubble_counter += 1;
+                self.bubbles_dirty = true;
+                break;
             }
+        }
+
+        var matched_existing: ?*Bubble = null;
+        for (self.bubbles[0..self.bubbles_len]) |*bubble| {
+            if (identityMatches(bubble, update)) {
+                matched_existing = bubble;
+                break;
+            }
+        }
+
+        // A child never owns a top-level card. If its parent has not appeared
+        // yet, drop the event rather than manufacturing a blank ghost card.
+        // The next meaningful parent update will establish the aggregate.
+        if (update.session_kind == .subagent) {
+            const parent = matched_existing orelse return self.bubble_counter;
+            if (update.message_kind != .assistant or std.mem.trim(u8, update.text, " \t\r\n").len == 0)
+                return self.bubble_counter;
+
+            var duplicate: ?usize = null;
+            for (parent.child_messages[0..parent.child_messages_len], 0..) |*message, i| {
+                if (childMessageMatches(message, update)) {
+                    duplicate = i;
+                    break;
+                }
+            }
+            if (duplicate) |index| {
+                if (childMessageEquivalent(&parent.child_messages[index], update)) {
+                    self.bubble_render_debug.suppressed_duplicates +%= 1;
+                    return self.bubble_counter;
+                }
+                // Move an updated duplicate to the tail so "two most recent"
+                // is chronological even when a provider replays an event.
+                const existing = parent.child_messages[index];
+                std.mem.copyForwards(ChildMessage, parent.child_messages[index .. parent.child_messages_len - 1], parent.child_messages[index + 1 .. parent.child_messages_len]);
+                parent.child_messages[parent.child_messages_len - 1] = existing;
+            } else {
+                if (parent.child_messages_len == max_child_messages) {
+                    std.mem.copyForwards(ChildMessage, parent.child_messages[0 .. max_child_messages - 1], parent.child_messages[1..max_child_messages]);
+                    parent.child_messages_len -= 1;
+                }
+                parent.child_messages[parent.child_messages_len] = .{};
+                parent.child_messages_len += 1;
+            }
+            var child = &parent.child_messages[parent.child_messages_len - 1];
+            child.text_len = copyField(&child.text, update.text);
+            child.label_len = copyField(&child.label, if (update.subagent_label.len > 0) update.subagent_label else "Subagent");
+            child.source_session_len = copyField(&child.source_session, update.source_session);
+            child.message_id_len = copyField(&child.message_id, update.message_id);
+            self.bubble_counter += 1;
+            child.counter = self.bubble_counter;
+            parent.counter = self.bubble_counter;
+            self.bubbles_dirty = true;
+            return parent.counter;
+        }
+
+        const is_new = matched_existing == null;
+        const slot = matched_existing orelse blk: {
+            var selected: *Bubble = undefined;
             if (self.bubbles_len < max_bubbles) {
-                const b = &self.bubbles[self.bubbles_len];
+                selected = &self.bubbles[self.bubbles_len];
                 self.bubbles_len += 1;
-                break :blk b;
+            } else {
+                selected = &self.bubbles[0];
+                for (self.bubbles[1..self.bubbles_len]) |*bubble| {
+                    if (bubble.counter < selected.counter) selected = bubble;
+                }
             }
-            var oldest = &self.bubbles[0];
-            for (self.bubbles[1..self.bubbles_len]) |*b| {
-                if (b.counter < oldest.counter) oldest = b;
-            }
-            break :blk oldest;
+            selected.* = .{};
+            selected.session_len = copyField(&selected.session, update.conversation_key);
+            selected.remote = update.remote;
+            break :blk selected;
         };
 
-        slot.* = .{};
-        const sn = @min(session.len, slot.session.len);
-        @memcpy(slot.session[0..sn], session[0..sn]);
-        slot.session_len = sn;
-        const n = @min(text.len, slot.text.len);
-        @memcpy(slot.text[0..n], text[0..n]);
-        slot.text_len = n;
-        const an = @min(agent.len, slot.agent.len);
-        @memcpy(slot.agent[0..an], agent[0..an]);
-        slot.agent_len = an;
-        const tn = @min(title.len, slot.title.len);
-        @memcpy(slot.title[0..tn], title[0..tn]);
-        slot.title_len = tn;
-        slot.origin_app = origin_app;
-        const tty_n = @min(source_tty.len, slot.source_tty.len);
-        @memcpy(slot.source_tty[0..tty_n], source_tty[0..tty_n]);
-        slot.source_tty_len = tty_n;
-        const cwd_n = @min(source_cwd.len, slot.source_cwd.len);
-        @memcpy(slot.source_cwd[0..cwd_n], source_cwd[0..cwd_n]);
-        slot.source_cwd_len = cwd_n;
-        const pane_n = @min(herdr_pane.len, slot.herdr_pane.len);
-        @memcpy(slot.herdr_pane[0..pane_n], herdr_pane[0..pane_n]);
-        slot.herdr_pane_len = pane_n;
-        slot.busy = busy;
+        // Sessionless integrations intentionally share one compatibility
+        // slot. Treat each write as unrelated so title/message provenance from
+        // an older legacy agent cannot leak into the next one.
+        const sessionless_replace = matched_existing != null and update.conversation_key.len == 0;
+        const before = slot.*;
+        if (sessionless_replace) {
+            slot.* = .{};
+            slot.remote = update.remote;
+        }
 
+        const metadata_wins = is_new or update.feed_source.rank() >= slot.feed_source.rank();
+        if (update.agent.len > 0 and (metadata_wins or slot.agent_len == 0)) slot.agent_len = copyField(&slot.agent, update.agent);
+        if (update.source_session.len > 0 and (metadata_wins or slot.source_session_len == 0)) slot.source_session_len = copyField(&slot.source_session, update.source_session);
+        if (update.parent_session.len > 0 and (metadata_wins or slot.parent_session_len == 0)) slot.parent_session_len = copyField(&slot.parent_session, update.parent_session);
+        slot.session_kind = .primary;
+        if (metadata_wins) slot.feed_source = update.feed_source;
+        if (update.origin_app != .none and (metadata_wins or slot.origin_app == .none)) slot.origin_app = update.origin_app;
+        if (update.source_tty.len > 0 and (metadata_wins or slot.source_tty_len == 0)) slot.source_tty_len = copyField(&slot.source_tty, update.source_tty);
+        if (update.source_cwd.len > 0 and (metadata_wins or slot.source_cwd_len == 0)) slot.source_cwd_len = copyField(&slot.source_cwd, update.source_cwd);
+        if (update.herdr_pane.len > 0 and (metadata_wins or slot.herdr_pane_len == 0)) slot.herdr_pane_len = copyField(&slot.herdr_pane, update.herdr_pane);
+        if (update.hostname.len > 0 and (metadata_wins or slot.hostname_len == 0)) slot.hostname_len = copyField(&slot.hostname, update.hostname);
+        slot.remote = update.remote;
+
+        const replace_title = update.title.len > 0 and switch (update.title_source) {
+            .server => true,
+            .prompt => slot.title_len == 0,
+            .unknown => slot.title_len == 0 or slot.title_source != .server,
+        };
+        if (replace_title) {
+            slot.title_len = copyField(&slot.title, update.title);
+            slot.title_source = update.title_source;
+        }
+
+        if (shouldReplaceMessage(slot, update)) {
+            slot.text_len = copyField(&slot.text, update.text);
+            slot.message_kind = update.message_kind;
+            slot.message_id_len = copyField(&slot.message_id, update.message_id);
+        }
+        const previous_status = slot.status;
+        var proposed_status = normalizedProposedStatus(update);
+        const activity_fingerprint = runningActivityFingerprint(update);
+        const meaningful_running_activity = proposed_status == .running and activity_fingerprint != 0 and
+            (is_new or sessionless_replace or activity_fingerprint != before.last_activity_fingerprint);
+        // Once a card has been quieted, an unchanged provider heartbeat is
+        // not evidence of new work. A changed assistant/tool/progress event
+        // clears the suppression and immediately restores the running state.
+        if (slot.stale_running_suppressed and proposed_status == .running and !meaningful_running_activity)
+            proposed_status = .idle;
+        const status = reconcileStatus(slot, update, proposed_status);
+        if (update.turn.len > 0) slot.turn_len = copyField(&slot.turn, update.turn);
+        slot.status = status;
+        slot.busy = status == .running;
+        slot.completed_at_ms = if (status == .completed)
+            (if (previous_status == .completed and slot.completed_at_ms > 0) slot.completed_at_ms else nowMs())
+        else
+            0;
+
+        // A newly running card has a lease even when an older integration
+        // cannot provide a message id yet.  Subsequent unkeyed heartbeats do
+        // not refresh it; that lets the 30s stale guard quiet every provider.
+        const started_running = status == .running and
+            (is_new or sessionless_replace or before.status != .running);
+        if ((meaningful_running_activity or started_running) and status == .running) {
+            slot.last_meaningful_activity_ms = nowMs();
+            slot.last_activity_fingerprint = activity_fingerprint;
+            slot.stale_running_suppressed = false;
+        } else if (status == .needs_input or status == .completed or status == .failed) {
+            // Terminal and attention states are explicit. They do not retain
+            // a stale-running marker that could interfere with a later turn.
+            slot.stale_running_suppressed = false;
+        }
+
+        const changed = is_new or sessionless_replace or meaningful_running_activity or
+            !bubblePresentationEquivalent(before, slot.*);
+        if (!changed) {
+            self.bubble_render_debug.suppressed_duplicates +%= 1;
+            return self.bubble_counter;
+        }
         self.bubble_counter += 1;
         slot.counter = self.bubble_counter;
         self.bubbles_dirty = true;
         return slot.counter;
+    }
+
+    /// Quiet running cards whose provider has stopped emitting meaningful
+    /// work. The card remains retained and becomes neutral; only a distinct
+    /// running event may wake it again.
+    pub fn suppressStaleRunning(self: *Mailbox, now_ms: i64, grace_ms: i64) usize {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        var suppressed: usize = 0;
+        for (self.bubbles[0..self.bubbles_len]) |*bubble| {
+            if (bubble.status != .running or bubble.last_meaningful_activity_ms <= 0) continue;
+            if (now_ms - bubble.last_meaningful_activity_ms < grace_ms) continue;
+            bubble.status = .idle;
+            bubble.busy = false;
+            bubble.stale_running_suppressed = true;
+            self.bubble_counter += 1;
+            bubble.counter = self.bubble_counter;
+            self.bubbles_dirty = true;
+            self.bubble_render_debug.stale_transitions +%= 1;
+            suppressed += 1;
+        }
+        return suppressed;
+    }
+
+    /// Apply an authoritative title without manufacturing a message update.
+    /// Used by agent servers that publish renames independently from tool and
+    /// lifecycle events (OpenCode's session.updated, Codex's title index).
+    pub fn setBubbleTitle(self: *Mailbox, session: []const u8, title: []const u8) ?u64 {
+        return self.setBubbleTitleIdentity(session, title, "", "", false, false);
+    }
+
+    pub fn setBubbleTitleIdentity(self: *Mailbox, session: []const u8, title: []const u8, agent: []const u8, hostname: []const u8, remote: bool, exact: bool) ?u64 {
+        if (session.len == 0 or title.len == 0) return null;
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        for (self.bubbles[0..self.bubbles_len]) |*bubble| {
+            if (!std.mem.eql(u8, bubble.sessionSlice(), session)) continue;
+            if (exact) {
+                if (bubble.remote != remote) continue;
+                if (!std.ascii.eqlIgnoreCase(bubble.agent[0..bubble.agent_len], agent)) continue;
+                if (remote and !std.ascii.eqlIgnoreCase(bubble.hostnameSlice(), hostname)) continue;
+            }
+            const capped = title[0..@min(title.len, bubble.title.len)];
+            if (std.mem.eql(u8, bubble.title[0..bubble.title_len], capped)) return bubble.counter;
+            @memset(&bubble.title, 0);
+            @memcpy(bubble.title[0..capped.len], capped);
+            bubble.title_len = capped.len;
+            bubble.title_source = .server;
+            self.bubble_counter += 1;
+            bubble.counter = self.bubble_counter;
+            self.bubbles_dirty = true;
+            return bubble.counter;
+        }
+        return null;
     }
 
     /// Drain the whole set into `out`, returning how many slots landed.
@@ -248,10 +896,19 @@ pub const Mailbox = struct {
     /// the slot is free for the next conversation. No dirty flag: the
     /// consumer already knows, it asked for this.
     pub fn dropBubble(self: *Mailbox, session: []const u8) void {
+        self.dropBubbleIdentity(session, "", "", false, false);
+    }
+
+    pub fn dropBubbleIdentity(self: *Mailbox, conversation: []const u8, agent: []const u8, hostname: []const u8, remote: bool, exact: bool) void {
         self.mutex.lock();
         defer self.mutex.unlock();
         for (self.bubbles[0..self.bubbles_len], 0..) |*b, i| {
-            if (!std.mem.eql(u8, b.sessionSlice(), session)) continue;
+            if (!std.mem.eql(u8, b.sessionSlice(), conversation)) continue;
+            if (exact) {
+                if (b.remote != remote) continue;
+                if (!std.ascii.eqlIgnoreCase(b.agent[0..b.agent_len], agent)) continue;
+                if (remote and !std.ascii.eqlIgnoreCase(b.hostnameSlice(), hostname)) continue;
+            }
             const last = self.bubbles_len - 1;
             if (i != last) self.bubbles[i] = self.bubbles[last];
             self.bubbles[last] = .{};
@@ -271,6 +928,48 @@ pub const Mailbox = struct {
 
 pub var mailbox: Mailbox = .{};
 
+const RemoteCredential = struct {
+    active: bool = false,
+    principal: [32]u8 = @splat(0),
+    principal_len: usize = 0,
+    secret: [64]u8 = @splat(0),
+};
+
+var remote_credentials_lock: SpinMutex = .{};
+var remote_credentials: [8]RemoteCredential = @splat(.{});
+
+pub fn issueRemoteCredential(principal: []const u8, out: []u8) ?[]const u8 {
+    if (principal.len == 0 or principal.len > 32) return null;
+    for (principal) |byte| if (!(std.ascii.isAlphanumeric(byte) or byte == '-' or byte == '_')) return null;
+    var raw: [32]u8 = undefined;
+    fillRandom(&raw) catch return null;
+    var secret: [64]u8 = undefined;
+    secret = std.fmt.bytesToHex(raw, .lower);
+
+    remote_credentials_lock.lock();
+    defer remote_credentials_lock.unlock();
+    var selected: *RemoteCredential = &remote_credentials[0];
+    for (&remote_credentials) |*entry| {
+        if (entry.active and std.mem.eql(u8, entry.principal[0..entry.principal_len], principal)) {
+            selected = entry;
+            break;
+        }
+        if (!entry.active) selected = entry;
+    }
+    selected.* = .{ .active = true, .secret = secret };
+    selected.principal_len = principal.len;
+    @memcpy(selected.principal[0..principal.len], principal);
+    return std.fmt.bufPrint(out, "remote:{s}:{s}", .{ principal, &secret }) catch null;
+}
+
+pub fn revokeRemoteCredential(principal: []const u8) void {
+    remote_credentials_lock.lock();
+    defer remote_credentials_lock.unlock();
+    for (&remote_credentials) |*entry| {
+        if (entry.active and std.mem.eql(u8, entry.principal[0..entry.principal_len], principal)) entry.* = .{};
+    }
+}
+
 const valid_states = [_][]const u8{
     "idle",    "running", "running-left", "running-right", "waving",
     "jumping", "failed",  "review",       "waiting",
@@ -283,6 +982,123 @@ const valid_states = [_][]const u8{
 const fillRandom = plat.fillRandom;
 
 const nowMs = plat.nowMs;
+const monotonicMs = plat.monotonicMs;
+
+const ReadDeadlineEntry = struct {
+    active: bool = false,
+    timed_out: bool = false,
+    stream: std.Io.net.Stream = undefined,
+    io: std.Io = undefined,
+    deadline: std.Io.Clock.Timestamp = undefined,
+};
+
+var read_deadline_lock: SpinMutex = .{};
+var read_deadlines: [max_active_connections]ReadDeadlineEntry = @splat(.{});
+var read_deadline_thread_started: std.atomic.Value(bool) = .init(false);
+
+fn readDeadlineTimer() void {
+    var scope = plat.Scope.init();
+    defer scope.deinit();
+    const io = scope.io();
+    while (true) {
+        std.Io.sleep(io, std.Io.Duration.fromMilliseconds(25), .awake) catch {};
+        const now = std.Io.Clock.Timestamp.now(io, .boot);
+        read_deadline_lock.lock();
+        for (&read_deadlines) |*entry| {
+            if (!entry.active or entry.timed_out or !entry.deadline.compare(.lte, now)) continue;
+            entry.timed_out = true;
+            // Closing an AFD-backed stream while Zig's Windows reader is
+            // pending produces STATUS_CANCELLED, which Zig 0.16 treats as an
+            // unreachable state. A full AFD partial-disconnect wakes that
+            // read as a normal disconnected socket; final handle close still
+            // belongs to the connection thread. Send the small 408 first so a
+            // responsive peer gets the same contract as POSIX, then disconnect
+            // even if a malicious peer is not reading the response.
+            var response_buffer: [256]u8 = undefined;
+            var response_writer = entry.stream.writer(entry.io, &response_buffer);
+            var conn: Conn = .{ .io = entry.io, .writer = &response_writer.interface };
+            respond(&conn, 408, "{\"ok\":false,\"error\":\"request_timeout\"}");
+            entry.stream.shutdown(entry.io, .both) catch {};
+        }
+        read_deadline_lock.unlock();
+    }
+}
+
+fn registerReadDeadline(stream: std.Io.net.Stream, io: std.Io, deadline: std.Io.Clock.Timestamp) ?usize {
+    if (read_deadline_thread_started.cmpxchgStrong(false, true, .acq_rel, .acquire) == null) {
+        const thread = std.Thread.spawn(.{}, readDeadlineTimer, .{}) catch {
+            read_deadline_thread_started.store(false, .release);
+            return null;
+        };
+        thread.detach();
+    }
+    read_deadline_lock.lock();
+    defer read_deadline_lock.unlock();
+    for (&read_deadlines, 0..) |*entry, index| {
+        if (entry.active) continue;
+        entry.* = .{ .active = true, .stream = stream, .io = io, .deadline = deadline };
+        return index;
+    }
+    return null;
+}
+
+fn removeReadDeadline(index: usize) bool {
+    read_deadline_lock.lock();
+    defer read_deadline_lock.unlock();
+    const timed_out = read_deadlines[index].timed_out;
+    read_deadlines[index] = .{};
+    return timed_out;
+}
+
+fn readBeforeDeadline(stream: std.Io.net.Stream, reader: *std.Io.Reader, io: std.Io, buffer: []u8, deadline: std.Io.Clock.Timestamp) ![]const u8 {
+    if (builtin.os.tag != .windows) return (try stream.socket.receiveTimeout(io, buffer, .{ .deadline = deadline })).data;
+    const slot = registerReadDeadline(stream, io, deadline) orelse return error.SystemResources;
+    // readSliceShort fills the entire destination before returning. Passing
+    // the 64 KiB request tail would therefore stall every ordinary HTTP
+    // request until the deadline. peekByte triggers one AFD receive into the
+    // reader's 1 KiB buffer; copy the bytes already delivered by that single
+    // receive without initiating a second blocking operation.
+    _ = reader.peekByte() catch |err| {
+        if (removeReadDeadline(slot)) return error.Timeout;
+        return err;
+    };
+    if (removeReadDeadline(slot)) return error.Timeout;
+    const count = @min(buffer.len, reader.bufferedLen());
+    @memcpy(buffer[0..count], reader.buffered()[0..count]);
+    reader.toss(count);
+    return buffer[0..count];
+}
+
+const AuthContext = struct {
+    remote: bool = false,
+    principal: []const u8 = "local",
+};
+
+const AuthClaimConflict = enum { remote, hostname };
+
+fn authClaimConflict(auth: AuthContext, claimed_remote: ?bool, hostname: []const u8) ?AuthClaimConflict {
+    if (claimed_remote) |value| if (value != auth.remote) return .remote;
+    if (auth.remote and hostname.len > 0 and !std.mem.eql(u8, hostname, auth.principal)) return .hostname;
+    return null;
+}
+
+/// State events are deliberately tiny, so equality must include both the
+/// semantic state and its optional dwell.  Treat the old directional running
+/// aliases as one activity class as well: they are sprite flavor, not a new
+/// piece of work worthy of rearming the whole desktop renderer.
+fn stateEventEquivalent(a: StateEvent, b: StateEvent) bool {
+    if (a.duration_ms != b.duration_ms) return false;
+    const a_state = a.slice();
+    const b_state = b.slice();
+    if (std.mem.eql(u8, a_state, b_state)) return true;
+    const a_running = std.mem.eql(u8, a_state, "running") or
+        std.mem.eql(u8, a_state, "running-left") or
+        std.mem.eql(u8, a_state, "running-right");
+    const b_running = std.mem.eql(u8, b_state, "running") or
+        std.mem.eql(u8, b_state, "running-left") or
+        std.mem.eql(u8, b_state, "running-right");
+    return a_running and b_running;
+}
 
 fn isValidState(s: []const u8) bool {
     for (valid_states) |v| {
@@ -292,6 +1108,13 @@ fn isValidState(s: []const u8) bool {
 }
 
 const Server = struct {
+    const PrincipalBucket = struct {
+        used: bool = false,
+        principal: [32]u8 = @splat(0),
+        principal_len: usize = 0,
+        bucket: f64 = 30,
+        stamp_ms: i64 = 0,
+    };
     allocator: std.mem.Allocator,
     runtime_dir: []const u8,
     token: [64]u8,
@@ -303,28 +1126,42 @@ const Server = struct {
     // Token-bucket limiter, sidecar budget: 30/s shared by state+bubble.
     bucket: f64 = 30,
     bucket_stamp_ms: i64 = 0,
-    running_toggle: bool = false,
+    principal_buckets: [8]PrincipalBucket = @splat(.{}),
     pid: i32,
 
-    fn rateLimitOk(self: *Server) bool {
+    fn rateLimitOk(self: *Server, auth: AuthContext) bool {
         self.request_lock.lock();
         defer self.request_lock.unlock();
-        const now = nowMs();
+        const now = monotonicMs();
+        if (auth.remote) {
+            var selected: *PrincipalBucket = &self.principal_buckets[0];
+            for (&self.principal_buckets) |*candidate| {
+                if (candidate.used and std.mem.eql(u8, candidate.principal[0..candidate.principal_len], auth.principal)) {
+                    selected = candidate;
+                    break;
+                }
+                if (!candidate.used) selected = candidate;
+            }
+            if (!selected.used or !std.mem.eql(u8, selected.principal[0..selected.principal_len], auth.principal)) {
+                selected.* = .{ .used = true };
+                selected.principal_len = @min(selected.principal.len, auth.principal.len);
+                @memcpy(selected.principal[0..selected.principal_len], auth.principal[0..selected.principal_len]);
+            }
+            if (selected.stamp_ms == 0) selected.stamp_ms = now;
+            const elapsed: f64 = @floatFromInt(@max(@as(i64, 0), now - selected.stamp_ms));
+            selected.bucket = @min(30.0, selected.bucket + elapsed * 30.0 / 1000.0);
+            selected.stamp_ms = now;
+            if (selected.bucket < 1) return false;
+            selected.bucket -= 1;
+            return true;
+        }
         if (self.bucket_stamp_ms == 0) self.bucket_stamp_ms = now;
-        const elapsed: f64 = @floatFromInt(now - self.bucket_stamp_ms);
+        const elapsed: f64 = @floatFromInt(@max(@as(i64, 0), now - self.bucket_stamp_ms));
         self.bucket = @min(30.0, self.bucket + elapsed * 30.0 / 1000.0);
         self.bucket_stamp_ms = now;
         if (self.bucket < 1) return false;
         self.bucket -= 1;
         return true;
-    }
-
-    fn nextRunningState(self: *Server) []const u8 {
-        self.request_lock.lock();
-        defer self.request_lock.unlock();
-        const state = if (self.running_toggle) "running-left" else "running-right";
-        self.running_toggle = !self.running_toggle;
-        return state;
     }
 };
 
@@ -384,10 +1221,10 @@ fn run(server: *Server) void {
             stream.close(io);
             continue;
         }
-        // A client can disappear after sending only part of a request. Keep
-        // that blocking read off the accept loop so later hooks still reach
-        // the server while the abandoned connection drains or closes.
-        const thread = std.Thread.spawn(.{}, handleConnectionThread, .{ server, stream }) catch {
+        // Keep an abandoned client off the accept loop, but retain the Io that
+        // accepted the stream. A replacement Threaded Io cannot safely operate
+        // the existing Winsock handle.
+        const thread = std.Thread.spawn(.{}, handleConnectionThread, .{ server, stream, io }) catch {
             _ = server.active_connections.fetchSub(1, .release);
             stream.close(io);
             continue;
@@ -396,69 +1233,99 @@ fn run(server: *Server) void {
     }
 }
 
-fn handleConnectionThread(server: *Server, stream: std.Io.net.Stream) void {
+fn handleConnectionThread(server: *Server, stream: std.Io.net.Stream, io: std.Io) void {
     defer _ = server.active_connections.fetchSub(1, .release);
-    var scope = plat.Scope.init();
-    defer scope.deinit();
-    const io = scope.io();
-    var conn: Conn = .{ .stream = stream, .io = io };
-    handleConnection(server, &conn);
-    stream.shutdown(io, .send) catch {};
-    if (builtin.os.tag == .windows) {
-        var drain: [1]u8 = undefined;
-        while (true) {
-            const message = stream.socket.receive(io, &drain) catch break;
-            if (message.data.len == 0) break;
-        }
-    }
-    stream.close(io);
-}
+    defer stream.close(io);
 
-fn handleConnection(server: *Server, conn: *Conn) void {
-    var buf: [max_request_bytes]u8 = undefined;
+    var request_buffer: [max_request_bytes]u8 = undefined;
+    var read_buffer: [1024]u8 = undefined;
+    var write_buffer: [1024]u8 = undefined;
+    var stream_reader = stream.reader(io, &read_buffer);
+    var stream_writer = stream.writer(io, &write_buffer);
+    var conn: Conn = .{
+        .io = io,
+        .writer = &stream_writer.interface,
+    };
+    const read_duration: std.Io.Clock.Duration = .{
+        .raw = std.Io.Duration.fromMilliseconds(connection_read_timeout_ms),
+        .clock = .boot,
+    };
+    const deadline = std.Io.Clock.Timestamp.fromNow(io, read_duration);
     var total: usize = 0;
-    var header_end: ?usize = null;
-    const timeout = (std.Io.Timeout{ .duration = .{
-        .raw = std.Io.Duration.fromMilliseconds(connection_timeout_ms),
-        .clock = .awake,
-    } }).toDeadline(conn.io);
-
-    // Read the complete header with a bounded deadline. A hook host can
-    // disappear after opening a socket, so no connection may wait forever.
-    while (header_end == null) {
-        if (total == buf.len) {
-            respond(conn, 413, "{\"ok\":false,\"error\":\"headers_too_large\"}");
-            return;
-        }
-        const got = receiveWithTimeout(conn, buf[total..], timeout) catch |err| {
-            std.debug.print("petdex: hook receive failed ({s})\n", .{@errorName(err)});
+    var request_len: ?usize = null;
+    while (request_len == null or total < request_len.?) {
+        if (total == request_buffer.len) return respond(&conn, 413, "{\"ok\":false,\"error\":\"request_too_large\"}");
+        const incoming = readBeforeDeadline(stream, &stream_reader.interface, io, request_buffer[total..], deadline) catch |err| {
+            if (err == error.Timeout) respond(&conn, 408, "{\"ok\":false,\"error\":\"request_timeout\"}");
             return;
         };
-        if (got == 0) return;
-        total += got;
-        header_end = if (std.mem.indexOf(u8, buf[0..total], "\r\n\r\n")) |at| at + 4 else null;
+        if (incoming.len == 0) return;
+        total += incoming.len;
+        if (request_len == null) {
+            const end_at = std.mem.indexOf(u8, request_buffer[0..total], "\r\n\r\n") orelse continue;
+            const head_len = end_at + 4;
+            const head = request_buffer[0..head_len];
+            const content_length = if (headerValue(head, "content-length")) |raw| std.fmt.parseInt(usize, raw, 10) catch
+                return respond(&conn, 400, "{\"ok\":false,\"error\":\"invalid_content_length\"}") else 0;
+            if (content_length > request_buffer.len - head_len) return respond(&conn, 413, "{\"ok\":false,\"error\":\"body_too_large\"}");
+            request_len = head_len + content_length;
+        }
+    }
+    handleConnection(server, &conn, request_buffer[0..request_len.?]);
+}
+
+const RequestObject = struct {
+    root: std.json.Value,
+    valid: bool = true,
+
+    fn string(self: *RequestObject, key: []const u8) ?[]const u8 {
+        const value = self.root.object.get(key) orelse return null;
+        // Older CLI hooks serialize an unknown optional agent source as
+        // JSON null. Treat null like an omitted optional field so the typed
+        // parser remains backward-compatible; concrete non-string values are
+        // still rejected below.
+        if (value == .null) return null;
+        if (value != .string) {
+            self.valid = false;
+            return null;
+        }
+        return value.string;
     }
 
-    const head_len = header_end.?;
-    const head = buf[0..head_len];
+    fn boolean(self: *RequestObject, key: []const u8) ?bool {
+        const value = self.root.object.get(key) orelse return null;
+        if (value != .bool) {
+            self.valid = false;
+            return null;
+        }
+        return value.bool;
+    }
+};
+
+fn parseRequest(allocator: std.mem.Allocator, body: []const u8) !std.json.Value {
+    if (!std.unicode.utf8ValidateSlice(body)) return error.InvalidJson;
+    const root = try std.json.parseFromSliceLeaky(std.json.Value, allocator, body, .{
+        .duplicate_field_behavior = .@"error",
+        .max_value_len = max_request_bytes,
+    });
+    if (root != .object) return error.InvalidJson;
+    return root;
+}
+
+fn handleConnection(server: *Server, conn: *Conn, request: []const u8) void {
+    const header_at = std.mem.indexOf(u8, request, "\r\n\r\n") orelse return;
+    const head_len = header_at + 4;
+    const head = request[0..head_len];
     const content_length = if (headerValue(head, "content-length")) |raw| std.fmt.parseInt(usize, raw, 10) catch {
         respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_content_length\"}");
         return;
     } else 0;
-    if (content_length > buf.len - head_len) {
+    if (content_length > request.len - head_len) {
         respond(conn, 413, "{\"ok\":false,\"error\":\"body_too_large\"}");
         return;
     }
     const request_len = head_len + content_length;
-    while (total < request_len) {
-        const got = receiveWithTimeout(conn, buf[total..request_len], timeout) catch |err| {
-            std.debug.print("petdex: hook body receive failed ({s})\n", .{@errorName(err)});
-            return;
-        };
-        if (got == 0) return;
-        total += got;
-    }
-    const body = buf[head_len..request_len];
+    const body = request[head_len..request_len];
 
     var line_it = std.mem.splitSequence(u8, head, "\r\n");
     const request_line = line_it.next() orelse return;
@@ -470,22 +1337,19 @@ fn handleConnection(server: *Server, conn: *Conn) void {
     route(server, conn, method, path, head, body);
 }
 
-fn receiveWithTimeout(conn: *Conn, buffer: []u8, timeout: std.Io.Timeout) !usize {
-    if (builtin.os.tag == .windows) {
-        var reader = conn.stream.reader(conn.io, &.{});
-        var data = [_][]u8{buffer};
-        return reader.interface.readVec(&data) catch |err| switch (err) {
-            error.EndOfStream => 0,
-            error.ReadFailed => return reader.err orelse error.Unexpected,
-        };
-    }
-    return (try conn.stream.socket.receiveTimeout(conn.io, buffer, timeout)).data.len;
-}
-
 fn route(server: *Server, conn: *Conn, method: []const u8, path: []const u8, head: []const u8, body: []const u8) void {
     const get = std.mem.eql(u8, method, "GET");
     const post = std.mem.eql(u8, method, "POST");
     var scratch: [512]u8 = undefined;
+    var json_memory: [max_request_bytes * 2]u8 = undefined;
+    var fixed = std.heap.FixedBufferAllocator.init(&json_memory);
+    var parsed_root: ?std.json.Value = null;
+    const typed_json_post = post and (std.mem.eql(u8, path, "/state") or
+        std.mem.eql(u8, path, "/bubble") or std.mem.eql(u8, path, "/bubble/title"));
+    if (typed_json_post and body.len > 0) {
+        const root = parseRequest(fixed.allocator(), body) catch return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_json\"}");
+        parsed_root = root;
+    }
 
     if (get and std.mem.eql(u8, path, "/health")) {
         return respond(conn, 200, "{\"ok\":true,\"port\":7777}");
@@ -507,18 +1371,22 @@ fn route(server: *Server, conn: *Conn, method: []const u8, path: []const u8, hea
         return respond(conn, 200, "{\"available\":false,\"installable\":false,\"status\":\"idle\",\"message\":null}");
     }
     if (post and (std.mem.eql(u8, path, "/update") or std.mem.eql(u8, path, "/update/handoff"))) {
-        if (!tokenOk(server, head)) return respond(conn, 401, "{\"ok\":false,\"error\":\"unauthorized\"}");
+        _ = authenticate(server, head) orelse return respond(conn, 401, "{\"ok\":false,\"error\":\"unauthorized\"}");
         return respond(conn, 409, "{\"ok\":false,\"error\":\"unsupported_install\",\"message\":\"Self-update lands in a later slice; download the current build from petdex.dev/download.\"}");
     }
 
     if (post and std.mem.eql(u8, path, "/state")) {
-        if (!tokenOk(server, head)) return respond(conn, 401, "{\"ok\":false,\"error\":\"unauthorized\"}");
-        if (!server.rateLimitOk()) return respond(conn, 429, "{\"ok\":false,\"error\":\"rate_limited\"}");
-        const state_raw = jsonString(body, "state") orelse
+        const auth = authenticate(server, head) orelse return respond(conn, 401, "{\"ok\":false,\"error\":\"unauthorized\"}");
+        if (!server.rateLimitOk(auth)) return respond(conn, 429, "{\"ok\":false,\"error\":\"rate_limited\"}");
+        var request: RequestObject = .{ .root = parsed_root orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_json\"}") };
+        const state_raw = request.string("state") orelse
             return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_state\"}");
         if (!isValidState(state_raw) or state_raw.len > 15) {
             return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_state\"}");
         }
+        // Keep the deployed hook contract: both the packaged TypeScript CLI
+        // and the native/remote runners send `duration`, and the legacy
+        // parser accepts JSON numbers before capping them to 30 seconds.
         var duration: u32 = 0;
         switch (parseDuration(body)) {
             .missing => {},
@@ -526,12 +1394,12 @@ fn route(server: *Server, conn: *Conn, method: []const u8, path: []const u8, hea
             .value => |value| duration = value,
         }
 
-        // Sidecar's sprite variation: bare "running" alternates
-        // left/right per session so consecutive tool calls vary.
-        var applied: []const u8 = state_raw;
-        if (std.mem.eql(u8, state_raw, "running")) {
-            applied = server.nextRunningState();
-        }
+        // A bare `running` is a stable semantic state.  Alternating it into
+        // left/right variants on every hook heartbeat made equivalent work
+        // look like a fresh state transition and continuously restarted the
+        // pet's frame timer.  Directional values are still accepted for
+        // direct gesture callers; provider hooks stay on the neutral row.
+        const applied = state_raw;
 
         var event = StateEvent{ .duration_ms = duration };
         event.state_len = applied.len;
@@ -547,25 +1415,82 @@ fn route(server: *Server, conn: *Conn, method: []const u8, path: []const u8, hea
         return respond(conn, 200, out);
     }
 
-    if (post and std.mem.eql(u8, path, "/bubble")) {
-        if (!tokenOk(server, head)) return respond(conn, 401, "{\"ok\":false,\"error\":\"unauthorized\"}");
-        if (!server.rateLimitOk()) return respond(conn, 429, "{\"ok\":false,\"error\":\"rate_limited\"}");
-        const text = jsonString(body, "text") orelse
-            return respond(conn, 400, "{\"ok\":false,\"error\":\"missing_text\"}");
-        const capped = text[0..@min(text.len, 200)];
-        const agent = jsonString(body, "agent_source") orelse "";
-        const title = jsonString(body, "title") orelse "";
-        const origin_app = plat.OriginApplication.fromTermProgram(jsonString(body, "source_app"));
-        const source_tty = plat.safeSourceTty(jsonString(body, "source_tty")) orelse "";
-        const source_cwd = plat.safeSourceCwd(jsonString(body, "source_cwd")) orelse "";
-        const herdr_pane = plat.safeHerdrPaneId(jsonString(body, "herdr_pane_id")) orelse "";
-        const busy = std.mem.indexOf(u8, body, "\"busy\":true") != null;
-        // Canonical conversation metadata wins over raw continuation/session
-        // ids. Arbitrary provider keys are normalized to the mailbox's fixed
-        // 64-byte key instead of being truncated into possible collisions.
+    if (post and std.mem.eql(u8, path, "/bubble/title")) {
+        const auth = authenticate(server, head) orelse return respond(conn, 401, "{\"ok\":false,\"error\":\"unauthorized\"}");
+        if (!server.rateLimitOk(auth)) return respond(conn, 429, "{\"ok\":false,\"error\":\"rate_limited\"}");
+        var request: RequestObject = .{ .root = parsed_root orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_json\"}") };
+        const session = request.string("conversation_key") orelse request.string("session_id") orelse
+            return respond(conn, 400, "{\"ok\":false,\"error\":\"missing_session_id\"}");
+        const title_raw = request.string("title") orelse
+            return respond(conn, 400, "{\"ok\":false,\"error\":\"missing_title\"}");
+        const title = boundedUtf8(title_raw, bubble_title_capacity) orelse
+            return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_title\"}");
+        const agent = request.string("agent_source") orelse "";
+        const hostname = request.string("hostname") orelse "";
+        const claimed_remote = request.boolean("remote");
+        if (!request.valid) return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_field_type\"}");
+        const remote = auth.remote;
+        if (authClaimConflict(auth, claimed_remote, hostname)) |conflict| switch (conflict) {
+            .remote => return respond(conn, 400, "{\"ok\":false,\"error\":\"contradictory_remote_identity\"}"),
+            .hostname => return respond(conn, 400, "{\"ok\":false,\"error\":\"contradictory_remote_hostname\"}"),
+        };
+        const exact = agent.len > 0 and (!remote or auth.principal.len > 0);
+        const safe_agent = boundedUtf8(agent, 24) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_agent\"}");
+        const safe_hostname = if (auth.remote) auth.principal else (boundedUtf8(hostname, 64) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_hostname\"}"));
         var session_hash: [64]u8 = undefined;
-        const session = bubbleSessionKey(body, &session_hash);
-        if (isDshHandshakeBubble(body)) {
+        const canonical_session = normalizeBubbleSession(session, &session_hash) orelse
+            return respond(conn, 400, "{\"ok\":false,\"error\":\"missing_session_id\"}");
+        const counter = mailbox.setBubbleTitleIdentity(
+            canonical_session,
+            title,
+            safe_agent,
+            safe_hostname,
+            remote,
+            exact,
+        );
+        const out = if (counter) |value|
+            std.fmt.bufPrint(&scratch, "{{\"ok\":true,\"updated\":true,\"counter\":{d}}}", .{value}) catch return
+        else
+            "{\"ok\":true,\"updated\":false}";
+        return respond(conn, 200, out);
+    }
+
+    if (post and std.mem.eql(u8, path, "/bubble")) {
+        const auth = authenticate(server, head) orelse return respond(conn, 401, "{\"ok\":false,\"error\":\"unauthorized\"}");
+        if (!server.rateLimitOk(auth)) return respond(conn, 429, "{\"ok\":false,\"error\":\"rate_limited\"}");
+        var request: RequestObject = .{ .root = parsed_root orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_json\"}") };
+        const text_raw = request.string("text") orelse
+            return respond(conn, 400, "{\"ok\":false,\"error\":\"missing_text\"}");
+        const capped = boundedUtf8(text_raw, bubble_text_capacity) orelse
+            return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_text\"}");
+        const agent = request.string("agent_source") orelse "";
+        const title = request.string("title") orelse "";
+        const origin_app = plat.OriginApplication.fromTermProgram(request.string("source_app"));
+        const source_tty = plat.safeSourceTty(request.string("source_tty")) orelse "";
+        const source_cwd = plat.safeSourceCwd(request.string("source_cwd")) orelse "";
+        const herdr_pane = plat.safeHerdrPaneId(request.string("herdr_pane_id")) orelse "";
+        const hostname = request.string("hostname") orelse "";
+        const turn = request.string("turn_id") orelse "";
+        const message_id = request.string("message_id") orelse "";
+        const event_kind = request.string("event_kind") orelse "";
+        const request_id = request.string("request_id") orelse "";
+        const resolves_request_id = request.string("resolves_request_id") orelse "";
+        const notification_kind = request.string("notification_kind") orelse "";
+        const parent_session = request.string("parent_session_id") orelse "";
+        const subagent_label = request.string("subagent_label") orelse "";
+        const remote = auth.remote;
+        const claimed_remote = request.boolean("remote");
+        const busy = request.boolean("busy") orelse false;
+        // No session_id means an agent that predates per-conversation
+        // bubbles (or the MCP path, which has no session): the empty key
+        // is one shared slot, so those callers keep the old behaviour.
+        // Canonical conversation metadata wins over raw continuation/session
+        // ids. Normalize arbitrary provider keys rather than truncating them
+        // into possible collisions in the mailbox's bounded identity field.
+        var conversation_hash: [64]u8 = undefined;
+        const conversation = requestSessionKey(&request, &conversation_hash);
+        const integration_version = request.string("integration_version") orelse "";
+        if (std.mem.eql(u8, agent, "dsh") and std.mem.eql(u8, integration_version, dsh_integration.integration_version)) {
             writeRuntimeFile(
                 server,
                 "dsh-handshake.json",
@@ -573,8 +1498,63 @@ fn route(server: *Server, conn: *Conn, method: []const u8, path: []const u8, hea
                 0o600,
             ) catch {};
         }
-        const counter = mailbox.setBubbleWithMetadata(session, capped, agent[0..@min(agent.len, 24)], title[0..@min(title.len, 96)], origin_app, source_tty, source_cwd, herdr_pane, busy);
-        mirrorBubble(server, capped, counter, title[0..@min(title.len, 96)], agent[0..@min(agent.len, 24)], busy) catch {};
+        const session = request.string("session_id") orelse "";
+        const source_session = request.string("source_session_id") orelse session;
+        const status: ?SessionStatus = if (request.string("status")) |raw|
+            (SessionStatus.fromWire(raw) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_status\"}"))
+        else
+            null;
+        const session_kind = request.string("session_kind") orelse "primary";
+        const message_kind = request.string("message_kind") orelse event_kind;
+        const title_source = request.string("title_source") orelse "unknown";
+        _ = request.string("feed_source");
+        if (!request.valid) return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_field_type\"}");
+        if (authClaimConflict(auth, claimed_remote, hostname)) |conflict| switch (conflict) {
+            .remote => return respond(conn, 400, "{\"ok\":false,\"error\":\"contradictory_remote_identity\"}"),
+            .hostname => return respond(conn, 400, "{\"ok\":false,\"error\":\"contradictory_remote_hostname\"}"),
+        };
+        const safe_agent = boundedUtf8(agent, 24) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_agent\"}");
+        const safe_hostname = if (auth.remote) auth.principal else (boundedUtf8(hostname, 64) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_hostname\"}"));
+        const safe_turn = boundedUtf8(turn, 64) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_turn_id\"}");
+        const safe_title = boundedUtf8(title, bubble_title_capacity) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_title\"}");
+        const safe_subagent_label = boundedUtf8(subagent_label, 48) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_subagent_label\"}");
+        const safe_message_id = boundedUtf8(message_id, bubble_message_id_capacity) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_message_id\"}");
+        const safe_event_kind = boundedUtf8(event_kind, 48) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_event_kind\"}");
+        const safe_request_id = boundedUtf8(request_id, bubble_message_id_capacity) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_request_id\"}");
+        const safe_resolves_request_id = boundedUtf8(resolves_request_id, bubble_message_id_capacity) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_resolves_request_id\"}");
+        const safe_notification_kind = boundedUtf8(notification_kind, 64) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_notification_kind\"}");
+        const counter = mailbox.applyBubbleUpdate(.{
+            .conversation_key = conversation[0..@min(conversation.len, bubble_session_capacity)],
+            // Mailbox owns canonical identity normalization. Passing the raw
+            // decoded values prevents distinct long provider ids that share a
+            // bounded prefix from colliding before they can be hashed.
+            .source_session = source_session,
+            .parent_session = parent_session,
+            .text = capped,
+            .agent = safe_agent,
+            .title = safe_title,
+            .origin_app = origin_app,
+            .source_tty = source_tty,
+            .source_cwd = source_cwd,
+            .herdr_pane = herdr_pane,
+            .hostname = safe_hostname,
+            .turn = safe_turn,
+            .message_id = safe_message_id,
+            .event_kind = safe_event_kind,
+            .request_id = safe_request_id,
+            .resolves_request_id = safe_resolves_request_id,
+            .notification_kind = safe_notification_kind,
+            .subagent_label = safe_subagent_label,
+            .remote = remote,
+            .busy = busy,
+            .status = status,
+            .session_kind = SessionKind.fromWire(session_kind),
+            .message_kind = MessageKind.fromWire(message_kind),
+            .title_source = TitleSource.fromWire(title_source),
+            .feed_source = .hook,
+        });
+        const mirror_busy = if (status) |value| value == .running else busy;
+        mirrorBubble(server, capped, counter, safe_title, safe_agent, safe_hostname, mirror_busy) catch {};
         const out = std.fmt.bufPrint(&scratch, "{{\"ok\":true,\"counter\":{d}}}", .{counter}) catch return;
         return respond(conn, 200, out);
     }
@@ -584,12 +1564,35 @@ fn route(server: *Server, conn: *Conn, method: []const u8, path: []const u8, hea
 
 // ------------------------------------------------------------------ auth
 
-fn tokenOk(server: *Server, head: []const u8) bool {
-    const provided = headerValue(head, "x-petdex-update-token") orelse return false;
-    if (provided.len != server.token.len) return false;
-    // Constant-time compare, same defense as the sidecar's.
+fn authenticate(server: *Server, head: []const u8) ?AuthContext {
+    const provided = headerValue(head, "x-petdex-update-token") orelse return null;
+    if (constantTimeEqual(provided, &server.token)) return .{};
+
+    const prefix = "remote:";
+    if (!std.mem.startsWith(u8, provided, prefix)) return null;
+    const rest = provided[prefix.len..];
+    const separator = std.mem.indexOfScalar(u8, rest, ':') orelse return null;
+    const principal = rest[0..separator];
+    const signature = rest[separator + 1 ..];
+    if (principal.len == 0 or principal.len > 32 or signature.len != 64) return null;
+    for (principal) |byte| if (!(std.ascii.isAlphanumeric(byte) or byte == '-' or byte == '_')) return null;
+
+    remote_credentials_lock.lock();
+    defer remote_credentials_lock.unlock();
+    var valid = false;
+    for (&remote_credentials) |*entry| {
+        if (!entry.active or !std.mem.eql(u8, entry.principal[0..entry.principal_len], principal)) continue;
+        valid = constantTimeEqual(signature, &entry.secret);
+        break;
+    }
+    if (!valid) return null;
+    return .{ .remote = true, .principal = principal };
+}
+
+fn constantTimeEqual(provided: []const u8, expected: []const u8) bool {
+    if (provided.len != expected.len) return false;
     var diff: u8 = 0;
-    for (provided, server.token) |a, b| diff |= a ^ b;
+    for (provided, expected) |a, b| diff |= a ^ b;
     return diff == 0;
 }
 
@@ -608,11 +1611,12 @@ fn respondRuntimeFile(server: *Server, conn: *Conn, name: []const u8, fallback: 
 // ------------------------------------------------------------ http helpers
 
 fn respond(conn: *Conn, status: u16, body: []const u8) void {
-    var buf: [1024]u8 = undefined;
+    var buf: [max_request_bytes]u8 = undefined;
     const reason = switch (status) {
         200 => "OK",
         400 => "Bad Request",
         401 => "Unauthorized",
+        408 => "Request Timeout",
         404 => "Not Found",
         409 => "Conflict",
         413 => "Payload Too Large",
@@ -620,11 +1624,13 @@ fn respond(conn: *Conn, status: u16, body: []const u8) void {
         else => "OK",
     };
     const head = std.fmt.bufPrint(&buf, "HTTP/1.1 {d} {s}\r\ncontent-type: application/json\r\ncontent-length: {d}\r\nconnection: close\r\n\r\n", .{ status, reason, body.len }) catch return;
-    var write_buf: [64]u8 = undefined;
-    var writer = conn.stream.writer(conn.io, &write_buf);
-    writer.interface.writeAll(head) catch return;
-    writer.interface.writeAll(body) catch return;
-    writer.interface.flush() catch return;
+    writeAll(conn, head);
+    writeAll(conn, body);
+}
+
+fn writeAll(conn: *Conn, bytes: []const u8) void {
+    conn.writer.writeAll(bytes) catch return;
+    conn.writer.flush() catch return;
 }
 
 fn headerValue(head: []const u8, name: []const u8) ?[]const u8 {
@@ -787,6 +1793,30 @@ fn jsonString(body: []const u8, key: []const u8) ?[]const u8 {
     return body[val_start..i];
 }
 
+fn jsonBool(body: []const u8, key: []const u8) ?bool {
+    const value_start = switch (jsonFieldStart(body, key)) {
+        .value => |value| value,
+        else => return null,
+    };
+    if (std.mem.startsWith(u8, body[value_start..], "true")) {
+        const end = value_start + 4;
+        if (end == body.len or body[end] == ',' or body[end] == '}' or body[end] == ']' or std.ascii.isWhitespace(body[end])) return true;
+    }
+    if (std.mem.startsWith(u8, body[value_start..], "false")) {
+        const end = value_start + 5;
+        if (end == body.len or body[end] == ',' or body[end] == '}' or body[end] == ']' or std.ascii.isWhitespace(body[end])) return false;
+    }
+    return null;
+}
+
+/// Bound a decoded JSON string without splitting a UTF-8 code point.
+fn boundedUtf8(value: []const u8, max: usize) ?[]const u8 {
+    if (!std.unicode.utf8ValidateSlice(value)) return null;
+    var cut = @min(value.len, max);
+    while (cut > 0 and !std.unicode.utf8ValidateSlice(value[0..cut])) cut -= 1;
+    return value[0..cut];
+}
+
 fn normalizeBubbleSession(raw: ?[]const u8, hash_buf: *[64]u8) ?[]const u8 {
     const value = raw orelse return null;
     if (value.len == 0) return null;
@@ -825,6 +1855,213 @@ test "bubble session key prefers and normalizes canonical conversations" {
     const normalized = bubbleSessionKey(body, &hash);
     try std.testing.expectEqual(@as(usize, 64), normalized.len);
     try std.testing.expect(!std.mem.eql(u8, normalized, long[0..64]));
+
+    var title_hash: [64]u8 = undefined;
+    try std.testing.expectEqualStrings(normalized, normalizeBubbleSession(long, &title_hash).?);
+}
+
+fn requestSessionKey(request: *RequestObject, hash_buf: *[64]u8) []const u8 {
+    if (normalizeBubbleSession(request.string("conversation_key"), hash_buf)) |key| return key;
+    if (normalizeBubbleSession(request.string("petdex_conversation_key"), hash_buf)) |key| return key;
+    if (normalizeBubbleSession(request.string("session_key"), hash_buf)) |key| return key;
+    return normalizeBubbleSession(request.string("session_id"), hash_buf) orelse "";
+}
+
+test "bounded decoded strings preserve utf8 boundaries" {
+    try std.testing.expectEqualStrings("abc\\", boundedUtf8("abc\\", 4).?);
+    try std.testing.expectEqualStrings("ab", boundedUtf8("ab🙂", 5).?);
+    try std.testing.expectEqualStrings("ab🙂", boundedUtf8("ab🙂", 6).?);
+    try std.testing.expect(boundedUtf8(&.{0xff}, 8) == null);
+}
+
+test "authenticated provenance rejects contradictory body claims" {
+    const local: AuthContext = .{};
+    const remote: AuthContext = .{ .remote = true, .principal = "buildbox" };
+    try std.testing.expectEqual(AuthClaimConflict.remote, authClaimConflict(local, true, "").?);
+    try std.testing.expectEqual(AuthClaimConflict.remote, authClaimConflict(remote, false, "buildbox").?);
+    try std.testing.expectEqual(AuthClaimConflict.hostname, authClaimConflict(remote, true, "other-host").?);
+    try std.testing.expect(authClaimConflict(remote, null, "") == null);
+    try std.testing.expect(authClaimConflict(remote, true, "buildbox") == null);
+    try std.testing.expect(authClaimConflict(local, false, "client-supplied-local-label") == null);
+}
+
+fn serveOneTestConnection(listener: *std.Io.net.Server, server: *Server, io: std.Io) void {
+    const stream = listener.accept(io) catch return;
+    _ = server.active_connections.fetchAdd(1, .acq_rel);
+    handleConnectionThread(server, stream, io);
+}
+
+fn testSocketDeadline(io: std.Io, milliseconds: i64) std.Io.Clock.Timestamp {
+    const duration: std.Io.Clock.Duration = .{
+        .raw = std.Io.Duration.fromMilliseconds(milliseconds),
+        .clock = .boot,
+    };
+    return std.Io.Clock.Timestamp.fromNow(io, duration);
+}
+
+fn readTestHttpResponse(stream: std.Io.net.Stream, reader: *std.Io.Reader, io: std.Io, buffer: []u8, deadline: std.Io.Clock.Timestamp) ![]const u8 {
+    var total: usize = 0;
+    var expected: ?usize = null;
+    while (total < buffer.len) {
+        const incoming = try readBeforeDeadline(stream, reader, io, buffer[total..], deadline);
+        if (incoming.len == 0) break;
+        total += incoming.len;
+        if (expected == null) {
+            if (std.mem.indexOf(u8, buffer[0..total], "\r\n\r\n")) |at| {
+                const head_len = at + 4;
+                const body_len = if (headerValue(buffer[0..head_len], "content-length")) |raw|
+                    try std.fmt.parseInt(usize, raw, 10)
+                else
+                    0;
+                expected = head_len + body_len;
+            }
+        }
+        if (expected) |length| if (total >= length) return buffer[0..length];
+    }
+    return error.IncompleteHttpResponse;
+}
+
+test "loopback slowloris times out and the next authenticated request succeeds" {
+    // Zig 0.16's Windows test runner cannot connect to and tear down its AFD
+    // listener reliably. The Windows desktop smoke exercises the production
+    // executable's timeout, liveness, slot release, and recovery instead.
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    const runtime_dir = ".zig-cache/petdex-hook-slowloris";
+    plat.makeDir(runtime_dir);
+    var server: Server = .{
+        .allocator = std.testing.allocator,
+        .runtime_dir = runtime_dir,
+        .token = @splat('a'),
+        .pid = 1,
+    };
+    var server_scope = plat.Scope.init();
+    defer server_scope.deinit();
+    const server_io = server_scope.io();
+    var client_scope = plat.Scope.init();
+    defer client_scope.deinit();
+    const client_io = client_scope.io();
+
+    var listener_opt: ?std.Io.net.Server = null;
+    var address: std.Io.net.IpAddress = undefined;
+    for (38171..38271) |port| {
+        address = .{ .ip4 = .loopback(@intCast(port)) };
+        listener_opt = address.listen(server_io, .{
+            .kernel_backlog = 4,
+            .reuse_address = true,
+            .mode = .stream,
+            .protocol = .tcp,
+        }) catch null;
+        if (listener_opt != null) break;
+    }
+    var listener = listener_opt orelse return error.SkipZigTest;
+    defer listener.deinit(server_io);
+    const slow_server_thread = try std.Thread.spawn(.{}, serveOneTestConnection, .{ &listener, &server, server_io });
+
+    var slow = try address.connect(client_io, .{ .mode = .stream, .protocol = .tcp });
+    var slow_write_buf: [256]u8 = undefined;
+    var slow_read_buf: [256]u8 = undefined;
+    var slow_reader = slow.reader(client_io, &slow_read_buf);
+    var slow_writer = slow.writer(client_io, &slow_write_buf);
+    try slow_writer.interface.writeAll("POST /state HTTP/1.1\r\nContent-Length: 32\r\n\r\n{\"state\":\"");
+    try slow_writer.interface.flush();
+    const started = plat.monotonicMs();
+    var response_buf: [512]u8 = undefined;
+    const timeout_response = readTestHttpResponse(slow, &slow_reader.interface, client_io, &response_buf, testSocketDeadline(client_io, 6_000)) catch |err| switch (err) {
+        else => if (builtin.os.tag == .windows) "" else return err,
+    };
+    const elapsed = plat.monotonicMs() - started;
+    slow.close(client_io);
+    slow_server_thread.join();
+    if (builtin.os.tag == .windows)
+        try std.testing.expectEqual(@as(usize, 0), timeout_response.len)
+    else
+        try std.testing.expect(std.mem.indexOf(u8, timeout_response, " 408 ") != null);
+    try std.testing.expect(elapsed >= 1_000 and elapsed < 6_000);
+
+    const healthy_server_thread = try std.Thread.spawn(.{}, serveOneTestConnection, .{ &listener, &server, server_io });
+    var healthy = try address.connect(client_io, .{ .mode = .stream, .protocol = .tcp });
+    var healthy_write_buf: [512]u8 = undefined;
+    var healthy_read_buf: [256]u8 = undefined;
+    var healthy_reader = healthy.reader(client_io, &healthy_read_buf);
+    var healthy_writer = healthy.writer(client_io, &healthy_write_buf);
+    const body = "{\"state\":\"idle\"}";
+    var request_buf: [512]u8 = undefined;
+    const authenticated = try std.fmt.bufPrint(&request_buf, "POST /state HTTP/1.1\r\nContent-Length: {d}\r\nx-petdex-update-token: {s}\r\n\r\n{s}", .{ body.len, &server.token, body });
+    try healthy_writer.interface.writeAll(authenticated);
+    try healthy_writer.interface.flush();
+    const healthy_response = try readTestHttpResponse(healthy, &healthy_reader.interface, client_io, &response_buf, testSocketDeadline(client_io, 3_000));
+    healthy.close(client_io);
+    healthy_server_thread.join();
+    try std.testing.expect(std.mem.indexOf(u8, healthy_response, " 200 ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, healthy_response, "\"ok\":true") != null);
+    try std.testing.expectEqual(@as(u32, 0), server.active_connections.load(.acquire));
+}
+
+test "typed request parsing decodes strings and rejects ambiguity" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const root = try parseRequest(arena.allocator(), "{\"text\":\"quote: \\\" slash: \\\\ line: \\n\",\"busy\":true}");
+    var request: RequestObject = .{ .root = root };
+    try std.testing.expectEqualStrings("quote: \" slash: \\ line: \n", request.string("text").?);
+    try std.testing.expectEqual(true, request.boolean("busy").?);
+    _ = request.string("busy");
+    try std.testing.expect(!request.valid);
+
+    _ = arena.reset(.retain_capacity);
+    const legacy_root = try parseRequest(arena.allocator(), "{\"text\":\"Thinking\",\"agent_source\":null}");
+    var legacy_request: RequestObject = .{ .root = legacy_root };
+    try std.testing.expectEqualStrings("Thinking", legacy_request.string("text").?);
+    try std.testing.expect(legacy_request.string("agent_source") == null);
+    try std.testing.expect(legacy_request.valid);
+
+    _ = arena.reset(.retain_capacity);
+    try std.testing.expectError(error.DuplicateField, parseRequest(arena.allocator(), "{\"text\":\"one\",\"text\":\"two\"}"));
+    try std.testing.expectError(error.InvalidJson, parseRequest(arena.allocator(), "[]"));
+}
+
+test "bubble mirror JSON round trips decoded control and escape characters" {
+    const json = try bubbleMirrorJson(std.testing.allocator, "quote \" slash \\ line\n🙂", 7, "title\tvalue", "codex", "host", true, 42);
+    defer std.testing.allocator.free(json);
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, json, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("quote \" slash \\ line\n🙂", parsed.value.object.get("text").?.string);
+    try std.testing.expectEqualStrings("title\tvalue", parsed.value.object.get("title").?.string);
+    try std.testing.expect(parsed.value.object.get("busy").?.bool);
+}
+
+test "remote credentials are scoped and identify their principal" {
+    var server: Server = undefined;
+    server.token = @splat('a');
+    var token: [128]u8 = undefined;
+    const principal = "buildbox";
+    const scoped = issueRemoteCredential(principal, &token).?;
+    var first_token: [128]u8 = undefined;
+    @memcpy(first_token[0..scoped.len], scoped);
+    const first = first_token[0..scoped.len];
+    var head_buf: [256]u8 = undefined;
+    const head = try std.fmt.bufPrint(&head_buf, "POST /bubble HTTP/1.1\r\nx-petdex-update-token: {s}\r\n\r\n", .{scoped});
+    const auth = authenticate(&server, head).?;
+    try std.testing.expect(auth.remote);
+    try std.testing.expectEqualStrings(principal, auth.principal);
+
+    const rotated = issueRemoteCredential(principal, &token).?;
+    try std.testing.expect(!std.mem.eql(u8, first, rotated));
+    try std.testing.expect(authenticate(&server, head) == null);
+    var rotated_head_buf: [256]u8 = undefined;
+    const rotated_head = try std.fmt.bufPrint(&rotated_head_buf, "POST /bubble HTTP/1.1\r\nx-petdex-update-token: {s}\r\n\r\n", .{rotated});
+    try std.testing.expectEqualStrings(principal, authenticate(&server, rotated_head).?.principal);
+
+    var peer_token_buf: [128]u8 = undefined;
+    const peer = issueRemoteCredential("peer", &peer_token_buf).?;
+    var peer_head_buf: [256]u8 = undefined;
+    const peer_head = try std.fmt.bufPrint(&peer_head_buf, "POST /bubble HTTP/1.1\r\nx-petdex-update-token: {s}\r\n\r\n", .{peer});
+    try std.testing.expectEqualStrings("peer", authenticate(&server, peer_head).?.principal);
+
+    revokeRemoteCredential(principal);
+    try std.testing.expect(authenticate(&server, rotated_head) == null);
+    try std.testing.expectEqualStrings("peer", authenticate(&server, peer_head).?.principal);
+    revokeRemoteCredential("peer");
+    try std.testing.expect(authenticate(&server, peer_head) == null);
 }
 
 test "two sessions hold two bubbles and neither overwrites the other" {
@@ -849,6 +2086,20 @@ test "two sessions hold two bubbles and neither overwrites the other" {
     try std.testing.expectEqual(beta_counter, out[1].counter);
 }
 
+test "mailbox canonicalizes long provider identities before matching" {
+    var mb: Mailbox = .{};
+    const prefix = "provider/session/identity/with/a/shared-prefix-that-is-longer-than-the-storage-boundary/";
+    const first = prefix ++ "alpha";
+    const second = prefix ++ "beta";
+    _ = mb.applyBubbleUpdate(.{ .conversation_key = first, .source_session = first, .text = "one", .agent = "codex", .feed_source = .native_store });
+    _ = mb.applyBubbleUpdate(.{ .conversation_key = second, .source_session = second, .text = "two", .agent = "codex", .feed_source = .native_store });
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 2), mb.takeBubbles(&out));
+    try std.testing.expectEqual(@as(usize, 64), out[0].session_len);
+    try std.testing.expectEqual(@as(usize, 64), out[1].session_len);
+    try std.testing.expect(!std.mem.eql(u8, out[0].sessionSlice(), out[1].sessionSlice()));
+}
+
 test "bubble metadata preserves the Herdr pane id" {
     var mb: Mailbox = .{};
     _ = mb.setBubbleWithMetadata("herdr:w1:p5", "Needs approval", "cursor", "Fix auth", .terminal, "", "/repo", "w1:p5", false);
@@ -856,6 +2107,423 @@ test "bubble metadata preserves the Herdr pane id" {
     var out: [max_bubbles]Bubble = @splat(.{});
     try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
     try std.testing.expectEqualStrings("w1:p5", out[0].herdrPaneSlice());
+}
+
+test "keyed bubble retains omitted title and accepts a later server rename" {
+    var mb: Mailbox = .{};
+    _ = mb.setBubble("thread-7", "Thinking…", "codex", "Prompt fallback", true);
+    // Tool hooks normally omit title. This update must not clear the card.
+    _ = mb.setBubble("thread-7", "Reading main.zig", "codex", "", true);
+
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqualStrings("Prompt fallback", out[0].title[0..out[0].title_len]);
+
+    // The authoritative title may arrive after the first prompt or change on
+    // the server while the session is alive. Non-empty always wins.
+    _ = mb.setBubble("thread-7", "Running tests", "codex", "Server generated title", true);
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqualStrings("Server generated title", out[0].title[0..out[0].title_len]);
+
+    // Sessionless callers share one compatibility slot; retaining here would
+    // leak a title between unrelated legacy agents.
+    _ = mb.setBubble("", "first", "codex", "Legacy title", true);
+    _ = mb.setBubble("", "second", "gemini", "", true);
+    try std.testing.expectEqual(@as(?usize, 2), mb.takeBubbles(&out));
+    for (out[0..2]) |bubble| {
+        if (bubble.session_len == 0) try std.testing.expectEqual(@as(usize, 0), bubble.title_len);
+    }
+}
+
+test "title-only sync updates an existing session without changing its message" {
+    var mb: Mailbox = .{};
+    _ = mb.setBubble("thread-9", "Running tests", "opencode", "Old title", true);
+    try std.testing.expect(mb.setBubbleTitle("thread-9", "Renamed on server") != null);
+    // Duplicate server events are a no-op for rendering and retain the same
+    // counter, while unknown/sessionless titles never create ghost cards.
+    const duplicate_counter = mb.setBubbleTitle("thread-9", "Renamed on server").?;
+    try std.testing.expect(mb.setBubbleTitle("missing", "No ghost") == null);
+    try std.testing.expect(mb.setBubbleTitle("", "No legacy leak") == null);
+
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqualStrings("Running tests", out[0].text[0..out[0].text_len]);
+    try std.testing.expectEqualStrings("Renamed on server", out[0].title[0..out[0].title_len]);
+    try std.testing.expectEqual(duplicate_counter, out[0].counter);
+    try std.testing.expect(out[0].busy);
+}
+
+test "title-only sync can target one agent and host sharing a conversation id" {
+    var mb: Mailbox = .{};
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "shared",
+        .source_session = "shared",
+        .text = "Local work",
+        .agent = "opencode",
+        .title = "Local title",
+        .hostname = "mac",
+        .remote = false,
+        .busy = true,
+    });
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "shared",
+        .source_session = "shared",
+        .text = "Remote work",
+        .agent = "opencode",
+        .title = "Remote title",
+        .hostname = "inframework",
+        .remote = true,
+        .busy = true,
+    });
+    try std.testing.expect(mb.setBubbleTitleIdentity("shared", "Remote rename", "opencode", "inframework", true, true) != null);
+
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 2), mb.takeBubbles(&out));
+    for (out[0..2]) |*bubble| {
+        if (bubble.remote) {
+            try std.testing.expectEqualStrings("Remote rename", bubble.title[0..bubble.title_len]);
+        } else {
+            try std.testing.expectEqualStrings("Local title", bubble.title[0..bubble.title_len]);
+        }
+    }
+}
+
+test "bubble context preserves host turn remote and launch metadata" {
+    var mb: Mailbox = .{};
+    _ = mb.setBubbleWithContext(
+        "thread-7",
+        "Running tests",
+        "codex",
+        "Revamp bubbles",
+        .codex,
+        "/dev/ttys003",
+        "/work/petdex",
+        "inframework",
+        "turn-9",
+        true,
+        true,
+    );
+
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqualStrings("inframework", out[0].hostnameSlice());
+    try std.testing.expectEqualStrings("turn-9", out[0].turnSlice());
+    try std.testing.expect(out[0].remote);
+    try std.testing.expectEqual(plat.OriginApplication.codex, out[0].origin_app);
+    try std.testing.expectEqualStrings("/work/petdex", out[0].cwdSlice());
+}
+
+test "canonical identity includes agent locality and remote host" {
+    var mb: Mailbox = .{};
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "conversation-1",
+        .source_session = "raw-local",
+        .agent = "codex",
+        .hostname = "shakib-mac",
+        .text = "Local Codex",
+        .status = .running,
+    });
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "conversation-1",
+        .source_session = "raw-remote",
+        .agent = "codex",
+        .hostname = "inframework",
+        .remote = true,
+        .text = "Remote Codex",
+        .status = .running,
+    });
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "conversation-1",
+        .source_session = "raw-hermes",
+        .agent = "hermes",
+        .hostname = "inframework",
+        .remote = true,
+        .text = "Remote Hermes",
+        .status = .running,
+    });
+
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 3), mb.takeBubbles(&out));
+}
+
+test "authoritative subagent update retracts provisional child card" {
+    var mb: Mailbox = .{};
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "root-conversation",
+        .source_session = "root-session",
+        .agent = "hermes",
+        .hostname = "inframework",
+        .remote = true,
+        .text = "Parent is working",
+        .message_kind = .reasoning,
+        .status = .running,
+    });
+    // Simulate the persistence race: the child's first hook was initially
+    // treated as a primary conversation under its raw session id.
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "child-session",
+        .source_session = "child-session",
+        .agent = "hermes",
+        .hostname = "inframework",
+        .remote = true,
+        .text = "Called terminal",
+        .message_kind = .tool,
+        .status = .running,
+    });
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "root-conversation",
+        .source_session = "child-session",
+        .parent_session = "root-session",
+        .session_kind = .subagent,
+        .agent = "hermes",
+        .hostname = "inframework",
+        .remote = true,
+        .text = "Called search_files",
+        .message_kind = .tool,
+        .status = .running,
+    });
+
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqualStrings("root-conversation", out[0].sessionSlice());
+    try std.testing.expectEqualStrings("Parent is working", out[0].text[0..out[0].text_len]);
+}
+
+test "subagent tool noise is ignored and assistant prose folds into parent" {
+    var mb: Mailbox = .{};
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "root-conversation",
+        .source_session = "root-session",
+        .agent = "hermes",
+        .hostname = "inframework",
+        .remote = true,
+        .text = "Working on the request",
+        .message_kind = .reasoning,
+        .status = .running,
+    });
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "root-conversation",
+        .source_session = "child-session",
+        .parent_session = "root-session",
+        .session_kind = .subagent,
+        .subagent_label = "Research",
+        .agent = "hermes",
+        .hostname = "inframework",
+        .remote = true,
+        .text = "Called terminal",
+        .message_kind = .tool,
+        .status = .running,
+    });
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "root-conversation",
+        .source_session = "child-session",
+        .parent_session = "root-session",
+        .session_kind = .subagent,
+        .subagent_label = "Research",
+        .agent = "hermes",
+        .hostname = "inframework",
+        .remote = true,
+        .text = "The migration needs one compatibility shim.",
+        .message_id = "child-message-1",
+        .message_kind = .assistant,
+        .status = .completed,
+    });
+
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqualStrings("Working on the request", out[0].text[0..out[0].text_len]);
+    try std.testing.expectEqual(@as(usize, 1), out[0].child_messages_len);
+    try std.testing.expectEqualStrings("Research", out[0].child_messages[0].labelSlice());
+    try std.testing.expectEqualStrings("The migration needs one compatibility shim.", out[0].child_messages[0].textSlice());
+}
+
+test "subagent prose is deduplicated and bounded to eight recent entries" {
+    var mb: Mailbox = .{};
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "root",
+        .source_session = "root",
+        .agent = "codex",
+        .text = "Parent",
+        .status = .running,
+    });
+    for (0..10) |index| {
+        var text_buf: [32]u8 = undefined;
+        var id_buf: [32]u8 = undefined;
+        const child_text = std.fmt.bufPrint(&text_buf, "Child answer {d}", .{index}) catch unreachable;
+        const message_id = std.fmt.bufPrint(&id_buf, "child-{d}", .{index}) catch unreachable;
+        _ = mb.applyBubbleUpdate(.{
+            .conversation_key = "root",
+            .source_session = "child",
+            .session_kind = .subagent,
+            .subagent_label = "Worker",
+            .agent = "codex",
+            .text = child_text,
+            .message_id = message_id,
+            .message_kind = .assistant,
+        });
+    }
+    // A replay updates ordering but does not create a ninth row.
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "root",
+        .source_session = "child",
+        .session_kind = .subagent,
+        .subagent_label = "Worker",
+        .agent = "codex",
+        .text = "Child answer 9",
+        .message_id = "child-9",
+        .message_kind = .assistant,
+    });
+
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqual(max_child_messages, out[0].child_messages_len);
+    try std.testing.expectEqualStrings("Child answer 2", out[0].child_messages[0].textSlice());
+    try std.testing.expectEqualStrings("Child answer 9", out[0].child_messages[max_child_messages - 1].textSlice());
+}
+
+test "assistant prose survives tool summaries and server title survives prompt fallback" {
+    var mb: Mailbox = .{};
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "thread",
+        .source_session = "thread",
+        .agent = "codex",
+        .title = "Authoritative title",
+        .title_source = .server,
+        .text = "Here is the actual assistant response.",
+        .message_kind = .assistant,
+        .status = .running,
+    });
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "thread",
+        .source_session = "thread",
+        .agent = "codex",
+        .title = "Intermediate prompt",
+        .title_source = .prompt,
+        .text = "Called terminal",
+        .message_kind = .tool,
+        .status = .running,
+    });
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqualStrings("Authoritative title", out[0].title[0..out[0].title_len]);
+    try std.testing.expectEqualStrings("Here is the actual assistant response.", out[0].text[0..out[0].text_len]);
+}
+
+test "pending inputs obey attention precedence until matching responses arrive" {
+    var mb: Mailbox = .{};
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "thread",
+        .source_session = "thread",
+        .agent = "codex",
+        .text = "Approve launch?",
+        .message_id = "approval-1",
+        .message_kind = .prompt,
+        .status = .needs_input,
+    });
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "thread",
+        .source_session = "thread",
+        .agent = "codex",
+        .text = "Choose a host",
+        .message_id = "question-2",
+        .message_kind = .prompt,
+        .status = .needs_input,
+    });
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "thread",
+        .source_session = "thread",
+        .agent = "codex",
+        .text = "Continuing",
+        .message_id = "approval-1",
+        .resolves_request_id = "approval-1",
+        .message_kind = .status,
+        .status = .running,
+    });
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqual(SessionStatus.needs_input, out[0].status);
+    try std.testing.expectEqual(@as(usize, 1), out[0].pending_input_ids_len);
+
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "thread",
+        .source_session = "thread",
+        .agent = "codex",
+        .text = "Thinking…",
+        .message_id = "question-2",
+        .resolves_request_id = "question-2",
+        .message_kind = .status,
+        .status = .running,
+    });
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqual(SessionStatus.running, out[0].status);
+    try std.testing.expectEqual(@as(usize, 0), out[0].pending_input_ids_len);
+}
+
+test "generic notifications and waiting phases never manufacture attention" {
+    for ([_][]const u8{ "notification", "waiting" }) |event_kind| {
+        var mb: Mailbox = .{};
+        _ = mb.applyBubbleUpdate(.{
+            .conversation_key = "thread",
+            .source_session = "thread",
+            .agent = "claude-code",
+            .text = "Informational event",
+            .event_kind = event_kind,
+            .notification_kind = "unknown_future_type",
+            .message_kind = .prompt,
+            .status = .needs_input,
+        });
+        var out: [max_bubbles]Bubble = @splat(.{});
+        try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+        try std.testing.expectEqual(SessionStatus.idle, out[0].status);
+        try std.testing.expectEqual(@as(usize, 0), out[0].pending_input_ids_len);
+        try std.testing.expect(!out[0].pending_unkeyed_input);
+    }
+}
+
+test "documented notification prompts create one bounded unkeyed request" {
+    for ([_][]const u8{ "permission_prompt", "elicitation_dialog", "elicitation_url_dialog", "agent_needs_input" }) |kind| {
+        var mb: Mailbox = .{};
+        _ = mb.applyBubbleUpdate(.{
+            .conversation_key = "thread",
+            .source_session = "thread",
+            .agent = "claude-code",
+            .text = "Waiting for you",
+            .event_kind = "notification",
+            .notification_kind = kind,
+            .message_kind = .prompt,
+            .status = .idle,
+        });
+        var out: [max_bubbles]Bubble = @splat(.{});
+        try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+        try std.testing.expectEqual(SessionStatus.needs_input, out[0].status);
+        try std.testing.expect(out[0].pending_unkeyed_input);
+    }
+}
+
+test "definitive tool progress clears only the unkeyed fallback" {
+    var mb: Mailbox = .{};
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "thread",
+        .source_session = "thread",
+        .agent = "hermes",
+        .text = "Approve?",
+        .event_kind = "approval-request",
+        .message_kind = .prompt,
+        .status = .needs_input,
+    });
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "thread",
+        .source_session = "thread",
+        .agent = "hermes",
+        .text = "Calling terminal",
+        .event_kind = "tool-progress",
+        .message_kind = .tool,
+        .status = .running,
+    });
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqual(SessionStatus.running, out[0].status);
+    try std.testing.expect(!out[0].pending_unkeyed_input);
 }
 
 test "a sessionless agent keeps the single shared slot" {
@@ -899,6 +2567,209 @@ test "takeBubbles only reports a set that changed" {
     _ = mb.setBubble("alpha", "hello", "codex", "", true);
     try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
     try std.testing.expectEqual(@as(?usize, null), mb.takeBubbles(&out));
+}
+
+test "identical running snapshots do not dirty the mailbox" {
+    var mb: Mailbox = .{};
+    const update = BubbleUpdate{
+        .conversation_key = "alpha",
+        .source_session = "alpha",
+        .agent = "codex",
+        .text = "Reading project files",
+        .message_id = "event-1",
+        .event_kind = "agent-progress",
+        .message_kind = .tool,
+        .status = .running,
+    };
+    const first = mb.applyBubbleUpdate(update);
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expect(out[0].last_meaningful_activity_ms > 0);
+
+    const duplicate = mb.applyBubbleUpdate(update);
+    try std.testing.expectEqual(first, duplicate);
+    try std.testing.expectEqual(@as(?usize, null), mb.takeBubbles(&out));
+    try std.testing.expectEqual(@as(u64, 1), mb.bubbleRenderDebugCounters().suppressed_duplicates);
+}
+
+test "stale running cards become idle until meaningful work resumes" {
+    var mb: Mailbox = .{};
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "alpha",
+        .source_session = "alpha",
+        .agent = "codex",
+        .text = "Reading project files",
+        .message_id = "event-1",
+        .event_kind = "agent-progress",
+        .message_kind = .tool,
+        .status = .running,
+    });
+    var out: [max_bubbles]Bubble = @splat(.{});
+    _ = mb.takeBubbles(&out);
+    const last_activity = out[0].last_meaningful_activity_ms;
+    try std.testing.expectEqual(@as(usize, 1), mb.suppressStaleRunning(last_activity + 30_000, 30_000));
+    try std.testing.expectEqual(@as(u64, 1), mb.bubbleRenderDebugCounters().stale_transitions);
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqual(SessionStatus.idle, out[0].status);
+    try std.testing.expect(out[0].stale_running_suppressed);
+
+    // A replayed heartbeat cannot restart the animation.
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "alpha",
+        .source_session = "alpha",
+        .agent = "codex",
+        .text = "Reading project files",
+        .message_id = "event-1",
+        .event_kind = "agent-progress",
+        .message_kind = .tool,
+        .status = .running,
+    });
+    try std.testing.expectEqual(@as(?usize, null), mb.takeBubbles(&out));
+
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "alpha",
+        .source_session = "alpha",
+        .agent = "codex",
+        .text = "Read package manifest",
+        .message_id = "event-2",
+        .event_kind = "agent-progress",
+        .message_kind = .tool,
+        .status = .running,
+    });
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqual(SessionStatus.running, out[0].status);
+    try std.testing.expect(!out[0].stale_running_suppressed);
+}
+
+test "unkeyed running cards still become stale after their initial lease" {
+    var mb: Mailbox = .{};
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "alpha",
+        .source_session = "alpha",
+        .agent = "legacy",
+        .status = .running,
+    });
+    var out: [max_bubbles]Bubble = @splat(.{});
+    _ = mb.takeBubbles(&out);
+    try std.testing.expect(out[0].last_meaningful_activity_ms > 0);
+    const lease = out[0].last_meaningful_activity_ms;
+    try std.testing.expectEqual(@as(usize, 1), mb.suppressStaleRunning(lease + 30_000, 30_000));
+    _ = mb.takeBubbles(&out);
+    try std.testing.expectEqual(SessionStatus.idle, out[0].status);
+
+    // A generic heartbeat cannot reanimate a card that has been quieted.
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "alpha",
+        .source_session = "alpha",
+        .agent = "legacy",
+        .status = .running,
+    });
+    try std.testing.expectEqual(@as(?usize, null), mb.takeBubbles(&out));
+}
+
+/// Lower a canonical bubble JSON record directly into a mailbox. Startup
+/// journals and passive provider adapters use this path so their validation,
+/// bounded identity, pending-input correlation, and subagent behavior cannot
+/// drift from the loopback HTTP endpoint. `feed_source` is transport-owned and
+/// therefore overrides an untrusted or stale value in the record.
+pub fn applyBubbleJson(target: *Mailbox, body: []const u8, feed_source: FeedSource) ?u64 {
+    if (body.len == 0 or body.len > max_request_bytes) return null;
+    var json_memory: [max_request_bytes * 2]u8 = undefined;
+    var fixed = std.heap.FixedBufferAllocator.init(&json_memory);
+    const root = parseRequest(fixed.allocator(), body) catch return null;
+    var request: RequestObject = .{ .root = root };
+
+    const text = boundedUtf8(request.string("text") orelse return null, bubble_text_capacity) orelse return null;
+    const agent = boundedUtf8(request.string("agent_source") orelse return null, 24) orelse return null;
+    const title = boundedUtf8(request.string("title") orelse "", bubble_title_capacity) orelse return null;
+    const source_app = request.string("source_app");
+    const origin_app = plat.OriginApplication.fromTermProgram(source_app);
+    const source_tty = plat.safeSourceTty(request.string("source_tty")) orelse "";
+    const source_cwd = plat.safeSourceCwd(request.string("source_cwd")) orelse "";
+    const hostname = boundedUtf8(request.string("hostname") orelse "", 64) orelse return null;
+    const turn = boundedUtf8(request.string("turn_id") orelse "", 64) orelse return null;
+    const message_id = boundedUtf8(request.string("message_id") orelse "", bubble_message_id_capacity) orelse return null;
+    const event_kind = boundedUtf8(request.string("event_kind") orelse "", 48) orelse return null;
+    const request_id = boundedUtf8(request.string("request_id") orelse "", bubble_message_id_capacity) orelse return null;
+    const resolves_request_id = boundedUtf8(request.string("resolves_request_id") orelse "", bubble_message_id_capacity) orelse return null;
+    const notification_kind = boundedUtf8(request.string("notification_kind") orelse "", 64) orelse return null;
+    const parent_session = request.string("parent_session_id") orelse "";
+    const subagent_label = boundedUtf8(request.string("subagent_label") orelse "", 48) orelse return null;
+    const remote = request.boolean("remote") orelse false;
+    const busy = request.boolean("busy") orelse false;
+    var conversation_hash: [64]u8 = undefined;
+    const conversation = requestSessionKey(&request, &conversation_hash);
+    const session = request.string("session_id") orelse "";
+    const source_session = request.string("source_session_id") orelse session;
+    const status: ?SessionStatus = if (request.string("status")) |raw| SessionStatus.fromWire(raw) orelse return null else null;
+    const session_kind = request.string("session_kind") orelse "primary";
+    const message_kind = request.string("message_kind") orelse event_kind;
+    const title_source = request.string("title_source") orelse "unknown";
+    _ = request.string("feed_source");
+    if (!request.valid) return null;
+    return target.applyBubbleUpdate(.{
+        .conversation_key = conversation[0..@min(conversation.len, bubble_session_capacity)],
+        .source_session = source_session,
+        .parent_session = parent_session,
+        .text = text,
+        .agent = agent,
+        .title = title,
+        .origin_app = origin_app,
+        .source_tty = source_tty,
+        .source_cwd = source_cwd,
+        .hostname = hostname,
+        .turn = turn,
+        .message_id = message_id,
+        .event_kind = event_kind,
+        .request_id = request_id,
+        .resolves_request_id = resolves_request_id,
+        .notification_kind = notification_kind,
+        .subagent_label = subagent_label,
+        .remote = remote,
+        .busy = busy,
+        .status = status,
+        .session_kind = SessionKind.fromWire(session_kind),
+        .message_kind = MessageKind.fromWire(message_kind),
+        .title_source = TitleSource.fromWire(title_source),
+        .feed_source = feed_source,
+    });
+}
+
+test "journal lowering decodes escaped Unicode and preserves UTF-8 boundaries" {
+    var mb: Mailbox = .{};
+    const body =
+        "{\"text\":\"quote: \\\" slash: \\\\ line: \\n smile: \\u263a \\ud83d\\ude42\",\"agent_source\":\"codex\",\"session_id\":\"escaped\",\"message_id\":\"id-\\u263a\",\"busy\":true}";
+    try std.testing.expect(applyBubbleJson(&mb, body, .journal) != null);
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqualStrings("quote: \" slash: \\ line: \n smile: ☺ 🙂", out[0].text[0..out[0].text_len]);
+    try std.testing.expectEqualStrings("id-☺", out[0].message_id[0..out[0].message_id_len]);
+    try std.testing.expect(std.unicode.utf8ValidateSlice(out[0].text[0..out[0].text_len]));
+}
+
+test "journal lowering hashes long source identities before bounded storage" {
+    const shared = "provider/session/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const first = shared ++ "-first";
+    const second = shared ++ "-second";
+    try std.testing.expect(first.len > bubble_session_capacity and second.len > bubble_session_capacity);
+    var first_buf: [512]u8 = undefined;
+    var second_buf: [512]u8 = undefined;
+    const first_body = try std.fmt.bufPrint(&first_buf, "{{\"text\":\"one\",\"agent_source\":\"codex\",\"conversation_key\":\"one\",\"source_session_id\":\"{s}\"}}", .{first});
+    const second_body = try std.fmt.bufPrint(&second_buf, "{{\"text\":\"two\",\"agent_source\":\"codex\",\"conversation_key\":\"two\",\"source_session_id\":\"{s}\"}}", .{second});
+    var mb: Mailbox = .{};
+    try std.testing.expect(applyBubbleJson(&mb, first_body, .journal) != null);
+    try std.testing.expect(applyBubbleJson(&mb, second_body, .journal) != null);
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 2), mb.takeBubbles(&out));
+    try std.testing.expectEqual(@as(usize, 64), out[0].source_session_len);
+    try std.testing.expectEqual(@as(usize, 64), out[1].source_session_len);
+    try std.testing.expect(!std.mem.eql(u8, out[0].source_session[0..out[0].source_session_len], out[1].source_session[0..out[1].source_session_len]));
+}
+
+test "journal lowering rejects duplicate and malformed field types" {
+    var mb: Mailbox = .{};
+    try std.testing.expect(applyBubbleJson(&mb, "{\"text\":\"one\",\"text\":\"two\",\"agent_source\":\"codex\"}", .journal) == null);
+    try std.testing.expect(applyBubbleJson(&mb, "{\"text\":7,\"agent_source\":\"codex\"}", .journal) == null);
 }
 
 test "dropping a session frees its slot and keeps the rest dense" {
@@ -984,16 +2855,26 @@ test "unqueued state never reaches the runtime mirror" {
     try std.testing.expectEqual(@as(u64, 0), server.last_state_mirror);
 }
 
-test "running state alternates without sharing mutable state with callers" {
-    var server = Server{
-        .allocator = std.testing.allocator,
-        .runtime_dir = "",
-        .token = undefined,
-        .pid = 0,
-    };
-    try std.testing.expectEqualStrings("running-right", server.nextRunningState());
-    try std.testing.expectEqualStrings("running-left", server.nextRunningState());
-    try std.testing.expectEqualStrings("running-right", server.nextRunningState());
+test "steady running state stays coalesced after the mailbox drains" {
+    var box: Mailbox = .{};
+    var running = StateEvent{};
+    running.state_len = "running".len;
+    @memcpy(running.state[0..running.state_len], "running");
+    try std.testing.expect(box.enqueue(running));
+    _ = box.pop();
+    try std.testing.expect(!box.enqueue(running));
+
+    var review = StateEvent{};
+    review.state_len = "review".len;
+    @memcpy(review.state[0..review.state_len], "review");
+    try std.testing.expect(box.enqueue(review));
+
+    var directional_running = StateEvent{};
+    directional_running.state_len = "running-left".len;
+    @memcpy(directional_running.state[0..directional_running.state_len], "running-left");
+    try std.testing.expect(box.enqueue(directional_running));
+    _ = box.pop();
+    try std.testing.expect(!box.enqueue(running));
 }
 
 fn jsonNumber(body: []const u8, key: []const u8) ?f64 {
@@ -1056,15 +2937,28 @@ fn mirrorQueuedState(server: *Server, state: []const u8, result: Mailbox.Enqueue
     try mirrorState(server, state, result.counter);
 }
 
-fn mirrorBubble(server: *Server, text: []const u8, counter: u64, title: []const u8, agent: []const u8, busy: bool) !void {
+fn mirrorBubble(server: *Server, text: []const u8, counter: u64, title: []const u8, agent: []const u8, hostname: []const u8, busy: bool) !void {
     var scope = plat.Scope.init();
     defer scope.deinit();
     const io = scope.io();
     server.mirror_lock.lock(io);
     defer server.mirror_lock.unlock(io);
     if (counter < server.last_bubble_mirror) return;
-    var buf: [1024]u8 = undefined;
-    const json = try std.fmt.bufPrint(&buf, "{{\"text\":\"{s}\",\"title\":\"{s}\",\"agent_source\":\"{s}\",\"busy\":{},\"counter\":{d},\"at\":{d}}}", .{ text, title, agent, busy, counter, nowMs() });
+    var memory: [max_request_bytes]u8 = undefined;
+    var fixed = std.heap.FixedBufferAllocator.init(&memory);
+    const json = try bubbleMirrorJson(fixed.allocator(), text, counter, title, agent, hostname, busy, nowMs());
     try writeRuntimeFile(server, "bubble.json", json, 0o644);
     server.last_bubble_mirror = counter;
+}
+
+fn bubbleMirrorJson(allocator: std.mem.Allocator, text: []const u8, counter: u64, title: []const u8, agent: []const u8, hostname: []const u8, busy: bool, at: i64) ![]u8 {
+    return std.json.Stringify.valueAlloc(allocator, .{
+        .text = text,
+        .title = title,
+        .agent_source = agent,
+        .hostname = hostname,
+        .busy = busy,
+        .counter = counter,
+        .at = at,
+    }, .{});
 }

--- a/packages/petdex-desktop-native/src/plat.zig
+++ b/packages/petdex-desktop-native/src/plat.zig
@@ -121,6 +121,51 @@ pub fn writeFileMode(path: []const u8, bytes: []const u8, mode: u16) bool {
     return writeFileIo(scope.io(), path, bytes, mode);
 }
 
+/// Append one bounded record and retain one rotated generation. A sibling
+/// advisory lock serializes concurrent hook processes across size, rotation,
+/// and write operations.
+pub fn appendFileModeRotating(path: []const u8, bytes: []const u8, mode: u16, rotate_at: u64) bool {
+    if (bytes.len == 0 or @as(u64, @intCast(bytes.len)) > rotate_at) return false;
+    var scope = Scope.init();
+    defer scope.deinit();
+    const io = scope.io();
+    var cwd = std.Io.Dir.cwd();
+
+    var lock_path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}.lock", .{path}) catch return false;
+    var lock_file = cwd.createFile(io, lock_path, .{
+        .read = true,
+        .truncate = false,
+        .lock = .exclusive,
+        .permissions = permissionsFromMode(mode),
+    }) catch return false;
+    defer lock_file.close(io);
+
+    var current_size: u64 = 0;
+    if (cwd.statFile(io, path, .{})) |stat| {
+        if (stat.kind != .file) return false;
+        current_size = stat.size;
+    } else |_| {}
+
+    if (current_size + @as(u64, @intCast(bytes.len)) > rotate_at) {
+        var previous_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+        const previous = std.fmt.bufPrint(&previous_buf, "{s}.1", .{path}) catch return false;
+        cwd.deleteFile(io, previous) catch {};
+        cwd.rename(path, cwd, previous, io) catch return false;
+        current_size = 0;
+    }
+
+    var file = cwd.createFile(io, path, .{
+        .read = true,
+        .truncate = false,
+        .permissions = permissionsFromMode(mode),
+    }) catch return false;
+    defer file.close(io);
+    file.writePositionalAll(io, bytes, current_size) catch return false;
+    file.sync(io) catch return false;
+    return true;
+}
+
 fn writeFileIo(io: std.Io, path: []const u8, bytes: []const u8, mode: ?u16) bool {
     // Replacing a symlink path atomically replaces the link itself. Runtime
     // files are user-managed, and a symlink is a supported way to relocate
@@ -155,6 +200,22 @@ fn permissionsFromMode(mode: ?u16) std.Io.File.Permissions {
     const m = mode orelse return .default_file;
     if (builtin.os.tag == .windows) return .default_file;
     return @enumFromInt(m);
+}
+
+test "rotating append retains one private previous generation" {
+    const dir = ".zig-cache/petdex-plat-append";
+    const path = dir ++ "/journal.jsonl";
+    makeDir(dir);
+    deleteFile(path);
+    deleteFile(path ++ ".1");
+    deleteFile(path ++ ".lock");
+    try std.testing.expect(appendFileModeRotating(path, "one\n", 0o600, 9));
+    try std.testing.expect(appendFileModeRotating(path, "two\n", 0o600, 9));
+    try std.testing.expect(appendFileModeRotating(path, "three\n", 0o600, 9));
+    var current_buf: [32]u8 = undefined;
+    var prior_buf: [32]u8 = undefined;
+    try std.testing.expectEqualStrings("three\n", readFile(path, &current_buf).?);
+    try std.testing.expectEqualStrings("one\ntwo\n", readFile(path ++ ".1", &prior_buf).?);
 }
 
 pub fn makeDir(path: []const u8) void {
@@ -281,6 +342,14 @@ pub fn nowMs() i64 {
     return @intCast(@divTrunc(ns, std.time.ns_per_ms));
 }
 
+/// Process-local monotonic time for leases, rate limits, and deadlines.
+pub fn monotonicMs() i64 {
+    var scope = Scope.init();
+    defer scope.deinit();
+    const ns = std.Io.Timestamp.now(scope.io(), .boot).nanoseconds;
+    return @intCast(@divTrunc(ns, std.time.ns_per_ms));
+}
+
 pub fn nowSeconds() i64 {
     return @divTrunc(nowMs(), 1000);
 }
@@ -387,6 +456,32 @@ pub fn processId() u32 {
     };
 }
 
+/// Short machine name for session provenance. Invalid or unavailable host
+/// metadata is ignored by the caller.
+pub fn hostName(buf: []u8) ?[]const u8 {
+    if (comptime builtin.os.tag == .windows) {
+        const Win = struct {
+            extern "kernel32" fn GetComputerNameA(buffer: [*]u8, size: *u32) callconv(.winapi) c_int;
+        };
+        if (buf.len == 0 or buf.len > std.math.maxInt(u32)) return null;
+        var length: u32 = @intCast(buf.len);
+        if (Win.GetComputerNameA(buf.ptr, &length) == 0 or length == 0) return null;
+        const name = buf[0..length];
+        for (name) |ch| {
+            if (!std.ascii.isAlphanumeric(ch) and ch != '-' and ch != '_' and ch != '.') return null;
+        }
+        return name;
+    }
+    var raw: [std.posix.HOST_NAME_MAX]u8 = undefined;
+    const name = std.posix.gethostname(&raw) catch return null;
+    if (name.len == 0 or name.len > buf.len) return null;
+    for (name) |ch| {
+        if (!std.ascii.isAlphanumeric(ch) and ch != '-' and ch != '_' and ch != '.') return null;
+    }
+    @memcpy(buf[0..name.len], name);
+    return buf[0..name.len];
+}
+
 /// GUI application that owns the terminal hosting the latest agent event.
 /// Hook metadata is allowlisted and never becomes an arbitrary bundle id.
 pub const OriginApplication = enum(u8) {
@@ -397,21 +492,24 @@ pub const OriginApplication = enum(u8) {
     /// terminal rows this is intentionally not a bundle identifier: the
     /// active HTTP handler is resolved at click time on macOS.
     default_browser,
+    codex,
 
     pub fn fromTermProgram(value: ?[]const u8) OriginApplication {
         const name = value orelse return .none;
-        if (std.mem.eql(u8, name, "Apple_Terminal")) return .terminal;
-        if (std.mem.eql(u8, name, "vscode")) return .vscode;
-        if (std.mem.eql(u8, name, "default_browser")) return .default_browser;
+        if (std.mem.eql(u8, name, "Apple_Terminal") or std.ascii.eqlIgnoreCase(name, "Windows_Terminal") or std.ascii.eqlIgnoreCase(name, "WindowsTerminal")) return .terminal;
+        if (std.ascii.eqlIgnoreCase(name, "vscode") or std.ascii.eqlIgnoreCase(name, "Visual Studio Code")) return .vscode;
+        if (std.ascii.eqlIgnoreCase(name, "default_browser")) return .default_browser;
+        if (std.ascii.eqlIgnoreCase(name, "codex") or std.ascii.eqlIgnoreCase(name, "ChatGPT")) return .codex;
         return .none;
     }
 
     pub fn wireName(self: OriginApplication) []const u8 {
         return switch (self) {
             .none => "",
-            .terminal => "Apple_Terminal",
+            .terminal => if (builtin.os.tag == .windows) "Windows_Terminal" else "Apple_Terminal",
             .vscode => "vscode",
             .default_browser => "default_browser",
+            .codex => "codex",
         };
     }
 
@@ -421,9 +519,18 @@ pub const OriginApplication = enum(u8) {
             .terminal => "com.apple.Terminal",
             .vscode => "com.microsoft.VSCode",
             .default_browser => null,
+            .codex => "com.openai.codex",
         };
     }
 };
+
+test "origin metadata recognizes allowlisted desktop application hints" {
+    try std.testing.expectEqual(OriginApplication.terminal, OriginApplication.fromTermProgram("Windows_Terminal"));
+    try std.testing.expectEqual(OriginApplication.vscode, OriginApplication.fromTermProgram("Visual Studio Code"));
+    try std.testing.expectEqual(OriginApplication.codex, OriginApplication.fromTermProgram("ChatGPT"));
+    try std.testing.expectEqual(OriginApplication.none, OriginApplication.fromTermProgram("untrusted.exe"));
+    try std.testing.expectEqualStrings("com.openai.codex", OriginApplication.codex.bundleIdentifier().?);
+}
 
 pub const BrowserActivation = enum {
     unsupported,
@@ -485,12 +592,28 @@ pub fn safeSourceTty(value: ?[]const u8) ?[]const u8 {
 
 pub fn safeSourceCwd(value: ?[]const u8) ?[]const u8 {
     const cwd = value orelse return null;
-    if (cwd.len == 0 or cwd.len > 511 or cwd[0] != '/') return null;
+    if (cwd.len == 0 or cwd.len > 511) return null;
+    const absolute = if (builtin.os.tag == .windows)
+        (cwd.len >= 3 and std.ascii.isAlphabetic(cwd[0]) and cwd[1] == ':' and (cwd[2] == '/' or cwd[2] == '\\')) or
+            (cwd.len >= 3 and (std.mem.startsWith(u8, cwd, "//") or std.mem.startsWith(u8, cwd, "\\\\")))
+    else
+        cwd[0] == '/';
+    if (!absolute) return null;
     if (!std.unicode.utf8ValidateSlice(cwd)) return null;
     for (cwd) |ch| {
-        if (ch < 0x20 or ch == '"' or ch == '\\') return null;
+        if (ch < 0x20 or ch == '"' or (builtin.os.tag != .windows and ch == '\\')) return null;
     }
     return cwd;
+}
+
+test "source cwd accepts only native absolute paths" {
+    if (builtin.os.tag == .windows) {
+        try std.testing.expectEqualStrings("C:\\work\\petdex", safeSourceCwd("C:\\work\\petdex").?);
+        try std.testing.expectEqualStrings("\\\\server\\share", safeSourceCwd("\\\\server\\share").?);
+    } else {
+        try std.testing.expectEqualStrings("/work/petdex", safeSourceCwd("/work/petdex").?);
+        try std.testing.expect(safeSourceCwd("C:\\work\\petdex") == null);
+    }
 }
 
 pub fn safeHerdrPaneId(value: ?[]const u8) ?[]const u8 {

--- a/packages/petdex-desktop-native/src/remote_runtime.zig
+++ b/packages/petdex-desktop-native/src/remote_runtime.zig
@@ -15,6 +15,7 @@ const agent_hooks = @import("agent_hooks.zig");
 const remote_agents = @import("remote_agents.zig");
 const remote_ssh = @import("remote_ssh.zig");
 const remote_writeback = @import("remote_writeback.zig");
+const hook_server = @import("hook_server.zig");
 const plat = @import("plat.zig");
 
 const AgentKind = agent_hooks.AgentKind;
@@ -274,6 +275,7 @@ fn probeAction(slot: *Slot) Action {
 }
 
 fn quiesceAction(slot: *Slot) Action {
+    hook_server.revokeRemoteCredential(slot.nameSlice());
     slot.op = .quiesce;
     slot.tunnel_ready = false;
     slot.sync_complete = false;
@@ -301,11 +303,11 @@ fn fetchAction(slot: *Slot) Action {
 fn tokenAction(slot: *Slot, slot_idx: usize, home: []const u8) Action {
     var path_buf: [512]u8 = undefined;
     const token_path = std.fmt.bufPrint(&path_buf, "{s}/.petdex/runtime/update-token", .{home}) catch return retry(slot, true);
-    const bytes = plat.readFile(token_path, &token_bufs[slot_idx]) orelse return retry(slot, true);
-    if (bytes.len > max_token_len) return retry(slot, true);
-    const trimmed = std.mem.trim(u8, bytes, " \t\r\n");
-    token_lens[slot_idx] = trimmed.len;
-    if (trimmed.len == 0) return retry(slot, true);
+    var probe: [max_token_len + 1]u8 = undefined;
+    const bytes = plat.readFile(token_path, &probe) orelse return retry(slot, true);
+    if (bytes.len > max_token_len or std.mem.trim(u8, bytes, " \t\r\n").len == 0) return retry(slot, true);
+    const scoped = hook_server.issueRemoteCredential(slot.nameSlice(), &token_bufs[slot_idx]) orelse return retry(slot, true);
+    token_lens[slot_idx] = scoped.len;
     slot.op = .token;
     return .{ .spawn = .{ .op = .token, .path = remote_ssh.remote_token_file, .stdin = token_bufs[slot_idx][0..token_lens[slot_idx]] } };
 }
@@ -542,6 +544,7 @@ pub fn onSpawnExitDetailed(slot: *Slot, slot_idx: usize, op: Op, code: i32, outp
         },
         .token => {
             if (code != 0) {
+                hook_server.revokeRemoteCredential(slot.nameSlice());
                 std.debug.print("petdex: remote '{s}': token gate open failed (ssh exit {d}); retrying\n", .{ slot.nameSlice(), code });
                 return retry(slot, true);
             }
@@ -555,6 +558,7 @@ pub fn onSpawnExitDetailed(slot: *Slot, slot_idx: usize, op: Op, code: i32, outp
             return tokenAction(slot, slot_idx, home);
         },
         .tunnel => {
+            hook_server.revokeRemoteCredential(slot.nameSlice());
             // Any tunnel exit is a reconnect: ssh only exits when the
             // connection dropped (ExitOnForwardFailure makes a taken
             // port a fast exit too).
@@ -860,7 +864,8 @@ test "driver gates feed until tunnel-ready patch pass completes" {
     try t.expect(act == .spawn and act.spawn.op == .watcher);
     act = onSpawnExit(&slot, idx, .watcher, 0, "", home);
     try t.expect(act == .spawn and act.spawn.op == .token);
-    try t.expectEqualStrings("tok-abc", act.spawn.stdin);
+    try t.expect(std.mem.startsWith(u8, act.spawn.stdin, "remote:rogue:"));
+    try t.expectEqual(@as(usize, "remote:rogue:".len + 64), act.spawn.stdin.len);
     act = onSpawnExit(&slot, idx, .token, 0, "", home);
     try t.expect(act == .none);
     try t.expect(slot.tunnel_ready);


### PR DESCRIPTION
## Scope

- define a backward-compatible session identity, status, provenance, origin, and child-message contract
- normalize supported agent producers into that contract while retaining legacy hook payloads
- extend mailbox semantics for per-session updates and bounded presentation-equivalent changes
- issue and revoke credentials scoped to an individual remote runtime
- add private, rotating event journals required by the follow-up recovery layer

## Why

The earlier bubble payload represented only one text/busy state. Durable reconciliation, concurrent sessions, safe remote attribution, and native presentation require one canonical event model without breaking installed hooks.

## Impact

Legacy payloads remain accepted. New metadata is optional, allowlisted, and bounded. This is groundwork for recovery and richer bubbles; it does **not** filter hidden Codex background tasks.

Refs #694

## Size

8 files changed, 3,408 insertions, 378 deletions.

## Validation

- `git diff --check`
- Zig formatting checks
- Biome check with no errors; one pre-existing informational suggestion in the CLI test
- pinned Native SDK release build with baseline CPU, tracing off, and automation enabled
- pinned Native SDK `native test .`: 253/253 passed
- `bun test integrations/dsh/package.test.ts`: 6/6 passed
- passing GitHub Actions app and lockfile checks
- passing GitHub Actions Native SDK builds and tests on macOS, Linux, and Windows

## Merge readiness

- Rewritten as one focused commit directly on `crafter-station/petdex:main` at `0243af6`.
- No web API, database, or CLI contract changes; the new desktop hook fields remain backward-compatible and optional.
- This remains a draft only because the Vercel preview needs Crafter Station team authorization. That is an external administrative gate; all repository checks passed.