### PR TITLE
feat(desktop): add durable session recovery

### DIFF
--- a/.github/workflows/desktop-native-ci.yml
+++ b/.github/workflows/desktop-native-ci.yml
@@ -222,6 +222,11 @@ jobs:
         run: |
           "$NATIVE_CLI" test .
 
+      - name: Test journal rotation across processes
+        working-directory: packages/petdex-desktop-native
+        shell: bash
+        run: bun tests/journal_process_check.mjs
+
       - name: Test remote helper runtimes
         if: matrix.platform != 'windows'
         working-directory: packages/petdex-desktop-native

--- a/packages/petdex-desktop-native/README.md
+++ b/packages/petdex-desktop-native/README.md
@@ -26,6 +26,22 @@ native automate screenshot pet-canvas
 
 Requires the `@native-sdk/cli` global (`bun add -g @native-sdk/cli`).
 
+## Durable session recovery
+
+Installed hooks remain the low-latency path for every supported agent. Local,
+read-only durable recovery is enabled only for formats backed by
+provider-owned artifacts and adapter-specific fixture/test evidence: Codex
+rollouts, Claude transcripts, Gemini chats, OMP session logs, and Hermes
+`state.db`. OpenCode, Qoder, Kimi Code, and CodeBuddy remain hook-supported,
+but their stores have no stable evidenced contract here; durable recovery
+fails closed instead of guessing a session from unrelated data.
+
+Recovery scans are bounded and remain the source of truth. Native directory
+notifications are coalesced hints, with a periodic polling sweep covering
+dropped events and backend failure. Only relevant durable roots are watched,
+including configured `CLAUDE_CONFIG_DIR`, `PI_CODING_AGENT_DIR`, and
+`HERMES_HOME` locations.
+
 For the pinned desktop build, set `NATIVE_CLI` and `NATIVE_SDK_PATH` to the
 CLI and SDK checkout used by the matching release workflow. The build scripts
 apply the Petdex-owned macOS Mach-O headerpad patch before compiling; they

--- a/packages/petdex-desktop-native/integrations/dsh/package.test.ts
+++ b/packages/petdex-desktop-native/integrations/dsh/package.test.ts
@@ -11,6 +11,10 @@ const packagedFiles = [
   "src/normalize.js",
 ];
 
+function normalizeNewlines(value: string) {
+  return value.replaceAll("\r\n", "\n");
+}
+
 function tar(...args: string[]) {
   const result = Bun.spawnSync(["tar", ...args], {
     cwd: root,
@@ -18,7 +22,10 @@ function tar(...args: string[]) {
     stderr: "pipe",
   });
   expect(result.exitCode).toBe(0);
-  return result.stdout.toString();
+  // bsdtar follows the host text convention for listings and git may check
+  // source fixtures out with CRLF on Windows. The archive contract is textual
+  // content, not a platform-specific newline encoding.
+  return normalizeNewlines(result.stdout.toString());
 }
 
 describe("embedded DSH plugin archive", () => {
@@ -34,7 +41,7 @@ describe("embedded DSH plugin archive", () => {
   for (const file of packagedFiles) {
     test(`keeps ${file} in sync with source`, async () => {
       const packed = tar("-xOzf", archive, `package/${file}`);
-      const source = await Bun.file(join(root, file)).text();
+      const source = normalizeNewlines(await Bun.file(join(root, file)).text());
       expect(packed).toBe(source);
     });
   }

--- a/packages/petdex-desktop-native/src/agent_hooks.zig
+++ b/packages/petdex-desktop-native/src/agent_hooks.zig
@@ -233,24 +233,37 @@ fn qoderStatus(allocator: std.mem.Allocator, home: []const u8) HookStatus {
 
 /// The five Claude-shaped hook events the bubble pipeline rides.
 const claude_events = [_]HookEvent{
-    .{ .event = "UserPromptSubmit", .phase = "user-prompt" },
-    .{ .event = "PreToolUse", .phase = "pre" },
-    .{ .event = "PostToolUse", .phase = "post" },
-    .{ .event = "Notification", .phase = "notification" },
-    .{ .event = "Stop", .phase = "stop" },
-};
-
-/// The Claude five plus PostToolUseFailure, the one event no other wired agent
-/// reports — it is what lights the `failed` sprite row. The two Post* events are
-/// mutually exclusive per tool call (coreToolHookTriggers.ts:288 gates
-/// PostToolUse on `!toolResult.error`), so no trailing `idle` stomps it.
-const qoder_events = [_]HookEvent{
+    .{ .event = "SessionStart", .phase = "session-start" },
     .{ .event = "UserPromptSubmit", .phase = "user-prompt" },
     .{ .event = "PreToolUse", .phase = "pre" },
     .{ .event = "PostToolUse", .phase = "post" },
     .{ .event = "PostToolUseFailure", .phase = "tool-failure" },
+    .{ .event = "PermissionRequest", .phase = "approval-request" },
     .{ .event = "Notification", .phase = "notification" },
+    .{ .event = "SubagentStart", .phase = "subagent-start" },
+    .{ .event = "SubagentStop", .phase = "subagent-stop" },
+    .{ .event = "StopFailure", .phase = "tool-failure" },
     .{ .event = "Stop", .phase = "stop" },
+    .{ .event = "SessionEnd", .phase = "session-end" },
+};
+
+/// Qoder exposes the same full lifecycle shape as Claude, including explicit
+/// permission, failure, and subagent events. Keeping those event names intact
+/// lets the shared normalizer correlate input and child sessions without
+/// guessing from prose in a tool result.
+const qoder_events = [_]HookEvent{
+    .{ .event = "SessionStart", .phase = "session-start" },
+    .{ .event = "UserPromptSubmit", .phase = "user-prompt" },
+    .{ .event = "PreToolUse", .phase = "pre" },
+    .{ .event = "PostToolUse", .phase = "post" },
+    .{ .event = "PostToolUseFailure", .phase = "tool-failure" },
+    .{ .event = "PermissionRequest", .phase = "approval-request" },
+    .{ .event = "Notification", .phase = "notification" },
+    .{ .event = "SubagentStart", .phase = "subagent-start" },
+    .{ .event = "SubagentStop", .phase = "subagent-stop" },
+    .{ .event = "StopFailure", .phase = "tool-failure" },
+    .{ .event = "Stop", .phase = "stop" },
+    .{ .event = "SessionEnd", .phase = "session-end" },
 };
 
 const codex_events = [_]HookEvent{
@@ -656,8 +669,14 @@ fn uninstallQoder(allocator: std.mem.Allocator, home: []const u8) bool {
 /// Gemini rides the exact same settings.json hook shape as Claude,
 /// with its own event names.
 const gemini_events = [_]HookEvent{
+    .{ .event = "SessionStart", .phase = "session-start" },
+    .{ .event = "BeforeAgent", .phase = "user-prompt" },
+    .{ .event = "BeforeModel", .phase = "pre-llm" },
     .{ .event = "BeforeTool", .phase = "pre" },
     .{ .event = "AfterTool", .phase = "post" },
+    .{ .event = "AfterModel", .phase = "assistant" },
+    .{ .event = "AfterAgent", .phase = "assistant" },
+    .{ .event = "Notification", .phase = "notification" },
     .{ .event = "SessionEnd", .phase = "stop" },
 };
 
@@ -720,23 +739,22 @@ pub fn installOmp(allocator: std.mem.Allocator, home: []const u8) bool {
 /// shape but never Claude's own file, so it needs its own row instead of
 /// a second config root on the Claude one.
 ///
-/// It declares 27+ events, of which only the Claude-shaped core has
-/// documented payload schemas. Wiring the long tail (Elicitation,
-/// TeammateIdle, WorktreeCreate, and friends) would mean guessing at
-/// field names, so this stays on the documented set.
-///
-/// No tool-failure event: unlike Kimi and Qoder, a failed call surfaces
-/// as the `tool_response` field on PostToolUse. Reading that would mean
-/// pattern-matching prose to decide what "failed" looks like, and a pet
-/// that flashes `failed` on a successful grep is worse than one that
-/// never flashes it at all. So `failed` stays dark here until CodeBuddy
-/// grows a distinct event, and `post` reports plain `idle`.
+/// CodeBuddy exposes the Claude-shaped documented lifecycle, including
+/// explicit failure, permission, and subagent events. The unrelated long tail
+/// remains deliberately unwired because it has no stable payload contract.
 const codebuddy_events = [_]HookEvent{
+    .{ .event = "SessionStart", .phase = "session-start" },
     .{ .event = "UserPromptSubmit", .phase = "user-prompt" },
     .{ .event = "PreToolUse", .phase = "pre" },
     .{ .event = "PostToolUse", .phase = "post" },
+    .{ .event = "PostToolUseFailure", .phase = "tool-failure" },
+    .{ .event = "PermissionRequest", .phase = "approval-request" },
     .{ .event = "Notification", .phase = "notification" },
+    .{ .event = "SubagentStart", .phase = "subagent-start" },
+    .{ .event = "SubagentStop", .phase = "subagent-stop" },
+    .{ .event = "StopFailure", .phase = "tool-failure" },
     .{ .event = "Stop", .phase = "stop" },
+    .{ .event = "SessionEnd", .phase = "session-end" },
 };
 
 pub fn installCodeBuddy(allocator: std.mem.Allocator, home: []const u8) bool {
@@ -760,12 +778,18 @@ pub fn installCodeBuddy(allocator: std.mem.Allocator, home: []const u8) bool {
 /// success), so the `failed` sprite row lights up the same way Qoder's
 /// does, with no trailing `idle` to stomp it.
 const kimi_events = [_]HookEvent{
+    .{ .event = "SessionStart", .phase = "session-start" },
     .{ .event = "UserPromptSubmit", .phase = "user-prompt" },
     .{ .event = "PreToolUse", .phase = "pre" },
     .{ .event = "PostToolUse", .phase = "post" },
     .{ .event = "PostToolUseFailure", .phase = "tool-failure" },
+    .{ .event = "PermissionRequest", .phase = "approval-request" },
     .{ .event = "Notification", .phase = "notification" },
+    .{ .event = "SubagentStart", .phase = "subagent-start" },
+    .{ .event = "SubagentStop", .phase = "subagent-stop" },
+    .{ .event = "StopFailure", .phase = "tool-failure" },
     .{ .event = "Stop", .phase = "stop" },
+    .{ .event = "SessionEnd", .phase = "session-end" },
 };
 
 /// `$KIMI_CODE_HOME/config.toml` when the variable is set and non-empty,
@@ -2173,6 +2197,14 @@ fn expectedCanonicalHookTextOccurrences() usize {
     return if (builtin.os.tag == .windows) 2 else 1;
 }
 
+fn hookPhaseCount(events: []const HookEvent, phase: []const u8) usize {
+    var count: usize = 0;
+    for (events) |event| {
+        if (std.mem.eql(u8, event.phase, phase)) count += 1;
+    }
+    return count;
+}
+
 test "claude merge preserves foreign keys and hooks, replaces petdex entries" {
     // Build a fixture settings.json with a user hook and an old petdex
     // node hook, run the merge logic pieces on it via Value.
@@ -2302,7 +2334,7 @@ test "CLAUDE_CONFIG_DIR redirects install, scan and uninstall" {
     try t.expectEqual(HookStatus.absent, blank[0].status);
 }
 
-test "installQoder writes six events and stays out of the rest of the config" {
+test "installQoder writes its documented lifecycle and preserves the rest of the config" {
     const home = ".zig-cache/petdex-qoder-fixture";
     plat.makeDir(home ++ "/.qoder");
     const fixture =
@@ -2317,8 +2349,20 @@ test "installQoder writes six events and stays out of the rest of the config" {
     const merged = readFileAlloc(t.allocator, cfg, 1024 * 1024).?;
     defer t.allocator.free(merged);
 
-    // All six events, including the one no other agent reports.
-    for ([_][]const u8{ "UserPromptSubmit", "PreToolUse", "PostToolUse", "PostToolUseFailure", "Notification", "Stop" }) |event| {
+    for ([_][]const u8{
+        "SessionStart",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "PermissionRequest",
+        "Notification",
+        "SubagentStart",
+        "SubagentStop",
+        "StopFailure",
+        "Stop",
+        "SessionEnd",
+    }) |event| {
         try t.expect(std.mem.indexOf(u8, merged, event) != null);
     }
     try t.expect(std.mem.indexOf(u8, merged, "bubble tool-failure qoder") != null);
@@ -2336,7 +2380,10 @@ test "installQoder writes six events and stays out of the rest of the config" {
     const merged2 = readFileAlloc(t.allocator, cfg, 1024 * 1024).?;
     defer t.allocator.free(merged2);
     try t.expectEqual(expectedCanonicalHookTextOccurrences(), std.mem.count(u8, merged2, "bubble pre qoder"));
-    try t.expectEqual(expectedCanonicalHookTextOccurrences(), std.mem.count(u8, merged2, "bubble tool-failure qoder"));
+    try t.expectEqual(
+        expectedCanonicalHookTextOccurrences() * hookPhaseCount(&qoder_events, "tool-failure"),
+        std.mem.count(u8, merged2, "bubble tool-failure qoder"),
+    );
 
     const bak = std.fmt.bufPrint(&pb, "{s}/.qoder/settings.json.pre-petdex-backup", .{home}) catch unreachable;
     try t.expect(fileExists(bak));
@@ -2985,23 +3032,26 @@ test "codebuddy merges into its own config and leaves Claude's alone" {
     try t.expect(std.mem.indexOf(u8, cleared, "my-own-hook") != null);
 }
 
-test "codebuddy wires only events with documented payloads" {
-    // It declares 27+ events; the long tail has no documented schema, so
-    // guessing at field names is how an adapter starts reading garbage.
-    for (codebuddy_events) |ev| {
-        const documented = std.mem.eql(u8, ev.event, "UserPromptSubmit") or
-            std.mem.eql(u8, ev.event, "PreToolUse") or
-            std.mem.eql(u8, ev.event, "PostToolUse") or
-            std.mem.eql(u8, ev.event, "Notification") or
-            std.mem.eql(u8, ev.event, "Stop");
-        try t.expect(documented);
-    }
-    // No tool-failure phase: CodeBuddy reports failure as a field on
-    // PostToolUse rather than its own event, and inferring it from prose
-    // would light `failed` on healthy calls. Deliberate, not an omission.
-    for (codebuddy_events) |ev| {
-        try t.expect(!std.mem.eql(u8, ev.phase, "tool-failure"));
-    }
+test "codebuddy wires the documented lifecycle without guessing at unrelated events" {
+    const expected = [_][]const u8{
+        "SessionStart",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "PermissionRequest",
+        "Notification",
+        "SubagentStart",
+        "SubagentStop",
+        "StopFailure",
+        "Stop",
+        "SessionEnd",
+    };
+    try t.expectEqual(expected.len, codebuddy_events.len);
+    for (expected, codebuddy_events) |event, hook| try t.expectEqualStrings(event, hook.event);
+    try t.expectEqual(@as(usize, 2), hookPhaseCount(&codebuddy_events, "tool-failure"));
+    try t.expectEqual(@as(usize, 1), hookPhaseCount(&codebuddy_events, "subagent-start"));
+    try t.expectEqual(@as(usize, 1), hookPhaseCount(&codebuddy_events, "subagent-stop"));
 }
 
 test "omp install writes the extension where OMP discovers it" {

--- a/packages/petdex-desktop-native/src/agent_hooks.zig
+++ b/packages/petdex-desktop-native/src/agent_hooks.zig
@@ -674,7 +674,9 @@ const gemini_events = [_]HookEvent{
     .{ .event = "BeforeModel", .phase = "pre-llm" },
     .{ .event = "BeforeTool", .phase = "pre" },
     .{ .event = "AfterTool", .phase = "post" },
-    .{ .event = "AfterModel", .phase = "assistant" },
+    // AfterModel fires for every model response inside the agent loop. Only
+    // AfterAgent marks the final response for the turn.
+    .{ .event = "AfterModel", .phase = "post-model" },
     .{ .event = "AfterAgent", .phase = "assistant" },
     .{ .event = "Notification", .phase = "notification" },
     .{ .event = "SessionEnd", .phase = "stop" },
@@ -2777,6 +2779,17 @@ test "installGemini enables hooks and uses a millisecond timeout" {
     try t.expect(std.mem.indexOf(u8, written, "\"keep\": true") != null);
 }
 
+test "Gemini model responses stay active until AfterAgent" {
+    var after_model_phase: ?[]const u8 = null;
+    var after_agent_phase: ?[]const u8 = null;
+    for (gemini_events) |hook| {
+        if (std.mem.eql(u8, hook.event, "AfterModel")) after_model_phase = hook.phase;
+        if (std.mem.eql(u8, hook.event, "AfterAgent")) after_agent_phase = hook.phase;
+    }
+    try t.expectEqualStrings("post-model", after_model_phase.?);
+    try t.expectEqualStrings("assistant", after_agent_phase.?);
+}
+
 test "legacy curl migration requires the complete Petdex command signature" {
     const command = "T=\"$(cat $HOME/.petdex/runtime/update-token 2>/dev/null)\"; [ -n \"$T\" ] && curl -s -m 0.3 -X POST http://127.0.0.1:7777/state -H \"X-Petdex-Update-Token: $T\"";
     try t.expectEqual(ManagedHookGeneration.legacy, commandGeneration(command));
@@ -3075,6 +3088,7 @@ test "omp install writes the extension where OMP discovers it" {
     try t.expect(std.mem.indexOf(u8, written, "export default function") != null);
     // Failure comes from isError on tool_result, not from parsing text.
     try t.expect(std.mem.indexOf(u8, written, "isError") != null);
+    try t.expect(std.mem.indexOf(u8, written, "agentState: \"failed\"") != null);
     // Each OMP event must identify its conversation so concurrent sessions
     // remain separate in the desktop mailbox.
     try t.expect(std.mem.indexOf(u8, written, "session_id") != null);

--- a/packages/petdex-desktop-native/src/agent_hooks.zig
+++ b/packages/petdex-desktop-native/src/agent_hooks.zig
@@ -3088,7 +3088,9 @@ test "omp install writes the extension where OMP discovers it" {
     try t.expect(std.mem.indexOf(u8, written, "export default function") != null);
     // Failure comes from isError on tool_result, not from parsing text.
     try t.expect(std.mem.indexOf(u8, written, "isError") != null);
-    try t.expect(std.mem.indexOf(u8, written, "agentState: \"failed\"") != null);
+    // Every later bubble overwrites a temporary failed state, so a successful
+    // tool result or terminal event cannot leave the Flock body stuck.
+    try t.expect(std.mem.indexOf(u8, written, "bubbleBody.agent_state = state") != null);
     // Each OMP event must identify its conversation so concurrent sessions
     // remain separate in the desktop mailbox.
     try t.expect(std.mem.indexOf(u8, written, "session_id") != null);

--- a/packages/petdex-desktop-native/src/agent_hooks.zig
+++ b/packages/petdex-desktop-native/src/agent_hooks.zig
@@ -741,20 +741,18 @@ pub fn installOmp(allocator: std.mem.Allocator, home: []const u8) bool {
 /// shape but never Claude's own file, so it needs its own row instead of
 /// a second config root on the Claude one.
 ///
-/// CodeBuddy exposes the Claude-shaped documented lifecycle, including
-/// explicit failure, permission, and subagent events. The unrelated long tail
-/// remains deliberately unwired because it has no stable payload contract.
+/// CodeBuddy documents only the Claude-shaped core below. Its larger event
+/// enum is not a payload contract, so unrelated names remain unwired.
+/// In particular, tool failure is `tool_response.success == false` on the
+/// supported PostToolUse payload and is lowered by hook_runner; there is no
+/// separate failure hook to install.
 const codebuddy_events = [_]HookEvent{
     .{ .event = "SessionStart", .phase = "session-start" },
     .{ .event = "UserPromptSubmit", .phase = "user-prompt" },
     .{ .event = "PreToolUse", .phase = "pre" },
     .{ .event = "PostToolUse", .phase = "post" },
-    .{ .event = "PostToolUseFailure", .phase = "tool-failure" },
-    .{ .event = "PermissionRequest", .phase = "approval-request" },
     .{ .event = "Notification", .phase = "notification" },
-    .{ .event = "SubagentStart", .phase = "subagent-start" },
     .{ .event = "SubagentStop", .phase = "subagent-stop" },
-    .{ .event = "StopFailure", .phase = "tool-failure" },
     .{ .event = "Stop", .phase = "stop" },
     .{ .event = "SessionEnd", .phase = "session-end" },
 };
@@ -3016,7 +3014,10 @@ test "codebuddy merges into its own config and leaves Claude's alone" {
     var pb: [512]u8 = undefined;
     const cfg = std.fmt.bufPrint(&pb, "{s}/.codebuddy/settings.json", .{home}) catch unreachable;
     try t.expect(writeFile(cfg,
-        \\{"model":"codebuddy-pro","hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"my-own-hook"}]}]}}
+        \\{"model":"codebuddy-pro","hooks":{
+        \\  "PreToolUse":[{"hooks":[{"type":"command","command":"my-own-hook"}]}],
+        \\  "PostToolUseFailure":[{"hooks":[{"type":"command","command":"$HOME/.petdex/bin/petdex-hook bubble tool-failure codebuddy"}]}]
+        \\}}
     ));
     // A Claude config that must not be touched: CodeBuddy is derived from
     // Claude Code, so writing to the wrong file is the plausible mistake.
@@ -3030,6 +3031,10 @@ test "codebuddy merges into its own config and leaves Claude's alone" {
     try t.expect(std.mem.indexOf(u8, written, "petdex-hook") != null);
     try t.expect(std.mem.indexOf(u8, written, "my-own-hook") != null);
     try t.expect(std.mem.indexOf(u8, written, "codebuddy-pro") != null);
+    try t.expect(std.mem.indexOf(u8, written, "bubble post codebuddy") != null);
+    try t.expect(std.mem.indexOf(u8, written, "bubble tool-failure codebuddy") == null);
+    try t.expect(std.mem.indexOf(u8, written, "bubble approval-request codebuddy") == null);
+    try t.expect(std.mem.indexOf(u8, written, "bubble subagent-start codebuddy") == null);
 
     const claude_after = readFileAlloc(t.allocator, claude_cfg, 1024 * 1024).?;
     defer t.allocator.free(claude_after);
@@ -3051,19 +3056,15 @@ test "codebuddy wires the documented lifecycle without guessing at unrelated eve
         "UserPromptSubmit",
         "PreToolUse",
         "PostToolUse",
-        "PostToolUseFailure",
-        "PermissionRequest",
         "Notification",
-        "SubagentStart",
         "SubagentStop",
-        "StopFailure",
         "Stop",
         "SessionEnd",
     };
     try t.expectEqual(expected.len, codebuddy_events.len);
     for (expected, codebuddy_events) |event, hook| try t.expectEqualStrings(event, hook.event);
-    try t.expectEqual(@as(usize, 2), hookPhaseCount(&codebuddy_events, "tool-failure"));
-    try t.expectEqual(@as(usize, 1), hookPhaseCount(&codebuddy_events, "subagent-start"));
+    try t.expectEqual(@as(usize, 0), hookPhaseCount(&codebuddy_events, "tool-failure"));
+    try t.expectEqual(@as(usize, 0), hookPhaseCount(&codebuddy_events, "subagent-start"));
     try t.expectEqual(@as(usize, 1), hookPhaseCount(&codebuddy_events, "subagent-stop"));
 }
 

--- a/packages/petdex-desktop-native/src/assets/omp-extension.ts
+++ b/packages/petdex-desktop-native/src/assets/omp-extension.ts
@@ -10,7 +10,14 @@
 // Each pi.on handler below maps one OMP event to one mascot state; edit
 // the state strings there to change what the pet does.
 
-import { existsSync } from "node:fs";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+} from "node:fs";
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -21,6 +28,46 @@ const RUNTIME_DIR = join(homedir(), ".petdex", "runtime");
 const TOKEN_PATH = join(RUNTIME_DIR, "update-token");
 const KILLSWITCH_PATH = join(RUNTIME_DIR, "hooks-disabled");
 const AGENT_SOURCE = "omp";
+const JOURNAL_DIR = join(RUNTIME_DIR, "session-journal");
+const JOURNAL_LIMIT = 4 * 1024 * 1024;
+
+function journalStem(
+  value: string | null | undefined,
+  fallback: string,
+): string {
+  const safe = String(value || fallback).replace(/[^a-zA-Z0-9_.-]/g, "_");
+  return safe.slice(0, 96) || fallback;
+}
+
+function appendJournal(body: Record<string, unknown>): void {
+  if (
+    typeof body.text !== "string" ||
+    body.text.length === 0 ||
+    typeof body.conversation_key !== "string"
+  )
+    return;
+  try {
+    mkdirSync(JOURNAL_DIR, { recursive: true, mode: 0o700 });
+    const path = join(
+      JOURNAL_DIR,
+      `${journalStem(String(body.agent_source ?? ""), "agent")}-${journalStem(body.conversation_key, "unkeyed")}.jsonl`,
+    );
+    const record = `${JSON.stringify({ journal_version: 1, event: body })}\n`;
+    if (
+      existsSync(path) &&
+      statSync(path).size + Buffer.byteLength(record) > JOURNAL_LIMIT
+    ) {
+      const previous = `${path}.1`;
+      try {
+        unlinkSync(previous);
+      } catch {}
+      renameSync(path, previous);
+    }
+    appendFileSync(path, record, { encoding: "utf8", mode: 0o600 });
+  } catch {
+    // Recovery is best-effort and must never stall the in-process extension.
+  }
+}
 
 // Read-only tools read as thinking rather than working, matching how the
 // other adapters split `review` from `running`.
@@ -64,6 +111,11 @@ type Notify = {
   title?: string;
   busy?: boolean;
   sessionId?: string | null;
+  status?: "idle" | "running" | "needs_input" | "completed" | "failed";
+  messageKind?: "status" | "prompt" | "tool" | "lifecycle";
+  eventKind?: string;
+  requestId?: string;
+  resolvesRequestId?: string;
 };
 
 type ExtensionContext = {
@@ -96,12 +148,15 @@ async function notify({
   title,
   busy,
   sessionId,
+  status,
+  messageKind,
+  eventKind,
+  requestId,
+  resolvesRequestId,
 }: Notify): Promise<void> {
   // Killswitch first, before the token read, so the disabled state costs
   // one existsSync and nothing else.
   if (existsSync(KILLSWITCH_PATH)) return;
-  const token = await readToken();
-  if (!token) return; // Hook server offline or missing; silently no-op.
   const stateBody: Record<string, unknown> =
     duration != null
       ? { state, duration, agent_source: AGENT_SOURCE }
@@ -113,9 +168,24 @@ async function notify({
   if (sessionId) {
     stateBody.session_id = sessionId;
     bubbleBody.session_id = sessionId;
+    bubbleBody.conversation_key = sessionId;
+    bubbleBody.source_session_id = sessionId;
+    bubbleBody.session_kind = "primary";
   }
-  if (title) bubbleBody.title = title;
+  if (title) {
+    bubbleBody.title = title;
+    bubbleBody.title_source = "prompt";
+  }
   if (busy !== undefined) bubbleBody.busy = busy;
+  if (status) bubbleBody.status = status;
+  if (messageKind) bubbleBody.message_kind = messageKind;
+  if (eventKind) bubbleBody.event_kind = eventKind;
+  if (requestId) bubbleBody.request_id = requestId;
+  if (resolvesRequestId) bubbleBody.resolves_request_id = resolvesRequestId;
+  bubbleBody.feed_source = "hook";
+  if (text) appendJournal(bubbleBody);
+  const token = await readToken();
+  if (!token) return; // Journal survives while the desktop is offline.
   await Promise.all([
     postJson(HOOK_SERVER_URL, stateBody, token),
     text
@@ -208,6 +278,8 @@ export default function petdex(pi: ExtensionAPI): void {
       state: "jumping",
       duration: 1200,
       busy: false,
+      status: "running",
+      eventKind: "session-start",
       sessionId: sessionIdFor(ctx),
     });
   }) as never);
@@ -221,6 +293,8 @@ export default function petdex(pi: ExtensionAPI): void {
       state: "jumping",
       duration: 900,
       busy: false,
+      status: "running",
+      eventKind: "user-prompt",
       sessionId,
     });
   }) as never);
@@ -233,6 +307,9 @@ export default function petdex(pi: ExtensionAPI): void {
       text: describeTool(name, event?.input ?? {}, false),
       title: titleFor(sessionId),
       busy: true,
+      status: "running",
+      messageKind: "tool",
+      eventKind: "tool-progress",
       sessionId,
     });
   }) as never);
@@ -249,6 +326,9 @@ export default function petdex(pi: ExtensionAPI): void {
         text: `${describeTool(event?.toolName ?? "", event?.input ?? {}, true)} failed`,
         title: titleFor(sessionId),
         busy: false,
+        status: "failed",
+        messageKind: "tool",
+        eventKind: "tool-failure",
         sessionId,
       });
       return;
@@ -258,6 +338,9 @@ export default function petdex(pi: ExtensionAPI): void {
       text: describeTool(event?.toolName ?? "", event?.input ?? {}, true),
       title: titleFor(sessionId),
       busy: true,
+      status: "running",
+      messageKind: "tool",
+      eventKind: "tool-progress",
       sessionId,
     });
   }) as never);
@@ -269,6 +352,9 @@ export default function petdex(pi: ExtensionAPI): void {
       text: "Waiting on you.",
       title: titleFor(sessionId),
       busy: false,
+      status: "needs_input",
+      messageKind: "prompt",
+      eventKind: "approval-request",
       sessionId,
     });
   }) as never);
@@ -281,6 +367,9 @@ export default function petdex(pi: ExtensionAPI): void {
       text: "Done.",
       title: titleFor(sessionId),
       busy: false,
+      status: "completed",
+      messageKind: "lifecycle",
+      eventKind: "session-end",
       sessionId,
     });
   }) as never);

--- a/packages/petdex-desktop-native/src/assets/omp-extension.ts
+++ b/packages/petdex-desktop-native/src/assets/omp-extension.ts
@@ -114,6 +114,7 @@ type Notify = {
   status?: "idle" | "running" | "needs_input" | "completed" | "failed";
   messageKind?: "status" | "prompt" | "tool" | "lifecycle";
   eventKind?: string;
+  agentState?: string;
   requestId?: string;
   resolvesRequestId?: string;
 };
@@ -151,6 +152,7 @@ async function notify({
   status,
   messageKind,
   eventKind,
+  agentState,
   requestId,
   resolvesRequestId,
 }: Notify): Promise<void> {
@@ -180,6 +182,7 @@ async function notify({
   if (status) bubbleBody.status = status;
   if (messageKind) bubbleBody.message_kind = messageKind;
   if (eventKind) bubbleBody.event_kind = eventKind;
+  if (agentState) bubbleBody.agent_state = agentState;
   if (requestId) bubbleBody.request_id = requestId;
   if (resolvesRequestId) bubbleBody.resolves_request_id = resolvesRequestId;
   bubbleBody.feed_source = "hook";
@@ -325,10 +328,11 @@ export default function petdex(pi: ExtensionAPI): void {
         duration: 2500,
         text: `${describeTool(event?.toolName ?? "", event?.input ?? {}, true)} failed`,
         title: titleFor(sessionId),
-        busy: false,
-        status: "failed",
+        busy: true,
+        status: "running",
         messageKind: "tool",
         eventKind: "tool-failure",
+        agentState: "failed",
         sessionId,
       });
       return;

--- a/packages/petdex-desktop-native/src/assets/omp-extension.ts
+++ b/packages/petdex-desktop-native/src/assets/omp-extension.ts
@@ -114,7 +114,6 @@ type Notify = {
   status?: "idle" | "running" | "needs_input" | "completed" | "failed";
   messageKind?: "status" | "prompt" | "tool" | "lifecycle";
   eventKind?: string;
-  agentState?: string;
   requestId?: string;
   resolvesRequestId?: string;
 };
@@ -152,7 +151,6 @@ async function notify({
   status,
   messageKind,
   eventKind,
-  agentState,
   requestId,
   resolvesRequestId,
 }: Notify): Promise<void> {
@@ -182,7 +180,10 @@ async function notify({
   if (status) bubbleBody.status = status;
   if (messageKind) bubbleBody.message_kind = messageKind;
   if (eventKind) bubbleBody.event_kind = eventKind;
-  if (agentState) bubbleBody.agent_state = agentState;
+  // Every bubble replaces the per-card state. In particular, the first event
+  // after a tool error must overwrite "failed" instead of leaving the Flock
+  // body stuck in its failure sprite.
+  bubbleBody.agent_state = state;
   if (requestId) bubbleBody.request_id = requestId;
   if (resolvesRequestId) bubbleBody.resolves_request_id = resolvesRequestId;
   bubbleBody.feed_source = "hook";
@@ -332,13 +333,12 @@ export default function petdex(pi: ExtensionAPI): void {
         status: "running",
         messageKind: "tool",
         eventKind: "tool-failure",
-        agentState: "failed",
         sessionId,
       });
       return;
     }
     await notify({
-      state: "idle",
+      state: "running",
       text: describeTool(event?.toolName ?? "", event?.input ?? {}, true),
       title: titleFor(sessionId),
       busy: true,

--- a/packages/petdex-desktop-native/src/assets/omp-extension.ts
+++ b/packages/petdex-desktop-native/src/assets/omp-extension.ts
@@ -10,6 +10,7 @@
 // Each pi.on handler below maps one OMP event to one mascot state; edit
 // the state strings there to change what the pet does.
 
+import { createHash } from "node:crypto";
 import {
   appendFileSync,
   existsSync,
@@ -31,12 +32,13 @@ const AGENT_SOURCE = "omp";
 const JOURNAL_DIR = join(RUNTIME_DIR, "session-journal");
 const JOURNAL_LIMIT = 4 * 1024 * 1024;
 
-function journalStem(
+export function journalStem(
   value: string | null | undefined,
   fallback: string,
 ): string {
-  const safe = String(value || fallback).replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return safe.slice(0, 96) || fallback;
+  return createHash("sha256")
+    .update(String(value || fallback), "utf8")
+    .digest("hex");
 }
 
 function appendJournal(body: Record<string, unknown>): void {

--- a/packages/petdex-desktop-native/src/assets/opencode-plugin.js
+++ b/packages/petdex-desktop-native/src/assets/opencode-plugin.js
@@ -2,16 +2,42 @@
 // Forwards OpenCode lifecycle events to the petdex desktop mascot via HTTP.
 // Edit STATE_MAP below to customize which state each event triggers.
 
-import { existsSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, unlinkSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
 const HOOK_SERVER_URL = "http://127.0.0.1:7777/state";
 const HOOK_SERVER_BUBBLE_URL = "http://127.0.0.1:7777/bubble";
+const HOOK_SERVER_TITLE_URL = "http://127.0.0.1:7777/bubble/title";
 const RUNTIME_DIR = join(homedir(), ".petdex", "runtime");
 const TOKEN_PATH = join(RUNTIME_DIR, "update-token");
 const KILLSWITCH_PATH = join(RUNTIME_DIR, "hooks-disabled");
+const REMOTE_HOST_PATH = join(RUNTIME_DIR, "remote-host");
+const JOURNAL_DIR = join(RUNTIME_DIR, "session-journal");
+const JOURNAL_LIMIT = 4 * 1024 * 1024;
+
+function journalStem(value, fallback) {
+  const safe = String(value || fallback).replace(/[^a-zA-Z0-9_.-]/g, "_");
+  return safe.slice(0, 96) || fallback;
+}
+
+function appendJournal(body) {
+  if (!body?.text || !body?.conversation_key) return;
+  try {
+    mkdirSync(JOURNAL_DIR, { recursive: true, mode: 0o700 });
+    const path = join(JOURNAL_DIR, `${journalStem(body.agent_source, "agent")}-${journalStem(body.conversation_key, "unkeyed")}.jsonl`);
+    const record = JSON.stringify({ journal_version: 1, event: body }) + "\n";
+    if (existsSync(path) && statSync(path).size + Buffer.byteLength(record) > JOURNAL_LIMIT) {
+      const previous = path + ".1";
+      try { unlinkSync(previous); } catch {}
+      renameSync(path, previous);
+    }
+    appendFileSync(path, record, { encoding: "utf8", mode: 0o600 });
+  } catch {
+    // Recovery is best-effort and must never stain the agent process.
+  }
+}
 
 async function readToken() {
   try {
@@ -38,11 +64,15 @@ function clip(text, max = 40) {
 
 function originMetadata() {
   const sourceApp = process.env.TERM_PROGRAM;
-  if (sourceApp !== "Apple_Terminal" && sourceApp !== "vscode") return {};
-  return {
-    source_app: sourceApp,
-    source_cwd: process.cwd(),
-  };
+  const metadata =
+    sourceApp === "Apple_Terminal" || sourceApp === "vscode"
+      ? { source_app: sourceApp, source_cwd: process.cwd() }
+      : { source_cwd: process.cwd() };
+  try {
+    const hostname = readFileSync(REMOTE_HOST_PATH, "utf8").trim().slice(0, 64);
+    if (hostname) return { ...metadata, hostname, remote: true };
+  } catch {}
+  return metadata;
 }
 
 function canonicalToolKind(toolName) {
@@ -128,17 +158,12 @@ async function postJson(url, body, token) {
   }
 }
 
-async function notify({ state, duration, text, title, busy, sessionId }) {
+async function notify({ state, duration, text, title, busy, sessionId, status, messageKind = "tool" }) {
   // Killswitch: users toggle this with /petdex inside their agent
   // (or 'petdex hooks toggle' from a shell). Bail before the token
   // read so the disabled state has zero filesystem cost beyond the
   // existsSync.
   if (existsSync(KILLSWITCH_PATH)) return;
-  // Token gate defends against drive-by no-cors POSTs from any site
-  // the user visits. The token rotates per desktop session and lives
-  // at mode 0600, so only this user can read it.
-  const token = await readToken();
-  if (!token) return; // Hook server offline or missing; silently no-op.
   // Stamp agent_source so the hook server can route per-pet when we
   // ship multi-mascot. Today the field is recorded for telemetry
   // but doesn't affect routing.
@@ -152,9 +177,23 @@ async function notify({ state, duration, text, title, busy, sessionId }) {
   if (sessionId) {
     stateBody.session_id = sessionId;
     bubbleBody.session_id = sessionId;
+    bubbleBody.conversation_key = sessionId;
+    bubbleBody.source_session_id = sessionId;
+    bubbleBody.session_kind = "primary";
   }
-  if (title) bubbleBody.title = title;
+  if (title) {
+    bubbleBody.title = title;
+    bubbleBody.title_source = "server";
+  }
   if (busy !== undefined) bubbleBody.busy = busy;
+  if (status) bubbleBody.status = status;
+  bubbleBody.message_kind = messageKind;
+  bubbleBody.feed_source = "hook";
+  appendJournal(bubbleBody);
+  // Journal first: an event remains recoverable when the desktop is closed.
+  // The rotating token still gates all loopback HTTP writes.
+  const token = await readToken();
+  if (!token) return;
   await Promise.all([
     postJson(HOOK_SERVER_URL, stateBody, token),
     text ? postJson(HOOK_SERVER_BUBBLE_URL, bubbleBody, token) : Promise.resolve(),
@@ -166,18 +205,35 @@ async function notify({ state, duration, text, title, busy, sessionId }) {
 // us opencode's own LLM-generated session titles for the bubble.
 const PetdexPlugin = async ({ client }) => {
   const titleCache = new Map();
+  const clippedTitle = (title) =>
+    typeof title === "string" && title.trim().length > 0
+      ? (title.trim().length > 60 ? title.trim().slice(0, 59) + "\u2026" : title.trim())
+      : null;
   async function sessionTitle(sessionID) {
     if (!sessionID || !client) return titleCache.get(sessionID) || null;
     try {
       const res = await client.session.get({ path: { id: sessionID } });
-      const title = res?.data?.title;
-      if (typeof title === "string" && title.length > 0) {
-        titleCache.set(sessionID, title.length > 60 ? title.slice(0, 59) + "\u2026" : title);
-      }
+      const title = clippedTitle(res?.data?.title);
+      if (title) titleCache.set(sessionID, title);
     } catch {
       // Hook-server silence: a missing title never stains the agent.
     }
     return titleCache.get(sessionID) || null;
+  }
+  async function syncServerTitle(sessionID, rawTitle) {
+    const title = clippedTitle(rawTitle);
+    if (!sessionID || !title) return;
+    titleCache.set(sessionID, title);
+    if (existsSync(KILLSWITCH_PATH)) return;
+    const token = await readToken();
+    if (!token) return;
+    await postJson(HOOK_SERVER_TITLE_URL, {
+      session_id: sessionID,
+      conversation_key: sessionID,
+      title,
+      agent_source: "opencode",
+      ...originMetadata(),
+    }, token);
   }
   return {
     "tool.execute.before": async (input, output) => notify({
@@ -186,6 +242,8 @@ const PetdexPlugin = async ({ client }) => {
       title: await sessionTitle(input.sessionID),
       busy: true,
       sessionId: input.sessionID,
+      status: "running",
+      messageKind: "tool",
     }),
     "tool.execute.after": async (input) => notify({
       state: "idle",
@@ -193,11 +251,16 @@ const PetdexPlugin = async ({ client }) => {
       title: await sessionTitle(input.sessionID),
       busy: true,
       sessionId: input.sessionID,
+      status: "running",
+      messageKind: "tool",
     }),
     event: async ({ event }) => {
-      const sessionId = event?.properties?.sessionID;
+      const info = event?.properties?.info;
+      const sessionId = event?.properties?.sessionID ?? info?.id;
       if (typeof sessionId !== "string" || sessionId.length === 0) return;
-      if (event.type === "session.idle") {
+      if (event.type === "session.updated" || event.type === "session.created") {
+        await syncServerTitle(sessionId, info?.title);
+      } else if (event.type === "session.idle") {
         await notify({
           state: "waving",
           duration: 1500,
@@ -205,6 +268,8 @@ const PetdexPlugin = async ({ client }) => {
           title: await sessionTitle(sessionId),
           busy: false,
           sessionId,
+          status: "completed",
+          messageKind: "lifecycle",
         });
       } else if (event.type === "session.error") {
         await notify({
@@ -214,6 +279,8 @@ const PetdexPlugin = async ({ client }) => {
           title: await sessionTitle(sessionId),
           busy: false,
           sessionId,
+          status: "failed",
+          messageKind: "lifecycle",
         });
       }
     },

--- a/packages/petdex-desktop-native/src/assets/opencode-plugin.js
+++ b/packages/petdex-desktop-native/src/assets/opencode-plugin.js
@@ -2,6 +2,7 @@
 // Forwards OpenCode lifecycle events to the petdex desktop mascot via HTTP.
 // Edit STATE_MAP below to customize which state each event triggers.
 
+import { createHash } from "node:crypto";
 import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, unlinkSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
@@ -17,9 +18,8 @@ const REMOTE_HOST_PATH = join(RUNTIME_DIR, "remote-host");
 const JOURNAL_DIR = join(RUNTIME_DIR, "session-journal");
 const JOURNAL_LIMIT = 4 * 1024 * 1024;
 
-function journalStem(value, fallback) {
-  const safe = String(value || fallback).replace(/[^a-zA-Z0-9_.-]/g, "_");
-  return safe.slice(0, 96) || fallback;
+export function journalStem(value, fallback) {
+  return createHash("sha256").update(String(value || fallback), "utf8").digest("hex");
 }
 
 function appendJournal(body) {

--- a/packages/petdex-desktop-native/src/assets/petdex-codex-watch.py
+++ b/packages/petdex-desktop-native/src/assets/petdex-codex-watch.py
@@ -283,6 +283,13 @@ def apply_rollout_bytes(state: dict[str, Any], raw: bytes) -> None:
             if final:
                 state["text"] = final
                 state["message_kind"] = "assistant"
+            elif state["message_kind"] != "assistant" or not str(state["text"]).strip():
+                # Codex can finish without repeating the final response.
+                # Preserve actual assistant prose, but clear a transient
+                # prompt, reasoning, or “Thinking…” cue from the terminal
+                # card.
+                state["text"] = "Done."
+                state["message_kind"] = "status"
             continue
         if event_type in {"turn_aborted", "task_failed"}:
             state["lifecycle"] = True

--- a/packages/petdex-desktop-native/src/assets/petdex-codex-watch.py
+++ b/packages/petdex-desktop-native/src/assets/petdex-codex-watch.py
@@ -12,7 +12,6 @@ import fcntl
 import hashlib
 import json
 import os
-import socket
 import sys
 import time
 import urllib.request
@@ -24,6 +23,7 @@ HOME = Path.home()
 CODEX = HOME / ".codex"
 RUNTIME = HOME / ".petdex" / "runtime"
 TOKEN = RUNTIME / "update-token"
+REMOTE_HOST = RUNTIME / "remote-host"
 LEASE = RUNTIME / "tunnel-lease"
 LOCK = RUNTIME / "codex-watch.lock"
 PID = RUNTIME / "codex-watch.pid"
@@ -81,6 +81,13 @@ def session_meta_prefix(path: Path) -> bytes:
 
 def compact(value: Any, limit: int) -> str:
     return " ".join(str(value or "").split())[:limit]
+
+
+def remote_hostname() -> str:
+    try:
+        return compact(REMOTE_HOST.read_text(encoding="utf-8"), 64)
+    except OSError:
+        return ""
 
 
 def lease_alive() -> bool:
@@ -381,7 +388,7 @@ def event_from_state(path: Path, title: str, state: dict[str, Any]) -> dict[str,
         "source_session_id": path.stem[-36:],
         "session_id": path.stem[-36:],
         "session_kind": "primary",
-        "hostname": compact(socket.gethostname(), 64),
+        "hostname": remote_hostname(),
         "remote": True,
         "source_cwd": state["cwd"],
         "turn_id": state["turn_id"],

--- a/packages/petdex-desktop-native/src/assets/petdex-hermes-watch.py
+++ b/packages/petdex-desktop-native/src/assets/petdex-hermes-watch.py
@@ -17,7 +17,6 @@ import hashlib
 import json
 import os
 import re
-import socket
 import sqlite3
 import sys
 import time
@@ -32,6 +31,7 @@ HERMES_ROOT = Path(sys.argv[1]).expanduser() if len(sys.argv) > 1 else Path(
 ).expanduser()
 RUNTIME = HOME / ".petdex" / "runtime"
 TOKEN = RUNTIME / "update-token"
+REMOTE_HOST = RUNTIME / "remote-host"
 LEASE = RUNTIME / "tunnel-lease"
 LOCK = RUNTIME / "hermes-watch.lock"
 PID = RUNTIME / "hermes-watch.pid"
@@ -60,6 +60,13 @@ SUBAGENT_SOURCES = {
 
 def compact(value: Any, limit: int) -> str:
     return " ".join(str(value or "").split())[:limit]
+
+
+def remote_hostname() -> str:
+    try:
+        return compact(REMOTE_HOST.read_text(encoding="utf-8"), 64)
+    except OSError:
+        return ""
 
 
 def canonical_key(value: Any) -> str:
@@ -176,7 +183,7 @@ def snapshot() -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]]] | None:
         return None
 
     now = time.time()
-    hostname = compact(socket.gethostname(), 64)
+    hostname = remote_hostname()
     events: list[dict[str, Any]] = []
     terminals: dict[str, dict[str, Any]] = {}
     for row in rows:

--- a/packages/petdex-desktop-native/src/assets/petdex-remote-hook.sh
+++ b/packages/petdex-desktop-native/src/assets/petdex-remote-hook.sh
@@ -639,6 +639,13 @@ case "$phase" in
         ;;
 esac
 
+# Every visible bubble replaces the prior per-conversation Flock state. A
+# tool failure is intermediate; later progress and terminal events must carry
+# their current state instead of leaving the previous `failed` value sticky.
+if [ -n "$text" ] && $post_bubble; then
+    agent_state=$state
+fi
+
 post() {
     # -m 2: the tunnel adds latency the local 300ms budget never sees,
     # but a wedged tunnel still must not stall the agent.

--- a/packages/petdex-desktop-native/src/assets/petdex-remote-hook.sh
+++ b/packages/petdex-desktop-native/src/assets/petdex-remote-hook.sh
@@ -669,7 +669,7 @@ if [ -n "$text" ] && $post_bubble; then
     [ -n "$notification_kind" ] && metadata="$metadata,\"notification_kind\":\"$notification_kind\""
     source_cwd=$(text_field cwd 240)
     [ -n "$source_cwd" ] && metadata="$metadata,\"source_cwd\":\"$source_cwd\""
-    hostname=$(hostname 2>/dev/null | head -n 1 | tr -cd 'A-Za-z0-9._-')
+    hostname=$(sed -n '1p' "$HOME/.petdex/runtime/remote-host" 2>/dev/null | tr -cd 'A-Za-z0-9_-')
     [ -n "$hostname" ] && metadata="$metadata,\"hostname\":\"$hostname\""
     turn_id=$(id_field turn_id)
     [ -n "$turn_id" ] && metadata="$metadata,\"turn_id\":\"$turn_id\""

--- a/packages/petdex-desktop-native/src/assets/petdex-remote-hook.sh
+++ b/packages/petdex-desktop-native/src/assets/petdex-remote-hook.sh
@@ -116,7 +116,7 @@ keys = (
     "petdex_conversation_key", "parent_session_id", "petdex_parent_session_id", "child_session_id",
     "petdex_session_kind", "petdex_subagent_label", "child_role", "prompt", "user_message", "userPrompt",
     "petdex_session_title", "notification_type", "notification_kind", "tool_name", "question", "description",
-    "command", "file_path", "path", "pattern", "query", "last_assistant_message", "assistant_response",
+    "command", "file_path", "path", "pattern", "query", "last_assistant_message", "assistant_response", "prompt_response",
     "message", "child_summary", "cwd", "turn_id", "message_id", "event_id", "call_id", "request_id",
     "tool_use_id",
 )
@@ -464,6 +464,7 @@ busy=false
 text=
 session_status=idle
 message_kind=status
+agent_state=
 post_bubble=true
 notification_kind=$(id_field notification_type)
 [ -n "$notification_kind" ] || notification_kind=$(id_field notification_kind)
@@ -540,8 +541,10 @@ case "$phase" in
         ;;
     tool-failure)
         state=failed
-        session_status=failed
+        busy=true
+        session_status=running
         message_kind=tool
+        agent_state=failed
         text="Tool failed"
         [ "$agent" = "codex" ] && post_bubble=false
         ;;
@@ -572,6 +575,7 @@ case "$phase" in
         message_kind=assistant
         text=$(text_field assistant_response 960)
         [ -n "$text" ] || text=$(text_field last_assistant_message 960)
+        [ -n "$text" ] || text=$(text_field prompt_response 960)
         [ -n "$text" ] || text=$(text_field message 960)
         [ -n "$text" ] || text="Done."
         ;;
@@ -666,6 +670,7 @@ if [ -n "$text" ] && $post_bubble; then
     [ -n "$subagent_label" ] && metadata="$metadata,\"subagent_label\":\"$subagent_label\""
     [ -n "$title" ] && metadata="$metadata,\"title\":\"$title\""
     metadata="$metadata,\"title_source\":\"$title_source\",\"feed_source\":\"hook\",\"event_kind\":\"$phase\",\"message_kind\":\"$message_kind\",\"status\":\"$session_status\""
+    [ -n "$agent_state" ] && metadata="$metadata,\"agent_state\":\"$agent_state\""
     [ -n "$notification_kind" ] && metadata="$metadata,\"notification_kind\":\"$notification_kind\""
     source_cwd=$(text_field cwd 240)
     [ -n "$source_cwd" ] && metadata="$metadata,\"source_cwd\":\"$source_cwd\""

--- a/packages/petdex-desktop-native/src/directory_watch.zig
+++ b/packages/petdex-desktop-native/src/directory_watch.zig
@@ -1,0 +1,74 @@
+//! Coalescing directory-watch policy above the platform backends in plat.zig.
+//! Native notifications are hints; bounded reconciliation scans remain the
+//! authority, and a low-frequency sweep covers dropped/unsupported events.
+
+const std = @import("std");
+const plat = @import("plat.zig");
+
+pub const safety_sweep_ms: i64 = 60_000;
+pub const polling_fallback_ms: i64 = 2_000;
+
+pub const Trigger = enum { none, changed, overflow, safety };
+
+pub const Controller = struct {
+    native: plat.DirectoryWatch,
+    started: bool = false,
+    last_sweep_ms: i64 = 0,
+    cursor: u64 = 0,
+
+    pub fn init(path: []const u8) ?Controller {
+        return .{ .native = plat.DirectoryWatch.init(path) orelse return null };
+    }
+
+    pub fn start(self: *Controller) void {
+        self.started = self.native.start();
+    }
+
+    pub fn root(self: *const Controller) []const u8 {
+        return self.native.root();
+    }
+
+    /// Coalesces any number of native events into one reconciliation trigger.
+    /// Overflow is explicit so callers reset their incremental scan cursor but
+    /// still honor the same per-pass work/time budget.
+    pub fn poll(self: *Controller, monotonic_now_ms: i64) Trigger {
+        const signal = if (self.started) self.native.take() else .none;
+        const interval = if (self.started) safety_sweep_ms else polling_fallback_ms;
+        const trigger = decide(signal, self.last_sweep_ms, monotonic_now_ms, interval);
+        if (trigger != .none) {
+            self.last_sweep_ms = monotonic_now_ms;
+            self.cursor +%= 1;
+        }
+        return trigger;
+    }
+};
+
+fn decide(signal: plat.DirectoryWatchSignal, last_ms: i64, now_ms: i64, interval_ms: i64) Trigger {
+    return switch (signal) {
+        .overflow => .overflow,
+        .dirty => .changed,
+        .none => if (last_ms == 0 or now_ms - last_ms >= interval_ms) .safety else .none,
+    };
+}
+
+test "watch policy prioritizes overflow and keeps bounded safety fallback" {
+    std.testing.refAllDecls(plat.DirectoryWatch);
+    try std.testing.expectEqual(Trigger.overflow, decide(.overflow, 1_000, 1_001, safety_sweep_ms));
+    try std.testing.expectEqual(Trigger.changed, decide(.dirty, 1_000, 1_001, safety_sweep_ms));
+    try std.testing.expectEqual(Trigger.none, decide(.none, 1_000, 1_999, polling_fallback_ms));
+    try std.testing.expectEqual(Trigger.safety, decide(.none, 1_000, 3_000, polling_fallback_ms));
+    try std.testing.expectEqual(Trigger.safety, decide(.none, 1_000, 61_000, safety_sweep_ms));
+}
+
+test "watch controller advances one cursor per coalesced scheduling decision" {
+    var controller = Controller.init("safe-root").?;
+    controller.started = true;
+    controller.native.dirty.store(true, .release);
+    controller.native.dirty.store(true, .release);
+    try std.testing.expectEqual(Trigger.changed, controller.poll(10));
+    try std.testing.expectEqual(@as(u64, 1), controller.cursor);
+    try std.testing.expectEqual(Trigger.none, controller.poll(11));
+    controller.native.overflow.store(true, .release);
+    try std.testing.expectEqual(Trigger.overflow, controller.poll(12));
+    try std.testing.expectEqual(@as(u64, 2), controller.cursor);
+}

--- a/packages/petdex-desktop-native/src/flock.zig
+++ b/packages/petdex-desktop-native/src/flock.zig
@@ -1,7 +1,7 @@
 //! Flock model: one body per live agent instead of one pet for all of them.
 //!
-//! The mailbox already keeps a bubble per conversation, keyed by session id
-//! and carrying the Herdr pane that produced it. Until now the app folded
+//! The mailbox already keeps a bubble per canonical conversation identity
+//! and carries the Herdr pane that produced it. Until now the app folded
 //! that set into a single `model.state`, so eight agents shared one mascot
 //! and one aggregate state. This module keeps the set intact and gives each
 //! member a body, a slot, and a state of its own.
@@ -20,8 +20,13 @@ pub const max_members = hook_server.max_bubbles;
 /// mailbox reuses its slots: a member has to survive the next drain that
 /// compacts the array underneath it.
 pub const Member = struct {
-    session: [64]u8 = @splat(0),
+    session: [hook_server.bubble_session_capacity]u8 = @splat(0),
     session_len: usize = 0,
+    agent: [24]u8 = @splat(0),
+    agent_len: usize = 0,
+    hostname: [64]u8 = @splat(0),
+    hostname_len: usize = 0,
+    remote: bool = false,
     label: [24]u8 = @splat(0),
     label_len: usize = 0,
     herdr_pane: [64]u8 = @splat(0),
@@ -31,6 +36,20 @@ pub const Member = struct {
 
     pub fn sessionSlice(self: *const Member) []const u8 {
         return self.session[0..self.session_len];
+    }
+    pub fn agentSlice(self: *const Member) []const u8 {
+        return self.agent[0..self.agent_len];
+    }
+    pub fn hostnameSlice(self: *const Member) []const u8 {
+        return self.hostname[0..self.hostname_len];
+    }
+    pub fn identity(self: *const Member) hook_server.BubbleIdentity {
+        return .{
+            .conversation_key = self.sessionSlice(),
+            .agent = self.agentSlice(),
+            .hostname = self.hostnameSlice(),
+            .remote = self.remote,
+        };
     }
     pub fn labelSlice(self: *const Member) []const u8 {
         return self.label[0..self.label_len];
@@ -96,12 +115,11 @@ pub fn reconcile(model: *Model, bubbles: []const hook_server.Bubble) void {
     var taken: [max_members]bool = @splat(false);
     var next_len: usize = 0;
 
-    // First pass: sessions we already had keep their existing slot.
+    // First pass: canonical identities we already had keep their slot.
     for (bubbles) |*bubble| {
-        const session = bubble.sessionSlice();
         for (model.members[0..model.len], 0..) |*existing, slot| {
             if (existing.session_len == 0) continue;
-            if (!std.mem.eql(u8, existing.sessionSlice(), session)) continue;
+            if (!existing.identity().matches(bubble.identity())) continue;
             if (slot >= max_members or taken[slot]) break;
             next[slot] = existing.*;
             next[slot].state = stateForBubble(bubble);
@@ -114,13 +132,12 @@ pub fn reconcile(model: *Model, bubbles: []const hook_server.Bubble) void {
         }
     }
 
-    // Second pass: new sessions fill the lowest free slot.
+    // Second pass: new canonical identities fill the lowest free slot.
     for (bubbles) |*bubble| {
-        const session = bubble.sessionSlice();
         var seen = false;
         for (next[0..], 0..) |*member, slot| {
             if (!taken[slot]) continue;
-            if (std.mem.eql(u8, member.sessionSlice(), session)) {
+            if (member.identity().matches(bubble.identity())) {
                 seen = true;
                 break;
             }
@@ -130,7 +147,10 @@ pub fn reconcile(model: *Model, bubbles: []const hook_server.Bubble) void {
         while (slot < max_members and taken[slot]) slot += 1;
         if (slot == max_members) break;
         var member: Member = .{};
-        copyInto(&member.session, &member.session_len, session);
+        copyInto(&member.session, &member.session_len, bubble.sessionSlice());
+        copyInto(&member.agent, &member.agent_len, bubble.agent[0..bubble.agent_len]);
+        copyInto(&member.hostname, &member.hostname_len, bubble.hostnameSlice());
+        member.remote = bubble.remote;
         copyInto(&member.label, &member.label_len, bubble.agent[0..bubble.agent_len]);
         copyInto(&member.herdr_pane, &member.herdr_pane_len, bubble.herdrPaneSlice());
         member.state = stateForBubble(bubble);
@@ -223,6 +243,13 @@ fn testBubble(session: []const u8, agent: []const u8, pane: []const u8, busy: bo
     return bubble;
 }
 
+fn testRemoteBubble(session: []const u8, agent: []const u8, hostname: []const u8, busy: bool) hook_server.Bubble {
+    var bubble = testBubble(session, agent, "", busy);
+    copyInto(&bubble.hostname, &bubble.hostname_len, hostname);
+    bubble.remote = true;
+    return bubble;
+}
+
 test "each live session gets its own body" {
     var model: Model = .{};
     const bubbles = [_]hook_server.Bubble{
@@ -233,6 +260,29 @@ test "each live session gets its own body" {
     try std.testing.expectEqual(@as(usize, 2), model.len);
     try std.testing.expectEqualStrings("s1", model.members[0].sessionSlice());
     try std.testing.expectEqualStrings("s2", model.members[1].sessionSlice());
+}
+
+test "shared conversation keys keep distinct agent and remote-host bodies" {
+    var model: Model = .{};
+    reconcile(&model, &[_]hook_server.Bubble{
+        testRemoteBubble("shared", "codex", "host-a", true),
+        testRemoteBubble("shared", "codex", "host-b", false),
+        testRemoteBubble("shared", "hermes", "host-a", true),
+    });
+    try std.testing.expectEqual(@as(usize, 3), model.len);
+    try std.testing.expectEqualStrings("host-a", model.members[0].hostnameSlice());
+    try std.testing.expectEqualStrings("host-b", model.members[1].hostnameSlice());
+    try std.testing.expectEqualStrings("hermes", model.members[2].agentSlice());
+
+    // A reordered drain updates the right member without moving its siblings.
+    reconcile(&model, &[_]hook_server.Bubble{
+        testRemoteBubble("shared", "hermes", "host-a", false),
+        testRemoteBubble("shared", "codex", "host-b", true),
+        testRemoteBubble("shared", "codex", "host-a", false),
+    });
+    try std.testing.expectEqual(sprite.State.idle, model.members[0].state);
+    try std.testing.expectEqual(sprite.State.running, model.members[1].state);
+    try std.testing.expectEqual(sprite.State.idle, model.members[2].state);
 }
 
 test "a busy agent runs while an idle one does not" {

--- a/packages/petdex-desktop-native/src/hook_runner.zig
+++ b/packages/petdex-desktop-native/src/hook_runner.zig
@@ -18,12 +18,15 @@ const plat = @import("plat.zig");
 const jsonString = hook_server.jsonStringPub;
 
 const stdin_cap = 64 * 1024;
-const title_max = 60;
-const preview_max = 110;
-const transcript_tail_cap = 64 * 1024;
+const title_max = hook_server.bubble_title_capacity;
+const preview_max = 960;
+const transcript_tail_cap = 256 * 1024;
+const post_body_capacity = 8 * 1024;
 const session_ttl_secs: i64 = 24 * 60 * 60;
 const post_timeout_ms: u64 = 300;
 const post_poll_ms: u64 = 5;
+const journal_version: u8 = 1;
+const journal_rotate_bytes: u64 = 4 * 1024 * 1024;
 
 // ------------------------------------------------------------- entry
 
@@ -44,6 +47,106 @@ pub fn run(phase: []const u8, arg_agent: ?[]const u8, origin_app: plat.OriginApp
         if (cReadFile(ks, &probe) != null) return;
     } else |_| {}
 
+    const agent = resolveAgent(payload, arg_agent);
+    const effective_origin: plat.OriginApplication = if (origin_app == .none and std.ascii.eqlIgnoreCase(agent, "codex")) .codex else origin_app;
+    const source_app = effective_origin.wireName();
+    var tty_buf: [64]u8 = undefined;
+    const source_tty = if (effective_origin == .terminal) (plat.controllingTty(&tty_buf) orelse "") else "";
+    const source_cwd = plat.safeSourceCwd(source_cwd_raw) orelse "";
+    const herdr_pane = plat.safeHerdrPaneId(herdr_pane_raw) orelse "";
+    var session_hash_buf: [64]u8 = undefined;
+    const session_id = payloadSessionId(phase, payload, &session_hash_buf);
+    const session_context = payloadSessionContext(agent, phase, payload, session_id);
+    const turn_id = safeSessionId(firstJsonString(payload, &.{ "turn_id", "turnId" }));
+    var hostname_buf: [64]u8 = undefined;
+    const hostname = plat.hostName(&hostname_buf) orelse "local";
+
+    // Session title precedence: the agent/server's generated title wins and
+    // may change at any time; the first user prompt is only a fallback. Every
+    // event re-resolves the authoritative source so delayed auto-titles and
+    // server-side renames flow into an already visible bubble.
+    var sessions_buf: [512]u8 = undefined;
+    const sessions_dir = std.fmt.bufPrint(&sessions_buf, "{s}/.petdex/runtime/sessions", .{home}) catch return;
+    if (session_id) |sid| {
+        var server_title_buf: [256]u8 = undefined;
+        if (authoritativeTitle(agent, home, sid, payload, &server_title_buf)) |server_title| {
+            rememberTitle(sessions_dir, sid, server_title, .server, true);
+        } else if (isPromptPhase(phase)) {
+            if (promptTitle(payload)) |prompt| rememberTitle(sessions_dir, sid, prompt, .prompt, false);
+        }
+    }
+    var title_buf: [256]u8 = undefined;
+    var title_source: hook_server.TitleSource = .unknown;
+    const title: []const u8 = if (session_id) |sid| blk: {
+        const record = readTitle(sessions_dir, sid, &title_buf) orelse break :blk "";
+        title_source = record.source;
+        break :blk record.text;
+    } else "";
+
+    var text_buf: [preview_max]u8 = undefined;
+    var text = formatBubble(phase, payload, &text_buf) orelse "";
+
+    var preview_buf: [512]u8 = undefined;
+    var tail_buf: [transcript_tail_cap]u8 = undefined;
+    if (isStopPhase(phase)) {
+        // Close-of-turn preview: Codex ships last_assistant_message in
+        // the payload; Claude Code needs the bounded transcript tail.
+        const written: ?[]const u8 = jsonString(payload, "last_assistant_message") orelse blk: {
+            const tp = jsonString(payload, "transcript_path") orelse break :blk null;
+            const tail = cReadTail(tp, &tail_buf) orelse break :blk null;
+            break :blk lastAssistantFromTail(tail);
+        };
+        if (written) |w| {
+            if (clipEscaped(w, preview_max, &preview_buf)) |p| {
+                if (p.len > 0) text = p;
+            }
+        }
+        pruneSessions(sessions_dir);
+    }
+
+    // A failed tool does not end the turn — the agent reacts to the error and
+    // keeps working — so the bubble keeps its spinner, same as `post`.
+    const tool_name = jsonString(payload, "tool_name");
+    const notification_kind = firstJsonString(payload, &.{ "notification_type", "notification_kind" }) orelse "";
+    const status = statusForEvent(phase, tool_name, notification_kind);
+    const busy = status == .running;
+    const state = stateForEventWithNotification(phase, tool_name, notification_kind);
+
+    // First lower the provider payload into the canonical event and persist it.
+    // The journal deliberately precedes the update-token/HTTP path, allowing a
+    // task that ran while Petdex was closed to be recovered on next launch.
+    var bubble_body_buf: [post_body_capacity]u8 = undefined;
+    var bubble_body: ?[]const u8 = null;
+    if (text.len > 0 and shouldPostBubble(agent, phase)) {
+        const correlation_id = firstJsonString(payload, &.{ "request_id", "tool_use_id", "message_id", "event_id", "call_id", "turn_id", "turnId" });
+        const is_request = status == .needs_input;
+        const is_response = std.mem.eql(u8, phase, "approval-response") or
+            (std.mem.eql(u8, phase, "post") and tool_name != null and asciiEqlLower(tool_name.?, "clarify"));
+        bubble_body = bubbleBodyWithContext(&bubble_body_buf, text, title, busy, agent, .{
+            .session_id = session_id,
+            .conversation_key = session_context.conversationKey(),
+            .parent_session_id = session_context.parentSession(),
+            .session_kind = session_context.kind,
+            .subagent_label = session_context.labelSlice(),
+            .source_app = source_app,
+            .source_tty = source_tty,
+            .source_cwd = source_cwd,
+            .herdr_pane = herdr_pane,
+            .hostname = hostname,
+            .turn_id = turn_id,
+            .message_id = correlation_id,
+            .event_kind = phase,
+            .request_id = if (is_request) correlation_id else null,
+            .resolves_request_id = if (is_response) correlation_id else null,
+            .notification_kind = notification_kind,
+            .message_kind = messageKindForEvent(phase, payload, notification_kind),
+            .title_source = title_source,
+            .status = status,
+            .agent_state = state,
+        });
+        if (bubble_body) |body| appendJournalEvent(home, agent, session_context.conversationKey(), body);
+    }
+
     var token_buf: [128]u8 = undefined;
     const token_raw = blk: {
         const tp = std.fmt.bufPrint(&path_buf, "{s}/.petdex/runtime/update-token", .{home}) catch break :blk null;
@@ -52,74 +155,18 @@ pub fn run(phase: []const u8, arg_agent: ?[]const u8, origin_app: plat.OriginApp
     const token = std.mem.trim(u8, token_raw, " \t\r\n");
     if (token.len == 0) return;
 
-    const agent = resolveAgent(payload, arg_agent);
-    const source_app = origin_app.wireName();
-    var tty_buf: [64]u8 = undefined;
-    const source_tty = if (origin_app == .terminal) (plat.controllingTty(&tty_buf) orelse "") else "";
-    const source_cwd = plat.safeSourceCwd(source_cwd_raw) orelse "";
-    const herdr_pane = plat.safeHerdrPaneId(herdr_pane_raw) orelse "";
-    var session_hash_buf: [64]u8 = undefined;
-    const session_id = payloadSessionId(payload, &session_hash_buf);
-
-    // Session title: user-prompt seeds it, every event attaches it.
-    var sessions_buf: [512]u8 = undefined;
-    const sessions_dir = std.fmt.bufPrint(&sessions_buf, "{s}/.petdex/runtime/sessions", .{home}) catch return;
-    if (session_id) |sid| {
-        if (isPromptPhase(phase)) {
-            if (jsonString(payload, "prompt") orelse jsonString(payload, "user_message")) |prompt| rememberTitle(sessions_dir, sid, prompt);
-        }
-    }
-    var title_buf: [256]u8 = undefined;
-    const title: []const u8 = jsonString(payload, "petdex_session_title") orelse if (session_id) |sid| (readTitle(sessions_dir, sid, &title_buf) orelse "") else "";
-
-    var text_buf: [256]u8 = undefined;
-    var text = formatBubble(phase, payload, &text_buf) orelse "";
-
-    var preview_buf: [512]u8 = undefined;
-    var tail_buf: [transcript_tail_cap]u8 = undefined;
-    if (isStopPhase(phase) or isAssistantPhase(phase) or isSubagentStopPhase(phase)) {
-        // Close-of-turn preview: Codex ships last_assistant_message in
-        // the payload; Claude Code needs the bounded transcript tail.
-        const written: ?[]const u8 = if (isAssistantPhase(phase))
-            jsonString(payload, "assistant_response")
-        else if (isSubagentStopPhase(phase))
-            jsonString(payload, "child_summary")
-        else
-            jsonString(payload, "last_assistant_message") orelse blk: {
-                const tp = jsonString(payload, "transcript_path") orelse break :blk null;
-                const tail = cReadTail(tp, &tail_buf) orelse break :blk null;
-                break :blk lastAssistantFromTail(tail);
-            };
-        if (written) |w| {
-            if (clipEscaped(w, preview_max, &preview_buf)) |p| {
-                if (p.len > 0) text = p;
-            }
-        }
-        if (!isSubagentStopPhase(phase)) pruneSessions(sessions_dir);
-    }
-
-    // A failed tool does not end the turn — the agent reacts to the error and
-    // keeps working — so the bubble keeps its spinner, same as `post`.
-    const busy = isPromptPhase(phase) or std.mem.eql(u8, phase, "pre") or
-        std.mem.eql(u8, phase, "post") or isToolFailurePhase(phase) or
-        std.mem.eql(u8, phase, "approval-response") or std.mem.eql(u8, phase, "subagent-start");
-    const state = stateForEvent(phase, jsonString(payload, "tool_name"));
-
     var posts: [2]PostJob = undefined;
     var post_count: usize = 0;
-    var body_buf: [1536]u8 = undefined;
-    if (text.len > 0) {
-        const body = bubbleBodyWithMetadata(&body_buf, text, title, busy, agent, session_id, source_app, source_tty, source_cwd, herdr_pane, state);
-        if (body) |b| {
-            if (startPost("/bubble", b, token)) |post| {
-                posts[post_count] = post;
-                post_count += 1;
-            }
+    if (bubble_body) |body| {
+        if (startPost("/bubble", body, token)) |post| {
+            posts[post_count] = post;
+            post_count += 1;
         }
     }
     if (state) |s| {
+        var state_body_buf: [post_body_capacity]u8 = undefined;
         const duration_ms: u32 = if (isToolFailurePhase(phase)) failed_duration_ms else 0;
-        const body = stateBody(&body_buf, s, duration_ms, agent);
+        const body = stateBody(&state_body_buf, s, duration_ms, agent);
         if (body) |b| {
             if (startPost("/state", b, token)) |post| {
                 posts[post_count] = post;
@@ -140,6 +187,46 @@ fn resolveAgent(payload: []const u8, arg_agent: ?[]const u8) []const u8 {
     return jsonString(payload, "agent_source") orelse "";
 }
 
+fn journalSafeStem(out: []u8, raw: []const u8, fallback: []const u8) []const u8 {
+    const source = if (raw.len > 0) raw else fallback;
+    var written: usize = 0;
+    for (source) |byte| {
+        if (written == out.len) break;
+        out[written] = if (std.ascii.isAlphanumeric(byte) or byte == '-' or byte == '_' or byte == '.') byte else '_';
+        written += 1;
+    }
+    return out[0..written];
+}
+
+fn appendJournalEvent(home: []const u8, agent: []const u8, conversation: ?[]const u8, body: []const u8) void {
+    var dir_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const dir = std.fmt.bufPrint(&dir_buf, "{s}/.petdex/runtime/session-journal", .{home}) catch return;
+    if (!plat.makeDirMode(dir, 0o700)) return;
+
+    var agent_buf: [32]u8 = undefined;
+    var conversation_buf: [96]u8 = undefined;
+    const agent_stem = journalSafeStem(&agent_buf, agent, "agent");
+    const conversation_stem = journalSafeStem(&conversation_buf, conversation orelse "", "unkeyed");
+    var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "{s}/{s}-{s}.jsonl", .{ dir, agent_stem, conversation_stem }) catch return;
+
+    var record_buf: [post_body_capacity + 64]u8 = undefined;
+    const record = std.fmt.bufPrint(&record_buf, "{{\"journal_version\":{d},\"event\":{s}}}\n", .{ journal_version, body }) catch return;
+    _ = plat.appendFileModeRotating(path, record, 0o600, journal_rotate_bytes);
+}
+
+/// Local Codex rollouts contain the same user-visible `agent_message` and
+/// `agent_reasoning` feed rendered by Codex Pet. Pre/post tool hooks still
+/// drive mascot state, but must not replace that feed with lower-level
+/// summaries such as "Ran rg". Other agents (and the remote shell adapter)
+/// continue using hook text because no local rollout is available for them.
+fn shouldPostBubble(agent: []const u8, phase: []const u8) bool {
+    if (!std.ascii.eqlIgnoreCase(agent, "codex")) return true;
+    return !(std.mem.eql(u8, phase, "pre") or
+        std.mem.eql(u8, phase, "post") or
+        isToolFailurePhase(phase));
+}
+
 fn isPromptPhase(phase: []const u8) bool {
     return std.mem.eql(u8, phase, "user-prompt") or std.mem.eql(u8, phase, "session-start");
 }
@@ -148,16 +235,61 @@ fn isStopPhase(phase: []const u8) bool {
     return std.mem.eql(u8, phase, "stop") or std.mem.eql(u8, phase, "session-end");
 }
 
-fn isAssistantPhase(phase: []const u8) bool {
-    return std.mem.eql(u8, phase, "assistant");
-}
-
-fn isSubagentStopPhase(phase: []const u8) bool {
-    return std.mem.eql(u8, phase, "subagent-stop");
-}
-
 fn isToolFailurePhase(phase: []const u8) bool {
     return std.mem.eql(u8, phase, "tool-failure");
+}
+
+fn notificationNeedsInput(kind: []const u8) bool {
+    return std.mem.eql(u8, kind, "permission_prompt") or
+        std.mem.eql(u8, kind, "elicitation_dialog") or
+        std.mem.eql(u8, kind, "elicitation_url_dialog") or
+        std.mem.eql(u8, kind, "agent_needs_input");
+}
+
+fn notificationCompletes(kind: []const u8) bool {
+    return std.mem.eql(u8, kind, "idle_prompt") or std.mem.eql(u8, kind, "agent_completed");
+}
+
+fn statusForEvent(phase: []const u8, tool_name: ?[]const u8, notification_kind: []const u8) hook_server.SessionStatus {
+    if (std.mem.eql(u8, phase, "approval-request")) return .needs_input;
+    if (std.mem.eql(u8, phase, "notification")) {
+        if (notificationNeedsInput(notification_kind)) return .needs_input;
+        if (notificationCompletes(notification_kind)) return .completed;
+        return .idle;
+    }
+    // `waiting` remains a sprite/state compatibility phase only. It is not a
+    // correlated request and therefore cannot make the session orange.
+    if (std.mem.eql(u8, phase, "waiting")) return .idle;
+    if (std.mem.eql(u8, phase, "pre") and tool_name != null and asciiEqlLower(tool_name.?, "clarify")) return .needs_input;
+    if (isToolFailurePhase(phase)) return .failed;
+    if (isStopPhase(phase) or std.mem.eql(u8, phase, "assistant")) return .completed;
+    if (isPromptPhase(phase) or
+        std.mem.eql(u8, phase, "pre") or
+        std.mem.eql(u8, phase, "post") or
+        std.mem.eql(u8, phase, "pre-llm") or
+        std.mem.eql(u8, phase, "approval-response") or
+        std.mem.eql(u8, phase, "subagent-start") or
+        std.mem.eql(u8, phase, "subagent-stop")) return .running;
+    return .idle;
+}
+
+fn messageKindForEvent(phase: []const u8, payload: []const u8, notification_kind: []const u8) hook_server.MessageKind {
+    if (std.mem.eql(u8, phase, "assistant")) return .assistant;
+    // Hermes emits `subagent_stop` on the parent's hook stream, but includes
+    // the child's concise result in `child_summary`. Preserve that one
+    // user-facing summary in the nested branch rather than demoting it to
+    // lifecycle noise (or replacing the parent's primary message).
+    if (std.mem.eql(u8, phase, "subagent-stop") and
+        firstJsonString(payload, &.{ "child_summary", "subagent_summary" }) != null)
+        return .assistant;
+    if (std.mem.eql(u8, phase, "pre") or std.mem.eql(u8, phase, "post") or isToolFailurePhase(phase)) return .tool;
+    if (std.mem.eql(u8, phase, "approval-request") or
+        (std.mem.eql(u8, phase, "notification") and notificationNeedsInput(notification_kind))) return .prompt;
+    if (isStopPhase(phase) or
+        std.mem.eql(u8, phase, "subagent-start") or
+        std.mem.eql(u8, phase, "subagent-stop")) return .lifecycle;
+    if (isPromptPhase(phase)) return .prompt;
+    return .status;
 }
 
 /// The /bubble request body, extracted and pure for the same reason stateBody
@@ -184,27 +316,75 @@ pub fn bubbleBody(out: []u8, text: []const u8, title: []const u8, busy: bool, ag
 /// hooks already compute (failed, review, waiting) have to travel here to
 /// survive. Senders that pass null keep the previous body byte for byte.
 pub fn bubbleBodyWithMetadata(out: []u8, text: []const u8, title: []const u8, busy: bool, agent: []const u8, session_id: ?[]const u8, source_app: []const u8, source_tty: []const u8, source_cwd: []const u8, herdr_pane: []const u8, agent_state: ?[]const u8) ?[]const u8 {
+    return bubbleBodyWithContext(out, text, title, busy, agent, .{
+        .session_id = session_id,
+        .source_app = source_app,
+        .source_tty = source_tty,
+        .source_cwd = source_cwd,
+        .herdr_pane = herdr_pane,
+        .agent_state = agent_state,
+    });
+}
+
+const BubbleWireContext = struct {
+    session_id: ?[]const u8 = null,
+    conversation_key: ?[]const u8 = null,
+    parent_session_id: ?[]const u8 = null,
+    session_kind: hook_server.SessionKind = .primary,
+    subagent_label: []const u8 = "",
+    source_app: []const u8 = "",
+    source_tty: []const u8 = "",
+    source_cwd: []const u8 = "",
+    herdr_pane: []const u8 = "",
+    hostname: []const u8 = "",
+    turn_id: ?[]const u8 = null,
+    message_id: ?[]const u8 = null,
+    event_kind: []const u8 = "",
+    request_id: ?[]const u8 = null,
+    resolves_request_id: ?[]const u8 = null,
+    notification_kind: []const u8 = "",
+    message_kind: hook_server.MessageKind = .status,
+    title_source: hook_server.TitleSource = .unknown,
+    status: hook_server.SessionStatus = .idle,
+    agent_state: ?[]const u8 = null,
+};
+
+fn bubbleBodyWithContext(out: []u8, text: []const u8, title: []const u8, busy: bool, agent: []const u8, context: BubbleWireContext) ?[]const u8 {
     var title_buf: [256]u8 = undefined;
     const title_part: []const u8 = if (title.len > 0)
         (std.fmt.bufPrint(&title_buf, ",\"title\":\"{s}\"", .{title}) catch return null)
     else
         "";
     var session_buf: [96]u8 = undefined;
-    const session_part: []const u8 = if (session_id) |sid|
+    const session_part: []const u8 = if (context.session_id) |sid|
         (std.fmt.bufPrint(&session_buf, ",\"session_id\":\"{s}\"", .{sid}) catch return null)
     else
         "";
-    var metadata_buf: [800]u8 = undefined;
-    const metadata = if (source_app.len > 0 or source_tty.len > 0 or source_cwd.len > 0 or herdr_pane.len > 0)
-        (std.fmt.bufPrint(&metadata_buf, ",\"source_app\":\"{s}\",\"source_tty\":\"{s}\",\"source_cwd\":\"{s}\",\"herdr_pane_id\":\"{s}\"", .{ source_app, source_tty, source_cwd, herdr_pane }) catch return null)
+    var context_buf: [2048]u8 = undefined;
+    const conversation = context.conversation_key orelse "";
+    const parent = context.parent_session_id orelse "";
+    const turn = context.turn_id orelse "";
+    const message_id = context.message_id orelse "";
+    const request_id = context.request_id orelse "";
+    const resolves_request_id = context.resolves_request_id orelse "";
+    const session_kind = if (context.session_kind == .subagent) "subagent" else "primary";
+    const has_canonical_context = conversation.len > 0 or parent.len > 0 or
+        context.session_kind == .subagent or context.subagent_label.len > 0 or
+        context.source_app.len > 0 or context.source_tty.len > 0 or
+        context.source_cwd.len > 0 or context.herdr_pane.len > 0 or context.hostname.len > 0 or turn.len > 0 or
+        message_id.len > 0 or context.event_kind.len > 0 or request_id.len > 0 or
+        resolves_request_id.len > 0 or context.notification_kind.len > 0 or context.message_kind != .status or
+        context.title_source != .unknown or context.status != .idle;
+    const context_part: []const u8 = if (has_canonical_context)
+        (std.fmt.bufPrint(&context_buf, ",\"conversation_key\":\"{s}\",\"source_session_id\":\"{s}\",\"parent_session_id\":\"{s}\",\"session_kind\":\"{s}\",\"subagent_label\":\"{s}\",\"source_app\":\"{s}\",\"source_tty\":\"{s}\",\"source_cwd\":\"{s}\",\"herdr_pane_id\":\"{s}\",\"hostname\":\"{s}\",\"turn_id\":\"{s}\",\"message_id\":\"{s}\",\"event_kind\":\"{s}\",\"request_id\":\"{s}\",\"resolves_request_id\":\"{s}\",\"notification_kind\":\"{s}\",\"message_kind\":\"{s}\",\"title_source\":\"{s}\",\"feed_source\":\"hook\",\"status\":\"{s}\"", .{ conversation, context.session_id orelse "", parent, session_kind, context.subagent_label, context.source_app, context.source_tty, context.source_cwd, context.herdr_pane, context.hostname, turn, message_id, context.event_kind, request_id, resolves_request_id, context.notification_kind, @tagName(context.message_kind), @tagName(context.title_source), context.status.wireName() }) catch return null)
     else
         "";
     var state_buf: [48]u8 = undefined;
-    const state_part: []const u8 = if (agent_state) |st|
+    const state_part: []const u8 = if (context.agent_state) |st|
         (std.fmt.bufPrint(&state_buf, ",\"agent_state\":\"{s}\"", .{st}) catch return null)
     else
         "";
-    return std.fmt.bufPrint(out, "{{\"text\":\"{s}\"{s},\"busy\":{},\"agent_source\":\"{s}\"{s}{s}{s}}}", .{ text, title_part, busy, agent, session_part, metadata, state_part }) catch null;
+    return std.fmt.bufPrint(out, "{{\"text\":\"{s}\"{s},\"busy\":{},\"agent_source\":\"{s}\"{s}{s}{s}}}", .{ text, title_part, busy, agent, session_part, context_part, state_part }) catch null;
 }
 
 /// The /state request body. Extracted and pure for one reason: `run()` reaches
@@ -232,22 +412,27 @@ pub fn stateBody(out: []u8, state: []const u8, duration_ms: u32, agent: []const 
 pub const failed_duration_ms: u32 = 1220;
 
 /// Port of stateForEvent: phase + tool → sprite state.
-pub fn stateForEvent(phase: []const u8, tool_name: ?[]const u8) ?[]const u8 {
+fn stateForEventWithNotification(phase: []const u8, tool_name: ?[]const u8, notification_kind: []const u8) ?[]const u8 {
     if (std.mem.eql(u8, phase, "pre")) {
         if (tool_name) |name| {
+            if (asciiEqlLower(name, "clarify")) return "waiting";
             if (asciiEqlLower(name, "read") or asciiEqlLower(name, "grep") or asciiEqlLower(name, "glob")) return "review";
         }
         return "running";
     }
-    if (std.mem.eql(u8, phase, "post")) return "idle";
+    if (std.mem.eql(u8, phase, "post") or std.mem.eql(u8, phase, "approval-response")) return "running";
     if (isToolFailurePhase(phase)) return "failed";
-    if (isStopPhase(phase)) return "waving";
-    if (isAssistantPhase(phase)) return "waving";
+    if (isStopPhase(phase) or std.mem.eql(u8, phase, "assistant")) return "waving";
     if (isPromptPhase(phase)) return "jumping";
-    if (std.mem.eql(u8, phase, "waiting") or std.mem.eql(u8, phase, "notification") or std.mem.eql(u8, phase, "approval-request")) return "waiting";
-    if (std.mem.eql(u8, phase, "approval-response") or std.mem.eql(u8, phase, "subagent-start")) return "running";
-    if (isSubagentStopPhase(phase)) return "idle";
+    if (std.mem.eql(u8, phase, "approval-request") or
+        (std.mem.eql(u8, phase, "notification") and notificationNeedsInput(notification_kind))) return "waiting";
+    if (std.mem.eql(u8, phase, "waiting")) return null;
+    if (std.mem.eql(u8, phase, "pre-llm") or std.mem.eql(u8, phase, "subagent-start") or std.mem.eql(u8, phase, "subagent-stop")) return "running";
     return null;
+}
+
+pub fn stateForEvent(phase: []const u8, tool_name: ?[]const u8) ?[]const u8 {
+    return stateForEventWithNotification(phase, tool_name, "");
 }
 
 // ---------------------------------------------------------- templates
@@ -257,13 +442,47 @@ pub fn stateForEvent(phase: []const u8, tool_name: ?[]const u8) ?[]const u8 {
 /// re-embedded into the POST body).
 pub fn formatBubble(phase: []const u8, payload: []const u8, out: []u8) ?[]const u8 {
     if (isPromptPhase(phase)) return "Thinking…";
-    if (isStopPhase(phase)) return "Done.";
-    if (isAssistantPhase(phase)) return "Done.";
-    if (std.mem.eql(u8, phase, "waiting") or std.mem.eql(u8, phase, "notification")) return "Waiting for you…";
-    if (std.mem.eql(u8, phase, "approval-request")) return "Waiting for approval…";
-    if (std.mem.eql(u8, phase, "approval-response")) return "Approval received";
-    if (std.mem.eql(u8, phase, "subagent-start")) return "Subagent working…";
-    if (isSubagentStopPhase(phase)) return "Subagent done";
+    // Hermes lifecycle callbacks report the parent as `session_id` and the
+    // worker separately as `child_session_id`. The start event is activity
+    // noise, while stop's summary is the one meaningful child message worth
+    // keeping beneath the parent card.
+    if (isSubagentLifecycle(phase, payload)) {
+        if (std.mem.eql(u8, phase, "subagent-stop")) {
+            if (firstJsonString(payload, &.{ "child_summary", "subagent_summary" })) |summary| {
+                return clipEscaped(summary, preview_max, out);
+            }
+        }
+        return null;
+    }
+    if (std.mem.eql(u8, phase, "assistant")) {
+        const response = firstJsonString(payload, &.{ "assistant_response", "last_assistant_message", "message", "response" }) orelse return "Done.";
+        return clipEscaped(response, preview_max, out);
+    }
+    if (isStopPhase(phase)) {
+        if (firstJsonString(payload, &.{ "last_assistant_message", "assistant_response" })) |response| {
+            return clipEscaped(response, preview_max, out);
+        }
+        return "Done.";
+    }
+    if (std.mem.eql(u8, phase, "notification")) {
+        const kind = firstJsonString(payload, &.{ "notification_type", "notification_kind" }) orelse "";
+        if (!notificationNeedsInput(kind)) {
+            if (notificationCompletes(kind)) return "Done.";
+            return null;
+        }
+        if (firstJsonString(payload, &.{ "question", "prompt", "message", "reason" })) |question| {
+            return clipEscaped(question, preview_max, out);
+        }
+        return "Waiting for you…";
+    }
+    if (std.mem.eql(u8, phase, "approval-request")) {
+        if (firstJsonString(payload, &.{ "question", "prompt", "message", "reason" })) |question| {
+            return clipEscaped(question, preview_max, out);
+        }
+        return "Waiting for you…";
+    }
+    if (std.mem.eql(u8, phase, "waiting")) return null;
+    if (std.mem.eql(u8, phase, "approval-response")) return "Continuing…";
     // Tool name only, never the payload's `error` string. jsonString stops at
     // the first `"` or `\` and decodes neither, and error text routinely carries
     // both; tool_name is a controlled identifier from the agent's own registry.
@@ -277,6 +496,14 @@ pub fn formatBubble(phase: []const u8, payload: []const u8, out: []u8) ?[]const 
     if (!running and !done) return null;
 
     const tool = jsonString(payload, "tool_name") orelse "tool";
+
+    if (asciiEqlLower(tool, "clarify")) {
+        if (done) return "Continuing…";
+        if (firstJsonString(payload, &.{ "question", "prompt", "message" })) |question| {
+            return clipEscaped(question, preview_max, out);
+        }
+        return "Waiting for you…";
+    }
 
     if (asciiEqlLower(tool, "read")) {
         if (pathField(payload)) |p| return fmt2(out, if (done) "Read " else "Reading ", clipBase(p, 40));
@@ -434,15 +661,24 @@ fn asciiEqlLower(text: []const u8, lower: []const u8) bool {
 
 // ------------------------------------------------------ session titles
 
-fn safeSessionId(raw: ?[]const u8) ?[]const u8 {
-    const sid = raw orelse return null;
-    if (sid.len == 0 or sid.len > 64) return null;
-    for (sid) |c| {
-        if (!(std.ascii.isAlphanumeric(c) or c == '-' or c == '_')) return null;
+const TitleSource = hook_server.TitleSource;
+
+const TitleRecord = struct {
+    text: []const u8,
+    source: TitleSource,
+};
+
+fn firstJsonString(payload: []const u8, keys: []const []const u8) ?[]const u8 {
+    for (keys) |key| {
+        if (jsonString(payload, key)) |value| {
+            if (std.mem.trim(u8, value, " \t\r\n").len > 0) return value;
+        }
     }
-    return sid;
+    return null;
 }
 
+/// Agent APIs do not agree on the conversation identifier spelling. Keep the
+/// aliases here, rather than teaching the mailbox about each harness.
 fn normalizedConversationKey(raw: ?[]const u8, hash_buf: *[64]u8) ?[]const u8 {
     const value = raw orelse return null;
     if (safeSessionId(value)) |safe| return safe;
@@ -453,26 +689,216 @@ fn normalizedConversationKey(raw: ?[]const u8, hash_buf: *[64]u8) ?[]const u8 {
     return hash_buf;
 }
 
-fn payloadSessionId(payload: []const u8, hash_buf: *[64]u8) ?[]const u8 {
-    if (jsonString(payload, "petdex_conversation_key")) |key| return normalizedConversationKey(key, hash_buf);
-    if (safeSessionId(jsonString(payload, "session_id"))) |session| return session;
-    if (jsonString(payload, "session_key")) |key| return normalizedConversationKey(key, hash_buf);
-    return safeSessionId(jsonString(payload, "parent_session_id"));
+fn payloadSessionId(phase: []const u8, payload: []const u8, hash_buf: *[64]u8) ?[]const u8 {
+    // Hermes's `subagent_start` / `subagent_stop` shell-hook payload places
+    // the parent in `session_id`, with the real worker id in
+    // `child_session_id`. Select the child before the generic aliases so the
+    // lifecycle event cannot overwrite the parent as a second primary feed.
+    if (isSubagentLifecycle(phase, payload)) {
+        if (safeSessionId(firstJsonString(payload, &.{ "child_session_id", "childSessionId" }))) |child| return child;
+    }
+    if (firstJsonString(payload, &.{ "petdex_conversation_key", "conversation_key" })) |key|
+        return normalizedConversationKey(key, hash_buf);
+    if (safeSessionId(firstJsonString(payload, &.{
+        "session_id",
+        "sessionId",
+        "sessionID",
+        "thread_id",
+        "conversation_id",
+    }))) |session| return session;
+    if (firstJsonString(payload, &.{"session_key"})) |key|
+        return normalizedConversationKey(key, hash_buf);
+    return safeSessionId(firstJsonString(payload, &.{ "parent_session_id", "parentSessionId" }));
 }
 
-fn rememberTitle(dir: []const u8, session_id: []const u8, prompt: []const u8) void {
+fn subagentLifecycleParent(payload: []const u8) ?[]const u8 {
+    return safeSessionId(firstJsonString(payload, &.{
+        "parent_session_id",
+        "parentSessionId",
+        // Hermes's shell-hook serializer maps parent_session_id into its
+        // top-level session_id field, so retain that documented fallback.
+        "session_id",
+        "sessionId",
+        "sessionID",
+    }));
+}
+
+fn isSubagentLifecycle(phase: []const u8, payload: []const u8) bool {
+    if (!(std.mem.eql(u8, phase, "subagent-start") or std.mem.eql(u8, phase, "subagent-stop"))) return false;
+    const child = safeSessionId(firstJsonString(payload, &.{ "child_session_id", "childSessionId" })) orelse return false;
+    const parent = subagentLifecycleParent(payload) orelse return true;
+    return !std.mem.eql(u8, child, parent);
+}
+
+const SessionContext = struct {
+    conversation_key: ?[]const u8 = null,
+    parent_session_id: ?[]const u8 = null,
+    label: []const u8 = "",
+    kind: hook_server.SessionKind = .primary,
+
+    fn conversationKey(self: SessionContext) ?[]const u8 {
+        return self.conversation_key;
+    }
+
+    fn parentSession(self: SessionContext) ?[]const u8 {
+        return self.parent_session_id;
+    }
+
+    fn labelSlice(self: SessionContext) []const u8 {
+        return self.label;
+    }
+};
+
+fn safeWireScalar(raw: ?[]const u8, max: usize) ?[]const u8 {
+    const value = raw orelse return null;
+    if (value.len == 0 or value.len > max) return null;
+    for (value) |c| {
+        if (c < 0x20 or c == '"' or c == '\\') return null;
+    }
+    return value;
+}
+
+/// Petdesk's Hermes adapters resolve continuation/subagent ancestry against
+/// state.db and attach the stable top-level key. Other harnesses can provide
+/// the same namespaced fields, while legacy payloads fall back to session_id.
+fn sourceMarksSubagent(raw: []const u8) bool {
+    // Source names are not a stable enum across Hermes surfaces. Exact
+    // delegate markers remain the authoritative path, but accept its known
+    // spelling variants and tool-only workers as a conservative fallback.
+    const names = [_][]const u8{
+        "subagent", "sub-agent", "sub_agent",  "child",      "worker",
+        "delegate", "delegated", "delegation", "background", "tool",
+    };
+    for (names) |name| {
+        if (std.ascii.eqlIgnoreCase(raw, name)) return true;
+    }
+    return false;
+}
+
+fn payloadSessionContext(agent: []const u8, phase: []const u8, payload: []const u8, session_id: ?[]const u8) SessionContext {
+    _ = agent;
+    const explicit_conversation = safeWireScalar(firstJsonString(payload, &.{
+        "petdex_conversation_key",
+        "conversation_key",
+        "session_key",
+    }), hook_server.bubble_session_capacity);
+    const explicit_parent = safeWireScalar(firstJsonString(payload, &.{
+        "petdex_parent_session_id",
+        "parent_session_id",
+        "parentSessionId",
+    }), hook_server.bubble_session_capacity);
+    const lifecycle_child = isSubagentLifecycle(phase, payload);
+    const parent = explicit_parent orelse if (lifecycle_child)
+        safeWireScalar(subagentLifecycleParent(payload), hook_server.bubble_session_capacity)
+    else
+        null;
+    const raw_kind = firstJsonString(payload, &.{ "petdex_session_kind", "session_kind", "source" });
+    const is_subagent = if (raw_kind) |kind|
+        (sourceMarksSubagent(kind) or lifecycle_child)
+    else
+        lifecycle_child;
+    const label = safeWireScalar(firstJsonString(payload, &.{
+        "petdex_subagent_label",
+        "subagent_label",
+        "child_role",
+        "subagent_role",
+        "display_name",
+    }), 48) orelse "";
+    const canonical = explicit_conversation orelse if (is_subagent) parent orelse session_id else session_id;
+    return .{
+        .conversation_key = canonical,
+        .parent_session_id = parent,
+        .label = label,
+        .kind = if (is_subagent) .subagent else .primary,
+    };
+}
+
+/// Prompt-shaped agents use `prompt`; Hermes' pre_llm_call uses
+/// `user_message`. The remaining aliases cover the Claude-derived harnesses
+/// without accepting a generic nested `text` field from tool input.
+fn promptTitle(payload: []const u8) ?[]const u8 {
+    return firstJsonString(payload, &.{ "prompt", "user_message", "userPrompt", "input" });
+}
+
+/// Latest matching entry wins because Codex appends another row when its
+/// server-generated thread title changes. Walking backward also makes a rename
+/// visible without confusing it with the initial "New chat"/prompt title.
+fn codexIndexTitleFromTail(tail: []const u8, session_id: []const u8, out: *[256]u8) ?[]const u8 {
+    var end = tail.len;
+    while (end > 0) {
+        const start = if (std.mem.lastIndexOfScalar(u8, tail[0..end], '\n')) |i| i + 1 else 0;
+        const line = std.mem.trim(u8, tail[start..end], " \t\r\n");
+        end = if (start == 0) 0 else start - 1;
+        if (line.len == 0) continue;
+        const id = jsonString(line, "id") orelse continue;
+        if (!std.mem.eql(u8, id, session_id)) continue;
+        const generated = jsonString(line, "thread_name") orelse continue;
+        return clipEscaped(generated, title_max, out);
+    }
+    return null;
+}
+
+fn codexServerTitle(home: []const u8, session_id: []const u8, out: *[256]u8) ?[]const u8 {
+    var path_buf: [512]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "{s}/.codex/session_index.jsonl", .{home}) catch return null;
+    // The current session can be renamed long after its original index row,
+    // and a busy installation may append enough unrelated rows to push that
+    // session beyond a small tail. Read the bounded catalog and walk backward;
+    // 4 MiB covers many years of the compact append-only index.
+    const index = plat.readFileAlloc(std.heap.page_allocator, path, 4 * 1024 * 1024) orelse return null;
+    defer std.heap.page_allocator.free(index);
+    return codexIndexTitleFromTail(index, session_id, out);
+}
+
+/// Resolve a title maintained outside the hook payload. The app polls this at
+/// a low frequency for visible local sessions so a manual/server rename also
+/// updates while the agent is idle and emitting no lifecycle events.
+pub fn storedServerTitle(agent: []const u8, home: []const u8, session_id: []const u8, out: *[256]u8) ?[]const u8 {
+    if (std.ascii.eqlIgnoreCase(agent, "codex")) return codexServerTitle(home, session_id, out);
+    return null;
+}
+
+fn authoritativeTitle(agent: []const u8, home: []const u8, session_id: []const u8, payload: []const u8, out: *[256]u8) ?[]const u8 {
+    // Petdesk-owned adapters use a namespaced field, so nested tool arguments
+    // named `title` can never masquerade as a conversation rename.
+    if (firstJsonString(payload, &.{ "petdex_session_title", "session_title", "thread_name" })) |title| {
+        return clipEscaped(title, title_max, out);
+    }
+    if (storedServerTitle(agent, home, session_id, out)) |title| return title;
+    return null;
+}
+
+fn safeSessionId(raw: ?[]const u8) ?[]const u8 {
+    const sid = raw orelse return null;
+    if (sid.len == 0 or sid.len > 64) return null;
+    for (sid) |c| {
+        if (!(std.ascii.isAlphanumeric(c) or c == '-' or c == '_')) return null;
+    }
+    return sid;
+}
+
+fn rememberTitle(dir: []const u8, session_id: []const u8, value: []const u8, source: TitleSource, replace: bool) void {
     plat.makeDir(dir);
     var title_buf: [256]u8 = undefined;
-    const title = clipEscaped(prompt, title_max, &title_buf) orelse return;
+    const title = clipEscaped(value, title_max, &title_buf) orelse return;
     if (title.len == 0) return;
+    if (!replace) {
+        var existing_buf: [256]u8 = undefined;
+        if (readTitle(dir, session_id, &existing_buf) != null) return;
+    }
     var path_buf: [512]u8 = undefined;
     const path = std.fmt.bufPrint(&path_buf, "{s}/{s}.json", .{ dir, session_id }) catch return;
     var json_buf: [512]u8 = undefined;
-    const json = std.fmt.bufPrint(&json_buf, "{{\"title\":\"{s}\",\"at\":{d}}}", .{ title, plat.nowSeconds() }) catch return;
+    const source_name = switch (source) {
+        .prompt => "prompt",
+        .server => "server",
+        .unknown => "unknown",
+    };
+    const json = std.fmt.bufPrint(&json_buf, "{{\"title\":\"{s}\",\"source\":\"{s}\",\"at\":{d}}}", .{ title, source_name, plat.nowSeconds() }) catch return;
     cWriteFile(path, json);
 }
 
-fn readTitle(dir: []const u8, session_id: []const u8, buf: *[256]u8) ?[]const u8 {
+fn readTitle(dir: []const u8, session_id: []const u8, buf: *[256]u8) ?TitleRecord {
     var path_buf: [512]u8 = undefined;
     const path = std.fmt.bufPrint(&path_buf, "{s}/{s}.json", .{ dir, session_id }) catch return null;
     var file_buf: [512]u8 = undefined;
@@ -480,7 +906,12 @@ fn readTitle(dir: []const u8, session_id: []const u8, buf: *[256]u8) ?[]const u8
     const title = jsonString(json, "title") orelse return null;
     if (title.len == 0 or title.len > buf.len) return null;
     @memcpy(buf[0..title.len], title);
-    return buf[0..title.len];
+    const source: TitleSource = if (jsonString(json, "source")) |name|
+        (if (std.mem.eql(u8, name, "server")) .server else .prompt)
+    else
+        // Files written by older Petdesk builds only contain title + stamp.
+        .prompt;
+    return .{ .text = buf[0..title.len], .source = source };
 }
 
 const PruneCtx = struct {
@@ -540,6 +971,217 @@ pub fn lastAssistantFromTail(tail: []const u8) ?[]const u8 {
     return null;
 }
 
+/// User-visible Codex activity recovered from a rollout tail. Codex writes the
+/// same `agent_reasoning` summaries and `agent_message` text consumed by its
+/// own UI into the JSONL rollout. Hidden reasoning items are deliberately not
+/// considered here.
+pub const CodexActivityKind = enum { status, reasoning, assistant, prompt };
+
+pub const CodexActivity = struct {
+    text: [preview_max]u8 = @splat(0),
+    text_len: usize = 0,
+    turn: [64]u8 = @splat(0),
+    turn_len: usize = 0,
+    request_id: [hook_server.bubble_message_id_capacity]u8 = @splat(0),
+    request_id_len: usize = 0,
+    resolves_request_id: [hook_server.bubble_message_id_capacity]u8 = @splat(0),
+    resolves_request_id_len: usize = 0,
+    busy: bool = false,
+    kind: CodexActivityKind = .status,
+    status: hook_server.SessionStatus = .idle,
+
+    pub fn textSlice(self: *const CodexActivity) []const u8 {
+        return self.text[0..self.text_len];
+    }
+
+    pub fn turnSlice(self: *const CodexActivity) []const u8 {
+        return self.turn[0..self.turn_len];
+    }
+
+    pub fn requestIdSlice(self: *const CodexActivity) []const u8 {
+        return self.request_id[0..self.request_id_len];
+    }
+
+    pub fn resolvesRequestIdSlice(self: *const CodexActivity) []const u8 {
+        return self.resolves_request_id[0..self.resolves_request_id_len];
+    }
+};
+
+fn inputCall(line: []const u8) bool {
+    if (std.mem.indexOf(u8, line, "\"type\":\"response_item\"") == null) return false;
+    if (std.mem.indexOf(u8, line, "\"name\":\"request_user_input\"") != null) return true;
+    if (std.mem.indexOf(u8, line, "\\\"sandbox_permissions\\\":\\\"require_escalated\\\"") != null) return true;
+    return std.mem.indexOf(u8, line, "\"type\":\"permission_request\"") != null or
+        std.mem.indexOf(u8, line, "\"type\":\"approval_request\"") != null or
+        std.mem.indexOf(u8, line, "\"type\":\"request_permissions\"") != null;
+}
+
+fn escapedArgument(line: []const u8, marker: []const u8, out: []u8) ?[]const u8 {
+    const at = std.mem.indexOf(u8, line, marker) orelse return null;
+    const start = at + marker.len;
+    var end = start;
+    while (end + 1 < line.len) : (end += 1) {
+        if (line[end] == '\\' and line[end + 1] == '"') break;
+    }
+    if (end <= start) return null;
+    return clipEscaped(line[start..end], preview_max, out);
+}
+
+fn inputPrompt(line: []const u8, out: []u8) ?[]const u8 {
+    const markers = [_][]const u8{
+        "\\\"question\\\":\\\"",
+        "\\\"justification\\\":\\\"",
+        "\\\"prompt\\\":\\\"",
+        "\\\"reason\\\":\\\"",
+    };
+    for (markers) |marker| {
+        if (escapedArgument(line, marker, out)) |value| {
+            if (value.len > 0) return value;
+        }
+    }
+    return null;
+}
+
+fn pendingCallIndex(pending: *const [8]?[]const u8, count: usize, call_id: []const u8) ?usize {
+    for (pending[0..count], 0..) |candidate, index| {
+        if (candidate) |value| {
+            if (std.mem.eql(u8, value, call_id)) return index;
+        }
+    }
+    return null;
+}
+
+pub fn codexActivityFromTail(tail: []const u8) ?CodexActivity {
+    var display: ?[]const u8 = null;
+    var kind: CodexActivityKind = .status;
+    var lifecycle_found = false;
+    var status: hook_server.SessionStatus = .idle;
+    var turn: []const u8 = "";
+    var pending: [8]?[]const u8 = @splat(null);
+    var pending_count: usize = 0;
+    var resolved_call_id: []const u8 = "";
+    var prompt_buf: [preview_max]u8 = undefined;
+
+    var lines = std.mem.splitScalar(u8, tail, '\n');
+    while (lines.next()) |raw_line| {
+        const line = std.mem.trim(u8, raw_line, " \t\r\n");
+        if (line.len == 0) continue;
+
+        if (std.mem.indexOf(u8, line, "\"type\":\"task_started\"") != null) {
+            lifecycle_found = true;
+            status = .running;
+            turn = jsonString(line, "turn_id") orelse "";
+            display = null;
+            kind = .status;
+            pending_count = 0;
+            continue;
+        }
+        if (std.mem.indexOf(u8, line, "\"type\":\"task_complete\"") != null) {
+            lifecycle_found = true;
+            status = .completed;
+            turn = jsonString(line, "turn_id") orelse "";
+            pending_count = 0;
+            const final_message = jsonString(line, "last_agent_message") orelse "";
+            if (std.mem.trim(u8, final_message, " \t\r\n").len > 0) {
+                display = final_message;
+                kind = .assistant;
+            } else if (kind != .assistant or display == null or std.mem.trim(u8, display.?, " \t\r\n").len == 0) {
+                // A bare completion must not leave a transient progress cue
+                // on a terminal card. Preserve actual assistant prose when
+                // it was already observed in the rollout.
+                display = "Done.";
+                kind = .status;
+            }
+            continue;
+        }
+        if (std.mem.indexOf(u8, line, "\"type\":\"turn_aborted\"") != null or
+            std.mem.indexOf(u8, line, "\"type\":\"task_failed\"") != null)
+        {
+            lifecycle_found = true;
+            status = .failed;
+            turn = jsonString(line, "turn_id") orelse turn;
+            pending_count = 0;
+            display = if (jsonString(line, "reason")) |reason|
+                (if (std.ascii.eqlIgnoreCase(reason, "interrupted")) "Interrupted." else "Session failed.")
+            else
+                "Session failed.";
+            kind = .status;
+            continue;
+        }
+
+        if (inputCall(line)) {
+            const call_id = jsonString(line, "call_id") orelse "input-request";
+            if (pendingCallIndex(&pending, pending_count, call_id) == null and pending_count < pending.len) {
+                pending[pending_count] = call_id;
+                pending_count += 1;
+            }
+            status = .needs_input;
+            display = inputPrompt(line, &prompt_buf) orelse "Waiting for you…";
+            kind = .prompt;
+            continue;
+        }
+        if (std.mem.indexOf(u8, line, "\"type\":\"function_call_output\"") != null) {
+            if (jsonString(line, "call_id")) |call_id| {
+                if (pendingCallIndex(&pending, pending_count, call_id)) |index| {
+                    resolved_call_id = call_id;
+                    std.mem.copyForwards(?[]const u8, pending[index .. pending_count - 1], pending[index + 1 .. pending_count]);
+                    pending_count -= 1;
+                    pending[pending_count] = null;
+                    if (pending_count == 0) {
+                        status = .running;
+                        display = "Thinking…";
+                        kind = .status;
+                    }
+                }
+            }
+            continue;
+        }
+
+        if (std.mem.indexOf(u8, line, "\"type\":\"agent_message\"") != null) {
+            if (jsonString(line, "message")) |message| {
+                if (std.mem.trim(u8, message, " ").len > 0) {
+                    display = message;
+                    kind = .assistant;
+                }
+            }
+        } else if (std.mem.indexOf(u8, line, "\"type\":\"agent_reasoning\"") != null) {
+            if (jsonString(line, "text")) |reasoning| {
+                if (kind != .assistant and std.mem.trim(u8, reasoning, " ").len > 0) {
+                    display = reasoning;
+                    kind = .reasoning;
+                }
+            }
+        }
+    }
+
+    // A single long Codex turn can exceed the bounded rollout tail, pushing
+    // its task_started record out while fresh visible commentary remains in
+    // range. No current task_complete can precede that commentary, so this is
+    // still an active turn. Treat it as busy instead of dropping the feed and
+    // letting a tool hook become the last writer.
+    if (!lifecycle_found) {
+        if (display == null) return null;
+        if (status == .idle) status = .running;
+    }
+    if (pending_count > 0) status = .needs_input;
+    var activity: CodexActivity = .{ .busy = status == .running, .kind = kind, .status = status };
+    const raw = display orelse if (status == .running) "Thinking…" else "Done.";
+    const clipped = clipEscaped(raw, preview_max, &activity.text) orelse return null;
+    activity.text_len = clipped.len;
+    const turn_len = @min(turn.len, activity.turn.len);
+    @memcpy(activity.turn[0..turn_len], turn[0..turn_len]);
+    activity.turn_len = turn_len;
+    if (pending_count > 0) {
+        const request_id = pending[pending_count - 1].?;
+        activity.request_id_len = @min(request_id.len, activity.request_id.len);
+        @memcpy(activity.request_id[0..activity.request_id_len], request_id[0..activity.request_id_len]);
+    } else if (resolved_call_id.len > 0) {
+        activity.resolves_request_id_len = @min(resolved_call_id.len, activity.resolves_request_id.len);
+        @memcpy(activity.resolves_request_id[0..activity.resolves_request_id_len], resolved_call_id[0..activity.resolves_request_id_len]);
+    }
+    return activity;
+}
+
 /// First {"type":"text","text":"..."} value in the line (raw escaped
 /// bytes; the caller re-embeds or flattens them).
 fn firstTextPart(line: []const u8) ?[]const u8 {
@@ -579,7 +1221,7 @@ const PostTask = struct {
     done: std.atomic.Value(bool) = .init(false),
     path: [16]u8 = undefined,
     path_len: usize = 0,
-    body: [1024]u8 = undefined,
+    body: [post_body_capacity]u8 = undefined,
     body_len: usize = 0,
     token: [128]u8 = undefined,
     token_len: usize = 0,
@@ -602,7 +1244,7 @@ const PostJob = struct {
 /// Start a localhost POST on a private worker. Every byte is copied into the
 /// task so the worker remains valid even when the hook's stack frame returns.
 fn startPost(path: []const u8, body: []const u8, token: []const u8) ?PostJob {
-    if (path.len > 16 or body.len > 1024 or token.len > 128) return null;
+    if (path.len > 16 or body.len > post_body_capacity or token.len > 128) return null;
     const task = std.heap.page_allocator.create(PostTask) catch return null;
     task.* = .{};
     @memcpy(task.path[0..path.len], path);
@@ -663,7 +1305,7 @@ fn postLocalhostBlocking(path: []const u8, body: []const u8, token: []const u8) 
     // with connection refused when no app listens.
     var stream = addr.connect(io, .{ .mode = .stream, .protocol = .tcp }) catch return;
     defer stream.close(io);
-    var req_buf: [1600]u8 = undefined;
+    var req_buf: [post_body_capacity + 768]u8 = undefined;
     const req = std.fmt.bufPrint(&req_buf, "POST {s} HTTP/1.1\r\nhost: 127.0.0.1\r\nx-petdex-update-token: {s}\r\ncontent-type: application/json\r\ncontent-length: {d}\r\nconnection: close\r\n\r\n{s}", .{ path, token, body.len, body }) catch return;
     var write_buf: [64]u8 = undefined;
     var writer = stream.writer(io, &write_buf);
@@ -742,43 +1384,32 @@ test "session phases render fixed strings" {
     var out: [256]u8 = undefined;
     try t.expectEqualStrings("Thinking…", formatBubble("user-prompt", "", &out).?);
     try t.expectEqualStrings("Done.", formatBubble("stop", "", &out).?);
-    try t.expectEqualStrings("Waiting for you…", formatBubble("notification", "", &out).?);
+    try t.expect(formatBubble("notification", "", &out) == null);
+    try t.expectEqualStrings("Waiting for you…", formatBubble("notification", "{\"notification_type\":\"permission_prompt\"}", &out).?);
 }
 
-test "Hermes lifecycle phases render bubbles and states" {
-    var out: [256]u8 = undefined;
-    try t.expectEqualStrings("Done.", formatBubble("assistant", "{}", &out).?);
-    try t.expectEqualStrings("Waiting for approval…", formatBubble("approval-request", "{}", &out).?);
-    try t.expectEqualStrings("Approval received", formatBubble("approval-response", "{}", &out).?);
-    try t.expectEqualStrings("Subagent working…", formatBubble("subagent-start", "{}", &out).?);
-    try t.expectEqualStrings("Subagent done", formatBubble("subagent-stop", "{}", &out).?);
-    try t.expectEqualStrings("waving", stateForEvent("assistant", null).?);
-    try t.expectEqualStrings("waiting", stateForEvent("approval-request", null).?);
-    try t.expectEqualStrings("running", stateForEvent("approval-response", null).?);
-    try t.expectEqualStrings("running", stateForEvent("subagent-start", null).?);
-    try t.expectEqualStrings("idle", stateForEvent("subagent-stop", null).?);
-}
-
-test "Hermes metadata chooses canonical conversation identity" {
-    var hash_buf: [64]u8 = undefined;
-    try t.expectEqualStrings(
-        "stable-session",
-        payloadSessionId("{\"session_id\":\"raw-session\",\"petdex_conversation_key\":\"stable-session\"}", &hash_buf).?,
-    );
-    try t.expectEqualStrings("approval-session", payloadSessionId("{\"session_key\":\"approval-session\"}", &hash_buf).?);
-    const gateway = payloadSessionId("{\"session_key\":\"agent:main:telegram:dm:123\"}", &hash_buf).?;
-    try t.expectEqual(@as(usize, 64), gateway.len);
-    try t.expect(std.mem.indexOfScalar(u8, gateway, ':') == null);
-}
-
-test "state mapping mirrors the TS runner" {
+test "state mapping keeps post-tool work active until the turn completes" {
     try t.expectEqualStrings("review", stateForEvent("pre", "Read").?);
     try t.expectEqualStrings("running", stateForEvent("pre", "Bash").?);
-    try t.expectEqualStrings("idle", stateForEvent("post", null).?);
+    try t.expectEqualStrings("running", stateForEvent("post", null).?);
     try t.expectEqualStrings("waving", stateForEvent("stop", null).?);
     try t.expectEqualStrings("jumping", stateForEvent("user-prompt", null).?);
-    try t.expectEqualStrings("waiting", stateForEvent("notification", null).?);
+    try t.expect(stateForEvent("notification", null) == null);
+    try t.expectEqualStrings("waiting", stateForEventWithNotification("notification", null, "agent_needs_input").?);
     try t.expectEqualStrings("failed", stateForEvent("tool-failure", "Bash").?);
+}
+
+test "Claude notification types follow the documented attention table" {
+    for ([_][]const u8{ "permission_prompt", "elicitation_dialog", "elicitation_url_dialog", "agent_needs_input" }) |kind| {
+        try t.expectEqual(hook_server.SessionStatus.needs_input, statusForEvent("notification", null, kind));
+        try t.expectEqualStrings("waiting", stateForEventWithNotification("notification", null, kind).?);
+    }
+    for ([_][]const u8{ "idle_prompt", "agent_completed" }) |kind|
+        try t.expectEqual(hook_server.SessionStatus.completed, statusForEvent("notification", null, kind));
+    for ([_][]const u8{ "auth_success", "elicitation_complete", "elicitation_response", "future_type" }) |kind| {
+        try t.expectEqual(hook_server.SessionStatus.idle, statusForEvent("notification", null, kind));
+        try t.expect(stateForEventWithNotification("notification", null, kind) == null);
+    }
 }
 
 test "tool-failure bubble names the tool and never the error text" {
@@ -854,9 +1485,102 @@ test "bubbleBody carries session_id, and omits it when there is none" {
 }
 
 test "bubble metadata carries the exact Herdr pane id" {
-    var buf: [1024]u8 = undefined;
-    const body = bubbleBodyWithMetadata(&buf, "Needs approval", "Fix auth", false, "cursor", "session-1", "ghostty", "", "/repo", "w1:p5", null).?;
+    var buf: [2048]u8 = undefined;
+    const body = bubbleBodyWithContext(&buf, "Needs approval", "Fix auth", false, "cursor", .{
+        .session_id = "session-1",
+        .source_app = "ghostty",
+        .source_cwd = "/repo",
+        .herdr_pane = "w1:p5",
+    }).?;
     try t.expectEqualStrings("w1:p5", hook_server.jsonStringPub(body, "herdr_pane_id").?);
+}
+
+test "bubble metadata carries hostname turn and a safe Codex origin" {
+    var buf: [2048]u8 = undefined;
+    const body = bubbleBodyWithContext(
+        &buf,
+        "Running tests",
+        "Revamp bubbles",
+        true,
+        "codex",
+        .{
+            .session_id = "thread-7",
+            .conversation_key = "thread-7",
+            .source_app = "codex",
+            .source_tty = "/dev/ttys003",
+            .source_cwd = "/work/petdex",
+            .hostname = "shakib-mac",
+            .turn_id = "turn-9",
+            .status = .running,
+        },
+    ).?;
+    try t.expectEqualStrings("shakib-mac", jsonString(body, "hostname").?);
+    try t.expectEqualStrings("turn-9", jsonString(body, "turn_id").?);
+    try t.expectEqualStrings("codex", jsonString(body, "source_app").?);
+    try t.expectEqualStrings("thread-7", jsonString(body, "session_id").?);
+}
+
+test "supported harness session and prompt aliases resolve consistently" {
+    var hash_buf: [64]u8 = undefined;
+    try t.expectEqualStrings("claude-1", payloadSessionId("pre", "{\"session_id\":\"claude-1\"}", &hash_buf).?);
+    try t.expectEqualStrings("omp-2", payloadSessionId("pre", "{\"sessionId\":\"omp-2\"}", &hash_buf).?);
+    try t.expectEqualStrings("open-3", payloadSessionId("pre", "{\"sessionID\":\"open-3\"}", &hash_buf).?);
+    try t.expectEqualStrings("codex-4", payloadSessionId("pre", "{\"thread_id\":\"codex-4\"}", &hash_buf).?);
+    try t.expectEqualStrings("hermes-5", payloadSessionId("pre", "{\"conversation_id\":\"hermes-5\"}", &hash_buf).?);
+    try t.expectEqualStrings("Fix the hooks", promptTitle("{\"prompt\":\"Fix the hooks\"}").?);
+    try t.expectEqualStrings("Sync Hermes", promptTitle("{\"user_message\":\"Sync Hermes\"}").?);
+}
+
+test "Hermes subagent lifecycle binds the child summary to its parent" {
+    const payload =
+        "{\"session_id\":\"parent-session\",\"extra\":{\"child_session_id\":\"worker-session\",\"child_role\":\"researcher\",\"child_summary\":\"Found the compatibility shim.\"}}";
+    var hash_buf: [64]u8 = undefined;
+    const child = payloadSessionId("subagent-stop", payload, &hash_buf).?;
+    try t.expectEqualStrings("worker-session", child);
+    const context = payloadSessionContext("hermes", "subagent-stop", payload, child);
+    try t.expectEqual(hook_server.SessionKind.subagent, context.kind);
+    try t.expectEqualStrings("parent-session", context.conversationKey().?);
+    try t.expectEqualStrings("parent-session", context.parentSession().?);
+    try t.expectEqualStrings("researcher", context.labelSlice());
+    try t.expectEqual(hook_server.MessageKind.assistant, messageKindForEvent("subagent-stop", payload, ""));
+    var rendered: [256]u8 = undefined;
+    try t.expectEqualStrings("Found the compatibility shim.", formatBubble("subagent-stop", payload, &rendered).?);
+    try t.expect(formatBubble("subagent-start", payload, &rendered) == null);
+}
+
+test "known Hermes worker source spellings remain children while continuations stay primary" {
+    const worker_payload = "{\"session_id\":\"worker\",\"parent_session_id\":\"root\",\"source\":\"delegated\"}";
+    const worker = payloadSessionContext("hermes", "assistant", worker_payload, "worker");
+    try t.expectEqual(hook_server.SessionKind.subagent, worker.kind);
+    try t.expectEqualStrings("root", worker.conversationKey().?);
+
+    // Parent linkage alone is intentionally insufficient: Hermes uses the
+    // same relation for compression and branch continuations.
+    const continuation_payload = "{\"session_id\":\"tip\",\"parent_session_id\":\"root\",\"source\":\"tui\"}";
+    const continuation = payloadSessionContext("hermes", "assistant", continuation_payload, "tip");
+    try t.expectEqual(hook_server.SessionKind.primary, continuation.kind);
+    try t.expectEqualStrings("tip", continuation.conversationKey().?);
+}
+
+test "Codex title index chooses the newest server-side rename" {
+    const index =
+        "{\"id\":\"other\",\"thread_name\":\"Other chat\"}\n" ++
+        "{\"id\":\"thread-7\",\"thread_name\":\"Initial prompt title\"}\n" ++
+        "{\"id\":\"thread-7\",\"thread_name\":\"Renamed by server\"}\n";
+    var out: [256]u8 = undefined;
+    try t.expectEqualStrings("Renamed by server", codexIndexTitleFromTail(index, "thread-7", &out).?);
+    try t.expect(codexIndexTitleFromTail(index, "missing", &out) == null);
+}
+
+test "namespaced adapter title wins without reading nested tool title" {
+    const payload =
+        "{\"tool_input\":{\"title\":\"Document heading\"}," ++
+        "\"petdex_session_title\":\"Hermes server title\"}";
+    var out: [256]u8 = undefined;
+    try t.expectEqualStrings(
+        "Hermes server title",
+        authoritativeTitle("hermes", "/missing", "session-1", payload, &out).?,
+    );
 }
 
 test "two runner sessions reach the mailbox as two bubbles" {
@@ -919,6 +1643,118 @@ test "transcript tail takes the newest assistant text" {
         "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"name\":\"Bash\"},{\"type\":\"text\",\"text\":\"Listo, el fix quedo\\npusheado.\"}]}}\n" ++
         "{\"type\":\"system\",\"subtype\":\"hook\"}\n";
     try t.expectEqualStrings("Listo, el fix quedo\\npusheado.", lastAssistantFromTail(tail).?);
+}
+
+test "Codex rollout activity follows visible reasoning during an active turn" {
+    const tail =
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_started\",\"turn_id\":\"turn-1\"}}\n" ++
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_reasoning\",\"text\":\"Inspecting the session index\"}}\n";
+    const activity = codexActivityFromTail(tail).?;
+    try std.testing.expect(activity.busy);
+    try std.testing.expectEqual(hook_server.SessionStatus.running, activity.status);
+    try std.testing.expectEqual(CodexActivityKind.reasoning, activity.kind);
+    try std.testing.expectEqualStrings("Inspecting the session index", activity.textSlice());
+    try std.testing.expectEqualStrings("turn-1", activity.turnSlice());
+}
+
+test "Codex assistant prose outranks later intermediate reasoning in the turn" {
+    const tail =
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_started\",\"turn_id\":\"turn-prose\"}}\n" ++
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_message\",\"message\":\"Here is the useful answer.\"}}\n" ++
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_reasoning\",\"text\":\"Checking one more detail\"}}\n";
+    const activity = codexActivityFromTail(tail).?;
+    try std.testing.expectEqual(CodexActivityKind.assistant, activity.kind);
+    try std.testing.expectEqualStrings("Here is the useful answer.", activity.textSlice());
+}
+
+test "Codex completed activity uses the final app-visible message" {
+    const tail =
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_started\",\"turn_id\":\"turn-2\"}}\n" ++
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_reasoning\",\"text\":\"Working\"}}\n" ++
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_complete\",\"turn_id\":\"turn-2\",\"last_agent_message\":\"Finished with details\"}}\n";
+    const activity = codexActivityFromTail(tail).?;
+    try std.testing.expect(!activity.busy);
+    try std.testing.expectEqual(hook_server.SessionStatus.completed, activity.status);
+    try std.testing.expectEqual(CodexActivityKind.assistant, activity.kind);
+    try std.testing.expectEqualStrings("Finished with details", activity.textSlice());
+}
+
+test "Codex bare completion clears transient copy but retains assistant prose" {
+    const transient =
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_started\",\"turn_id\":\"turn-bare\"}}\n" ++
+        "{\"type\":\"response_item\",\"payload\":{\"type\":\"function_call\",\"name\":\"request_user_input\",\"arguments\":\"{\\\"questions\\\":[{\\\"question\\\":\\\"Continue?\\\"}]}\",\"call_id\":\"call-bare\"}}\n" ++
+        "{\"type\":\"response_item\",\"payload\":{\"type\":\"function_call_output\",\"call_id\":\"call-bare\"}}\n" ++
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_complete\",\"turn_id\":\"turn-bare\"}}\n";
+    const done = codexActivityFromTail(transient).?;
+    try std.testing.expectEqual(hook_server.SessionStatus.completed, done.status);
+    try std.testing.expect(!done.busy);
+    try std.testing.expectEqual(CodexActivityKind.status, done.kind);
+    try std.testing.expectEqualStrings("Done.", done.textSlice());
+
+    const prose =
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_started\",\"turn_id\":\"turn-prose-complete\"}}\n" ++
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_message\",\"message\":\"Useful final answer.\"}}\n" ++
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_complete\",\"turn_id\":\"turn-prose-complete\",\"last_agent_message\":\"   \"}}\n";
+    const retained = codexActivityFromTail(prose).?;
+    try std.testing.expectEqual(hook_server.SessionStatus.completed, retained.status);
+    try std.testing.expect(!retained.busy);
+    try std.testing.expectEqual(CodexActivityKind.assistant, retained.kind);
+    try std.testing.expectEqualStrings("Useful final answer.", retained.textSlice());
+}
+
+test "Codex aborted activity remains a terminal failure cue" {
+    const tail =
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_started\",\"turn_id\":\"turn-stop\"}}\n" ++
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"turn_aborted\",\"turn_id\":\"turn-stop\",\"reason\":\"interrupted\"}}\n";
+    const activity = codexActivityFromTail(tail).?;
+    try std.testing.expect(!activity.busy);
+    try std.testing.expectEqual(hook_server.SessionStatus.failed, activity.status);
+    try std.testing.expectEqualStrings("Interrupted.", activity.textSlice());
+}
+
+test "Codex unmatched input call exposes the question until its response" {
+    const waiting_tail =
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_started\",\"turn_id\":\"turn-input\"}}\n" ++
+        "{\"type\":\"response_item\",\"payload\":{\"type\":\"function_call\",\"name\":\"request_user_input\",\"arguments\":\"{\\\"questions\\\":[{\\\"question\\\":\\\"Which host should I use?\\\"}]}\",\"call_id\":\"call-input\"}}\n";
+    const waiting = codexActivityFromTail(waiting_tail).?;
+    try std.testing.expectEqual(hook_server.SessionStatus.needs_input, waiting.status);
+    try std.testing.expectEqual(CodexActivityKind.prompt, waiting.kind);
+    try std.testing.expectEqualStrings("Which host should I use?", waiting.textSlice());
+
+    const resumed_tail = waiting_tail ++
+        "{\"type\":\"response_item\",\"payload\":{\"type\":\"function_call_output\",\"call_id\":\"call-input\",\"output\":\"inframework\"}}\n";
+    const resumed = codexActivityFromTail(resumed_tail).?;
+    try std.testing.expectEqual(hook_server.SessionStatus.running, resumed.status);
+    try std.testing.expectEqualStrings("Thinking…", resumed.textSlice());
+}
+
+test "Codex escalation call is user-input-required until tool output" {
+    const tail =
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_started\",\"turn_id\":\"turn-approval\"}}\n" ++
+        "{\"type\":\"response_item\",\"payload\":{\"type\":\"function_call\",\"name\":\"exec_command\",\"arguments\":\"{\\\"sandbox_permissions\\\":\\\"require_escalated\\\",\\\"justification\\\":\\\"Allow launching Petdesk?\\\"}\",\"call_id\":\"call-approval\"}}\n";
+    const activity = codexActivityFromTail(tail).?;
+    try std.testing.expectEqual(hook_server.SessionStatus.needs_input, activity.status);
+    try std.testing.expectEqualStrings("Allow launching Petdesk?", activity.textSlice());
+}
+
+test "Codex truncated active tail keeps the latest app-visible commentary" {
+    const tail =
+        "{\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_message\",\"message\":\"I’m matching the Codex Pet feed\"}}\n" ++
+        "{\"type\":\"response_item\",\"payload\":{\"type\":\"custom_tool_call\",\"name\":\"exec_command\"}}\n" ++
+        "{\"type\":\"response_item\",\"payload\":{\"type\":\"custom_tool_call_output\",\"output\":\"done\"}}\n";
+    const activity = codexActivityFromTail(tail).?;
+    try std.testing.expect(activity.busy);
+    try std.testing.expectEqual(CodexActivityKind.assistant, activity.kind);
+    try std.testing.expectEqualStrings("I’m matching the Codex Pet feed", activity.textSlice());
+}
+
+test "local Codex tool hooks update mascot state without replacing feed" {
+    try std.testing.expect(!shouldPostBubble("codex", "pre"));
+    try std.testing.expect(!shouldPostBubble("CODEX", "post"));
+    try std.testing.expect(!shouldPostBubble("codex", "tool-failure"));
+    try std.testing.expect(shouldPostBubble("codex", "user-prompt"));
+    try std.testing.expect(shouldPostBubble("codex", "stop"));
+    try std.testing.expect(shouldPostBubble("hermes", "post"));
 }
 
 test "clipEscaped flattens escapes and collapses spaces" {

--- a/packages/petdex-desktop-native/src/hook_runner.zig
+++ b/packages/petdex-desktop-native/src/hook_runner.zig
@@ -205,15 +205,12 @@ fn effectiveHookPhase(raw_phase: []const u8, agent: []const u8, payload: []const
     return "tool-failure";
 }
 
-fn journalSafeStem(out: []u8, raw: []const u8, fallback: []const u8) []const u8 {
+fn journalHashStem(out: *[std.crypto.hash.sha2.Sha256.digest_length * 2]u8, raw: []const u8, fallback: []const u8) []const u8 {
     const source = if (raw.len > 0) raw else fallback;
-    var written: usize = 0;
-    for (source) |byte| {
-        if (written == out.len) break;
-        out[written] = if (std.ascii.isAlphanumeric(byte) or byte == '-' or byte == '_' or byte == '.') byte else '_';
-        written += 1;
-    }
-    return out[0..written];
+    var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(source, &digest, .{});
+    out.* = std.fmt.bytesToHex(digest, .lower);
+    return out;
 }
 
 fn appendJournalEvent(home: []const u8, agent: []const u8, conversation: ?[]const u8, body: []const u8) void {
@@ -221,16 +218,30 @@ fn appendJournalEvent(home: []const u8, agent: []const u8, conversation: ?[]cons
     const dir = std.fmt.bufPrint(&dir_buf, "{s}/.petdex/runtime/session-journal", .{home}) catch return;
     if (!plat.makeDirMode(dir, 0o700)) return;
 
-    var agent_buf: [32]u8 = undefined;
-    var conversation_buf: [96]u8 = undefined;
-    const agent_stem = journalSafeStem(&agent_buf, agent, "agent");
-    const conversation_stem = journalSafeStem(&conversation_buf, conversation orelse "", "unkeyed");
+    var agent_buf: [std.crypto.hash.sha2.Sha256.digest_length * 2]u8 = undefined;
+    var conversation_buf: [std.crypto.hash.sha2.Sha256.digest_length * 2]u8 = undefined;
+    const agent_stem = journalHashStem(&agent_buf, agent, "agent");
+    const conversation_stem = journalHashStem(&conversation_buf, conversation orelse "", "unkeyed");
     var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
     const path = std.fmt.bufPrint(&path_buf, "{s}/{s}-{s}.jsonl", .{ dir, agent_stem, conversation_stem }) catch return;
 
     var record_buf: [post_body_capacity + 64]u8 = undefined;
     const record = std.fmt.bufPrint(&record_buf, "{{\"journal_version\":{d},\"event\":{s}}}\n", .{ journal_version, body }) catch return;
     _ = plat.appendFileModeRotating(path, record, 0o600, journal_rotate_bytes);
+}
+
+test "journal stems preserve punctuation-distinct identities" {
+    var slash_buf: [std.crypto.hash.sha2.Sha256.digest_length * 2]u8 = undefined;
+    var colon_buf: [std.crypto.hash.sha2.Sha256.digest_length * 2]u8 = undefined;
+    var fallback_buf: [std.crypto.hash.sha2.Sha256.digest_length * 2]u8 = undefined;
+    const slash = journalHashStem(&slash_buf, "team/a", "unkeyed");
+    const colon = journalHashStem(&colon_buf, "team:a", "unkeyed");
+    const fallback = journalHashStem(&fallback_buf, "", "unkeyed");
+
+    try std.testing.expectEqualStrings("65f838a2fbff37d81a09242f44268f116e339d56e03dec44785d0badda4b1341", slash);
+    try std.testing.expectEqualStrings("5752fddeb3d6826d1281d4ecd54493c1eca7c0d93bf64bae0ff098c833f1fee3", colon);
+    try std.testing.expectEqualStrings("d43eaed1b24b2617fb850c9c81dd86891d3b64edbb62712c94f08b8b32279ebf", fallback);
+    try std.testing.expect(!std.mem.eql(u8, slash, colon));
 }
 
 /// Local Codex rollouts contain the same user-visible `agent_message` and

--- a/packages/petdex-desktop-native/src/hook_runner.zig
+++ b/packages/petdex-desktop-native/src/hook_runner.zig
@@ -32,7 +32,7 @@ const journal_rotate_bytes: u64 = 4 * 1024 * 1024;
 
 /// argv tail after "bubble": [phase, agent?]. Reads stdin, formats,
 /// POSTs bubble + state to the in-process hook server. Never fails outward.
-pub fn run(phase: []const u8, arg_agent: ?[]const u8, origin_app: plat.OriginApplication, source_cwd_raw: ?[]const u8, herdr_pane_raw: ?[]const u8, home: []const u8) void {
+pub fn run(raw_phase: []const u8, arg_agent: ?[]const u8, origin_app: plat.OriginApplication, source_cwd_raw: ?[]const u8, herdr_pane_raw: ?[]const u8, home: []const u8) void {
     // Always finish consuming the host's payload before any early return.
     // The host may still be writing after the useful 64 KiB prefix, and
     // closing the read end early propagates EPIPE/Broken pipe to the agent.
@@ -48,6 +48,7 @@ pub fn run(phase: []const u8, arg_agent: ?[]const u8, origin_app: plat.OriginApp
     } else |_| {}
 
     const agent = resolveAgent(payload, arg_agent);
+    const phase = effectiveHookPhase(raw_phase, agent, payload);
     const effective_origin: plat.OriginApplication = if (origin_app == .none and std.ascii.eqlIgnoreCase(agent, "codex")) .codex else origin_app;
     const source_app = effective_origin.wireName();
     var tty_buf: [64]u8 = undefined;
@@ -185,6 +186,23 @@ fn resolveAgent(payload: []const u8, arg_agent: ?[]const u8) []const u8 {
         if (agent.len > 0) return agent;
     }
     return jsonString(payload, "agent_source") orelse "";
+}
+
+/// CodeBuddy has no distinct failure callback in the documented core hook
+/// contract. Its PostToolUse payload instead carries a structured response;
+/// recognize only the explicit boolean signal so arbitrary tool output or a
+/// user-controlled nested `success` field cannot manufacture a failed state.
+fn effectiveHookPhase(raw_phase: []const u8, agent: []const u8, payload: []const u8) []const u8 {
+    if (!std.mem.eql(u8, raw_phase, "post") or !std.ascii.eqlIgnoreCase(agent, "codebuddy")) return raw_phase;
+
+    const parsed = std.json.parseFromSlice(std.json.Value, std.heap.page_allocator, payload, .{}) catch return raw_phase;
+    defer parsed.deinit();
+    if (parsed.value != .object) return raw_phase;
+    const response = parsed.value.object.get("tool_response") orelse return raw_phase;
+    if (response != .object) return raw_phase;
+    const success = response.object.get("success") orelse return raw_phase;
+    if (success != .bool or success.bool) return raw_phase;
+    return "tool-failure";
 }
 
 fn journalSafeStem(out: []u8, raw: []const u8, fallback: []const u8) []const u8 {
@@ -1461,6 +1479,25 @@ test "tool failures keep the session running while the agent briefly fails" {
         statusForEvent("tool-failure", "Bash", ""),
     );
     try t.expectEqualStrings("failed", stateForEvent("tool-failure", "Bash").?);
+}
+
+test "CodeBuddy derives failure only from its scoped PostToolUse success flag" {
+    const failed_payload =
+        \\{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"success":true},"tool_response":{"success":false,"error":"exit 1"}}
+    ;
+    const failed_phase = effectiveHookPhase("post", "codebuddy", failed_payload);
+    try t.expectEqualStrings("tool-failure", failed_phase);
+    try t.expectEqual(hook_server.SessionStatus.running, statusForEvent(failed_phase, "Bash", ""));
+    try t.expectEqualStrings("failed", stateForEvent(failed_phase, "Bash").?);
+    var out: [256]u8 = undefined;
+    try t.expectEqualStrings("Bash failed", formatBubble(failed_phase, failed_payload, &out).?);
+
+    const successful_payload =
+        \\{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"success":false},"tool_response":{"success":true,"error":"user prose only"}}
+    ;
+    try t.expectEqualStrings("post", effectiveHookPhase("post", "codebuddy", successful_payload));
+    try t.expectEqualStrings("post", effectiveHookPhase("post", "qoder", failed_payload));
+    try t.expectEqualStrings("post", effectiveHookPhase("post", "codebuddy", "{malformed"));
 }
 
 test "Claude notification types follow the documented attention table" {

--- a/packages/petdex-desktop-native/src/hook_runner.zig
+++ b/packages/petdex-desktop-native/src/hook_runner.zig
@@ -271,6 +271,7 @@ fn statusForEvent(phase: []const u8, tool_name: ?[]const u8, notification_kind: 
         std.mem.eql(u8, phase, "pre") or
         std.mem.eql(u8, phase, "post") or
         std.mem.eql(u8, phase, "pre-llm") or
+        std.mem.eql(u8, phase, "post-model") or
         std.mem.eql(u8, phase, "approval-response") or
         std.mem.eql(u8, phase, "subagent-start") or
         std.mem.eql(u8, phase, "subagent-stop")) return .running;
@@ -471,7 +472,7 @@ fn stateForEventWithNotification(phase: []const u8, tool_name: ?[]const u8, noti
     if (std.mem.eql(u8, phase, "approval-request") or
         (std.mem.eql(u8, phase, "notification") and notificationNeedsInput(notification_kind))) return "waiting";
     if (std.mem.eql(u8, phase, "waiting")) return null;
-    if (std.mem.eql(u8, phase, "pre-llm") or std.mem.eql(u8, phase, "subagent-start") or std.mem.eql(u8, phase, "subagent-stop")) return "running";
+    if (std.mem.eql(u8, phase, "pre-llm") or std.mem.eql(u8, phase, "post-model") or std.mem.eql(u8, phase, "subagent-start") or std.mem.eql(u8, phase, "subagent-stop")) return "running";
     return null;
 }
 
@@ -499,7 +500,7 @@ pub fn formatBubble(phase: []const u8, payload: []const u8, out: []u8) ?[]const 
         return null;
     }
     if (std.mem.eql(u8, phase, "assistant")) {
-        const response = firstJsonString(payload, &.{ "assistant_response", "last_assistant_message", "message", "response" }) orelse return "Done.";
+        const response = firstJsonString(payload, &.{ "assistant_response", "last_assistant_message", "prompt_response", "message", "response" }) orelse return "Done.";
         return clipEscaped(response, preview_max, out);
     }
     if (isStopPhase(phase)) {
@@ -1441,6 +1442,17 @@ test "state mapping keeps post-tool work active until the turn completes" {
     try t.expect(stateForEvent("notification", null) == null);
     try t.expectEqualStrings("waiting", stateForEventWithNotification("notification", null, "agent_needs_input").?);
     try t.expectEqualStrings("failed", stateForEvent("tool-failure", "Bash").?);
+    try t.expectEqualStrings("running", stateForEvent("post-model", null).?);
+    try t.expectEqual(hook_server.SessionStatus.running, statusForEvent("post-model", null, ""));
+}
+
+test "Gemini final response uses its documented prompt_response field" {
+    var out: [256]u8 = undefined;
+    try t.expectEqualStrings(
+        "Gemini answer",
+        formatBubble("assistant", "{\"prompt_response\":\"Gemini answer\"}", &out).?,
+    );
+    try t.expect(formatBubble("post-model", "{\"prompt_response\":\"intermediate\"}", &out) == null);
 }
 
 test "tool failures keep the session running while the agent briefly fails" {

--- a/packages/petdex-desktop-native/src/hook_runner.zig
+++ b/packages/petdex-desktop-native/src/hook_runner.zig
@@ -261,7 +261,11 @@ fn statusForEvent(phase: []const u8, tool_name: ?[]const u8, notification_kind: 
     // correlated request and therefore cannot make the session orange.
     if (std.mem.eql(u8, phase, "waiting")) return .idle;
     if (std.mem.eql(u8, phase, "pre") and tool_name != null and asciiEqlLower(tool_name.?, "clarify")) return .needs_input;
-    if (isToolFailurePhase(phase)) return .failed;
+    // A failed tool is an intermediate event: the harness reports the error
+    // back to the agent and the same turn continues. Keep the conversation
+    // active while `stateForEvent` independently drives the brief failed
+    // sprite.
+    if (isToolFailurePhase(phase)) return .running;
     if (isStopPhase(phase) or std.mem.eql(u8, phase, "assistant")) return .completed;
     if (isPromptPhase(phase) or
         std.mem.eql(u8, phase, "pre") or
@@ -349,6 +353,41 @@ const BubbleWireContext = struct {
     agent_state: ?[]const u8 = null,
 };
 
+fn jsonEscapeString(value: []const u8, output: []u8) ?[]const u8 {
+    var len: usize = 0;
+    for (value) |byte| {
+        const escape: ?u8 = switch (byte) {
+            '"' => '"',
+            '\\' => '\\',
+            '\n' => 'n',
+            '\r' => 'r',
+            '\t' => 't',
+            else => null,
+        };
+        if (escape) |escaped| {
+            if (len + 2 > output.len) return null;
+            output[len] = '\\';
+            output[len + 1] = escaped;
+            len += 2;
+        } else if (byte < 0x20) {
+            if (len + 6 > output.len) return null;
+            const hex = "0123456789abcdef";
+            output[len] = '\\';
+            output[len + 1] = 'u';
+            output[len + 2] = '0';
+            output[len + 3] = '0';
+            output[len + 4] = hex[@as(usize, byte >> 4)];
+            output[len + 5] = hex[@as(usize, byte & 0x0f)];
+            len += 6;
+        } else {
+            if (len >= output.len) return null;
+            output[len] = byte;
+            len += 1;
+        }
+    }
+    return output[0..len];
+}
+
 fn bubbleBodyWithContext(out: []u8, text: []const u8, title: []const u8, busy: bool, agent: []const u8, context: BubbleWireContext) ?[]const u8 {
     var title_buf: [256]u8 = undefined;
     const title_part: []const u8 = if (title.len > 0)
@@ -367,6 +406,11 @@ fn bubbleBodyWithContext(out: []u8, text: []const u8, title: []const u8, busy: b
     const message_id = context.message_id orelse "";
     const request_id = context.request_id orelse "";
     const resolves_request_id = context.resolves_request_id orelse "";
+    // Unlike provider-derived fields, source_cwd is a decoded environment
+    // value. Windows paths therefore contain literal backslashes and must be
+    // escaped before this format string becomes JSON.
+    var source_cwd_buf: [3072]u8 = undefined;
+    const source_cwd = jsonEscapeString(context.source_cwd, &source_cwd_buf) orelse return null;
     const session_kind = if (context.session_kind == .subagent) "subagent" else "primary";
     const has_canonical_context = conversation.len > 0 or parent.len > 0 or
         context.session_kind == .subagent or context.subagent_label.len > 0 or
@@ -376,7 +420,7 @@ fn bubbleBodyWithContext(out: []u8, text: []const u8, title: []const u8, busy: b
         resolves_request_id.len > 0 or context.notification_kind.len > 0 or context.message_kind != .status or
         context.title_source != .unknown or context.status != .idle;
     const context_part: []const u8 = if (has_canonical_context)
-        (std.fmt.bufPrint(&context_buf, ",\"conversation_key\":\"{s}\",\"source_session_id\":\"{s}\",\"parent_session_id\":\"{s}\",\"session_kind\":\"{s}\",\"subagent_label\":\"{s}\",\"source_app\":\"{s}\",\"source_tty\":\"{s}\",\"source_cwd\":\"{s}\",\"herdr_pane_id\":\"{s}\",\"hostname\":\"{s}\",\"turn_id\":\"{s}\",\"message_id\":\"{s}\",\"event_kind\":\"{s}\",\"request_id\":\"{s}\",\"resolves_request_id\":\"{s}\",\"notification_kind\":\"{s}\",\"message_kind\":\"{s}\",\"title_source\":\"{s}\",\"feed_source\":\"hook\",\"status\":\"{s}\"", .{ conversation, context.session_id orelse "", parent, session_kind, context.subagent_label, context.source_app, context.source_tty, context.source_cwd, context.herdr_pane, context.hostname, turn, message_id, context.event_kind, request_id, resolves_request_id, context.notification_kind, @tagName(context.message_kind), @tagName(context.title_source), context.status.wireName() }) catch return null)
+        (std.fmt.bufPrint(&context_buf, ",\"conversation_key\":\"{s}\",\"source_session_id\":\"{s}\",\"parent_session_id\":\"{s}\",\"session_kind\":\"{s}\",\"subagent_label\":\"{s}\",\"source_app\":\"{s}\",\"source_tty\":\"{s}\",\"source_cwd\":\"{s}\",\"herdr_pane_id\":\"{s}\",\"hostname\":\"{s}\",\"turn_id\":\"{s}\",\"message_id\":\"{s}\",\"event_kind\":\"{s}\",\"request_id\":\"{s}\",\"resolves_request_id\":\"{s}\",\"notification_kind\":\"{s}\",\"message_kind\":\"{s}\",\"title_source\":\"{s}\",\"feed_source\":\"hook\",\"status\":\"{s}\"", .{ conversation, context.session_id orelse "", parent, session_kind, context.subagent_label, context.source_app, context.source_tty, source_cwd, context.herdr_pane, context.hostname, turn, message_id, context.event_kind, request_id, resolves_request_id, context.notification_kind, @tagName(context.message_kind), @tagName(context.title_source), context.status.wireName() }) catch return null)
     else
         "";
     var state_buf: [48]u8 = undefined;
@@ -1399,6 +1443,14 @@ test "state mapping keeps post-tool work active until the turn completes" {
     try t.expectEqualStrings("failed", stateForEvent("tool-failure", "Bash").?);
 }
 
+test "tool failures keep the session running while the agent briefly fails" {
+    try t.expectEqual(
+        hook_server.SessionStatus.running,
+        statusForEvent("tool-failure", "Bash", ""),
+    );
+    try t.expectEqualStrings("failed", stateForEvent("tool-failure", "Bash").?);
+}
+
 test "Claude notification types follow the documented attention table" {
     for ([_][]const u8{ "permission_prompt", "elicitation_dialog", "elicitation_url_dialog", "agent_needs_input" }) |kind| {
         try t.expectEqual(hook_server.SessionStatus.needs_input, statusForEvent("notification", null, kind));
@@ -1493,6 +1545,33 @@ test "bubble metadata carries the exact Herdr pane id" {
         .herdr_pane = "w1:p5",
     }).?;
     try t.expectEqualStrings("w1:p5", hook_server.jsonStringPub(body, "herdr_pane_id").?);
+}
+
+test "bubble metadata JSON-escapes Windows source paths" {
+    const source_cwd = "C:\\Users\\me\\petdex";
+    var buf: [4096]u8 = undefined;
+    const body = bubbleBodyWithMetadata(
+        &buf,
+        "Running tests",
+        "Fix hooks",
+        true,
+        "claude-code",
+        "session-1",
+        "windows-terminal",
+        "",
+        source_cwd,
+        "",
+        "running",
+    ).?;
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, t.allocator, body, .{});
+    defer parsed.deinit();
+    try t.expectEqualStrings(source_cwd, parsed.value.object.get("source_cwd").?.string);
+
+    // The production reader is strict JSON too; malformed `\U` escapes used
+    // to make this exact body disappear as invalid_json.
+    var mailbox: hook_server.Mailbox = .{};
+    try t.expect(hook_server.applyBubbleJson(&mailbox, body, .hook) != null);
 }
 
 test "bubble metadata carries hostname turn and a safe Codex origin" {

--- a/packages/petdex-desktop-native/src/hook_server.zig
+++ b/packages/petdex-desktop-native/src/hook_server.zig
@@ -1,6 +1,6 @@
 //! In-process replacement for the Node sidecar's HTTP surface on
 //! 127.0.0.1:7777. Same contract the hooks already speak: token-gated
-//! POST /state and /bubble (header x-petdex-update-token, token file
+//! POST /state, /bubble and /bubble/title (header x-petdex-update-token, token file
 //! at ~/.petdex/runtime/update-token mode 0600, regenerated per
 //! session), shared 30/s rate limit, and the read endpoints /health,
 //! /whoami, /state, /bubble, /init-status. /update endpoints answer
@@ -20,12 +20,12 @@ const builtin = @import("builtin");
 const plat = @import("plat.zig");
 const dsh_integration = @import("dsh_integration.zig");
 
-/// One connection, plus the Io that owns it. Everything downstream of
-/// accept() needs both, and passing them as a pair keeps the response
-/// helpers' signatures as flat as the old bare fd was.
+/// One connection with the persistent buffered writer used for its response.
+/// The request is pre-read under one absolute deadline before routing.
 const Conn = struct {
     stream: std.Io.net.Stream,
     io: std.Io,
+    writer: *std.Io.Writer,
 };
 
 pub const max_pending = 50;
@@ -33,6 +33,132 @@ const max_active_connections: u32 = 64;
 const max_request_bytes: usize = 8192;
 const connection_timeout_ms: i64 = 5_000;
 const response_drain_grace_ms: i64 = 300;
+pub const bubble_text_capacity: usize = 4096;
+pub const bubble_title_capacity: usize = 256;
+pub const bubble_session_capacity: usize = 96;
+pub const bubble_message_id_capacity: usize = 96;
+pub const bubble_child_message_capacity: usize = 512;
+pub const max_child_messages: usize = 8;
+pub const max_pending_inputs: usize = 4;
+
+pub const SessionStatus = enum(u8) {
+    idle,
+    running,
+    needs_input,
+    completed,
+    failed,
+
+    pub fn fromWire(raw: []const u8) ?SessionStatus {
+        if (std.mem.eql(u8, raw, "idle")) return .idle;
+        if (std.mem.eql(u8, raw, "running")) return .running;
+        if (std.mem.eql(u8, raw, "needs_input")) return .needs_input;
+        if (std.mem.eql(u8, raw, "completed")) return .completed;
+        if (std.mem.eql(u8, raw, "failed")) return .failed;
+        return null;
+    }
+
+    pub fn wireName(self: SessionStatus) []const u8 {
+        return switch (self) {
+            .idle => "idle",
+            .running => "running",
+            .needs_input => "needs_input",
+            .completed => "completed",
+            .failed => "failed",
+        };
+    }
+};
+
+pub const SessionKind = enum(u8) {
+    primary,
+    subagent,
+
+    fn fromWire(raw: []const u8) SessionKind {
+        return if (std.mem.eql(u8, raw, "subagent")) .subagent else .primary;
+    }
+};
+
+pub const MessageKind = enum(u8) {
+    status,
+    reasoning,
+    assistant,
+    tool,
+    lifecycle,
+    prompt,
+
+    fn fromWire(raw: []const u8) MessageKind {
+        if (std.mem.eql(u8, raw, "reasoning")) return .reasoning;
+        if (std.mem.eql(u8, raw, "assistant")) return .assistant;
+        if (std.mem.eql(u8, raw, "tool")) return .tool;
+        if (std.mem.eql(u8, raw, "lifecycle")) return .lifecycle;
+        if (std.mem.eql(u8, raw, "prompt")) return .prompt;
+        return .status;
+    }
+};
+
+pub const TitleSource = enum(u8) {
+    unknown,
+    prompt,
+    server,
+
+    fn fromWire(raw: []const u8) TitleSource {
+        if (std.mem.eql(u8, raw, "server")) return .server;
+        if (std.mem.eql(u8, raw, "prompt")) return .prompt;
+        return .unknown;
+    }
+};
+
+pub const FeedSource = enum(u8) {
+    hook,
+    journal,
+    native_store,
+    local_api,
+
+    fn fromWire(raw: []const u8) FeedSource {
+        if (std.mem.eql(u8, raw, "journal")) return .journal;
+        if (std.mem.eql(u8, raw, "native_store") or
+            std.mem.eql(u8, raw, "rollout") or
+            std.mem.eql(u8, raw, "hermes_state")) return .native_store;
+        if (std.mem.eql(u8, raw, "local_api")) return .local_api;
+        return .hook;
+    }
+
+    fn rank(self: FeedSource) u8 {
+        return switch (self) {
+            .journal => 1,
+            .native_store => 2,
+            .local_api => 3,
+            .hook => 4,
+        };
+    }
+};
+
+pub const ChildMessage = struct {
+    text: [bubble_child_message_capacity]u8 = @splat(0),
+    text_len: usize = 0,
+    label: [48]u8 = @splat(0),
+    label_len: usize = 0,
+    source_session: [bubble_session_capacity]u8 = @splat(0),
+    source_session_len: usize = 0,
+    message_id: [bubble_message_id_capacity]u8 = @splat(0),
+    message_id_len: usize = 0,
+    counter: u64 = 0,
+
+    pub fn textSlice(self: *const ChildMessage) []const u8 {
+        return self.text[0..self.text_len];
+    }
+
+    pub fn labelSlice(self: *const ChildMessage) []const u8 {
+        return self.label[0..self.label_len];
+    }
+
+    pub fn sourceSessionSlice(self: *const ChildMessage) []const u8 {
+        return self.source_session[0..self.source_session_len];
+    }
+
+    pub fn messageIdSlice(self: *const ChildMessage) []const u8 {
+        return self.message_id[0..self.message_id_len];
+    }
+};
 
 /// Windows' std.Io stream reader intentionally waits for the AFD receive
 /// operation to complete, but it has no stream-level timeout API. Poll the
@@ -76,17 +202,40 @@ pub const StateEvent = struct {
 };
 
 pub const Bubble = struct {
-    text: [200]u8 = @splat(0),
+    text: [bubble_text_capacity]u8 = @splat(0),
     text_len: usize = 0,
-    title: [96]u8 = @splat(0),
+    title: [bubble_title_capacity]u8 = @splat(0),
     title_len: usize = 0,
     agent: [24]u8 = @splat(0),
     agent_len: usize = 0,
     /// Which conversation this bubble belongs to. Empty is the sentinel
     /// key an agent without a session_id lands on (older CLI, the MCP
     /// path), which is what keeps single-bubble behaviour identical.
-    session: [64]u8 = @splat(0),
+    session: [bubble_session_capacity]u8 = @splat(0),
     session_len: usize = 0,
+    /// Raw provider session that emitted the current primary update. The
+    /// `session` field above is the stable canonical conversation key.
+    source_session: [bubble_session_capacity]u8 = @splat(0),
+    source_session_len: usize = 0,
+    parent_session: [bubble_session_capacity]u8 = @splat(0),
+    parent_session_len: usize = 0,
+    session_kind: SessionKind = .primary,
+    status: SessionStatus = .idle,
+    message_kind: MessageKind = .status,
+    title_source: TitleSource = .unknown,
+    feed_source: FeedSource = .hook,
+    message_id: [bubble_message_id_capacity]u8 = @splat(0),
+    message_id_len: usize = 0,
+    pending_input_ids: [max_pending_inputs][bubble_message_id_capacity]u8 = @splat(@splat(0)),
+    pending_input_id_lens: [max_pending_inputs]usize = @splat(0),
+    pending_input_ids_len: usize = 0,
+    /// Providers that cannot supply a correlation id get one bounded pending
+    /// request per conversation. Unlike keyed requests, definitive resumed
+    /// work may safely clear this fallback.
+    pending_unkeyed_input: bool = false,
+    completed_at_ms: i64 = 0,
+    child_messages: [max_child_messages]ChildMessage = @splat(.{}),
+    child_messages_len: usize = 0,
     origin_app: plat.OriginApplication = .none,
     source_tty: [64]u8 = @splat(0),
     source_tty_len: usize = 0,
@@ -94,6 +243,16 @@ pub const Bubble = struct {
     source_cwd_len: usize = 0,
     herdr_pane: [64]u8 = @splat(0),
     herdr_pane_len: usize = 0,
+    /// Machine that owns the agent process. Local hooks report the Mac's
+    /// hostname; SSH hooks report the remote host, so the header never has
+    /// to infer locality from a filesystem path.
+    hostname: [64]u8 = @splat(0),
+    hostname_len: usize = 0,
+    /// Active agent turn. Codex requires both thread + turn ids for a safe
+    /// interrupt/steer request; other agents leave this empty.
+    turn: [64]u8 = @splat(0),
+    turn_len: usize = 0,
+    remote: bool = false,
     busy: bool = false,
     /// Per-agent attention, when the sender knows it. `busy` alone cannot
     /// tell a blocked agent from an idle one, and that distinction is the
@@ -101,6 +260,15 @@ pub const Bubble = struct {
     /// not say, and readers fall back to `busy`.
     agent_state: [16]u8 = @splat(0),
     agent_state_len: usize = 0,
+    /// Last distinct running event accepted for this conversation. This is
+    /// intentionally separate from `counter`: repeated transport heartbeats
+    /// must not keep an abandoned card visually active forever.
+    last_meaningful_activity_ms: i64 = 0,
+    last_activity_fingerprint: u64 = 0,
+    /// Set after the desktop has quieted a running card. An identical running
+    /// snapshot must not immediately restart its animation; a meaningful
+    /// event below clears this flag.
+    stale_running_suppressed: bool = false,
     counter: u64 = 0,
 
     pub fn sessionSlice(self: *const Bubble) []const u8 {
@@ -118,11 +286,255 @@ pub const Bubble = struct {
     pub fn agentStateSlice(self: *const Bubble) []const u8 {
         return self.agent_state[0..self.agent_state_len];
     }
+    pub fn hostnameSlice(self: *const Bubble) []const u8 {
+        return self.hostname[0..self.hostname_len];
+    }
+    pub fn turnSlice(self: *const Bubble) []const u8 {
+        return self.turn[0..self.turn_len];
+    }
+    pub fn sourceSessionSlice(self: *const Bubble) []const u8 {
+        return self.source_session[0..self.source_session_len];
+    }
+    pub fn parentSessionSlice(self: *const Bubble) []const u8 {
+        return self.parent_session[0..self.parent_session_len];
+    }
+    pub fn messageIdSlice(self: *const Bubble) []const u8 {
+        return self.message_id[0..self.message_id_len];
+    }
 };
 
 /// How many conversations can narrate at once. Fixed because the
 /// mailbox holds them inline: no allocator runs on the hook hot path.
 pub const max_bubbles = 8;
+
+/// Provider-neutral update accepted by the mailbox. The HTTP route and
+/// in-process rollout reconcilers both lower their event shapes into this one
+/// record, so canonical identity and message precedence cannot drift by feed.
+pub const BubbleUpdate = struct {
+    conversation_key: []const u8 = "",
+    source_session: []const u8 = "",
+    parent_session: []const u8 = "",
+    text: []const u8 = "",
+    agent: []const u8 = "",
+    title: []const u8 = "",
+    origin_app: plat.OriginApplication = .none,
+    source_tty: []const u8 = "",
+    source_cwd: []const u8 = "",
+    herdr_pane: []const u8 = "",
+    hostname: []const u8 = "",
+    turn: []const u8 = "",
+    message_id: []const u8 = "",
+    event_kind: []const u8 = "",
+    request_id: []const u8 = "",
+    resolves_request_id: []const u8 = "",
+    notification_kind: []const u8 = "",
+    subagent_label: []const u8 = "",
+    remote: bool = false,
+    busy: bool = false,
+    status: ?SessionStatus = null,
+    session_kind: SessionKind = .primary,
+    message_kind: MessageKind = .status,
+    title_source: TitleSource = .unknown,
+    feed_source: FeedSource = .hook,
+};
+
+fn copyField(destination: []u8, source: []const u8) usize {
+    const count = @min(destination.len, source.len);
+    @memset(destination, 0);
+    @memcpy(destination[0..count], source[0..count]);
+    return count;
+}
+
+fn identityMatches(bubble: *const Bubble, update: BubbleUpdate) bool {
+    if (!std.mem.eql(u8, bubble.sessionSlice(), update.conversation_key)) return false;
+    // Empty is the compatibility slot used by pre-session integrations.
+    if (update.conversation_key.len == 0) return true;
+    if (bubble.remote != update.remote) return false;
+    if (!std.ascii.eqlIgnoreCase(bubble.agent[0..bubble.agent_len], update.agent)) return false;
+    if (!update.remote) return true;
+    return std.ascii.eqlIgnoreCase(bubble.hostnameSlice(), update.hostname);
+}
+
+/// Match a provisional card opened under a raw child id before its provider
+/// had persisted canonical ancestry. Once that same raw id is authoritatively
+/// identified as a subagent, the provisional card must disappear rather than
+/// survive beside its parent until normal expiry.
+fn sourceSessionIdentityMatches(bubble: *const Bubble, update: BubbleUpdate) bool {
+    if (update.source_session.len == 0 or
+        std.mem.eql(u8, update.source_session, update.conversation_key) or
+        !std.mem.eql(u8, bubble.sessionSlice(), update.source_session)) return false;
+    if (bubble.remote != update.remote) return false;
+    if (!std.ascii.eqlIgnoreCase(bubble.agent[0..bubble.agent_len], update.agent)) return false;
+    if (!update.remote) return true;
+    return std.ascii.eqlIgnoreCase(bubble.hostnameSlice(), update.hostname);
+}
+
+fn shouldReplaceMessage(bubble: *const Bubble, update: BubbleUpdate) bool {
+    if (std.mem.trim(u8, update.text, " \t\r\n").len == 0) return false;
+    if (bubble.text_len == 0) return true;
+    if (update.status == .failed) return true;
+    if (update.message_kind == .assistant or update.message_kind == .prompt) return true;
+    if (update.status == .needs_input) return true;
+    if (update.turn.len > 0 and !std.mem.eql(u8, bubble.turnSlice(), update.turn)) return true;
+    // Once user-visible assistant prose exists for this turn, lower-level
+    // reasoning, tools and lifecycle summaries may update state but not the
+    // feed text. This is the Codex Pet/Petdesk parity invariant.
+    if (bubble.message_kind == .assistant) return false;
+    if (update.message_kind == .reasoning) return true;
+    if (update.message_kind == .tool and bubble.message_kind != .reasoning) return true;
+    return bubble.message_kind == .status or bubble.message_kind == .lifecycle;
+}
+
+fn childMessageMatches(message: *const ChildMessage, update: BubbleUpdate) bool {
+    if (update.message_id.len > 0 and message.message_id_len > 0)
+        return std.mem.eql(u8, message.messageIdSlice(), update.message_id);
+    return std.mem.eql(u8, message.sourceSessionSlice(), update.source_session) and
+        std.mem.eql(u8, message.textSlice(), update.text);
+}
+
+fn childMessageEquivalent(message: *const ChildMessage, update: BubbleUpdate) bool {
+    return std.mem.eql(u8, message.textSlice(), update.text) and
+        std.mem.eql(u8, message.labelSlice(), if (update.subagent_label.len > 0) update.subagent_label else "Subagent") and
+        std.mem.eql(u8, message.sourceSessionSlice(), update.source_session) and
+        std.mem.eql(u8, message.messageIdSlice(), update.message_id);
+}
+
+/// A provider may poll/replay a `running` status for minutes without any new
+/// assistant work. Only an event with a distinct, user-relevant token is
+/// allowed to refresh a card's activity lease.
+fn runningActivityFingerprint(update: BubbleUpdate) u64 {
+    if (update.message_id.len == 0 and update.turn.len == 0 and update.text.len == 0 and update.event_kind.len == 0)
+        return 0;
+    var hash: u64 = 1469598103934665603;
+    const mix = struct {
+        fn apply(current: *u64, value: []const u8) void {
+            for (value) |byte| current.* = (current.* ^ byte) *% 1099511628211;
+            current.* = (current.* ^ 0xff) *% 1099511628211;
+        }
+    }.apply;
+    mix(&hash, update.message_id);
+    mix(&hash, update.turn);
+    mix(&hash, update.event_kind);
+    mix(&hash, update.text);
+    return hash;
+}
+
+fn bubblePresentationEquivalent(before: Bubble, after: Bubble) bool {
+    var left = before;
+    var right = after;
+    // These fields govern feed freshness and ordering, not visible card
+    // content. Comparing them would turn an otherwise identical heartbeat
+    // into a redraw.
+    left.counter = 0;
+    right.counter = 0;
+    left.last_meaningful_activity_ms = 0;
+    right.last_meaningful_activity_ms = 0;
+    left.last_activity_fingerprint = 0;
+    right.last_activity_fingerprint = 0;
+    return std.meta.eql(left, right);
+}
+
+fn pendingInputKey(update: BubbleUpdate) []const u8 {
+    if (update.request_id.len > 0) return update.request_id;
+    return update.message_id;
+}
+
+fn pendingInputIndex(bubble: *const Bubble, key: []const u8) ?usize {
+    if (key.len == 0) return null;
+    for (0..bubble.pending_input_ids_len) |index| {
+        if (std.mem.eql(u8, bubble.pending_input_ids[index][0..bubble.pending_input_id_lens[index]], key)) return index;
+    }
+    return null;
+}
+
+fn clearPendingInputs(bubble: *Bubble) void {
+    bubble.pending_input_ids_len = 0;
+    bubble.pending_unkeyed_input = false;
+    @memset(&bubble.pending_input_ids, @splat(0));
+    @memset(&bubble.pending_input_id_lens, 0);
+}
+
+fn notificationNeedsInput(kind: []const u8) bool {
+    return std.mem.eql(u8, kind, "permission_prompt") or
+        std.mem.eql(u8, kind, "elicitation_dialog") or
+        std.mem.eql(u8, kind, "elicitation_url_dialog") or
+        std.mem.eql(u8, kind, "agent_needs_input");
+}
+
+fn notificationCompletes(kind: []const u8) bool {
+    return std.mem.eql(u8, kind, "idle_prompt") or
+        std.mem.eql(u8, kind, "agent_completed");
+}
+
+fn normalizedProposedStatus(update: BubbleUpdate) SessionStatus {
+    const proposed = update.status orelse if (update.busy) SessionStatus.running else SessionStatus.idle;
+    // Claude-shaped Notification hooks are deliberately closed over the
+    // documented notification_type values. Unknown or authentication-only
+    // notifications must never manufacture an orange card.
+    if (std.mem.eql(u8, update.event_kind, "notification")) {
+        if (notificationNeedsInput(update.notification_kind)) return .needs_input;
+        if (notificationCompletes(update.notification_kind)) return .completed;
+        return if (update.busy) .running else .idle;
+    }
+    // `waiting` is a mascot phase used by older integrations, not evidence of
+    // an outstanding user request. Explicit approval/question event kinds and
+    // legacy callers without event_kind retain their intended status.
+    if (std.mem.eql(u8, update.event_kind, "waiting"))
+        return if (update.busy) .running else .idle;
+    return proposed;
+}
+
+fn isDefinitiveResume(update: BubbleUpdate) bool {
+    if (std.mem.eql(u8, update.event_kind, "user-prompt") or
+        std.mem.eql(u8, update.event_kind, "new-turn") or
+        std.mem.eql(u8, update.event_kind, "assistant") or
+        std.mem.eql(u8, update.event_kind, "approval-response")) return true;
+    return update.message_kind == .assistant or update.message_kind == .reasoning or
+        update.message_kind == .tool or
+        (update.turn.len > 0);
+}
+
+fn removePendingInput(bubble: *Bubble, index: usize) void {
+    if (index >= bubble.pending_input_ids_len) return;
+    std.mem.copyForwards([bubble_message_id_capacity]u8, bubble.pending_input_ids[index .. bubble.pending_input_ids_len - 1], bubble.pending_input_ids[index + 1 .. bubble.pending_input_ids_len]);
+    std.mem.copyForwards(usize, bubble.pending_input_id_lens[index .. bubble.pending_input_ids_len - 1], bubble.pending_input_id_lens[index + 1 .. bubble.pending_input_ids_len]);
+    bubble.pending_input_ids_len -= 1;
+    bubble.pending_input_ids[bubble.pending_input_ids_len] = @splat(0);
+    bubble.pending_input_id_lens[bubble.pending_input_ids_len] = 0;
+}
+
+fn reconcileStatus(bubble: *Bubble, update: BubbleUpdate, proposed: SessionStatus) SessionStatus {
+    const key = pendingInputKey(update);
+    switch (proposed) {
+        .failed, .completed, .idle => clearPendingInputs(bubble),
+        .needs_input => {
+            if (key.len > 0 and pendingInputIndex(bubble, key) == null) {
+                if (bubble.pending_input_ids_len == max_pending_inputs) removePendingInput(bubble, 0);
+                const index = bubble.pending_input_ids_len;
+                bubble.pending_input_id_lens[index] = copyField(&bubble.pending_input_ids[index], key);
+                bubble.pending_input_ids_len += 1;
+            } else if (key.len == 0) {
+                bubble.pending_unkeyed_input = true;
+            }
+        },
+        .running => {
+            const resolving_key = if (update.resolves_request_id.len > 0) update.resolves_request_id else "";
+            if (pendingInputIndex(bubble, resolving_key)) |index| {
+                removePendingInput(bubble, index);
+            }
+            if (bubble.pending_unkeyed_input and isDefinitiveResume(update))
+                bubble.pending_unkeyed_input = false;
+            // A genuinely new turn invalidates even keyed requests from the
+            // previous turn. Ordinary tool/assistant progress only resolves
+            // the bounded unkeyed fallback.
+            if (std.mem.eql(u8, update.event_kind, "user-prompt") or
+                std.mem.eql(u8, update.event_kind, "new-turn")) clearPendingInputs(bubble);
+        },
+    }
+    if (proposed == .failed) return .failed;
+    if (bubble.pending_input_ids_len > 0 or bubble.pending_unkeyed_input) return .needs_input;
+    return proposed;
+}
 
 /// Shared mailbox between the server thread (producer) and the app's
 /// poll timer (consumer). Everything behind one mutex; operations are
@@ -156,9 +568,21 @@ const BlockingMutex = struct {
 };
 
 pub const Mailbox = struct {
+    /// In-process diagnostic counters for duplicate/stale feed behavior.
+    /// They deliberately stay with each mailbox instance and are not emitted
+    /// as telemetry.
+    pub const BubbleRenderDebugCounters = struct {
+        suppressed_duplicates: u64 = 0,
+        stale_transitions: u64 = 0,
+    };
+
     mutex: SpinMutex = .{},
     pending: [max_pending]StateEvent = @splat(.{}),
     pending_len: usize = 0,
+    /// Last semantic sprite state accepted by the queue.  It intentionally
+    /// survives a drain: providers commonly emit the same `running` state for
+    /// every tool heartbeat, and re-enqueuing it after each poll would restart
+    /// the pet animation forever without conveying new user-visible state.
     last_enqueued: StateEvent = .{},
     /// One live bubble per conversation, keyed by session id. Slots
     /// below bubbles_len are occupied; the array is compacted on evict
@@ -170,14 +594,17 @@ pub const Mailbox = struct {
     /// its LRU stamp: the smallest one is the least recently updated.
     bubble_counter: u64 = 0,
     state_counter: u64 = 0,
+    bubble_render_debug: BubbleRenderDebugCounters = .{},
 
     pub const EnqueueResult = struct {
         queued: bool,
         counter: u64,
     };
 
-    /// Coalesce + append, sidecar semantics: consecutive identical
-    /// states collapse. Returns whether the event was queued.
+    /// Coalesce + append, sidecar semantics: identical steady states collapse
+    /// even after the consumer drains them.  A different state (or duration)
+    /// remains an explicit transition, so completion, failure, and the next
+    /// task still reach the mascot immediately.
     pub fn enqueue(self: *Mailbox, event: StateEvent) bool {
         return self.enqueueWithCounter(event).queued;
     }
@@ -185,10 +612,8 @@ pub const Mailbox = struct {
     pub fn enqueueWithCounter(self: *Mailbox, event: StateEvent) EnqueueResult {
         self.mutex.lock();
         defer self.mutex.unlock();
-        if (self.pending_len > 0 or self.last_enqueued.state_len > 0) {
-            if (std.mem.eql(u8, self.last_enqueued.slice(), event.slice())) {
-                return .{ .queued = false, .counter = self.state_counter };
-            }
+        if (self.last_enqueued.state_len > 0 and stateEventEquivalent(self.last_enqueued, event)) {
+            return .{ .queued = false, .counter = self.state_counter };
         }
         if (self.pending_len >= max_pending) {
             return .{ .queued = false, .counter = self.state_counter };
@@ -203,14 +628,17 @@ pub const Mailbox = struct {
     pub fn pop(self: *Mailbox) ?StateEvent {
         self.mutex.lock();
         defer self.mutex.unlock();
-        if (self.pending_len == 0) {
-            self.last_enqueued = .{};
-            return null;
-        }
+        if (self.pending_len == 0) return null;
         const head = self.pending[0];
         std.mem.copyForwards(StateEvent, self.pending[0 .. self.pending_len - 1], self.pending[1..self.pending_len]);
         self.pending_len -= 1;
         return head;
+    }
+
+    pub fn bubbleRenderDebugCounters(self: *Mailbox) BubbleRenderDebugCounters {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        return self.bubble_render_debug;
     }
 
     /// Update the bubble for `session`, or open a slot for it. A repeat
@@ -223,50 +651,217 @@ pub const Mailbox = struct {
     }
 
     pub fn setBubbleWithMetadata(self: *Mailbox, session: []const u8, text: []const u8, agent: []const u8, title: []const u8, origin_app: plat.OriginApplication, source_tty: []const u8, source_cwd: []const u8, herdr_pane: []const u8, busy: bool) u64 {
+        return self.applyBubbleUpdate(.{
+            .conversation_key = session,
+            .source_session = session,
+            .text = text,
+            .agent = agent,
+            .title = title,
+            .origin_app = origin_app,
+            .source_tty = source_tty,
+            .source_cwd = source_cwd,
+            .herdr_pane = herdr_pane,
+            .busy = busy,
+            .status = if (busy) .running else .idle,
+        });
+    }
+
+    pub fn setBubbleWithContext(self: *Mailbox, session: []const u8, text: []const u8, agent: []const u8, title: []const u8, origin_app: plat.OriginApplication, source_tty: []const u8, source_cwd: []const u8, hostname: []const u8, turn: []const u8, remote: bool, busy: bool) u64 {
+        return self.applyBubbleUpdate(.{
+            .conversation_key = session,
+            .source_session = session,
+            .text = text,
+            .agent = agent,
+            .title = title,
+            .origin_app = origin_app,
+            .source_tty = source_tty,
+            .source_cwd = source_cwd,
+            .hostname = hostname,
+            .turn = turn,
+            .remote = remote,
+            .busy = busy,
+            .status = if (busy) .running else .idle,
+        });
+    }
+
+    pub fn applyBubbleUpdate(self: *Mailbox, update_raw: BubbleUpdate) u64 {
+        var conversation_hash: [64]u8 = undefined;
+        var source_hash: [64]u8 = undefined;
+        var parent_hash: [64]u8 = undefined;
+        var update = update_raw;
+        update.conversation_key = normalizeBubbleSession(update_raw.conversation_key, &conversation_hash) orelse "";
+        update.source_session = normalizeBubbleSession(update_raw.source_session, &source_hash) orelse "";
+        update.parent_session = normalizeBubbleSession(update_raw.parent_session, &parent_hash) orelse "";
         self.mutex.lock();
         defer self.mutex.unlock();
 
-        const slot = blk: {
-            for (self.bubbles[0..self.bubbles_len]) |*b| {
-                if (std.mem.eql(u8, b.sessionSlice(), session)) break :blk b;
+        // Hermes can emit a child's first tool event before state.db contains
+        // `_delegate_from`. Older adapters therefore opened a raw child card,
+        // then correctly classified later events without ever retracting that
+        // provisional card. An authoritative child update owns the cleanup.
+        if (update.session_kind == .subagent) {
+            var index: usize = 0;
+            while (index < self.bubbles_len) : (index += 1) {
+                if (!sourceSessionIdentityMatches(&self.bubbles[index], update)) continue;
+                if (index + 1 < self.bubbles_len)
+                    std.mem.copyForwards(Bubble, self.bubbles[index .. self.bubbles_len - 1], self.bubbles[index + 1 .. self.bubbles_len]);
+                self.bubbles_len -= 1;
+                self.bubbles[self.bubbles_len] = .{};
+                self.bubble_counter += 1;
+                self.bubbles_dirty = true;
+                break;
             }
+        }
+
+        var matched_existing: ?*Bubble = null;
+        for (self.bubbles[0..self.bubbles_len]) |*bubble| {
+            if (identityMatches(bubble, update)) {
+                matched_existing = bubble;
+                break;
+            }
+        }
+
+        // A child never owns a top-level card. If its parent has not appeared
+        // yet, drop the event rather than manufacturing a blank ghost card.
+        // The next meaningful parent update will establish the aggregate.
+        if (update.session_kind == .subagent) {
+            const parent = matched_existing orelse return self.bubble_counter;
+            if (update.message_kind != .assistant or std.mem.trim(u8, update.text, " \t\r\n").len == 0)
+                return self.bubble_counter;
+
+            var duplicate: ?usize = null;
+            for (parent.child_messages[0..parent.child_messages_len], 0..) |*message, i| {
+                if (childMessageMatches(message, update)) {
+                    duplicate = i;
+                    break;
+                }
+            }
+            if (duplicate) |index| {
+                if (childMessageEquivalent(&parent.child_messages[index], update)) {
+                    self.bubble_render_debug.suppressed_duplicates +%= 1;
+                    return self.bubble_counter;
+                }
+                // Move an updated duplicate to the tail so "two most recent"
+                // is chronological even when a provider replays an event.
+                const existing = parent.child_messages[index];
+                std.mem.copyForwards(ChildMessage, parent.child_messages[index .. parent.child_messages_len - 1], parent.child_messages[index + 1 .. parent.child_messages_len]);
+                parent.child_messages[parent.child_messages_len - 1] = existing;
+            } else {
+                if (parent.child_messages_len == max_child_messages) {
+                    std.mem.copyForwards(ChildMessage, parent.child_messages[0 .. max_child_messages - 1], parent.child_messages[1..max_child_messages]);
+                    parent.child_messages_len -= 1;
+                }
+                parent.child_messages[parent.child_messages_len] = .{};
+                parent.child_messages_len += 1;
+            }
+            var child = &parent.child_messages[parent.child_messages_len - 1];
+            child.text_len = copyField(&child.text, update.text);
+            child.label_len = copyField(&child.label, if (update.subagent_label.len > 0) update.subagent_label else "Subagent");
+            child.source_session_len = copyField(&child.source_session, update.source_session);
+            child.message_id_len = copyField(&child.message_id, update.message_id);
+            self.bubble_counter += 1;
+            child.counter = self.bubble_counter;
+            parent.counter = self.bubble_counter;
+            self.bubbles_dirty = true;
+            return parent.counter;
+        }
+
+        const is_new = matched_existing == null;
+        const slot = matched_existing orelse blk: {
+            var selected: *Bubble = undefined;
             if (self.bubbles_len < max_bubbles) {
-                const b = &self.bubbles[self.bubbles_len];
+                selected = &self.bubbles[self.bubbles_len];
                 self.bubbles_len += 1;
-                break :blk b;
+            } else {
+                selected = &self.bubbles[0];
+                for (self.bubbles[1..self.bubbles_len]) |*bubble| {
+                    if (bubble.counter < selected.counter) selected = bubble;
+                }
             }
-            var oldest = &self.bubbles[0];
-            for (self.bubbles[1..self.bubbles_len]) |*b| {
-                if (b.counter < oldest.counter) oldest = b;
-            }
-            break :blk oldest;
+            selected.* = .{};
+            selected.session_len = copyField(&selected.session, update.conversation_key);
+            selected.remote = update.remote;
+            break :blk selected;
         };
 
-        slot.* = .{};
-        const sn = @min(session.len, slot.session.len);
-        @memcpy(slot.session[0..sn], session[0..sn]);
-        slot.session_len = sn;
-        const n = @min(text.len, slot.text.len);
-        @memcpy(slot.text[0..n], text[0..n]);
-        slot.text_len = n;
-        const an = @min(agent.len, slot.agent.len);
-        @memcpy(slot.agent[0..an], agent[0..an]);
-        slot.agent_len = an;
-        const tn = @min(title.len, slot.title.len);
-        @memcpy(slot.title[0..tn], title[0..tn]);
-        slot.title_len = tn;
-        slot.origin_app = origin_app;
-        const tty_n = @min(source_tty.len, slot.source_tty.len);
-        @memcpy(slot.source_tty[0..tty_n], source_tty[0..tty_n]);
-        slot.source_tty_len = tty_n;
-        const cwd_n = @min(source_cwd.len, slot.source_cwd.len);
-        @memcpy(slot.source_cwd[0..cwd_n], source_cwd[0..cwd_n]);
-        slot.source_cwd_len = cwd_n;
-        const pane_n = @min(herdr_pane.len, slot.herdr_pane.len);
-        @memcpy(slot.herdr_pane[0..pane_n], herdr_pane[0..pane_n]);
-        slot.herdr_pane_len = pane_n;
-        slot.busy = busy;
+        // Sessionless integrations intentionally share one compatibility
+        // slot. Treat each write as unrelated so title/message provenance from
+        // an older legacy agent cannot leak into the next one.
+        const sessionless_replace = matched_existing != null and update.conversation_key.len == 0;
+        const before = slot.*;
+        if (sessionless_replace) {
+            slot.* = .{};
+            slot.remote = update.remote;
+        }
 
+        const metadata_wins = is_new or update.feed_source.rank() >= slot.feed_source.rank();
+        if (update.agent.len > 0 and (metadata_wins or slot.agent_len == 0)) slot.agent_len = copyField(&slot.agent, update.agent);
+        if (update.source_session.len > 0 and (metadata_wins or slot.source_session_len == 0)) slot.source_session_len = copyField(&slot.source_session, update.source_session);
+        if (update.parent_session.len > 0 and (metadata_wins or slot.parent_session_len == 0)) slot.parent_session_len = copyField(&slot.parent_session, update.parent_session);
+        slot.session_kind = .primary;
+        if (metadata_wins) slot.feed_source = update.feed_source;
+        if (update.origin_app != .none and (metadata_wins or slot.origin_app == .none)) slot.origin_app = update.origin_app;
+        if (update.source_tty.len > 0 and (metadata_wins or slot.source_tty_len == 0)) slot.source_tty_len = copyField(&slot.source_tty, update.source_tty);
+        if (update.source_cwd.len > 0 and (metadata_wins or slot.source_cwd_len == 0)) slot.source_cwd_len = copyField(&slot.source_cwd, update.source_cwd);
+        if (update.herdr_pane.len > 0 and (metadata_wins or slot.herdr_pane_len == 0)) slot.herdr_pane_len = copyField(&slot.herdr_pane, update.herdr_pane);
+        if (update.hostname.len > 0 and (metadata_wins or slot.hostname_len == 0)) slot.hostname_len = copyField(&slot.hostname, update.hostname);
+        slot.remote = update.remote;
+
+        const replace_title = update.title.len > 0 and switch (update.title_source) {
+            .server => true,
+            .prompt => slot.title_len == 0,
+            .unknown => slot.title_len == 0 or slot.title_source != .server,
+        };
+        if (replace_title) {
+            slot.title_len = copyField(&slot.title, update.title);
+            slot.title_source = update.title_source;
+        }
+
+        if (shouldReplaceMessage(slot, update)) {
+            slot.text_len = copyField(&slot.text, update.text);
+            slot.message_kind = update.message_kind;
+            slot.message_id_len = copyField(&slot.message_id, update.message_id);
+        }
+        const previous_status = slot.status;
+        var proposed_status = normalizedProposedStatus(update);
+        const activity_fingerprint = runningActivityFingerprint(update);
+        const meaningful_running_activity = proposed_status == .running and activity_fingerprint != 0 and
+            (is_new or sessionless_replace or activity_fingerprint != before.last_activity_fingerprint);
+        // Once a card has been quieted, an unchanged provider heartbeat is
+        // not evidence of new work. A changed assistant/tool/progress event
+        // clears the suppression and immediately restores the running state.
+        if (slot.stale_running_suppressed and proposed_status == .running and !meaningful_running_activity)
+            proposed_status = .idle;
+        const status = reconcileStatus(slot, update, proposed_status);
+        if (update.turn.len > 0) slot.turn_len = copyField(&slot.turn, update.turn);
+        slot.status = status;
+        slot.busy = status == .running;
+        slot.completed_at_ms = if (status == .completed)
+            (if (previous_status == .completed and slot.completed_at_ms > 0) slot.completed_at_ms else nowMs())
+        else
+            0;
+
+        // A newly running card has a lease even when an older integration
+        // cannot provide a message id yet.  Subsequent unkeyed heartbeats do
+        // not refresh it; that lets the 30s stale guard quiet every provider.
+        const started_running = status == .running and
+            (is_new or sessionless_replace or before.status != .running);
+        if ((meaningful_running_activity or started_running) and status == .running) {
+            slot.last_meaningful_activity_ms = nowMs();
+            slot.last_activity_fingerprint = activity_fingerprint;
+            slot.stale_running_suppressed = false;
+        } else if (status == .needs_input or status == .completed or status == .failed) {
+            // Terminal and attention states are explicit. They do not retain
+            // a stale-running marker that could interfere with a later turn.
+            slot.stale_running_suppressed = false;
+        }
+
+        const changed = is_new or sessionless_replace or meaningful_running_activity or
+            !bubblePresentationEquivalent(before, slot.*);
+        if (!changed) {
+            self.bubble_render_debug.suppressed_duplicates +%= 1;
+            return self.bubble_counter;
+        }
         self.bubble_counter += 1;
         slot.counter = self.bubble_counter;
         self.bubbles_dirty = true;
@@ -292,6 +887,60 @@ pub const Mailbox = struct {
         }
     }
 
+    /// Quiet running cards whose provider has stopped emitting meaningful
+    /// work. The card remains retained and becomes neutral; only a distinct
+    /// running event may wake it again.
+    pub fn suppressStaleRunning(self: *Mailbox, now_ms: i64, grace_ms: i64) usize {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        var suppressed: usize = 0;
+        for (self.bubbles[0..self.bubbles_len]) |*bubble| {
+            if (bubble.status != .running or bubble.last_meaningful_activity_ms <= 0) continue;
+            if (now_ms - bubble.last_meaningful_activity_ms < grace_ms) continue;
+            bubble.status = .idle;
+            bubble.busy = false;
+            bubble.stale_running_suppressed = true;
+            self.bubble_counter += 1;
+            bubble.counter = self.bubble_counter;
+            self.bubbles_dirty = true;
+            self.bubble_render_debug.stale_transitions +%= 1;
+            suppressed += 1;
+        }
+        return suppressed;
+    }
+
+    /// Apply an authoritative title without manufacturing a message update.
+    /// Used by agent servers that publish renames independently from tool and
+    /// lifecycle events (OpenCode's session.updated, Codex's title index).
+    pub fn setBubbleTitle(self: *Mailbox, session: []const u8, title: []const u8) ?u64 {
+        return self.setBubbleTitleIdentity(session, title, "", "", false, false);
+    }
+
+    pub fn setBubbleTitleIdentity(self: *Mailbox, session: []const u8, title: []const u8, agent: []const u8, hostname: []const u8, remote: bool, exact: bool) ?u64 {
+        if (session.len == 0 or title.len == 0) return null;
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        for (self.bubbles[0..self.bubbles_len]) |*bubble| {
+            if (!std.mem.eql(u8, bubble.sessionSlice(), session)) continue;
+            if (exact) {
+                if (bubble.remote != remote) continue;
+                if (!std.ascii.eqlIgnoreCase(bubble.agent[0..bubble.agent_len], agent)) continue;
+                if (remote and !std.ascii.eqlIgnoreCase(bubble.hostnameSlice(), hostname)) continue;
+            }
+            const capped = title[0..@min(title.len, bubble.title.len)];
+            if (std.mem.eql(u8, bubble.title[0..bubble.title_len], capped)) return bubble.counter;
+            @memset(&bubble.title, 0);
+            @memcpy(bubble.title[0..capped.len], capped);
+            bubble.title_len = capped.len;
+            bubble.title_source = .server;
+            self.bubble_counter += 1;
+            bubble.counter = self.bubble_counter;
+            self.bubbles_dirty = true;
+            return bubble.counter;
+        }
+        return null;
+    }
+
     /// Drain the whole set into `out`, returning how many slots landed.
     /// All-or-nothing rather than per-bubble: the consumer re-renders
     /// the stack as a unit, so a partial copy has no meaning.
@@ -308,10 +957,19 @@ pub const Mailbox = struct {
     /// the slot is free for the next conversation. No dirty flag: the
     /// consumer already knows, it asked for this.
     pub fn dropBubble(self: *Mailbox, session: []const u8) void {
+        self.dropBubbleIdentity(session, "", "", false, false);
+    }
+
+    pub fn dropBubbleIdentity(self: *Mailbox, conversation: []const u8, agent: []const u8, hostname: []const u8, remote: bool, exact: bool) void {
         self.mutex.lock();
         defer self.mutex.unlock();
         for (self.bubbles[0..self.bubbles_len], 0..) |*b, i| {
-            if (!std.mem.eql(u8, b.sessionSlice(), session)) continue;
+            if (!std.mem.eql(u8, b.sessionSlice(), conversation)) continue;
+            if (exact) {
+                if (b.remote != remote) continue;
+                if (!std.ascii.eqlIgnoreCase(b.agent[0..b.agent_len], agent)) continue;
+                if (remote and !std.ascii.eqlIgnoreCase(b.hostnameSlice(), hostname)) continue;
+            }
             const last = self.bubbles_len - 1;
             if (i != last) self.bubbles[i] = self.bubbles[last];
             self.bubbles[last] = .{};
@@ -375,6 +1033,48 @@ pub const AuthMailbox = struct {
 
 pub var auth_mailbox: AuthMailbox = .{};
 
+const RemoteCredential = struct {
+    active: bool = false,
+    principal: [32]u8 = @splat(0),
+    principal_len: usize = 0,
+    secret: [64]u8 = @splat(0),
+};
+
+var remote_credentials_lock: SpinMutex = .{};
+var remote_credentials: [8]RemoteCredential = @splat(.{});
+
+pub fn issueRemoteCredential(principal: []const u8, out: []u8) ?[]const u8 {
+    if (principal.len == 0 or principal.len > 32) return null;
+    for (principal) |byte| if (!(std.ascii.isAlphanumeric(byte) or byte == '-' or byte == '_')) return null;
+    var raw: [32]u8 = undefined;
+    fillRandom(&raw) catch return null;
+    var secret: [64]u8 = undefined;
+    secret = std.fmt.bytesToHex(raw, .lower);
+
+    remote_credentials_lock.lock();
+    defer remote_credentials_lock.unlock();
+    var selected: *RemoteCredential = &remote_credentials[0];
+    for (&remote_credentials) |*entry| {
+        if (entry.active and std.mem.eql(u8, entry.principal[0..entry.principal_len], principal)) {
+            selected = entry;
+            break;
+        }
+        if (!entry.active) selected = entry;
+    }
+    selected.* = .{ .active = true, .secret = secret };
+    selected.principal_len = principal.len;
+    @memcpy(selected.principal[0..principal.len], principal);
+    return std.fmt.bufPrint(out, "remote:{s}:{s}", .{ principal, &secret }) catch null;
+}
+
+pub fn revokeRemoteCredential(principal: []const u8) void {
+    remote_credentials_lock.lock();
+    defer remote_credentials_lock.unlock();
+    for (&remote_credentials) |*entry| {
+        if (entry.active and std.mem.eql(u8, entry.principal[0..entry.principal_len], principal)) entry.* = .{};
+    }
+}
+
 const valid_states = [_][]const u8{
     "idle",    "running", "running-left", "running-right", "waving",
     "jumping", "failed",  "review",       "waiting",
@@ -387,6 +1087,123 @@ const valid_states = [_][]const u8{
 const fillRandom = plat.fillRandom;
 
 const nowMs = plat.nowMs;
+const monotonicMs = plat.monotonicMs;
+
+const ReadDeadlineEntry = struct {
+    active: bool = false,
+    timed_out: bool = false,
+    stream: std.Io.net.Stream = undefined,
+    io: std.Io = undefined,
+    deadline: std.Io.Clock.Timestamp = undefined,
+};
+
+var read_deadline_lock: SpinMutex = .{};
+var read_deadlines: [max_active_connections]ReadDeadlineEntry = @splat(.{});
+var read_deadline_thread_started: std.atomic.Value(bool) = .init(false);
+
+fn readDeadlineTimer() void {
+    var scope = plat.Scope.init();
+    defer scope.deinit();
+    const io = scope.io();
+    while (true) {
+        std.Io.sleep(io, std.Io.Duration.fromMilliseconds(25), .awake) catch {};
+        const now = std.Io.Clock.Timestamp.now(io, .boot);
+        read_deadline_lock.lock();
+        for (&read_deadlines) |*entry| {
+            if (!entry.active or entry.timed_out or !entry.deadline.compare(.lte, now)) continue;
+            entry.timed_out = true;
+            // Closing an AFD-backed stream while Zig's Windows reader is
+            // pending produces STATUS_CANCELLED, which Zig 0.16 treats as an
+            // unreachable state. A full AFD partial-disconnect wakes that
+            // read as a normal disconnected socket; final handle close still
+            // belongs to the connection thread. Send the small 408 first so a
+            // responsive peer gets the same contract as POSIX, then disconnect
+            // even if a malicious peer is not reading the response.
+            var response_buffer: [256]u8 = undefined;
+            var response_writer = entry.stream.writer(entry.io, &response_buffer);
+            var conn: Conn = .{ .stream = entry.stream, .io = entry.io, .writer = &response_writer.interface };
+            respond(&conn, 408, "{\"ok\":false,\"error\":\"request_timeout\"}");
+            entry.stream.shutdown(entry.io, .both) catch {};
+        }
+        read_deadline_lock.unlock();
+    }
+}
+
+fn registerReadDeadline(stream: std.Io.net.Stream, io: std.Io, deadline: std.Io.Clock.Timestamp) ?usize {
+    if (read_deadline_thread_started.cmpxchgStrong(false, true, .acq_rel, .acquire) == null) {
+        const thread = std.Thread.spawn(.{}, readDeadlineTimer, .{}) catch {
+            read_deadline_thread_started.store(false, .release);
+            return null;
+        };
+        thread.detach();
+    }
+    read_deadline_lock.lock();
+    defer read_deadline_lock.unlock();
+    for (&read_deadlines, 0..) |*entry, index| {
+        if (entry.active) continue;
+        entry.* = .{ .active = true, .stream = stream, .io = io, .deadline = deadline };
+        return index;
+    }
+    return null;
+}
+
+fn removeReadDeadline(index: usize) bool {
+    read_deadline_lock.lock();
+    defer read_deadline_lock.unlock();
+    const timed_out = read_deadlines[index].timed_out;
+    read_deadlines[index] = .{};
+    return timed_out;
+}
+
+fn readBeforeDeadline(stream: std.Io.net.Stream, reader: *std.Io.Reader, io: std.Io, buffer: []u8, deadline: std.Io.Clock.Timestamp) ![]const u8 {
+    if (builtin.os.tag != .windows) return (try stream.socket.receiveTimeout(io, buffer, .{ .deadline = deadline })).data;
+    const slot = registerReadDeadline(stream, io, deadline) orelse return error.SystemResources;
+    // readSliceShort fills the entire destination before returning. Passing
+    // the 64 KiB request tail would therefore stall every ordinary HTTP
+    // request until the deadline. peekByte triggers one AFD receive into the
+    // reader's 1 KiB buffer; copy the bytes already delivered by that single
+    // receive without initiating a second blocking operation.
+    _ = reader.peekByte() catch |err| {
+        if (removeReadDeadline(slot)) return error.Timeout;
+        return err;
+    };
+    if (removeReadDeadline(slot)) return error.Timeout;
+    const count = @min(buffer.len, reader.bufferedLen());
+    @memcpy(buffer[0..count], reader.buffered()[0..count]);
+    reader.toss(count);
+    return buffer[0..count];
+}
+
+const AuthContext = struct {
+    remote: bool = false,
+    principal: []const u8 = "local",
+};
+
+const AuthClaimConflict = enum { remote, hostname };
+
+fn authClaimConflict(auth: AuthContext, claimed_remote: ?bool, hostname: []const u8) ?AuthClaimConflict {
+    if (claimed_remote) |value| if (value != auth.remote) return .remote;
+    if (auth.remote and hostname.len > 0 and !std.mem.eql(u8, hostname, auth.principal)) return .hostname;
+    return null;
+}
+
+/// State events are deliberately tiny, so equality must include both the
+/// semantic state and its optional dwell.  Treat the old directional running
+/// aliases as one activity class as well: they are sprite flavor, not a new
+/// piece of work worthy of rearming the whole desktop renderer.
+fn stateEventEquivalent(a: StateEvent, b: StateEvent) bool {
+    if (a.duration_ms != b.duration_ms) return false;
+    const a_state = a.slice();
+    const b_state = b.slice();
+    if (std.mem.eql(u8, a_state, b_state)) return true;
+    const a_running = std.mem.eql(u8, a_state, "running") or
+        std.mem.eql(u8, a_state, "running-left") or
+        std.mem.eql(u8, a_state, "running-right");
+    const b_running = std.mem.eql(u8, b_state, "running") or
+        std.mem.eql(u8, b_state, "running-left") or
+        std.mem.eql(u8, b_state, "running-right");
+    return a_running and b_running;
+}
 
 fn isValidState(s: []const u8) bool {
     for (valid_states) |v| {
@@ -396,6 +1213,13 @@ fn isValidState(s: []const u8) bool {
 }
 
 const Server = struct {
+    const PrincipalBucket = struct {
+        used: bool = false,
+        principal: [32]u8 = @splat(0),
+        principal_len: usize = 0,
+        bucket: f64 = 30,
+        stamp_ms: i64 = 0,
+    };
     allocator: std.mem.Allocator,
     runtime_dir: []const u8,
     token: [64]u8,
@@ -407,28 +1231,42 @@ const Server = struct {
     // Token-bucket limiter, sidecar budget: 30/s shared by state+bubble.
     bucket: f64 = 30,
     bucket_stamp_ms: i64 = 0,
-    running_toggle: bool = false,
+    principal_buckets: [8]PrincipalBucket = @splat(.{}),
     pid: i32,
 
-    fn rateLimitOk(self: *Server) bool {
+    fn rateLimitOk(self: *Server, auth: AuthContext) bool {
         self.request_lock.lock();
         defer self.request_lock.unlock();
-        const now = nowMs();
+        const now = monotonicMs();
+        if (auth.remote) {
+            var selected: *PrincipalBucket = &self.principal_buckets[0];
+            for (&self.principal_buckets) |*candidate| {
+                if (candidate.used and std.mem.eql(u8, candidate.principal[0..candidate.principal_len], auth.principal)) {
+                    selected = candidate;
+                    break;
+                }
+                if (!candidate.used) selected = candidate;
+            }
+            if (!selected.used or !std.mem.eql(u8, selected.principal[0..selected.principal_len], auth.principal)) {
+                selected.* = .{ .used = true };
+                selected.principal_len = @min(selected.principal.len, auth.principal.len);
+                @memcpy(selected.principal[0..selected.principal_len], auth.principal[0..selected.principal_len]);
+            }
+            if (selected.stamp_ms == 0) selected.stamp_ms = now;
+            const elapsed: f64 = @floatFromInt(@max(@as(i64, 0), now - selected.stamp_ms));
+            selected.bucket = @min(30.0, selected.bucket + elapsed * 30.0 / 1000.0);
+            selected.stamp_ms = now;
+            if (selected.bucket < 1) return false;
+            selected.bucket -= 1;
+            return true;
+        }
         if (self.bucket_stamp_ms == 0) self.bucket_stamp_ms = now;
-        const elapsed: f64 = @floatFromInt(now - self.bucket_stamp_ms);
+        const elapsed: f64 = @floatFromInt(@max(@as(i64, 0), now - self.bucket_stamp_ms));
         self.bucket = @min(30.0, self.bucket + elapsed * 30.0 / 1000.0);
         self.bucket_stamp_ms = now;
         if (self.bucket < 1) return false;
         self.bucket -= 1;
         return true;
-    }
-
-    fn nextRunningState(self: *Server) []const u8 {
-        self.request_lock.lock();
-        defer self.request_lock.unlock();
-        const state = if (self.running_toggle) "running-left" else "running-right";
-        self.running_toggle = !self.running_toggle;
-        return state;
     }
 };
 
@@ -495,10 +1333,10 @@ fn run(server: *Server) void {
             stream.close(io);
             continue;
         }
-        // A client can disappear after sending only part of a request. Keep
-        // that blocking read off the accept loop so later hooks still reach
-        // the server while the abandoned connection drains or closes.
-        const thread = std.Thread.spawn(.{}, handleConnectionThread, .{ server, stream }) catch {
+        // Keep an abandoned client off the accept loop, but retain the Io that
+        // accepted the stream. A replacement Threaded Io cannot safely operate
+        // the existing Winsock handle.
+        const thread = std.Thread.spawn(.{}, handleConnectionThread, .{ server, stream, io }) catch {
             _ = server.active_connections.fetchSub(1, .release);
             stream.close(io);
             continue;
@@ -507,73 +1345,109 @@ fn run(server: *Server) void {
     }
 }
 
-fn handleConnectionThread(server: *Server, stream: std.Io.net.Stream) void {
+fn handleConnectionThread(server: *Server, stream: std.Io.net.Stream, io: std.Io) void {
     defer _ = server.active_connections.fetchSub(1, .release);
-    var scope = plat.Scope.init();
-    defer scope.deinit();
-    const io = scope.io();
-    var conn: Conn = .{ .stream = stream, .io = io };
-    handleConnection(server, &conn);
+    defer stream.close(io);
+
+    var request_buffer: [max_request_bytes]u8 = undefined;
+    var write_buffer: [1024]u8 = undefined;
+    var stream_writer = stream.writer(io, &write_buffer);
+    var conn: Conn = .{
+        .stream = stream,
+        .io = io,
+        .writer = &stream_writer.interface,
+    };
+    const timeout = (std.Io.Timeout{ .duration = .{
+        .raw = std.Io.Duration.fromMilliseconds(connection_timeout_ms),
+        .clock = .awake,
+    } }).toDeadline(io);
+    var total: usize = 0;
+    var request_len: ?usize = null;
+    while (request_len == null or total < request_len.?) {
+        if (total == request_buffer.len) return respond(&conn, 413, "{\"ok\":false,\"error\":\"request_too_large\"}");
+        const incoming = receiveWithTimeout(&conn, request_buffer[total..], timeout) catch |err| {
+            if (err == error.Timeout) respond(&conn, 408, "{\"ok\":false,\"error\":\"request_timeout\"}");
+            return;
+        };
+        if (incoming == 0) return;
+        total += incoming;
+        if (request_len == null) {
+            const end_at = std.mem.indexOf(u8, request_buffer[0..total], "\r\n\r\n") orelse continue;
+            const head_len = end_at + 4;
+            const head = request_buffer[0..head_len];
+            const content_length = if (headerValue(head, "content-length")) |raw| std.fmt.parseInt(usize, raw, 10) catch
+                return respond(&conn, 400, "{\"ok\":false,\"error\":\"invalid_content_length\"}") else 0;
+            if (content_length > request_buffer.len - head_len) return respond(&conn, 413, "{\"ok\":false,\"error\":\"body_too_large\"}");
+            request_len = head_len + content_length;
+        }
+    }
+    handleConnection(server, &conn, request_buffer[0..request_len.?]);
     stream.shutdown(io, .send) catch {};
     if (builtin.os.tag == .windows) {
         var drain: [1024]u8 = undefined;
-        const timeout = (std.Io.Timeout{ .duration = .{
+        const drain_timeout = (std.Io.Timeout{ .duration = .{
             .raw = std.Io.Duration.fromMilliseconds(response_drain_grace_ms),
             .clock = .awake,
         } }).toDeadline(io);
         while (true) {
-            const received = receiveWithTimeout(&conn, &drain, timeout) catch break;
+            const received = receiveWithTimeout(&conn, &drain, drain_timeout) catch break;
             if (received == 0) break;
         }
     }
-    stream.close(io);
 }
 
-fn handleConnection(server: *Server, conn: *Conn) void {
-    var buf: [max_request_bytes]u8 = undefined;
-    var total: usize = 0;
-    var header_end: ?usize = null;
-    const timeout = (std.Io.Timeout{ .duration = .{
-        .raw = std.Io.Duration.fromMilliseconds(connection_timeout_ms),
-        .clock = .awake,
-    } }).toDeadline(conn.io);
+const RequestObject = struct {
+    root: std.json.Value,
+    valid: bool = true,
 
-    // Read the complete header with a bounded deadline. A hook host can
-    // disappear after opening a socket, so no connection may wait forever.
-    while (header_end == null) {
-        if (total == buf.len) {
-            respond(conn, 413, "{\"ok\":false,\"error\":\"headers_too_large\"}");
-            return;
+    fn string(self: *RequestObject, key: []const u8) ?[]const u8 {
+        const value = self.root.object.get(key) orelse return null;
+        // Older CLI hooks serialize an unknown optional agent source as
+        // JSON null. Treat null like an omitted optional field so the typed
+        // parser remains backward-compatible; concrete non-string values are
+        // still rejected below.
+        if (value == .null) return null;
+        if (value != .string) {
+            self.valid = false;
+            return null;
         }
-        const got = receiveWithTimeout(conn, buf[total..], timeout) catch |err| {
-            std.debug.print("petdex: hook receive failed ({s})\n", .{@errorName(err)});
-            return;
-        };
-        if (got == 0) return;
-        total += got;
-        header_end = if (std.mem.indexOf(u8, buf[0..total], "\r\n\r\n")) |at| at + 4 else null;
+        return value.string;
     }
 
-    const head_len = header_end.?;
-    const head = buf[0..head_len];
+    fn boolean(self: *RequestObject, key: []const u8) ?bool {
+        const value = self.root.object.get(key) orelse return null;
+        if (value != .bool) {
+            self.valid = false;
+            return null;
+        }
+        return value.bool;
+    }
+};
+
+fn parseRequest(allocator: std.mem.Allocator, body: []const u8) !std.json.Value {
+    if (!std.unicode.utf8ValidateSlice(body)) return error.InvalidJson;
+    const root = try std.json.parseFromSliceLeaky(std.json.Value, allocator, body, .{
+        .duplicate_field_behavior = .@"error",
+        .max_value_len = max_request_bytes,
+    });
+    if (root != .object) return error.InvalidJson;
+    return root;
+}
+
+fn handleConnection(server: *Server, conn: *Conn, request: []const u8) void {
+    const header_at = std.mem.indexOf(u8, request, "\r\n\r\n") orelse return;
+    const head_len = header_at + 4;
+    const head = request[0..head_len];
     const content_length = if (headerValue(head, "content-length")) |raw| std.fmt.parseInt(usize, raw, 10) catch {
         respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_content_length\"}");
         return;
     } else 0;
-    if (content_length > buf.len - head_len) {
+    if (content_length > request.len - head_len) {
         respond(conn, 413, "{\"ok\":false,\"error\":\"body_too_large\"}");
         return;
     }
     const request_len = head_len + content_length;
-    while (total < request_len) {
-        const got = receiveWithTimeout(conn, buf[total..request_len], timeout) catch |err| {
-            std.debug.print("petdex: hook body receive failed ({s})\n", .{@errorName(err)});
-            return;
-        };
-        if (got == 0) return;
-        total += got;
-    }
-    const body = buf[head_len..request_len];
+    const body = request[head_len..request_len];
 
     var line_it = std.mem.splitSequence(u8, head, "\r\n");
     const request_line = line_it.next() orelse return;
@@ -661,6 +1535,15 @@ fn route(server: *Server, conn: *Conn, method: []const u8, target: []const u8, p
     const get = std.mem.eql(u8, method, "GET");
     const post = std.mem.eql(u8, method, "POST");
     var scratch: [512]u8 = undefined;
+    var json_memory: [max_request_bytes * 2]u8 = undefined;
+    var fixed = std.heap.FixedBufferAllocator.init(&json_memory);
+    var parsed_root: ?std.json.Value = null;
+    const typed_json_post = post and (std.mem.eql(u8, path, "/state") or
+        std.mem.eql(u8, path, "/bubble") or std.mem.eql(u8, path, "/bubble/title"));
+    if (typed_json_post and body.len > 0) {
+        const root = parseRequest(fixed.allocator(), body) catch return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_json\"}");
+        parsed_root = root;
+    }
 
     if (get and std.mem.eql(u8, path, "/callback")) {
         const query = if (std.mem.indexOfScalar(u8, target, '?')) |q| target[q + 1 ..] else "";
@@ -699,18 +1582,22 @@ fn route(server: *Server, conn: *Conn, method: []const u8, target: []const u8, p
         return respond(conn, 200, "{\"available\":false,\"installable\":false,\"status\":\"idle\",\"message\":null}");
     }
     if (post and (std.mem.eql(u8, path, "/update") or std.mem.eql(u8, path, "/update/handoff"))) {
-        if (!tokenOk(server, head)) return respond(conn, 401, "{\"ok\":false,\"error\":\"unauthorized\"}");
+        _ = authenticate(server, head) orelse return respond(conn, 401, "{\"ok\":false,\"error\":\"unauthorized\"}");
         return respond(conn, 409, "{\"ok\":false,\"error\":\"unsupported_install\",\"message\":\"Self-update lands in a later slice; download the current build from petdex.dev/download.\"}");
     }
 
     if (post and std.mem.eql(u8, path, "/state")) {
-        if (!tokenOk(server, head)) return respond(conn, 401, "{\"ok\":false,\"error\":\"unauthorized\"}");
-        if (!server.rateLimitOk()) return respond(conn, 429, "{\"ok\":false,\"error\":\"rate_limited\"}");
-        const state_raw = jsonString(body, "state") orelse
+        const auth = authenticate(server, head) orelse return respond(conn, 401, "{\"ok\":false,\"error\":\"unauthorized\"}");
+        if (!server.rateLimitOk(auth)) return respond(conn, 429, "{\"ok\":false,\"error\":\"rate_limited\"}");
+        var request: RequestObject = .{ .root = parsed_root orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_json\"}") };
+        const state_raw = request.string("state") orelse
             return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_state\"}");
         if (!isValidState(state_raw) or state_raw.len > 15) {
             return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_state\"}");
         }
+        // Keep the deployed hook contract: both the packaged TypeScript CLI
+        // and the native/remote runners send `duration`, and the legacy
+        // parser accepts JSON numbers before capping them to 30 seconds.
         var duration: u32 = 0;
         switch (parseDuration(body)) {
             .missing => {},
@@ -718,12 +1605,12 @@ fn route(server: *Server, conn: *Conn, method: []const u8, target: []const u8, p
             .value => |value| duration = value,
         }
 
-        // Sidecar's sprite variation: bare "running" alternates
-        // left/right per session so consecutive tool calls vary.
-        var applied: []const u8 = state_raw;
-        if (std.mem.eql(u8, state_raw, "running")) {
-            applied = server.nextRunningState();
-        }
+        // A bare `running` is a stable semantic state.  Alternating it into
+        // left/right variants on every hook heartbeat made equivalent work
+        // look like a fresh state transition and continuously restarted the
+        // pet's frame timer.  Directional values are still accepted for
+        // direct gesture callers; provider hooks stay on the neutral row.
+        const applied = state_raw;
 
         var event = StateEvent{ .duration_ms = duration };
         event.state_len = applied.len;
@@ -739,25 +1626,83 @@ fn route(server: *Server, conn: *Conn, method: []const u8, target: []const u8, p
         return respond(conn, 200, out);
     }
 
-    if (post and std.mem.eql(u8, path, "/bubble")) {
-        if (!tokenOk(server, head)) return respond(conn, 401, "{\"ok\":false,\"error\":\"unauthorized\"}");
-        if (!server.rateLimitOk()) return respond(conn, 429, "{\"ok\":false,\"error\":\"rate_limited\"}");
-        const text = jsonString(body, "text") orelse
-            return respond(conn, 400, "{\"ok\":false,\"error\":\"missing_text\"}");
-        const capped = text[0..@min(text.len, 200)];
-        const agent = jsonString(body, "agent_source") orelse "";
-        const title = jsonString(body, "title") orelse "";
-        const origin_app = plat.OriginApplication.fromTermProgram(jsonString(body, "source_app"));
-        const source_tty = plat.safeSourceTty(jsonString(body, "source_tty")) orelse "";
-        const source_cwd = plat.safeSourceCwd(jsonString(body, "source_cwd")) orelse "";
-        const herdr_pane = plat.safeHerdrPaneId(jsonString(body, "herdr_pane_id")) orelse "";
-        const busy = std.mem.indexOf(u8, body, "\"busy\":true") != null;
-        // Canonical conversation metadata wins over raw continuation/session
-        // ids. Arbitrary provider keys are normalized to the mailbox's fixed
-        // 64-byte key instead of being truncated into possible collisions.
+    if (post and std.mem.eql(u8, path, "/bubble/title")) {
+        const auth = authenticate(server, head) orelse return respond(conn, 401, "{\"ok\":false,\"error\":\"unauthorized\"}");
+        if (!server.rateLimitOk(auth)) return respond(conn, 429, "{\"ok\":false,\"error\":\"rate_limited\"}");
+        var request: RequestObject = .{ .root = parsed_root orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_json\"}") };
+        const session = request.string("conversation_key") orelse request.string("session_id") orelse
+            return respond(conn, 400, "{\"ok\":false,\"error\":\"missing_session_id\"}");
+        const title_raw = request.string("title") orelse
+            return respond(conn, 400, "{\"ok\":false,\"error\":\"missing_title\"}");
+        const title = boundedUtf8(title_raw, bubble_title_capacity) orelse
+            return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_title\"}");
+        const agent = request.string("agent_source") orelse "";
+        const hostname = request.string("hostname") orelse "";
+        const claimed_remote = request.boolean("remote");
+        if (!request.valid) return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_field_type\"}");
+        const remote = auth.remote;
+        if (authClaimConflict(auth, claimed_remote, hostname)) |conflict| switch (conflict) {
+            .remote => return respond(conn, 400, "{\"ok\":false,\"error\":\"contradictory_remote_identity\"}"),
+            .hostname => return respond(conn, 400, "{\"ok\":false,\"error\":\"contradictory_remote_hostname\"}"),
+        };
+        const exact = agent.len > 0 and (!remote or auth.principal.len > 0);
+        const safe_agent = boundedUtf8(agent, 24) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_agent\"}");
+        const safe_hostname = if (auth.remote) auth.principal else (boundedUtf8(hostname, 64) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_hostname\"}"));
         var session_hash: [64]u8 = undefined;
-        const session = bubbleSessionKey(body, &session_hash);
-        if (isDshHandshakeBubble(body)) {
+        const canonical_session = normalizeBubbleSession(session, &session_hash) orelse
+            return respond(conn, 400, "{\"ok\":false,\"error\":\"missing_session_id\"}");
+        const counter = mailbox.setBubbleTitleIdentity(
+            canonical_session,
+            title,
+            safe_agent,
+            safe_hostname,
+            remote,
+            exact,
+        );
+        const out = if (counter) |value|
+            std.fmt.bufPrint(&scratch, "{{\"ok\":true,\"updated\":true,\"counter\":{d}}}", .{value}) catch return
+        else
+            "{\"ok\":true,\"updated\":false}";
+        return respond(conn, 200, out);
+    }
+
+    if (post and std.mem.eql(u8, path, "/bubble")) {
+        const auth = authenticate(server, head) orelse return respond(conn, 401, "{\"ok\":false,\"error\":\"unauthorized\"}");
+        if (!server.rateLimitOk(auth)) return respond(conn, 429, "{\"ok\":false,\"error\":\"rate_limited\"}");
+        var request: RequestObject = .{ .root = parsed_root orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_json\"}") };
+        const text_raw = request.string("text") orelse
+            return respond(conn, 400, "{\"ok\":false,\"error\":\"missing_text\"}");
+        const capped = boundedUtf8(text_raw, bubble_text_capacity) orelse
+            return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_text\"}");
+        const agent = request.string("agent_source") orelse "";
+        const title = request.string("title") orelse "";
+        const origin_app = plat.OriginApplication.fromTermProgram(request.string("source_app"));
+        const source_tty = plat.safeSourceTty(request.string("source_tty")) orelse "";
+        const source_cwd = plat.safeSourceCwd(request.string("source_cwd")) orelse "";
+        const herdr_pane = plat.safeHerdrPaneId(request.string("herdr_pane_id")) orelse "";
+        const hostname = request.string("hostname") orelse "";
+        const turn = request.string("turn_id") orelse "";
+        const message_id = request.string("message_id") orelse "";
+        const event_kind = request.string("event_kind") orelse "";
+        const request_id = request.string("request_id") orelse "";
+        const resolves_request_id = request.string("resolves_request_id") orelse "";
+        const notification_kind = request.string("notification_kind") orelse "";
+        const parent_session = request.string("parent_session_id") orelse "";
+        const subagent_label = request.string("subagent_label") orelse "";
+        const agent_state = request.string("agent_state") orelse "";
+        const remote = auth.remote;
+        const claimed_remote = request.boolean("remote");
+        const busy = request.boolean("busy") orelse false;
+        // No session_id means an agent that predates per-conversation
+        // bubbles (or the MCP path, which has no session): the empty key
+        // is one shared slot, so those callers keep the old behaviour.
+        // Canonical conversation metadata wins over raw continuation/session
+        // ids. Normalize arbitrary provider keys rather than truncating them
+        // into possible collisions in the mailbox's bounded identity field.
+        var conversation_hash: [64]u8 = undefined;
+        const conversation = requestSessionKey(&request, &conversation_hash);
+        const integration_version = request.string("integration_version") orelse "";
+        if (std.mem.eql(u8, agent, "dsh") and std.mem.eql(u8, integration_version, dsh_integration.integration_version)) {
             writeRuntimeFile(
                 server,
                 "dsh-handshake.json",
@@ -765,13 +1710,65 @@ fn route(server: *Server, conn: *Conn, method: []const u8, target: []const u8, p
                 0o600,
             ) catch {};
         }
-        const counter = mailbox.setBubbleWithMetadata(session, capped, agent[0..@min(agent.len, 24)], title[0..@min(title.len, 96)], origin_app, source_tty, source_cwd, herdr_pane, busy);
-        // Optional: a sender that can tell blocked from working says so
-        // here. Older senders omit it and keep the busy-only behaviour.
-        if (jsonString(body, "agent_state")) |state| {
-            mailbox.setBubbleAgentState(session, state[0..@min(state.len, 16)]);
-        }
-        mirrorBubble(server, capped, counter, title[0..@min(title.len, 96)], agent[0..@min(agent.len, 24)], busy) catch {};
+        const session = request.string("session_id") orelse "";
+        const source_session = request.string("source_session_id") orelse session;
+        const status: ?SessionStatus = if (request.string("status")) |raw|
+            (SessionStatus.fromWire(raw) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_status\"}"))
+        else
+            null;
+        const session_kind = request.string("session_kind") orelse "primary";
+        const message_kind = request.string("message_kind") orelse event_kind;
+        const title_source = request.string("title_source") orelse "unknown";
+        _ = request.string("feed_source");
+        if (!request.valid) return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_field_type\"}");
+        if (authClaimConflict(auth, claimed_remote, hostname)) |conflict| switch (conflict) {
+            .remote => return respond(conn, 400, "{\"ok\":false,\"error\":\"contradictory_remote_identity\"}"),
+            .hostname => return respond(conn, 400, "{\"ok\":false,\"error\":\"contradictory_remote_hostname\"}"),
+        };
+        const safe_agent = boundedUtf8(agent, 24) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_agent\"}");
+        const safe_hostname = if (auth.remote) auth.principal else (boundedUtf8(hostname, 64) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_hostname\"}"));
+        const safe_turn = boundedUtf8(turn, 64) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_turn_id\"}");
+        const safe_title = boundedUtf8(title, bubble_title_capacity) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_title\"}");
+        const safe_subagent_label = boundedUtf8(subagent_label, 48) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_subagent_label\"}");
+        const safe_message_id = boundedUtf8(message_id, bubble_message_id_capacity) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_message_id\"}");
+        const safe_event_kind = boundedUtf8(event_kind, 48) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_event_kind\"}");
+        const safe_request_id = boundedUtf8(request_id, bubble_message_id_capacity) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_request_id\"}");
+        const safe_resolves_request_id = boundedUtf8(resolves_request_id, bubble_message_id_capacity) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_resolves_request_id\"}");
+        const safe_notification_kind = boundedUtf8(notification_kind, 64) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_notification_kind\"}");
+        const safe_agent_state = boundedUtf8(agent_state, 16) orelse return respond(conn, 400, "{\"ok\":false,\"error\":\"invalid_agent_state\"}");
+        const counter = mailbox.applyBubbleUpdate(.{
+            .conversation_key = conversation[0..@min(conversation.len, bubble_session_capacity)],
+            // Mailbox owns canonical identity normalization. Passing the raw
+            // decoded values prevents distinct long provider ids that share a
+            // bounded prefix from colliding before they can be hashed.
+            .source_session = source_session,
+            .parent_session = parent_session,
+            .text = capped,
+            .agent = safe_agent,
+            .title = safe_title,
+            .origin_app = origin_app,
+            .source_tty = source_tty,
+            .source_cwd = source_cwd,
+            .herdr_pane = herdr_pane,
+            .hostname = safe_hostname,
+            .turn = safe_turn,
+            .message_id = safe_message_id,
+            .event_kind = safe_event_kind,
+            .request_id = safe_request_id,
+            .resolves_request_id = safe_resolves_request_id,
+            .notification_kind = safe_notification_kind,
+            .subagent_label = safe_subagent_label,
+            .remote = remote,
+            .busy = busy,
+            .status = status,
+            .session_kind = SessionKind.fromWire(session_kind),
+            .message_kind = MessageKind.fromWire(message_kind),
+            .title_source = TitleSource.fromWire(title_source),
+            .feed_source = .hook,
+        });
+        if (safe_agent_state.len > 0) mailbox.setBubbleAgentState(conversation, safe_agent_state);
+        const mirror_busy = if (status) |value| value == .running else busy;
+        mirrorBubble(server, capped, counter, safe_title, safe_agent, safe_hostname, mirror_busy) catch {};
         const out = std.fmt.bufPrint(&scratch, "{{\"ok\":true,\"counter\":{d}}}", .{counter}) catch return;
         return respond(conn, 200, out);
     }
@@ -781,12 +1778,35 @@ fn route(server: *Server, conn: *Conn, method: []const u8, target: []const u8, p
 
 // ------------------------------------------------------------------ auth
 
-fn tokenOk(server: *Server, head: []const u8) bool {
-    const provided = headerValue(head, "x-petdex-update-token") orelse return false;
-    if (provided.len != server.token.len) return false;
-    // Constant-time compare, same defense as the sidecar's.
+fn authenticate(server: *Server, head: []const u8) ?AuthContext {
+    const provided = headerValue(head, "x-petdex-update-token") orelse return null;
+    if (constantTimeEqual(provided, &server.token)) return .{};
+
+    const prefix = "remote:";
+    if (!std.mem.startsWith(u8, provided, prefix)) return null;
+    const rest = provided[prefix.len..];
+    const separator = std.mem.indexOfScalar(u8, rest, ':') orelse return null;
+    const principal = rest[0..separator];
+    const signature = rest[separator + 1 ..];
+    if (principal.len == 0 or principal.len > 32 or signature.len != 64) return null;
+    for (principal) |byte| if (!(std.ascii.isAlphanumeric(byte) or byte == '-' or byte == '_')) return null;
+
+    remote_credentials_lock.lock();
+    defer remote_credentials_lock.unlock();
+    var valid = false;
+    for (&remote_credentials) |*entry| {
+        if (!entry.active or !std.mem.eql(u8, entry.principal[0..entry.principal_len], principal)) continue;
+        valid = constantTimeEqual(signature, &entry.secret);
+        break;
+    }
+    if (!valid) return null;
+    return .{ .remote = true, .principal = principal };
+}
+
+fn constantTimeEqual(provided: []const u8, expected: []const u8) bool {
+    if (provided.len != expected.len) return false;
     var diff: u8 = 0;
-    for (provided, server.token) |a, b| diff |= a ^ b;
+    for (provided, expected) |a, b| diff |= a ^ b;
     return diff == 0;
 }
 
@@ -813,11 +1833,12 @@ fn respondHtml(conn: *Conn, status: u16, body: []const u8) void {
 }
 
 fn respondTyped(conn: *Conn, status: u16, content_type: []const u8, body: []const u8) void {
-    var buf: [1024]u8 = undefined;
+    var buf: [max_request_bytes]u8 = undefined;
     const reason = switch (status) {
         200 => "OK",
         400 => "Bad Request",
         401 => "Unauthorized",
+        408 => "Request Timeout",
         404 => "Not Found",
         409 => "Conflict",
         413 => "Payload Too Large",
@@ -825,11 +1846,13 @@ fn respondTyped(conn: *Conn, status: u16, content_type: []const u8, body: []cons
         else => "OK",
     };
     const head = std.fmt.bufPrint(&buf, "HTTP/1.1 {d} {s}\r\ncontent-type: {s}\r\ncontent-length: {d}\r\nconnection: close\r\n\r\n", .{ status, reason, content_type, body.len }) catch return;
-    var write_buf: [64]u8 = undefined;
-    var writer = conn.stream.writer(conn.io, &write_buf);
-    writer.interface.writeAll(head) catch return;
-    writer.interface.writeAll(body) catch return;
-    writer.interface.flush() catch return;
+    writeAll(conn, head);
+    writeAll(conn, body);
+}
+
+fn writeAll(conn: *Conn, bytes: []const u8) void {
+    conn.writer.writeAll(bytes) catch return;
+    conn.writer.flush() catch return;
 }
 
 fn hexValue(c: u8) ?u8 {
@@ -1024,6 +2047,30 @@ fn jsonString(body: []const u8, key: []const u8) ?[]const u8 {
     return body[val_start..i];
 }
 
+fn jsonBool(body: []const u8, key: []const u8) ?bool {
+    const value_start = switch (jsonFieldStart(body, key)) {
+        .value => |value| value,
+        else => return null,
+    };
+    if (std.mem.startsWith(u8, body[value_start..], "true")) {
+        const end = value_start + 4;
+        if (end == body.len or body[end] == ',' or body[end] == '}' or body[end] == ']' or std.ascii.isWhitespace(body[end])) return true;
+    }
+    if (std.mem.startsWith(u8, body[value_start..], "false")) {
+        const end = value_start + 5;
+        if (end == body.len or body[end] == ',' or body[end] == '}' or body[end] == ']' or std.ascii.isWhitespace(body[end])) return false;
+    }
+    return null;
+}
+
+/// Bound a decoded JSON string without splitting a UTF-8 code point.
+fn boundedUtf8(value: []const u8, max: usize) ?[]const u8 {
+    if (!std.unicode.utf8ValidateSlice(value)) return null;
+    var cut = @min(value.len, max);
+    while (cut > 0 and !std.unicode.utf8ValidateSlice(value[0..cut])) cut -= 1;
+    return value[0..cut];
+}
+
 fn normalizeBubbleSession(raw: ?[]const u8, hash_buf: *[64]u8) ?[]const u8 {
     const value = raw orelse return null;
     if (value.len == 0) return null;
@@ -1062,6 +2109,213 @@ test "bubble session key prefers and normalizes canonical conversations" {
     const normalized = bubbleSessionKey(body, &hash);
     try std.testing.expectEqual(@as(usize, 64), normalized.len);
     try std.testing.expect(!std.mem.eql(u8, normalized, long[0..64]));
+
+    var title_hash: [64]u8 = undefined;
+    try std.testing.expectEqualStrings(normalized, normalizeBubbleSession(long, &title_hash).?);
+}
+
+fn requestSessionKey(request: *RequestObject, hash_buf: *[64]u8) []const u8 {
+    if (normalizeBubbleSession(request.string("conversation_key"), hash_buf)) |key| return key;
+    if (normalizeBubbleSession(request.string("petdex_conversation_key"), hash_buf)) |key| return key;
+    if (normalizeBubbleSession(request.string("session_key"), hash_buf)) |key| return key;
+    return normalizeBubbleSession(request.string("session_id"), hash_buf) orelse "";
+}
+
+test "bounded decoded strings preserve utf8 boundaries" {
+    try std.testing.expectEqualStrings("abc\\", boundedUtf8("abc\\", 4).?);
+    try std.testing.expectEqualStrings("ab", boundedUtf8("ab🙂", 5).?);
+    try std.testing.expectEqualStrings("ab🙂", boundedUtf8("ab🙂", 6).?);
+    try std.testing.expect(boundedUtf8(&.{0xff}, 8) == null);
+}
+
+test "authenticated provenance rejects contradictory body claims" {
+    const local: AuthContext = .{};
+    const remote: AuthContext = .{ .remote = true, .principal = "buildbox" };
+    try std.testing.expectEqual(AuthClaimConflict.remote, authClaimConflict(local, true, "").?);
+    try std.testing.expectEqual(AuthClaimConflict.remote, authClaimConflict(remote, false, "buildbox").?);
+    try std.testing.expectEqual(AuthClaimConflict.hostname, authClaimConflict(remote, true, "other-host").?);
+    try std.testing.expect(authClaimConflict(remote, null, "") == null);
+    try std.testing.expect(authClaimConflict(remote, true, "buildbox") == null);
+    try std.testing.expect(authClaimConflict(local, false, "client-supplied-local-label") == null);
+}
+
+fn serveOneTestConnection(listener: *std.Io.net.Server, server: *Server, io: std.Io) void {
+    const stream = listener.accept(io) catch return;
+    _ = server.active_connections.fetchAdd(1, .acq_rel);
+    handleConnectionThread(server, stream, io);
+}
+
+fn testSocketDeadline(io: std.Io, milliseconds: i64) std.Io.Clock.Timestamp {
+    const duration: std.Io.Clock.Duration = .{
+        .raw = std.Io.Duration.fromMilliseconds(milliseconds),
+        .clock = .boot,
+    };
+    return std.Io.Clock.Timestamp.fromNow(io, duration);
+}
+
+fn readTestHttpResponse(stream: std.Io.net.Stream, reader: *std.Io.Reader, io: std.Io, buffer: []u8, deadline: std.Io.Clock.Timestamp) ![]const u8 {
+    var total: usize = 0;
+    var expected: ?usize = null;
+    while (total < buffer.len) {
+        const incoming = try readBeforeDeadline(stream, reader, io, buffer[total..], deadline);
+        if (incoming.len == 0) break;
+        total += incoming.len;
+        if (expected == null) {
+            if (std.mem.indexOf(u8, buffer[0..total], "\r\n\r\n")) |at| {
+                const head_len = at + 4;
+                const body_len = if (headerValue(buffer[0..head_len], "content-length")) |raw|
+                    try std.fmt.parseInt(usize, raw, 10)
+                else
+                    0;
+                expected = head_len + body_len;
+            }
+        }
+        if (expected) |length| if (total >= length) return buffer[0..length];
+    }
+    return error.IncompleteHttpResponse;
+}
+
+test "loopback slowloris times out and the next authenticated request succeeds" {
+    // Zig 0.16's Windows test runner cannot connect to and tear down its AFD
+    // listener reliably. The Windows desktop smoke exercises the production
+    // executable's timeout, liveness, slot release, and recovery instead.
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    const runtime_dir = ".zig-cache/petdex-hook-slowloris";
+    plat.makeDir(runtime_dir);
+    var server: Server = .{
+        .allocator = std.testing.allocator,
+        .runtime_dir = runtime_dir,
+        .token = @splat('a'),
+        .pid = 1,
+    };
+    var server_scope = plat.Scope.init();
+    defer server_scope.deinit();
+    const server_io = server_scope.io();
+    var client_scope = plat.Scope.init();
+    defer client_scope.deinit();
+    const client_io = client_scope.io();
+
+    var listener_opt: ?std.Io.net.Server = null;
+    var address: std.Io.net.IpAddress = undefined;
+    for (38171..38271) |port| {
+        address = .{ .ip4 = .loopback(@intCast(port)) };
+        listener_opt = address.listen(server_io, .{
+            .kernel_backlog = 4,
+            .reuse_address = true,
+            .mode = .stream,
+            .protocol = .tcp,
+        }) catch null;
+        if (listener_opt != null) break;
+    }
+    var listener = listener_opt orelse return error.SkipZigTest;
+    defer listener.deinit(server_io);
+    const slow_server_thread = try std.Thread.spawn(.{}, serveOneTestConnection, .{ &listener, &server, server_io });
+
+    var slow = try address.connect(client_io, .{ .mode = .stream, .protocol = .tcp });
+    var slow_write_buf: [256]u8 = undefined;
+    var slow_read_buf: [256]u8 = undefined;
+    var slow_reader = slow.reader(client_io, &slow_read_buf);
+    var slow_writer = slow.writer(client_io, &slow_write_buf);
+    try slow_writer.interface.writeAll("POST /state HTTP/1.1\r\nContent-Length: 32\r\n\r\n{\"state\":\"");
+    try slow_writer.interface.flush();
+    const started = plat.monotonicMs();
+    var response_buf: [512]u8 = undefined;
+    const timeout_response = readTestHttpResponse(slow, &slow_reader.interface, client_io, &response_buf, testSocketDeadline(client_io, 6_000)) catch |err| switch (err) {
+        else => if (builtin.os.tag == .windows) "" else return err,
+    };
+    const elapsed = plat.monotonicMs() - started;
+    slow.close(client_io);
+    slow_server_thread.join();
+    if (builtin.os.tag == .windows)
+        try std.testing.expectEqual(@as(usize, 0), timeout_response.len)
+    else
+        try std.testing.expect(std.mem.indexOf(u8, timeout_response, " 408 ") != null);
+    try std.testing.expect(elapsed >= 1_000 and elapsed < 6_000);
+
+    const healthy_server_thread = try std.Thread.spawn(.{}, serveOneTestConnection, .{ &listener, &server, server_io });
+    var healthy = try address.connect(client_io, .{ .mode = .stream, .protocol = .tcp });
+    var healthy_write_buf: [512]u8 = undefined;
+    var healthy_read_buf: [256]u8 = undefined;
+    var healthy_reader = healthy.reader(client_io, &healthy_read_buf);
+    var healthy_writer = healthy.writer(client_io, &healthy_write_buf);
+    const body = "{\"state\":\"idle\"}";
+    var request_buf: [512]u8 = undefined;
+    const authenticated = try std.fmt.bufPrint(&request_buf, "POST /state HTTP/1.1\r\nContent-Length: {d}\r\nx-petdex-update-token: {s}\r\n\r\n{s}", .{ body.len, &server.token, body });
+    try healthy_writer.interface.writeAll(authenticated);
+    try healthy_writer.interface.flush();
+    const healthy_response = try readTestHttpResponse(healthy, &healthy_reader.interface, client_io, &response_buf, testSocketDeadline(client_io, 3_000));
+    healthy.close(client_io);
+    healthy_server_thread.join();
+    try std.testing.expect(std.mem.indexOf(u8, healthy_response, " 200 ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, healthy_response, "\"ok\":true") != null);
+    try std.testing.expectEqual(@as(u32, 0), server.active_connections.load(.acquire));
+}
+
+test "typed request parsing decodes strings and rejects ambiguity" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const root = try parseRequest(arena.allocator(), "{\"text\":\"quote: \\\" slash: \\\\ line: \\n\",\"busy\":true}");
+    var request: RequestObject = .{ .root = root };
+    try std.testing.expectEqualStrings("quote: \" slash: \\ line: \n", request.string("text").?);
+    try std.testing.expectEqual(true, request.boolean("busy").?);
+    _ = request.string("busy");
+    try std.testing.expect(!request.valid);
+
+    _ = arena.reset(.retain_capacity);
+    const legacy_root = try parseRequest(arena.allocator(), "{\"text\":\"Thinking\",\"agent_source\":null}");
+    var legacy_request: RequestObject = .{ .root = legacy_root };
+    try std.testing.expectEqualStrings("Thinking", legacy_request.string("text").?);
+    try std.testing.expect(legacy_request.string("agent_source") == null);
+    try std.testing.expect(legacy_request.valid);
+
+    _ = arena.reset(.retain_capacity);
+    try std.testing.expectError(error.DuplicateField, parseRequest(arena.allocator(), "{\"text\":\"one\",\"text\":\"two\"}"));
+    try std.testing.expectError(error.InvalidJson, parseRequest(arena.allocator(), "[]"));
+}
+
+test "bubble mirror JSON round trips decoded control and escape characters" {
+    const json = try bubbleMirrorJson(std.testing.allocator, "quote \" slash \\ line\n🙂", 7, "title\tvalue", "codex", "host", true, 42);
+    defer std.testing.allocator.free(json);
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, json, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("quote \" slash \\ line\n🙂", parsed.value.object.get("text").?.string);
+    try std.testing.expectEqualStrings("title\tvalue", parsed.value.object.get("title").?.string);
+    try std.testing.expect(parsed.value.object.get("busy").?.bool);
+}
+
+test "remote credentials are scoped and identify their principal" {
+    var server: Server = undefined;
+    server.token = @splat('a');
+    var token: [128]u8 = undefined;
+    const principal = "buildbox";
+    const scoped = issueRemoteCredential(principal, &token).?;
+    var first_token: [128]u8 = undefined;
+    @memcpy(first_token[0..scoped.len], scoped);
+    const first = first_token[0..scoped.len];
+    var head_buf: [256]u8 = undefined;
+    const head = try std.fmt.bufPrint(&head_buf, "POST /bubble HTTP/1.1\r\nx-petdex-update-token: {s}\r\n\r\n", .{scoped});
+    const auth = authenticate(&server, head).?;
+    try std.testing.expect(auth.remote);
+    try std.testing.expectEqualStrings(principal, auth.principal);
+
+    const rotated = issueRemoteCredential(principal, &token).?;
+    try std.testing.expect(!std.mem.eql(u8, first, rotated));
+    try std.testing.expect(authenticate(&server, head) == null);
+    var rotated_head_buf: [256]u8 = undefined;
+    const rotated_head = try std.fmt.bufPrint(&rotated_head_buf, "POST /bubble HTTP/1.1\r\nx-petdex-update-token: {s}\r\n\r\n", .{rotated});
+    try std.testing.expectEqualStrings(principal, authenticate(&server, rotated_head).?.principal);
+
+    var peer_token_buf: [128]u8 = undefined;
+    const peer = issueRemoteCredential("peer", &peer_token_buf).?;
+    var peer_head_buf: [256]u8 = undefined;
+    const peer_head = try std.fmt.bufPrint(&peer_head_buf, "POST /bubble HTTP/1.1\r\nx-petdex-update-token: {s}\r\n\r\n", .{peer});
+    try std.testing.expectEqualStrings("peer", authenticate(&server, peer_head).?.principal);
+
+    revokeRemoteCredential(principal);
+    try std.testing.expect(authenticate(&server, rotated_head) == null);
+    try std.testing.expectEqualStrings("peer", authenticate(&server, peer_head).?.principal);
+    revokeRemoteCredential("peer");
+    try std.testing.expect(authenticate(&server, peer_head) == null);
 }
 
 test "OAuth callback query values are decoded and bounded" {
@@ -1093,6 +2347,20 @@ test "two sessions hold two bubbles and neither overwrites the other" {
     try std.testing.expectEqual(beta_counter, out[1].counter);
 }
 
+test "mailbox canonicalizes long provider identities before matching" {
+    var mb: Mailbox = .{};
+    const prefix = "provider/session/identity/with/a/shared-prefix-that-is-longer-than-the-storage-boundary/";
+    const first = prefix ++ "alpha";
+    const second = prefix ++ "beta";
+    _ = mb.applyBubbleUpdate(.{ .conversation_key = first, .source_session = first, .text = "one", .agent = "codex", .feed_source = .native_store });
+    _ = mb.applyBubbleUpdate(.{ .conversation_key = second, .source_session = second, .text = "two", .agent = "codex", .feed_source = .native_store });
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 2), mb.takeBubbles(&out));
+    try std.testing.expectEqual(@as(usize, 64), out[0].session_len);
+    try std.testing.expectEqual(@as(usize, 64), out[1].session_len);
+    try std.testing.expect(!std.mem.eql(u8, out[0].sessionSlice(), out[1].sessionSlice()));
+}
+
 test "bubble metadata preserves the Herdr pane id" {
     var mb: Mailbox = .{};
     _ = mb.setBubbleWithMetadata("herdr:w1:p5", "Needs approval", "cursor", "Fix auth", .terminal, "", "/repo", "w1:p5", false);
@@ -1100,6 +2368,423 @@ test "bubble metadata preserves the Herdr pane id" {
     var out: [max_bubbles]Bubble = @splat(.{});
     try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
     try std.testing.expectEqualStrings("w1:p5", out[0].herdrPaneSlice());
+}
+
+test "keyed bubble retains omitted title and accepts a later server rename" {
+    var mb: Mailbox = .{};
+    _ = mb.setBubble("thread-7", "Thinking…", "codex", "Prompt fallback", true);
+    // Tool hooks normally omit title. This update must not clear the card.
+    _ = mb.setBubble("thread-7", "Reading main.zig", "codex", "", true);
+
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqualStrings("Prompt fallback", out[0].title[0..out[0].title_len]);
+
+    // The authoritative title may arrive after the first prompt or change on
+    // the server while the session is alive. Non-empty always wins.
+    _ = mb.setBubble("thread-7", "Running tests", "codex", "Server generated title", true);
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqualStrings("Server generated title", out[0].title[0..out[0].title_len]);
+
+    // Sessionless callers share one compatibility slot; retaining here would
+    // leak a title between unrelated legacy agents.
+    _ = mb.setBubble("", "first", "codex", "Legacy title", true);
+    _ = mb.setBubble("", "second", "gemini", "", true);
+    try std.testing.expectEqual(@as(?usize, 2), mb.takeBubbles(&out));
+    for (out[0..2]) |bubble| {
+        if (bubble.session_len == 0) try std.testing.expectEqual(@as(usize, 0), bubble.title_len);
+    }
+}
+
+test "title-only sync updates an existing session without changing its message" {
+    var mb: Mailbox = .{};
+    _ = mb.setBubble("thread-9", "Running tests", "opencode", "Old title", true);
+    try std.testing.expect(mb.setBubbleTitle("thread-9", "Renamed on server") != null);
+    // Duplicate server events are a no-op for rendering and retain the same
+    // counter, while unknown/sessionless titles never create ghost cards.
+    const duplicate_counter = mb.setBubbleTitle("thread-9", "Renamed on server").?;
+    try std.testing.expect(mb.setBubbleTitle("missing", "No ghost") == null);
+    try std.testing.expect(mb.setBubbleTitle("", "No legacy leak") == null);
+
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqualStrings("Running tests", out[0].text[0..out[0].text_len]);
+    try std.testing.expectEqualStrings("Renamed on server", out[0].title[0..out[0].title_len]);
+    try std.testing.expectEqual(duplicate_counter, out[0].counter);
+    try std.testing.expect(out[0].busy);
+}
+
+test "title-only sync can target one agent and host sharing a conversation id" {
+    var mb: Mailbox = .{};
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "shared",
+        .source_session = "shared",
+        .text = "Local work",
+        .agent = "opencode",
+        .title = "Local title",
+        .hostname = "mac",
+        .remote = false,
+        .busy = true,
+    });
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "shared",
+        .source_session = "shared",
+        .text = "Remote work",
+        .agent = "opencode",
+        .title = "Remote title",
+        .hostname = "inframework",
+        .remote = true,
+        .busy = true,
+    });
+    try std.testing.expect(mb.setBubbleTitleIdentity("shared", "Remote rename", "opencode", "inframework", true, true) != null);
+
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 2), mb.takeBubbles(&out));
+    for (out[0..2]) |*bubble| {
+        if (bubble.remote) {
+            try std.testing.expectEqualStrings("Remote rename", bubble.title[0..bubble.title_len]);
+        } else {
+            try std.testing.expectEqualStrings("Local title", bubble.title[0..bubble.title_len]);
+        }
+    }
+}
+
+test "bubble context preserves host turn remote and launch metadata" {
+    var mb: Mailbox = .{};
+    _ = mb.setBubbleWithContext(
+        "thread-7",
+        "Running tests",
+        "codex",
+        "Revamp bubbles",
+        .codex,
+        "/dev/ttys003",
+        "/work/petdex",
+        "inframework",
+        "turn-9",
+        true,
+        true,
+    );
+
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqualStrings("inframework", out[0].hostnameSlice());
+    try std.testing.expectEqualStrings("turn-9", out[0].turnSlice());
+    try std.testing.expect(out[0].remote);
+    try std.testing.expectEqual(plat.OriginApplication.codex, out[0].origin_app);
+    try std.testing.expectEqualStrings("/work/petdex", out[0].cwdSlice());
+}
+
+test "canonical identity includes agent locality and remote host" {
+    var mb: Mailbox = .{};
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "conversation-1",
+        .source_session = "raw-local",
+        .agent = "codex",
+        .hostname = "shakib-mac",
+        .text = "Local Codex",
+        .status = .running,
+    });
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "conversation-1",
+        .source_session = "raw-remote",
+        .agent = "codex",
+        .hostname = "inframework",
+        .remote = true,
+        .text = "Remote Codex",
+        .status = .running,
+    });
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "conversation-1",
+        .source_session = "raw-hermes",
+        .agent = "hermes",
+        .hostname = "inframework",
+        .remote = true,
+        .text = "Remote Hermes",
+        .status = .running,
+    });
+
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 3), mb.takeBubbles(&out));
+}
+
+test "authoritative subagent update retracts provisional child card" {
+    var mb: Mailbox = .{};
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "root-conversation",
+        .source_session = "root-session",
+        .agent = "hermes",
+        .hostname = "inframework",
+        .remote = true,
+        .text = "Parent is working",
+        .message_kind = .reasoning,
+        .status = .running,
+    });
+    // Simulate the persistence race: the child's first hook was initially
+    // treated as a primary conversation under its raw session id.
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "child-session",
+        .source_session = "child-session",
+        .agent = "hermes",
+        .hostname = "inframework",
+        .remote = true,
+        .text = "Called terminal",
+        .message_kind = .tool,
+        .status = .running,
+    });
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "root-conversation",
+        .source_session = "child-session",
+        .parent_session = "root-session",
+        .session_kind = .subagent,
+        .agent = "hermes",
+        .hostname = "inframework",
+        .remote = true,
+        .text = "Called search_files",
+        .message_kind = .tool,
+        .status = .running,
+    });
+
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqualStrings("root-conversation", out[0].sessionSlice());
+    try std.testing.expectEqualStrings("Parent is working", out[0].text[0..out[0].text_len]);
+}
+
+test "subagent tool noise is ignored and assistant prose folds into parent" {
+    var mb: Mailbox = .{};
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "root-conversation",
+        .source_session = "root-session",
+        .agent = "hermes",
+        .hostname = "inframework",
+        .remote = true,
+        .text = "Working on the request",
+        .message_kind = .reasoning,
+        .status = .running,
+    });
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "root-conversation",
+        .source_session = "child-session",
+        .parent_session = "root-session",
+        .session_kind = .subagent,
+        .subagent_label = "Research",
+        .agent = "hermes",
+        .hostname = "inframework",
+        .remote = true,
+        .text = "Called terminal",
+        .message_kind = .tool,
+        .status = .running,
+    });
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "root-conversation",
+        .source_session = "child-session",
+        .parent_session = "root-session",
+        .session_kind = .subagent,
+        .subagent_label = "Research",
+        .agent = "hermes",
+        .hostname = "inframework",
+        .remote = true,
+        .text = "The migration needs one compatibility shim.",
+        .message_id = "child-message-1",
+        .message_kind = .assistant,
+        .status = .completed,
+    });
+
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqualStrings("Working on the request", out[0].text[0..out[0].text_len]);
+    try std.testing.expectEqual(@as(usize, 1), out[0].child_messages_len);
+    try std.testing.expectEqualStrings("Research", out[0].child_messages[0].labelSlice());
+    try std.testing.expectEqualStrings("The migration needs one compatibility shim.", out[0].child_messages[0].textSlice());
+}
+
+test "subagent prose is deduplicated and bounded to eight recent entries" {
+    var mb: Mailbox = .{};
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "root",
+        .source_session = "root",
+        .agent = "codex",
+        .text = "Parent",
+        .status = .running,
+    });
+    for (0..10) |index| {
+        var text_buf: [32]u8 = undefined;
+        var id_buf: [32]u8 = undefined;
+        const child_text = std.fmt.bufPrint(&text_buf, "Child answer {d}", .{index}) catch unreachable;
+        const message_id = std.fmt.bufPrint(&id_buf, "child-{d}", .{index}) catch unreachable;
+        _ = mb.applyBubbleUpdate(.{
+            .conversation_key = "root",
+            .source_session = "child",
+            .session_kind = .subagent,
+            .subagent_label = "Worker",
+            .agent = "codex",
+            .text = child_text,
+            .message_id = message_id,
+            .message_kind = .assistant,
+        });
+    }
+    // A replay updates ordering but does not create a ninth row.
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "root",
+        .source_session = "child",
+        .session_kind = .subagent,
+        .subagent_label = "Worker",
+        .agent = "codex",
+        .text = "Child answer 9",
+        .message_id = "child-9",
+        .message_kind = .assistant,
+    });
+
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqual(max_child_messages, out[0].child_messages_len);
+    try std.testing.expectEqualStrings("Child answer 2", out[0].child_messages[0].textSlice());
+    try std.testing.expectEqualStrings("Child answer 9", out[0].child_messages[max_child_messages - 1].textSlice());
+}
+
+test "assistant prose survives tool summaries and server title survives prompt fallback" {
+    var mb: Mailbox = .{};
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "thread",
+        .source_session = "thread",
+        .agent = "codex",
+        .title = "Authoritative title",
+        .title_source = .server,
+        .text = "Here is the actual assistant response.",
+        .message_kind = .assistant,
+        .status = .running,
+    });
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "thread",
+        .source_session = "thread",
+        .agent = "codex",
+        .title = "Intermediate prompt",
+        .title_source = .prompt,
+        .text = "Called terminal",
+        .message_kind = .tool,
+        .status = .running,
+    });
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqualStrings("Authoritative title", out[0].title[0..out[0].title_len]);
+    try std.testing.expectEqualStrings("Here is the actual assistant response.", out[0].text[0..out[0].text_len]);
+}
+
+test "pending inputs obey attention precedence until matching responses arrive" {
+    var mb: Mailbox = .{};
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "thread",
+        .source_session = "thread",
+        .agent = "codex",
+        .text = "Approve launch?",
+        .message_id = "approval-1",
+        .message_kind = .prompt,
+        .status = .needs_input,
+    });
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "thread",
+        .source_session = "thread",
+        .agent = "codex",
+        .text = "Choose a host",
+        .message_id = "question-2",
+        .message_kind = .prompt,
+        .status = .needs_input,
+    });
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "thread",
+        .source_session = "thread",
+        .agent = "codex",
+        .text = "Continuing",
+        .message_id = "approval-1",
+        .resolves_request_id = "approval-1",
+        .message_kind = .status,
+        .status = .running,
+    });
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqual(SessionStatus.needs_input, out[0].status);
+    try std.testing.expectEqual(@as(usize, 1), out[0].pending_input_ids_len);
+
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "thread",
+        .source_session = "thread",
+        .agent = "codex",
+        .text = "Thinking…",
+        .message_id = "question-2",
+        .resolves_request_id = "question-2",
+        .message_kind = .status,
+        .status = .running,
+    });
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqual(SessionStatus.running, out[0].status);
+    try std.testing.expectEqual(@as(usize, 0), out[0].pending_input_ids_len);
+}
+
+test "generic notifications and waiting phases never manufacture attention" {
+    for ([_][]const u8{ "notification", "waiting" }) |event_kind| {
+        var mb: Mailbox = .{};
+        _ = mb.applyBubbleUpdate(.{
+            .conversation_key = "thread",
+            .source_session = "thread",
+            .agent = "claude-code",
+            .text = "Informational event",
+            .event_kind = event_kind,
+            .notification_kind = "unknown_future_type",
+            .message_kind = .prompt,
+            .status = .needs_input,
+        });
+        var out: [max_bubbles]Bubble = @splat(.{});
+        try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+        try std.testing.expectEqual(SessionStatus.idle, out[0].status);
+        try std.testing.expectEqual(@as(usize, 0), out[0].pending_input_ids_len);
+        try std.testing.expect(!out[0].pending_unkeyed_input);
+    }
+}
+
+test "documented notification prompts create one bounded unkeyed request" {
+    for ([_][]const u8{ "permission_prompt", "elicitation_dialog", "elicitation_url_dialog", "agent_needs_input" }) |kind| {
+        var mb: Mailbox = .{};
+        _ = mb.applyBubbleUpdate(.{
+            .conversation_key = "thread",
+            .source_session = "thread",
+            .agent = "claude-code",
+            .text = "Waiting for you",
+            .event_kind = "notification",
+            .notification_kind = kind,
+            .message_kind = .prompt,
+            .status = .idle,
+        });
+        var out: [max_bubbles]Bubble = @splat(.{});
+        try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+        try std.testing.expectEqual(SessionStatus.needs_input, out[0].status);
+        try std.testing.expect(out[0].pending_unkeyed_input);
+    }
+}
+
+test "definitive tool progress clears only the unkeyed fallback" {
+    var mb: Mailbox = .{};
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "thread",
+        .source_session = "thread",
+        .agent = "hermes",
+        .text = "Approve?",
+        .event_kind = "approval-request",
+        .message_kind = .prompt,
+        .status = .needs_input,
+    });
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "thread",
+        .source_session = "thread",
+        .agent = "hermes",
+        .text = "Calling terminal",
+        .event_kind = "tool-progress",
+        .message_kind = .tool,
+        .status = .running,
+    });
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqual(SessionStatus.running, out[0].status);
+    try std.testing.expect(!out[0].pending_unkeyed_input);
 }
 
 test "a sessionless agent keeps the single shared slot" {
@@ -1143,6 +2828,209 @@ test "takeBubbles only reports a set that changed" {
     _ = mb.setBubble("alpha", "hello", "codex", "", true);
     try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
     try std.testing.expectEqual(@as(?usize, null), mb.takeBubbles(&out));
+}
+
+test "identical running snapshots do not dirty the mailbox" {
+    var mb: Mailbox = .{};
+    const update = BubbleUpdate{
+        .conversation_key = "alpha",
+        .source_session = "alpha",
+        .agent = "codex",
+        .text = "Reading project files",
+        .message_id = "event-1",
+        .event_kind = "agent-progress",
+        .message_kind = .tool,
+        .status = .running,
+    };
+    const first = mb.applyBubbleUpdate(update);
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expect(out[0].last_meaningful_activity_ms > 0);
+
+    const duplicate = mb.applyBubbleUpdate(update);
+    try std.testing.expectEqual(first, duplicate);
+    try std.testing.expectEqual(@as(?usize, null), mb.takeBubbles(&out));
+    try std.testing.expectEqual(@as(u64, 1), mb.bubbleRenderDebugCounters().suppressed_duplicates);
+}
+
+test "stale running cards become idle until meaningful work resumes" {
+    var mb: Mailbox = .{};
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "alpha",
+        .source_session = "alpha",
+        .agent = "codex",
+        .text = "Reading project files",
+        .message_id = "event-1",
+        .event_kind = "agent-progress",
+        .message_kind = .tool,
+        .status = .running,
+    });
+    var out: [max_bubbles]Bubble = @splat(.{});
+    _ = mb.takeBubbles(&out);
+    const last_activity = out[0].last_meaningful_activity_ms;
+    try std.testing.expectEqual(@as(usize, 1), mb.suppressStaleRunning(last_activity + 30_000, 30_000));
+    try std.testing.expectEqual(@as(u64, 1), mb.bubbleRenderDebugCounters().stale_transitions);
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqual(SessionStatus.idle, out[0].status);
+    try std.testing.expect(out[0].stale_running_suppressed);
+
+    // A replayed heartbeat cannot restart the animation.
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "alpha",
+        .source_session = "alpha",
+        .agent = "codex",
+        .text = "Reading project files",
+        .message_id = "event-1",
+        .event_kind = "agent-progress",
+        .message_kind = .tool,
+        .status = .running,
+    });
+    try std.testing.expectEqual(@as(?usize, null), mb.takeBubbles(&out));
+
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "alpha",
+        .source_session = "alpha",
+        .agent = "codex",
+        .text = "Read package manifest",
+        .message_id = "event-2",
+        .event_kind = "agent-progress",
+        .message_kind = .tool,
+        .status = .running,
+    });
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqual(SessionStatus.running, out[0].status);
+    try std.testing.expect(!out[0].stale_running_suppressed);
+}
+
+test "unkeyed running cards still become stale after their initial lease" {
+    var mb: Mailbox = .{};
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "alpha",
+        .source_session = "alpha",
+        .agent = "legacy",
+        .status = .running,
+    });
+    var out: [max_bubbles]Bubble = @splat(.{});
+    _ = mb.takeBubbles(&out);
+    try std.testing.expect(out[0].last_meaningful_activity_ms > 0);
+    const lease = out[0].last_meaningful_activity_ms;
+    try std.testing.expectEqual(@as(usize, 1), mb.suppressStaleRunning(lease + 30_000, 30_000));
+    _ = mb.takeBubbles(&out);
+    try std.testing.expectEqual(SessionStatus.idle, out[0].status);
+
+    // A generic heartbeat cannot reanimate a card that has been quieted.
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "alpha",
+        .source_session = "alpha",
+        .agent = "legacy",
+        .status = .running,
+    });
+    try std.testing.expectEqual(@as(?usize, null), mb.takeBubbles(&out));
+}
+
+/// Lower a canonical bubble JSON record directly into a mailbox. Startup
+/// journals and passive provider adapters use this path so their validation,
+/// bounded identity, pending-input correlation, and subagent behavior cannot
+/// drift from the loopback HTTP endpoint. `feed_source` is transport-owned and
+/// therefore overrides an untrusted or stale value in the record.
+pub fn applyBubbleJson(target: *Mailbox, body: []const u8, feed_source: FeedSource) ?u64 {
+    if (body.len == 0 or body.len > max_request_bytes) return null;
+    var json_memory: [max_request_bytes * 2]u8 = undefined;
+    var fixed = std.heap.FixedBufferAllocator.init(&json_memory);
+    const root = parseRequest(fixed.allocator(), body) catch return null;
+    var request: RequestObject = .{ .root = root };
+
+    const text = boundedUtf8(request.string("text") orelse return null, bubble_text_capacity) orelse return null;
+    const agent = boundedUtf8(request.string("agent_source") orelse return null, 24) orelse return null;
+    const title = boundedUtf8(request.string("title") orelse "", bubble_title_capacity) orelse return null;
+    const source_app = request.string("source_app");
+    const origin_app = plat.OriginApplication.fromTermProgram(source_app);
+    const source_tty = plat.safeSourceTty(request.string("source_tty")) orelse "";
+    const source_cwd = plat.safeSourceCwd(request.string("source_cwd")) orelse "";
+    const hostname = boundedUtf8(request.string("hostname") orelse "", 64) orelse return null;
+    const turn = boundedUtf8(request.string("turn_id") orelse "", 64) orelse return null;
+    const message_id = boundedUtf8(request.string("message_id") orelse "", bubble_message_id_capacity) orelse return null;
+    const event_kind = boundedUtf8(request.string("event_kind") orelse "", 48) orelse return null;
+    const request_id = boundedUtf8(request.string("request_id") orelse "", bubble_message_id_capacity) orelse return null;
+    const resolves_request_id = boundedUtf8(request.string("resolves_request_id") orelse "", bubble_message_id_capacity) orelse return null;
+    const notification_kind = boundedUtf8(request.string("notification_kind") orelse "", 64) orelse return null;
+    const parent_session = request.string("parent_session_id") orelse "";
+    const subagent_label = boundedUtf8(request.string("subagent_label") orelse "", 48) orelse return null;
+    const remote = request.boolean("remote") orelse false;
+    const busy = request.boolean("busy") orelse false;
+    var conversation_hash: [64]u8 = undefined;
+    const conversation = requestSessionKey(&request, &conversation_hash);
+    const session = request.string("session_id") orelse "";
+    const source_session = request.string("source_session_id") orelse session;
+    const status: ?SessionStatus = if (request.string("status")) |raw| SessionStatus.fromWire(raw) orelse return null else null;
+    const session_kind = request.string("session_kind") orelse "primary";
+    const message_kind = request.string("message_kind") orelse event_kind;
+    const title_source = request.string("title_source") orelse "unknown";
+    _ = request.string("feed_source");
+    if (!request.valid) return null;
+    return target.applyBubbleUpdate(.{
+        .conversation_key = conversation[0..@min(conversation.len, bubble_session_capacity)],
+        .source_session = source_session,
+        .parent_session = parent_session,
+        .text = text,
+        .agent = agent,
+        .title = title,
+        .origin_app = origin_app,
+        .source_tty = source_tty,
+        .source_cwd = source_cwd,
+        .hostname = hostname,
+        .turn = turn,
+        .message_id = message_id,
+        .event_kind = event_kind,
+        .request_id = request_id,
+        .resolves_request_id = resolves_request_id,
+        .notification_kind = notification_kind,
+        .subagent_label = subagent_label,
+        .remote = remote,
+        .busy = busy,
+        .status = status,
+        .session_kind = SessionKind.fromWire(session_kind),
+        .message_kind = MessageKind.fromWire(message_kind),
+        .title_source = TitleSource.fromWire(title_source),
+        .feed_source = feed_source,
+    });
+}
+
+test "journal lowering decodes escaped Unicode and preserves UTF-8 boundaries" {
+    var mb: Mailbox = .{};
+    const body =
+        "{\"text\":\"quote: \\\" slash: \\\\ line: \\n smile: \\u263a \\ud83d\\ude42\",\"agent_source\":\"codex\",\"session_id\":\"escaped\",\"message_id\":\"id-\\u263a\",\"busy\":true}";
+    try std.testing.expect(applyBubbleJson(&mb, body, .journal) != null);
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqualStrings("quote: \" slash: \\ line: \n smile: ☺ 🙂", out[0].text[0..out[0].text_len]);
+    try std.testing.expectEqualStrings("id-☺", out[0].message_id[0..out[0].message_id_len]);
+    try std.testing.expect(std.unicode.utf8ValidateSlice(out[0].text[0..out[0].text_len]));
+}
+
+test "journal lowering hashes long source identities before bounded storage" {
+    const shared = "provider/session/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const first = shared ++ "-first";
+    const second = shared ++ "-second";
+    try std.testing.expect(first.len > bubble_session_capacity and second.len > bubble_session_capacity);
+    var first_buf: [512]u8 = undefined;
+    var second_buf: [512]u8 = undefined;
+    const first_body = try std.fmt.bufPrint(&first_buf, "{{\"text\":\"one\",\"agent_source\":\"codex\",\"conversation_key\":\"one\",\"source_session_id\":\"{s}\"}}", .{first});
+    const second_body = try std.fmt.bufPrint(&second_buf, "{{\"text\":\"two\",\"agent_source\":\"codex\",\"conversation_key\":\"two\",\"source_session_id\":\"{s}\"}}", .{second});
+    var mb: Mailbox = .{};
+    try std.testing.expect(applyBubbleJson(&mb, first_body, .journal) != null);
+    try std.testing.expect(applyBubbleJson(&mb, second_body, .journal) != null);
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 2), mb.takeBubbles(&out));
+    try std.testing.expectEqual(@as(usize, 64), out[0].source_session_len);
+    try std.testing.expectEqual(@as(usize, 64), out[1].source_session_len);
+    try std.testing.expect(!std.mem.eql(u8, out[0].source_session[0..out[0].source_session_len], out[1].source_session[0..out[1].source_session_len]));
+}
+
+test "journal lowering rejects duplicate and malformed field types" {
+    var mb: Mailbox = .{};
+    try std.testing.expect(applyBubbleJson(&mb, "{\"text\":\"one\",\"text\":\"two\",\"agent_source\":\"codex\"}", .journal) == null);
+    try std.testing.expect(applyBubbleJson(&mb, "{\"text\":7,\"agent_source\":\"codex\"}", .journal) == null);
 }
 
 test "dropping a session frees its slot and keeps the rest dense" {
@@ -1255,16 +3143,26 @@ test "unqueued state never reaches the runtime mirror" {
     try std.testing.expectEqual(@as(u64, 0), server.last_state_mirror);
 }
 
-test "running state alternates without sharing mutable state with callers" {
-    var server = Server{
-        .allocator = std.testing.allocator,
-        .runtime_dir = "",
-        .token = undefined,
-        .pid = 0,
-    };
-    try std.testing.expectEqualStrings("running-right", server.nextRunningState());
-    try std.testing.expectEqualStrings("running-left", server.nextRunningState());
-    try std.testing.expectEqualStrings("running-right", server.nextRunningState());
+test "steady running state stays coalesced after the mailbox drains" {
+    var box: Mailbox = .{};
+    var running = StateEvent{};
+    running.state_len = "running".len;
+    @memcpy(running.state[0..running.state_len], "running");
+    try std.testing.expect(box.enqueue(running));
+    _ = box.pop();
+    try std.testing.expect(!box.enqueue(running));
+
+    var review = StateEvent{};
+    review.state_len = "review".len;
+    @memcpy(review.state[0..review.state_len], "review");
+    try std.testing.expect(box.enqueue(review));
+
+    var directional_running = StateEvent{};
+    directional_running.state_len = "running-left".len;
+    @memcpy(directional_running.state[0..directional_running.state_len], "running-left");
+    try std.testing.expect(box.enqueue(directional_running));
+    _ = box.pop();
+    try std.testing.expect(!box.enqueue(running));
 }
 
 fn jsonNumber(body: []const u8, key: []const u8) ?f64 {
@@ -1327,15 +3225,28 @@ fn mirrorQueuedState(server: *Server, state: []const u8, result: Mailbox.Enqueue
     try mirrorState(server, state, result.counter);
 }
 
-fn mirrorBubble(server: *Server, text: []const u8, counter: u64, title: []const u8, agent: []const u8, busy: bool) !void {
+fn mirrorBubble(server: *Server, text: []const u8, counter: u64, title: []const u8, agent: []const u8, hostname: []const u8, busy: bool) !void {
     var scope = plat.Scope.init();
     defer scope.deinit();
     const io = scope.io();
     server.mirror_lock.lock(io);
     defer server.mirror_lock.unlock(io);
     if (counter < server.last_bubble_mirror) return;
-    var buf: [1024]u8 = undefined;
-    const json = try std.fmt.bufPrint(&buf, "{{\"text\":\"{s}\",\"title\":\"{s}\",\"agent_source\":\"{s}\",\"busy\":{},\"counter\":{d},\"at\":{d}}}", .{ text, title, agent, busy, counter, nowMs() });
+    var memory: [max_request_bytes]u8 = undefined;
+    var fixed = std.heap.FixedBufferAllocator.init(&memory);
+    const json = try bubbleMirrorJson(fixed.allocator(), text, counter, title, agent, hostname, busy, nowMs());
     try writeRuntimeFile(server, "bubble.json", json, 0o644);
     server.last_bubble_mirror = counter;
+}
+
+fn bubbleMirrorJson(allocator: std.mem.Allocator, text: []const u8, counter: u64, title: []const u8, agent: []const u8, hostname: []const u8, busy: bool, at: i64) ![]u8 {
+    return std.json.Stringify.valueAlloc(allocator, .{
+        .text = text,
+        .title = title,
+        .agent_source = agent,
+        .hostname = hostname,
+        .busy = busy,
+        .counter = counter,
+        .at = at,
+    }, .{});
 }

--- a/packages/petdex-desktop-native/src/hook_server.zig
+++ b/packages/petdex-desktop-native/src/hook_server.zig
@@ -374,6 +374,42 @@ pub const BubbleUpdate = struct {
     feed_source: FeedSource = .hook,
 };
 
+/// Child summaries may arrive before bounded provider discovery has admitted
+/// their parent. Retain them outside the live bubble array so the race cannot
+/// manufacture a ghost card, lose the summary, or consume a parent slot.
+const max_deferred_child_messages = max_bubbles * max_child_messages;
+const DeferredChildMessage = struct {
+    conversation: [bubble_session_capacity]u8 = @splat(0),
+    conversation_len: usize = 0,
+    agent: [24]u8 = @splat(0),
+    agent_len: usize = 0,
+    hostname: [64]u8 = @splat(0),
+    hostname_len: usize = 0,
+    remote: bool = false,
+    message: ChildMessage = .{},
+
+    fn conversationSlice(self: *const DeferredChildMessage) []const u8 {
+        return self.conversation[0..self.conversation_len];
+    }
+
+    fn agentSlice(self: *const DeferredChildMessage) []const u8 {
+        return self.agent[0..self.agent_len];
+    }
+
+    fn hostnameSlice(self: *const DeferredChildMessage) []const u8 {
+        return self.hostname[0..self.hostname_len];
+    }
+
+    fn identity(self: *const DeferredChildMessage) BubbleIdentity {
+        return .{
+            .conversation_key = self.conversationSlice(),
+            .agent = self.agentSlice(),
+            .hostname = self.hostnameSlice(),
+            .remote = self.remote,
+        };
+    }
+};
+
 fn copyField(destination: []u8, source: []const u8) usize {
     const count = @min(destination.len, source.len);
     @memset(destination, 0);
@@ -432,6 +468,13 @@ fn childMessageEquivalent(message: *const ChildMessage, update: BubbleUpdate) bo
         std.mem.eql(u8, message.labelSlice(), if (update.subagent_label.len > 0) update.subagent_label else "Subagent") and
         std.mem.eql(u8, message.sourceSessionSlice(), update.source_session) and
         std.mem.eql(u8, message.messageIdSlice(), update.message_id);
+}
+
+fn writeChildMessage(message: *ChildMessage, update: BubbleUpdate) void {
+    message.text_len = copyField(&message.text, update.text);
+    message.label_len = copyField(&message.label, if (update.subagent_label.len > 0) update.subagent_label else "Subagent");
+    message.source_session_len = copyField(&message.source_session, update.source_session);
+    message.message_id_len = copyField(&message.message_id, update.message_id);
 }
 
 /// A provider may poll/replay a `running` status for minutes without any new
@@ -625,6 +668,8 @@ pub const Mailbox = struct {
     bubbles: [max_bubbles]Bubble = @splat(.{}),
     bubbles_len: usize = 0,
     bubbles_dirty: bool = false,
+    deferred_children: [max_deferred_child_messages]DeferredChildMessage = @splat(.{}),
+    deferred_children_len: usize = 0,
     /// Monotonic across every session, so a bubble's counter doubles as
     /// its LRU stamp: the smallest one is the least recently updated.
     bubble_counter: u64 = 0,
@@ -719,6 +764,107 @@ pub const Mailbox = struct {
         });
     }
 
+    fn attachChildMessageLocked(self: *Mailbox, parent: *Bubble, update: BubbleUpdate) u64 {
+        var duplicate: ?usize = null;
+        for (parent.child_messages[0..parent.child_messages_len], 0..) |*message, index| {
+            if (childMessageMatches(message, update)) {
+                duplicate = index;
+                break;
+            }
+        }
+        if (duplicate) |index| {
+            if (childMessageEquivalent(&parent.child_messages[index], update)) {
+                self.bubble_render_debug.suppressed_duplicates +%= 1;
+                return parent.counter;
+            }
+            // Move an updated duplicate to the tail so "two most recent" is
+            // chronological even when a provider replays an event.
+            const existing = parent.child_messages[index];
+            std.mem.copyForwards(ChildMessage, parent.child_messages[index .. parent.child_messages_len - 1], parent.child_messages[index + 1 .. parent.child_messages_len]);
+            parent.child_messages[parent.child_messages_len - 1] = existing;
+        } else {
+            if (parent.child_messages_len == max_child_messages) {
+                std.mem.copyForwards(ChildMessage, parent.child_messages[0 .. max_child_messages - 1], parent.child_messages[1..max_child_messages]);
+                parent.child_messages_len -= 1;
+            }
+            parent.child_messages[parent.child_messages_len] = .{};
+            parent.child_messages_len += 1;
+        }
+        const child = &parent.child_messages[parent.child_messages_len - 1];
+        writeChildMessage(child, update);
+        self.bubble_counter += 1;
+        child.counter = self.bubble_counter;
+        parent.counter = self.bubble_counter;
+        self.bubbles_dirty = true;
+        return parent.counter;
+    }
+
+    fn deferChildMessageLocked(self: *Mailbox, update: BubbleUpdate) u64 {
+        const update_identity: BubbleIdentity = .{
+            .conversation_key = update.conversation_key,
+            .agent = update.agent,
+            .hostname = update.hostname,
+            .remote = update.remote,
+        };
+        var duplicate: ?usize = null;
+        for (self.deferred_children[0..self.deferred_children_len], 0..) |*candidate, index| {
+            if (candidate.identity().matches(update_identity) and childMessageMatches(&candidate.message, update)) {
+                duplicate = index;
+                break;
+            }
+        }
+        if (duplicate) |index| {
+            if (childMessageEquivalent(&self.deferred_children[index].message, update)) {
+                self.bubble_render_debug.suppressed_duplicates +%= 1;
+                return self.bubble_counter;
+            }
+            const existing = self.deferred_children[index];
+            std.mem.copyForwards(DeferredChildMessage, self.deferred_children[index .. self.deferred_children_len - 1], self.deferred_children[index + 1 .. self.deferred_children_len]);
+            self.deferred_children[self.deferred_children_len - 1] = existing;
+        } else {
+            if (self.deferred_children_len == max_deferred_child_messages) {
+                std.mem.copyForwards(DeferredChildMessage, self.deferred_children[0 .. max_deferred_child_messages - 1], self.deferred_children[1..max_deferred_child_messages]);
+                self.deferred_children_len -= 1;
+            }
+            self.deferred_children[self.deferred_children_len] = .{};
+            self.deferred_children_len += 1;
+        }
+        const deferred = &self.deferred_children[self.deferred_children_len - 1];
+        deferred.conversation_len = copyField(&deferred.conversation, update.conversation_key);
+        deferred.agent_len = copyField(&deferred.agent, update.agent);
+        deferred.hostname_len = copyField(&deferred.hostname, update.hostname);
+        deferred.remote = update.remote;
+        writeChildMessage(&deferred.message, update);
+        return self.bubble_counter;
+    }
+
+    fn flushDeferredChildrenLocked(self: *Mailbox, parent: *Bubble) void {
+        var index: usize = 0;
+        while (index < self.deferred_children_len) {
+            const deferred = &self.deferred_children[index];
+            if (!deferred.identity().matches(parent.identity())) {
+                index += 1;
+                continue;
+            }
+            _ = self.attachChildMessageLocked(parent, .{
+                .conversation_key = deferred.conversationSlice(),
+                .source_session = deferred.message.sourceSessionSlice(),
+                .text = deferred.message.textSlice(),
+                .agent = deferred.agentSlice(),
+                .hostname = deferred.hostnameSlice(),
+                .message_id = deferred.message.messageIdSlice(),
+                .subagent_label = deferred.message.labelSlice(),
+                .remote = deferred.remote,
+                .session_kind = .subagent,
+                .message_kind = .assistant,
+            });
+            if (index + 1 < self.deferred_children_len)
+                std.mem.copyForwards(DeferredChildMessage, self.deferred_children[index .. self.deferred_children_len - 1], self.deferred_children[index + 1 .. self.deferred_children_len]);
+            self.deferred_children_len -= 1;
+            self.deferred_children[self.deferred_children_len] = .{};
+        }
+    }
+
     pub fn applyBubbleUpdate(self: *Mailbox, update_raw: BubbleUpdate) u64 {
         var conversation_hash: [64]u8 = undefined;
         var source_hash: [64]u8 = undefined;
@@ -756,49 +902,14 @@ pub const Mailbox = struct {
             }
         }
 
-        // A child never owns a top-level card. If its parent has not appeared
-        // yet, drop the event rather than manufacturing a blank ghost card.
-        // The next meaningful parent update will establish the aggregate.
+        // A child never owns a top-level card. Meaningful prose that wins the
+        // discovery race is retained outside the live bubble set and attached
+        // automatically after its parent arrives.
         if (update.session_kind == .subagent) {
-            const parent = matched_existing orelse return self.bubble_counter;
             if (update.message_kind != .assistant or std.mem.trim(u8, update.text, " \t\r\n").len == 0)
                 return self.bubble_counter;
-
-            var duplicate: ?usize = null;
-            for (parent.child_messages[0..parent.child_messages_len], 0..) |*message, i| {
-                if (childMessageMatches(message, update)) {
-                    duplicate = i;
-                    break;
-                }
-            }
-            if (duplicate) |index| {
-                if (childMessageEquivalent(&parent.child_messages[index], update)) {
-                    self.bubble_render_debug.suppressed_duplicates +%= 1;
-                    return self.bubble_counter;
-                }
-                // Move an updated duplicate to the tail so "two most recent"
-                // is chronological even when a provider replays an event.
-                const existing = parent.child_messages[index];
-                std.mem.copyForwards(ChildMessage, parent.child_messages[index .. parent.child_messages_len - 1], parent.child_messages[index + 1 .. parent.child_messages_len]);
-                parent.child_messages[parent.child_messages_len - 1] = existing;
-            } else {
-                if (parent.child_messages_len == max_child_messages) {
-                    std.mem.copyForwards(ChildMessage, parent.child_messages[0 .. max_child_messages - 1], parent.child_messages[1..max_child_messages]);
-                    parent.child_messages_len -= 1;
-                }
-                parent.child_messages[parent.child_messages_len] = .{};
-                parent.child_messages_len += 1;
-            }
-            var child = &parent.child_messages[parent.child_messages_len - 1];
-            child.text_len = copyField(&child.text, update.text);
-            child.label_len = copyField(&child.label, if (update.subagent_label.len > 0) update.subagent_label else "Subagent");
-            child.source_session_len = copyField(&child.source_session, update.source_session);
-            child.message_id_len = copyField(&child.message_id, update.message_id);
-            self.bubble_counter += 1;
-            child.counter = self.bubble_counter;
-            parent.counter = self.bubble_counter;
-            self.bubbles_dirty = true;
-            return parent.counter;
+            const parent = matched_existing orelse return self.deferChildMessageLocked(update);
+            return self.attachChildMessageLocked(parent, update);
         }
 
         const is_new = matched_existing == null;
@@ -841,6 +952,7 @@ pub const Mailbox = struct {
         if (update.herdr_pane.len > 0 and (metadata_wins or slot.herdr_pane_len == 0)) slot.herdr_pane_len = copyField(&slot.herdr_pane, update.herdr_pane);
         if (update.hostname.len > 0 and (metadata_wins or slot.hostname_len == 0)) slot.hostname_len = copyField(&slot.hostname, update.hostname);
         slot.remote = update.remote;
+        self.flushDeferredChildrenLocked(slot);
 
         const replace_title = update.title.len > 0 and switch (update.title_source) {
             .server => true,
@@ -1030,6 +1142,8 @@ pub const Mailbox = struct {
         self.bubbles = @splat(.{});
         self.bubbles_len = 0;
         self.bubbles_dirty = false;
+        self.deferred_children = @splat(.{});
+        self.deferred_children_len = 0;
     }
 };
 
@@ -2619,6 +2733,61 @@ test "authoritative subagent update retracts provisional child card" {
     try std.testing.expectEqualStrings("Parent is working", out[0].text[0..out[0].text_len]);
 }
 
+test "subagent prose arriving before its parent is retained by full identity" {
+    var mb: Mailbox = .{};
+    const child: BubbleUpdate = .{
+        .conversation_key = "root-conversation",
+        .source_session = "child-session",
+        .parent_session = "root-session",
+        .session_kind = .subagent,
+        .subagent_label = "Research",
+        .agent = "hermes",
+        .hostname = "host-a",
+        .remote = true,
+        .text = "The migration needs one compatibility shim.",
+        .message_id = "child-message-1",
+        .message_kind = .assistant,
+        .status = .completed,
+    };
+    _ = mb.applyBubbleUpdate(child);
+    _ = mb.applyBubbleUpdate(child);
+
+    // Deferral is invisible and deduplicated: a child cannot manufacture a
+    // ghost card while provider discovery is still admitting its parent.
+    try std.testing.expectEqual(@as(usize, 1), mb.deferred_children_len);
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, null), mb.takeBubbles(&out));
+
+    // A colliding remote conversation on another host cannot claim it.
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "root-conversation",
+        .source_session = "root-session-b",
+        .agent = "hermes",
+        .hostname = "host-b",
+        .remote = true,
+        .text = "Unrelated parent",
+        .status = .running,
+    });
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqual(@as(usize, 0), out[0].child_messages_len);
+    try std.testing.expectEqual(@as(usize, 1), mb.deferred_children_len);
+
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "root-conversation",
+        .source_session = "root-session",
+        .agent = "hermes",
+        .hostname = "host-a",
+        .remote = true,
+        .text = "Matching parent",
+        .status = .running,
+    });
+    try std.testing.expectEqual(@as(?usize, 2), mb.takeBubbles(&out));
+    try std.testing.expectEqual(@as(usize, 0), mb.deferred_children_len);
+    try std.testing.expectEqual(@as(usize, 1), out[1].child_messages_len);
+    try std.testing.expectEqualStrings("Research", out[1].child_messages[0].labelSlice());
+    try std.testing.expectEqualStrings("The migration needs one compatibility shim.", out[1].child_messages[0].textSlice());
+}
+
 test "subagent tool noise is ignored and assistant prose folds into parent" {
     var mb: Mailbox = .{};
     _ = mb.applyBubbleUpdate(.{
@@ -3117,8 +3286,18 @@ test "dropping a session frees its slot and keeps the rest dense" {
     }
     mb.dropBubble("nobody");
     _ = mb.takeBubbles(&out);
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "deferred-parent",
+        .source_session = "deferred-child",
+        .session_kind = .subagent,
+        .agent = "codex",
+        .text = "Deferred summary",
+        .message_kind = .assistant,
+    });
+    try std.testing.expectEqual(@as(usize, 1), mb.deferred_children_len);
     mb.clearBubbles();
     try std.testing.expectEqual(@as(?usize, null), mb.takeBubbles(&out));
+    try std.testing.expectEqual(@as(usize, 0), mb.deferred_children_len);
 }
 
 test "json string scanner preserves escaped multiline content" {

--- a/packages/petdex-desktop-native/src/hook_server.zig
+++ b/packages/petdex-desktop-native/src/hook_server.zig
@@ -201,6 +201,26 @@ pub const StateEvent = struct {
     }
 };
 
+/// Stable bubble identity shared by producers and every consumer that keeps
+/// per-conversation state. Provider conversation ids are scoped by agent and
+/// locality; remote identities are additionally scoped by configured host.
+pub const BubbleIdentity = struct {
+    conversation_key: []const u8,
+    agent: []const u8,
+    hostname: []const u8,
+    remote: bool,
+
+    pub fn matches(self: BubbleIdentity, other: BubbleIdentity) bool {
+        if (!std.mem.eql(u8, self.conversation_key, other.conversation_key)) return false;
+        // Empty is the compatibility slot used by pre-session integrations.
+        if (other.conversation_key.len == 0) return true;
+        if (self.remote != other.remote) return false;
+        if (!std.ascii.eqlIgnoreCase(self.agent, other.agent)) return false;
+        if (!other.remote) return true;
+        return std.ascii.eqlIgnoreCase(self.hostname, other.hostname);
+    }
+};
+
 pub const Bubble = struct {
     text: [bubble_text_capacity]u8 = @splat(0),
     text_len: usize = 0,
@@ -243,9 +263,9 @@ pub const Bubble = struct {
     source_cwd_len: usize = 0,
     herdr_pane: [64]u8 = @splat(0),
     herdr_pane_len: usize = 0,
-    /// Machine that owns the agent process. Local hooks report the Mac's
-    /// hostname; SSH hooks report the remote host, so the header never has
-    /// to infer locality from a filesystem path.
+    /// Machine identity that owns the agent process. Local hooks report the
+    /// Mac's hostname; authenticated SSH hooks report their configured remote
+    /// principal, so the header never infers locality from a filesystem path.
     hostname: [64]u8 = @splat(0),
     hostname_len: usize = 0,
     /// Active agent turn. Codex requires both thread + turn ids for a safe
@@ -302,20 +322,20 @@ pub const Bubble = struct {
         return self.message_id[0..self.message_id_len];
     }
 
+    pub fn identity(self: *const Bubble) BubbleIdentity {
+        return .{
+            .conversation_key = self.sessionSlice(),
+            .agent = self.agent[0..self.agent_len],
+            .hostname = self.hostnameSlice(),
+            .remote = self.remote,
+        };
+    }
+
     /// The canonical identity used by both mailbox producers and the app
     /// consumer. Conversation ids are only unique within an agent/locality
     /// boundary, and remote ids are additionally scoped to their host.
     pub fn sameIdentity(self: *const Bubble, other: *const Bubble) bool {
-        return bubbleIdentityPartsMatch(
-            self.sessionSlice(),
-            self.agent[0..self.agent_len],
-            self.hostnameSlice(),
-            self.remote,
-            other.sessionSlice(),
-            other.agent[0..other.agent_len],
-            other.hostnameSlice(),
-            other.remote,
-        );
+        return self.identity().matches(other.identity());
     }
 };
 
@@ -361,27 +381,13 @@ fn copyField(destination: []u8, source: []const u8) usize {
     return count;
 }
 
-fn bubbleIdentityPartsMatch(left_conversation: []const u8, left_agent: []const u8, left_hostname: []const u8, left_remote: bool, right_conversation: []const u8, right_agent: []const u8, right_hostname: []const u8, right_remote: bool) bool {
-    if (!std.mem.eql(u8, left_conversation, right_conversation)) return false;
-    // Empty is the compatibility slot used by pre-session integrations.
-    if (right_conversation.len == 0) return true;
-    if (left_remote != right_remote) return false;
-    if (!std.ascii.eqlIgnoreCase(left_agent, right_agent)) return false;
-    if (!right_remote) return true;
-    return std.ascii.eqlIgnoreCase(left_hostname, right_hostname);
-}
-
 fn identityMatches(bubble: *const Bubble, update: BubbleUpdate) bool {
-    return bubbleIdentityPartsMatch(
-        bubble.sessionSlice(),
-        bubble.agent[0..bubble.agent_len],
-        bubble.hostnameSlice(),
-        bubble.remote,
-        update.conversation_key,
-        update.agent,
-        update.hostname,
-        update.remote,
-    );
+    return bubble.identity().matches(.{
+        .conversation_key = update.conversation_key,
+        .agent = update.agent,
+        .hostname = update.hostname,
+        .remote = update.remote,
+    });
 }
 
 /// Match a provisional card opened under a raw child id before its provider
@@ -903,10 +909,21 @@ pub const Mailbox = struct {
     /// knows the state calls this right after, and one that does not
     /// leaves the field empty for readers to fall back on `busy`.
     pub fn setBubbleAgentState(self: *Mailbox, session: []const u8, state: []const u8) void {
+        self.setBubbleAgentStateIdentity(session, state, "", "", false, false);
+    }
+
+    pub fn setBubbleAgentStateIdentity(self: *Mailbox, conversation: []const u8, state: []const u8, agent: []const u8, hostname: []const u8, remote: bool, exact: bool) void {
         self.mutex.lock();
         defer self.mutex.unlock();
         for (self.bubbles[0..self.bubbles_len]) |*b| {
-            if (!std.mem.eql(u8, b.sessionSlice(), session)) continue;
+            if (exact) {
+                if (!b.identity().matches(.{
+                    .conversation_key = conversation,
+                    .agent = agent,
+                    .hostname = hostname,
+                    .remote = remote,
+                })) continue;
+            } else if (!std.mem.eql(u8, b.sessionSlice(), conversation)) continue;
             const n = @min(state.len, b.agent_state.len);
             @memcpy(b.agent_state[0..n], state[0..n]);
             @memset(b.agent_state[n..], 0);
@@ -1795,7 +1812,7 @@ fn route(server: *Server, conn: *Conn, method: []const u8, target: []const u8, p
             .title_source = TitleSource.fromWire(title_source),
             .feed_source = .hook,
         });
-        if (safe_agent_state.len > 0) mailbox.setBubbleAgentState(conversation, safe_agent_state);
+        if (safe_agent_state.len > 0) mailbox.setBubbleAgentStateIdentity(conversation, safe_agent_state, safe_agent, safe_hostname, remote, true);
         const mirror_busy = if (status) |value| value == .running else busy;
         mirrorBubble(server, capped, counter, safe_title, safe_agent, safe_hostname, mirror_busy) catch {};
         const out = std.fmt.bufPrint(&scratch, "{{\"ok\":true,\"counter\":{d}}}", .{counter}) catch return;
@@ -2534,6 +2551,29 @@ test "canonical identity includes agent locality and remote host" {
 
     var out: [max_bubbles]Bubble = @splat(.{});
     try std.testing.expectEqual(@as(?usize, 3), mb.takeBubbles(&out));
+}
+
+test "agent state targets the full bubble identity" {
+    var mb: Mailbox = .{};
+    inline for (.{
+        BubbleUpdate{ .conversation_key = "shared", .source_session = "a", .agent = "codex", .hostname = "host-a", .remote = true, .text = "A" },
+        BubbleUpdate{ .conversation_key = "shared", .source_session = "b", .agent = "codex", .hostname = "host-b", .remote = true, .text = "B" },
+        BubbleUpdate{ .conversation_key = "shared", .source_session = "c", .agent = "hermes", .hostname = "host-a", .remote = true, .text = "C" },
+    }) |update| _ = mb.applyBubbleUpdate(update);
+
+    mb.setBubbleAgentStateIdentity("shared", "waiting", "codex", "host-b", true, true);
+    mb.setBubbleAgentStateIdentity("shared", "failed", "hermes", "host-a", true, true);
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 3), mb.takeBubbles(&out));
+    for (out[0..3]) |*bubble| {
+        if (std.mem.eql(u8, bubble.agent[0..bubble.agent_len], "hermes")) {
+            try std.testing.expectEqualStrings("failed", bubble.agentStateSlice());
+        } else if (std.mem.eql(u8, bubble.hostnameSlice(), "host-b")) {
+            try std.testing.expectEqualStrings("waiting", bubble.agentStateSlice());
+        } else {
+            try std.testing.expectEqual(@as(usize, 0), bubble.agent_state_len);
+        }
+    }
 }
 
 test "authoritative subagent update retracts provisional child card" {

--- a/packages/petdex-desktop-native/src/hook_server.zig
+++ b/packages/petdex-desktop-native/src/hook_server.zig
@@ -301,6 +301,22 @@ pub const Bubble = struct {
     pub fn messageIdSlice(self: *const Bubble) []const u8 {
         return self.message_id[0..self.message_id_len];
     }
+
+    /// The canonical identity used by both mailbox producers and the app
+    /// consumer. Conversation ids are only unique within an agent/locality
+    /// boundary, and remote ids are additionally scoped to their host.
+    pub fn sameIdentity(self: *const Bubble, other: *const Bubble) bool {
+        return bubbleIdentityPartsMatch(
+            self.sessionSlice(),
+            self.agent[0..self.agent_len],
+            self.hostnameSlice(),
+            self.remote,
+            other.sessionSlice(),
+            other.agent[0..other.agent_len],
+            other.hostnameSlice(),
+            other.remote,
+        );
+    }
 };
 
 /// How many conversations can narrate at once. Fixed because the
@@ -345,14 +361,27 @@ fn copyField(destination: []u8, source: []const u8) usize {
     return count;
 }
 
-fn identityMatches(bubble: *const Bubble, update: BubbleUpdate) bool {
-    if (!std.mem.eql(u8, bubble.sessionSlice(), update.conversation_key)) return false;
+fn bubbleIdentityPartsMatch(left_conversation: []const u8, left_agent: []const u8, left_hostname: []const u8, left_remote: bool, right_conversation: []const u8, right_agent: []const u8, right_hostname: []const u8, right_remote: bool) bool {
+    if (!std.mem.eql(u8, left_conversation, right_conversation)) return false;
     // Empty is the compatibility slot used by pre-session integrations.
-    if (update.conversation_key.len == 0) return true;
-    if (bubble.remote != update.remote) return false;
-    if (!std.ascii.eqlIgnoreCase(bubble.agent[0..bubble.agent_len], update.agent)) return false;
-    if (!update.remote) return true;
-    return std.ascii.eqlIgnoreCase(bubble.hostnameSlice(), update.hostname);
+    if (right_conversation.len == 0) return true;
+    if (left_remote != right_remote) return false;
+    if (!std.ascii.eqlIgnoreCase(left_agent, right_agent)) return false;
+    if (!right_remote) return true;
+    return std.ascii.eqlIgnoreCase(left_hostname, right_hostname);
+}
+
+fn identityMatches(bubble: *const Bubble, update: BubbleUpdate) bool {
+    return bubbleIdentityPartsMatch(
+        bubble.sessionSlice(),
+        bubble.agent[0..bubble.agent_len],
+        bubble.hostnameSlice(),
+        bubble.remote,
+        update.conversation_key,
+        update.agent,
+        update.hostname,
+        update.remote,
+    );
 }
 
 /// Match a provisional card opened under a raw child id before its provider

--- a/packages/petdex-desktop-native/src/hook_server.zig
+++ b/packages/petdex-desktop-native/src/hook_server.zig
@@ -1036,6 +1036,19 @@ pub const Mailbox = struct {
                     .remote = remote,
                 })) continue;
             } else if (!std.mem.eql(u8, b.sessionSlice(), conversation)) continue;
+            // The HTTP route applies the canonical bubble update first and
+            // then lowers its optional agent_state through this setter. An
+            // unchanged heartbeat must not restore an animated Flock state
+            // after stale suppression; meaningful work clears the marker in
+            // applyBubbleUpdate before reaching this point.
+            if (b.stale_running_suppressed) {
+                if (b.agent_state_len > 0) {
+                    @memset(&b.agent_state, 0);
+                    b.agent_state_len = 0;
+                    self.bubbles_dirty = true;
+                }
+                return;
+            }
             const n = @min(state.len, b.agent_state.len);
             @memcpy(b.agent_state[0..n], state[0..n]);
             @memset(b.agent_state[n..], 0);
@@ -1057,6 +1070,8 @@ pub const Mailbox = struct {
             if (now_ms - bubble.last_meaningful_activity_ms < grace_ms) continue;
             bubble.status = .idle;
             bubble.busy = false;
+            @memset(&bubble.agent_state, 0);
+            bubble.agent_state_len = 0;
             bubble.stale_running_suppressed = true;
             self.bubble_counter += 1;
             bubble.counter = self.bubble_counter;
@@ -3103,13 +3118,16 @@ test "stale running cards become idle until meaningful work resumes" {
         .message_kind = .tool,
         .status = .running,
     });
+    mb.setBubbleAgentStateIdentity("alpha", "review", "codex", "", false, true);
     var out: [max_bubbles]Bubble = @splat(.{});
     _ = mb.takeBubbles(&out);
+    try std.testing.expectEqualStrings("review", out[0].agentStateSlice());
     const last_activity = out[0].last_meaningful_activity_ms;
     try std.testing.expectEqual(@as(usize, 1), mb.suppressStaleRunning(last_activity + 30_000, 30_000));
     try std.testing.expectEqual(@as(u64, 1), mb.bubbleRenderDebugCounters().stale_transitions);
     try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
     try std.testing.expectEqual(SessionStatus.idle, out[0].status);
+    try std.testing.expectEqual(@as(usize, 0), out[0].agent_state_len);
     try std.testing.expect(out[0].stale_running_suppressed);
 
     // A replayed heartbeat cannot restart the animation.
@@ -3123,6 +3141,8 @@ test "stale running cards become idle until meaningful work resumes" {
         .message_kind = .tool,
         .status = .running,
     });
+    mb.setBubbleAgentStateIdentity("alpha", "review", "codex", "", false, true);
+    try std.testing.expectEqual(@as(usize, 0), mb.bubbles[0].agent_state_len);
     try std.testing.expectEqual(@as(?usize, null), mb.takeBubbles(&out));
 
     _ = mb.applyBubbleUpdate(.{
@@ -3135,8 +3155,10 @@ test "stale running cards become idle until meaningful work resumes" {
         .message_kind = .tool,
         .status = .running,
     });
+    mb.setBubbleAgentStateIdentity("alpha", "running", "codex", "", false, true);
     try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
     try std.testing.expectEqual(SessionStatus.running, out[0].status);
+    try std.testing.expectEqualStrings("running", out[0].agentStateSlice());
     try std.testing.expect(!out[0].stale_running_suppressed);
 }
 

--- a/packages/petdex-desktop-native/src/hook_server.zig
+++ b/packages/petdex-desktop-native/src/hook_server.zig
@@ -512,6 +512,22 @@ fn bubblePresentationEquivalent(before: Bubble, after: Bubble) bool {
     return std.meta.eql(left, right);
 }
 
+fn agentStateForStatus(status: SessionStatus) []const u8 {
+    return switch (status) {
+        .running => "running",
+        .needs_input => "waiting",
+        .failed => "failed",
+        .idle, .completed => "",
+    };
+}
+
+fn writeBubbleAgentState(bubble: *Bubble, state: []const u8) void {
+    const n = @min(state.len, bubble.agent_state.len);
+    @memcpy(bubble.agent_state[0..n], state[0..n]);
+    @memset(bubble.agent_state[n..], 0);
+    bubble.agent_state_len = n;
+}
+
 fn pendingInputKey(update: BubbleUpdate) []const u8 {
     if (update.request_id.len > 0) return update.request_id;
     return update.message_id;
@@ -866,6 +882,17 @@ pub const Mailbox = struct {
     }
 
     pub fn applyBubbleUpdate(self: *Mailbox, update_raw: BubbleUpdate) u64 {
+        return self.applyBubbleUpdateInternal(update_raw, false);
+    }
+
+    /// Recovery feeds know lifecycle but not a separate hook phase. Derive
+    /// their Flock state from the status actually accepted by reconciliation,
+    /// in the same canonical-identity critical section as the bubble update.
+    pub fn applyBubbleUpdateWithDerivedAgentState(self: *Mailbox, update_raw: BubbleUpdate) u64 {
+        return self.applyBubbleUpdateInternal(update_raw, true);
+    }
+
+    fn applyBubbleUpdateInternal(self: *Mailbox, update_raw: BubbleUpdate, derive_agent_state: bool) u64 {
         var conversation_hash: [64]u8 = undefined;
         var source_hash: [64]u8 = undefined;
         var parent_hash: [64]u8 = undefined;
@@ -1002,6 +1029,8 @@ pub const Mailbox = struct {
             // a stale-running marker that could interfere with a later turn.
             slot.stale_running_suppressed = false;
         }
+
+        if (derive_agent_state) writeBubbleAgentState(slot, agentStateForStatus(status));
 
         const changed = is_new or sessionless_replace or meaningful_running_activity or
             !bubblePresentationEquivalent(before, slot.*);

--- a/packages/petdex-desktop-native/src/hook_server.zig
+++ b/packages/petdex-desktop-native/src/hook_server.zig
@@ -1445,12 +1445,35 @@ const Server = struct {
     }
 };
 
-/// Spawn the listener thread. Never blocks the caller; failures to
-/// bind are printed and the thread exits (the desktop keeps running,
-/// hooks just get connection refused, same as a dead sidecar).
-pub fn start(allocator: std.mem.Allocator, home: []const u8) !void {
+pub const StartResult = enum {
+    listening,
+    unavailable,
+
+    pub fn ownsListener(self: StartResult) bool {
+        return self == .listening;
+    }
+};
+
+const StartupState = enum(u8) { pending, listening, unavailable };
+const StartupHandshake = struct {
+    state: std.atomic.Value(StartupState) = .init(.pending),
+    ready: std.Io.Event = .unset,
+
+    fn publish(self: *StartupHandshake, io: std.Io, state: StartupState) void {
+        self.state.store(state, .release);
+        self.ready.set(io);
+    }
+};
+
+/// Spawn the listener thread and wait only for its bind/token startup.
+/// The result is an ownership contract: a second Petdex process may keep its
+/// UI running, but must not create process-local credentials for remotes whose
+/// tunnel actually terminates at the first process's listener.
+pub fn start(allocator: std.mem.Allocator, home: []const u8) !StartResult {
     const runtime_dir = try std.fs.path.join(allocator, &.{ home, ".petdex", "runtime" });
+    errdefer allocator.free(runtime_dir);
     const server = try allocator.create(Server);
+    errdefer allocator.destroy(server);
     server.* = .{
         .allocator = allocator,
         .runtime_dir = runtime_dir,
@@ -1460,11 +1483,27 @@ pub fn start(allocator: std.mem.Allocator, home: []const u8) !void {
     var raw: [32]u8 = undefined;
     try fillRandom(&raw);
     _ = std.fmt.bufPrint(&server.token, "{x}", .{&raw}) catch unreachable;
-    const thread = try std.Thread.spawn(.{}, run, .{server});
-    thread.detach();
+    var handshake: StartupHandshake = .{};
+    const thread = try std.Thread.spawn(.{}, run, .{ server, &handshake });
+    var scope = plat.Scope.init();
+    defer scope.deinit();
+    handshake.ready.waitUncancelable(scope.io());
+    switch (handshake.state.load(.acquire)) {
+        .pending => unreachable,
+        .listening => {
+            thread.detach();
+            return .listening;
+        },
+        .unavailable => {
+            thread.join();
+            allocator.free(runtime_dir);
+            allocator.destroy(server);
+            return .unavailable;
+        },
+    }
 }
 
-fn run(server: *Server) void {
+fn run(server: *Server, handshake: *StartupHandshake) void {
     // This thread owns its Io for its whole life: the listener blocks
     // in accept() forever and must never touch the main thread's.
     var scope = plat.Scope.init();
@@ -1481,6 +1520,7 @@ fn run(server: *Server) void {
         .mode = .stream,
         .protocol = .tcp,
     }) catch {
+        handshake.publish(io, .unavailable);
         std.debug.print("petdex: :7777 bind failed; is another petdex running?\n", .{});
         return;
     };
@@ -1490,6 +1530,7 @@ fn run(server: *Server) void {
     // fail to bind; it must not invalidate the token of the listener that is
     // already serving hooks.
     writeRuntimeFile(server, "update-token", &server.token, 0o600) catch |err| {
+        handshake.publish(io, .unavailable);
         std.debug.print("petdex: token write failed ({s})\n", .{@errorName(err)});
         return;
     };
@@ -1498,6 +1539,7 @@ fn run(server: *Server) void {
     // Installation is not connection. Each Petdex process requires a fresh
     // event from the plugin before Settings may show DSH as connected.
     deleteRuntimeFile(server, "dsh-handshake.json");
+    handshake.publish(io, .listening);
     std.debug.print("petdex: hook server on 127.0.0.1:7777 (in-process)\n", .{});
 
     while (true) {
@@ -2301,6 +2343,11 @@ test "bounded decoded strings preserve utf8 boundaries" {
     try std.testing.expectEqualStrings("ab", boundedUtf8("ab🙂", 5).?);
     try std.testing.expectEqualStrings("ab🙂", boundedUtf8("ab🙂", 6).?);
     try std.testing.expect(boundedUtf8(&.{0xff}, 8) == null);
+}
+
+test "only a listening hook server owns remote supervision" {
+    try std.testing.expect(StartResult.listening.ownsListener());
+    try std.testing.expect(!StartResult.unavailable.ownsListener());
 }
 
 test "authenticated provenance rejects contradictory body claims" {

--- a/packages/petdex-desktop-native/src/hook_server.zig
+++ b/packages/petdex-desktop-native/src/hook_server.zig
@@ -3207,6 +3207,7 @@ pub fn applyBubbleJson(target: *Mailbox, body: []const u8, feed_source: FeedSour
     const origin_app = plat.OriginApplication.fromTermProgram(source_app);
     const source_tty = plat.safeSourceTty(request.string("source_tty")) orelse "";
     const source_cwd = plat.safeSourceCwd(request.string("source_cwd")) orelse "";
+    const herdr_pane = plat.safeHerdrPaneId(request.string("herdr_pane_id")) orelse "";
     const hostname = boundedUtf8(request.string("hostname") orelse "", 64) orelse return null;
     const turn = boundedUtf8(request.string("turn_id") orelse "", 64) orelse return null;
     const message_id = boundedUtf8(request.string("message_id") orelse "", bubble_message_id_capacity) orelse return null;
@@ -3216,6 +3217,7 @@ pub fn applyBubbleJson(target: *Mailbox, body: []const u8, feed_source: FeedSour
     const notification_kind = boundedUtf8(request.string("notification_kind") orelse "", 64) orelse return null;
     const parent_session = request.string("parent_session_id") orelse "";
     const subagent_label = boundedUtf8(request.string("subagent_label") orelse "", 48) orelse return null;
+    const agent_state = boundedUtf8(request.string("agent_state") orelse "", 16) orelse return null;
     const remote = request.boolean("remote") orelse false;
     const busy = request.boolean("busy") orelse false;
     var conversation_hash: [64]u8 = undefined;
@@ -3228,7 +3230,7 @@ pub fn applyBubbleJson(target: *Mailbox, body: []const u8, feed_source: FeedSour
     const title_source = request.string("title_source") orelse "unknown";
     _ = request.string("feed_source");
     if (!request.valid) return null;
-    return target.applyBubbleUpdate(.{
+    const counter = target.applyBubbleUpdate(.{
         .conversation_key = conversation[0..@min(conversation.len, bubble_session_capacity)],
         .source_session = source_session,
         .parent_session = parent_session,
@@ -3238,6 +3240,7 @@ pub fn applyBubbleJson(target: *Mailbox, body: []const u8, feed_source: FeedSour
         .origin_app = origin_app,
         .source_tty = source_tty,
         .source_cwd = source_cwd,
+        .herdr_pane = herdr_pane,
         .hostname = hostname,
         .turn = turn,
         .message_id = message_id,
@@ -3254,6 +3257,8 @@ pub fn applyBubbleJson(target: *Mailbox, body: []const u8, feed_source: FeedSour
         .title_source = TitleSource.fromWire(title_source),
         .feed_source = feed_source,
     });
+    if (agent_state.len > 0) target.setBubbleAgentStateIdentity(conversation, agent_state, agent, hostname, remote, true);
+    return counter;
 }
 
 test "journal lowering decodes escaped Unicode and preserves UTF-8 boundaries" {
@@ -3266,6 +3271,25 @@ test "journal lowering decodes escaped Unicode and preserves UTF-8 boundaries" {
     try std.testing.expectEqualStrings("quote: \" slash: \\ line: \n smile: ☺ 🙂", out[0].text[0..out[0].text_len]);
     try std.testing.expectEqualStrings("id-☺", out[0].message_id[0..out[0].message_id_len]);
     try std.testing.expect(std.unicode.utf8ValidateSlice(out[0].text[0..out[0].text_len]));
+}
+
+test "journal lowering preserves bounded agent state and safe Herdr pane identity" {
+    var mb: Mailbox = .{};
+    const body =
+        "{\"text\":\"Reviewing changes\",\"agent_source\":\"hermes\",\"conversation_key\":\"review-root\",\"source_session_id\":\"review-root\",\"herdr_pane_id\":\"w1:p5\",\"agent_state\":\"review\",\"busy\":true,\"status\":\"running\"}";
+    try std.testing.expect(applyBubbleJson(&mb, body, .journal) != null);
+
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqualStrings("w1:p5", out[0].herdrPaneSlice());
+    try std.testing.expectEqualStrings("review", out[0].agentStateSlice());
+
+    const unsafe =
+        "{\"text\":\"Unsafe pane\",\"agent_source\":\"hermes\",\"conversation_key\":\"unsafe-root\",\"source_session_id\":\"unsafe-root\",\"herdr_pane_id\":\"w1:p5;open\",\"agent_state\":\"waiting\"}";
+    try std.testing.expect(applyBubbleJson(&mb, unsafe, .journal) != null);
+    try std.testing.expectEqual(@as(?usize, 2), mb.takeBubbles(&out));
+    try std.testing.expectEqual(@as(usize, 0), out[1].herdr_pane_len);
+    try std.testing.expectEqualStrings("waiting", out[1].agentStateSlice());
 }
 
 test "journal lowering hashes long source identities before bounded storage" {

--- a/packages/petdex-desktop-native/src/hook_server.zig
+++ b/packages/petdex-desktop-native/src/hook_server.zig
@@ -363,6 +363,10 @@ pub const BubbleUpdate = struct {
     event_kind: []const u8 = "",
     request_id: []const u8 = "",
     resolves_request_id: []const u8 = "",
+    /// The provider has authoritative state but no request-level correlation.
+    /// A running update carrying this flag releases only the unkeyed fallback;
+    /// keyed approvals remain protected until their exact resolution arrives.
+    resolves_unkeyed_input: bool = false,
     notification_kind: []const u8 = "",
     subagent_label: []const u8 = "",
     remote: bool = false,
@@ -599,6 +603,10 @@ fn removePendingInput(bubble: *Bubble, index: usize) void {
 
 fn reconcileStatus(bubble: *Bubble, update: BubbleUpdate, proposed: SessionStatus) SessionStatus {
     const key = pendingInputKey(update);
+    // A provider may resolve one request while another remains outstanding,
+    // so correlation is independent of the aggregate status it publishes.
+    const resolving_key = if (update.resolves_request_id.len > 0) update.resolves_request_id else "";
+    if (pendingInputIndex(bubble, resolving_key)) |index| removePendingInput(bubble, index);
     switch (proposed) {
         .failed, .completed, .idle => clearPendingInputs(bubble),
         .needs_input => {
@@ -612,11 +620,7 @@ fn reconcileStatus(bubble: *Bubble, update: BubbleUpdate, proposed: SessionStatu
             }
         },
         .running => {
-            const resolving_key = if (update.resolves_request_id.len > 0) update.resolves_request_id else "";
-            if (pendingInputIndex(bubble, resolving_key)) |index| {
-                removePendingInput(bubble, index);
-            }
-            if (bubble.pending_unkeyed_input and isDefinitiveResume(update))
+            if (bubble.pending_unkeyed_input and (update.resolves_unkeyed_input or isDefinitiveResume(update)))
                 bubble.pending_unkeyed_input = false;
             // A genuinely new turn invalidates even keyed requests from the
             // previous turn. Ordinary tool/assistant progress only resolves
@@ -3023,11 +3027,12 @@ test "pending inputs obey attention precedence until matching responses arrive" 
         .conversation_key = "thread",
         .source_session = "thread",
         .agent = "codex",
-        .text = "Continuing",
-        .message_id = "approval-1",
+        .text = "Choose a host",
+        .message_id = "question-2",
+        .request_id = "question-2",
         .resolves_request_id = "approval-1",
-        .message_kind = .status,
-        .status = .running,
+        .message_kind = .prompt,
+        .status = .needs_input,
     });
     var out: [max_bubbles]Bubble = @splat(.{});
     try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
@@ -3114,6 +3119,32 @@ test "definitive tool progress clears only the unkeyed fallback" {
     try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
     try std.testing.expectEqual(SessionStatus.running, out[0].status);
     try std.testing.expect(!out[0].pending_unkeyed_input);
+}
+
+test "authoritative unkeyed resolution never clears a keyed approval" {
+    var mb: Mailbox = .{};
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "thread",
+        .source_session = "thread",
+        .agent = "hermes",
+        .text = "Approve?",
+        .request_id = "approval-1",
+        .message_kind = .prompt,
+        .status = .needs_input,
+    });
+    _ = mb.applyBubbleUpdate(.{
+        .conversation_key = "thread",
+        .source_session = "thread",
+        .agent = "hermes",
+        .text = "Recovered provider progress",
+        .resolves_unkeyed_input = true,
+        .message_kind = .status,
+        .status = .running,
+    });
+    var out: [max_bubbles]Bubble = @splat(.{});
+    try std.testing.expectEqual(@as(?usize, 1), mb.takeBubbles(&out));
+    try std.testing.expectEqual(SessionStatus.needs_input, out[0].status);
+    try std.testing.expectEqual(@as(usize, 1), out[0].pending_input_ids_len);
 }
 
 test "a sessionless agent keeps the single shared slot" {

--- a/packages/petdex-desktop-native/src/macos_fsevents.zig
+++ b/packages/petdex-desktop-native/src/macos_fsevents.zig
@@ -1,0 +1,229 @@
+//! Minimal recursive macOS directory-change backend.
+//!
+//! CoreServices is loaded dynamically so consumers do not need to change their
+//! framework link set. The callback deliberately reports only a coalesced hint;
+//! the bounded reconciliation scan remains authoritative.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub const Signal = enum { dirty, overflow };
+
+/// `publish` runs on a private serial GCD queue and must be thread-safe,
+/// non-blocking, and remain valid for the lifetime of `run`.
+pub const Sink = struct {
+    context: *anyopaque,
+    publish: *const fn (context: *anyopaque, signal: Signal) void,
+};
+
+pub const Error = error{
+    UnsupportedPlatform,
+    OpenFrameworkFailed,
+    MissingCoreServicesSymbol,
+    SystemResources,
+    InvalidPath,
+    CreateStreamFailed,
+    StartStreamFailed,
+    RootChanged,
+};
+
+/// Starts one recursive FSEvent stream and blocks permanently. The caller is
+/// expected to own a dedicated process-lifetime watcher thread.
+pub fn run(path: []const u8, sink: Sink) Error!void {
+    if (comptime builtin.os.tag != .macos) return error.UnsupportedPlatform;
+    if (path.len == 0 or !std.unicode.utf8ValidateSlice(path)) return error.InvalidPath;
+
+    const dispatch = std.c.dispatch;
+    var core_services = std.DynLib.open("/System/Library/Frameworks/CoreServices.framework/CoreServices") catch
+        return error.OpenFrameworkFailed;
+    defer core_services.close();
+
+    var symbols: Symbols = undefined;
+    inline for (@typeInfo(Symbols).@"struct".fields) |field| {
+        @field(symbols, field.name) = core_services.lookup(field.type, field.name) orelse
+            return error.MissingCoreServicesSymbol;
+    }
+
+    const path_z = std.heap.page_allocator.dupeZ(u8, path) catch return error.SystemResources;
+    defer std.heap.page_allocator.free(path_z);
+    const cf_path = symbols.CFStringCreateWithCString(null, path_z, .utf8) orelse return error.InvalidPath;
+    defer symbols.CFRelease(cf_path);
+    const path_values = [1]?*const anyopaque{@ptrCast(cf_path)};
+    const paths = symbols.CFArrayCreate(null, &path_values, path_values.len, null) orelse
+        return error.SystemResources;
+    defer symbols.CFRelease(paths);
+
+    const queue = dispatch.queue_create("petdex-session-watch", dispatch.QUEUE_SERIAL()) orelse
+        return error.SystemResources;
+    defer queue.as_object().release();
+    const blocker = dispatch.semaphore_create(0) orelse return error.SystemResources;
+    defer blocker.as_object().release();
+
+    var callback_context: CallbackContext = .{ .sink = sink, .restart = @ptrCast(blocker) };
+    const stream = symbols.FSEventStreamCreate(
+        null,
+        eventCallback,
+        &.{
+            .version = 0,
+            .info = &callback_context,
+            .retain = null,
+            .release = null,
+            .copy_description = null,
+        },
+        paths,
+        .since_now,
+        0.1,
+        .{ .no_defer = true, .watch_root = true, .file_events = true },
+    ) orelse return error.CreateStreamFailed;
+    defer symbols.FSEventStreamRelease(stream);
+    symbols.FSEventStreamSetDispatchQueue(stream, queue);
+    defer symbols.FSEventStreamInvalidate(stream);
+    if (!symbols.FSEventStreamStart(stream)) return error.StartStreamFailed;
+    defer symbols.FSEventStreamStop(stream);
+
+    // The process-lifetime watcher has no stop path today. Keeping this frame
+    // alive also keeps the callback context and dynamically loaded symbols
+    // valid for every dispatch callback.
+    _ = blocker.wait(.FOREVER);
+    return error.RootChanged;
+}
+
+const CallbackContext = struct {
+    sink: Sink,
+    restart: ?*anyopaque,
+};
+
+fn eventCallback(
+    stream: ConstFSEventStreamRef,
+    raw_context: ?*anyopaque,
+    event_count: usize,
+    event_paths: *anyopaque,
+    event_flags: [*]const FSEventStreamEventFlags,
+    event_ids: [*]const FSEventStreamEventId,
+) callconv(.c) void {
+    _ = stream;
+    _ = event_paths;
+    _ = event_ids;
+    const context: *CallbackContext = @ptrCast(@alignCast(raw_context orelse return));
+    var saw_dirty = false;
+    for (event_flags[0..event_count]) |flags| {
+        if (flags.history_done) continue;
+        if (flags.root_changed) {
+            context.sink.publish(context.sink.context, .overflow);
+            if (comptime builtin.os.tag == .macos) {
+                const restart: std.c.dispatch.semaphore_t = @ptrCast(@alignCast(context.restart orelse return));
+                _ = restart.signal();
+            }
+            return;
+        }
+        if (flags.must_scan_sub_dirs or flags.user_dropped or flags.kernel_dropped or
+            flags.event_ids_wrapped or flags.mount or flags.unmount)
+        {
+            context.sink.publish(context.sink.context, .overflow);
+            return;
+        }
+        saw_dirty = true;
+    }
+    if (saw_dirty) context.sink.publish(context.sink.context, .dirty);
+}
+
+const Symbols = struct {
+    FSEventStreamCreate: *const fn (
+        allocator: CFAllocatorRef,
+        callback: FSEventStreamCallback,
+        context: ?*const FSEventStreamContext,
+        paths: CFArrayRef,
+        since_when: FSEventStreamEventId,
+        latency: f64,
+        flags: FSEventStreamCreateFlags,
+    ) callconv(.c) ?FSEventStreamRef,
+    FSEventStreamSetDispatchQueue: *const fn (stream: FSEventStreamRef, queue: std.c.dispatch.queue_t) callconv(.c) void,
+    FSEventStreamStart: *const fn (stream: FSEventStreamRef) callconv(.c) bool,
+    FSEventStreamStop: *const fn (stream: FSEventStreamRef) callconv(.c) void,
+    FSEventStreamInvalidate: *const fn (stream: FSEventStreamRef) callconv(.c) void,
+    FSEventStreamRelease: *const fn (stream: FSEventStreamRef) callconv(.c) void,
+    CFRelease: *const fn (value: *const anyopaque) callconv(.c) void,
+    CFArrayCreate: *const fn (
+        allocator: CFAllocatorRef,
+        values: [*]const ?*const anyopaque,
+        count: isize,
+        callbacks: ?*const anyopaque,
+    ) callconv(.c) ?CFArrayRef,
+    CFStringCreateWithCString: *const fn (
+        allocator: CFAllocatorRef,
+        value: [*:0]const u8,
+        encoding: CFStringEncoding,
+    ) callconv(.c) ?CFStringRef,
+};
+
+const CFAllocatorRef = ?*const opaque {};
+const CFArrayRef = *const opaque {};
+const CFStringRef = *const opaque {};
+const CFStringEncoding = enum(u32) { utf8 = 0x08000100 };
+const CFIndex = isize;
+const CFAllocatorRetainCallBack = *const fn (info: ?*const anyopaque) callconv(.c) *const anyopaque;
+const CFAllocatorReleaseCallBack = *const fn (info: ?*const anyopaque) callconv(.c) void;
+const CFAllocatorCopyDescriptionCallBack = *const fn (info: ?*const anyopaque) callconv(.c) CFStringRef;
+
+const FSEventStreamRef = *opaque {};
+const ConstFSEventStreamRef = *const @typeInfo(FSEventStreamRef).pointer.child;
+const FSEventStreamCallback = *const fn (
+    stream: ConstFSEventStreamRef,
+    context: ?*anyopaque,
+    event_count: usize,
+    event_paths: *anyopaque,
+    event_flags: [*]const FSEventStreamEventFlags,
+    event_ids: [*]const FSEventStreamEventId,
+) callconv(.c) void;
+const FSEventStreamContext = extern struct {
+    version: CFIndex,
+    info: ?*anyopaque,
+    retain: ?CFAllocatorRetainCallBack,
+    release: ?CFAllocatorReleaseCallBack,
+    copy_description: ?CFAllocatorCopyDescriptionCallBack,
+};
+const FSEventStreamEventId = enum(u64) {
+    since_now = std.math.maxInt(u64),
+    _,
+};
+const FSEventStreamCreateFlags = packed struct(u32) {
+    use_cf_types: bool = false,
+    no_defer: bool = false,
+    watch_root: bool = false,
+    ignore_self: bool = false,
+    file_events: bool = false,
+    _: u27 = 0,
+};
+const FSEventStreamEventFlags = packed struct(u32) {
+    must_scan_sub_dirs: bool = false,
+    user_dropped: bool = false,
+    kernel_dropped: bool = false,
+    event_ids_wrapped: bool = false,
+    history_done: bool = false,
+    root_changed: bool = false,
+    mount: bool = false,
+    unmount: bool = false,
+    _: u24 = 0,
+};
+
+test "overflow-class FSEvent flags dominate a dirty batch" {
+    const TestSink = struct {
+        fn publish(raw: *anyopaque, signal: Signal) void {
+            const result: *Signal = @ptrCast(@alignCast(raw));
+            result.* = signal;
+        }
+    };
+    var result: Signal = .dirty;
+    var context: CallbackContext = .{
+        .sink = .{ .context = &result, .publish = TestSink.publish },
+        .restart = null,
+    };
+    const flags = [_]FSEventStreamEventFlags{
+        .{},
+        .{ .kernel_dropped = true },
+    };
+    const ids = [_]FSEventStreamEventId{ @enumFromInt(1), @enumFromInt(2) };
+    var unused_paths: u8 = 0;
+    eventCallback(undefined, &context, flags.len, &unused_paths, &flags, &ids);
+    try std.testing.expectEqual(Signal.overflow, result);
+}

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -19,6 +19,7 @@ extern "c" fn system(command: [*:0]const u8) c_int;
 const native_sdk = @import("native_sdk");
 const hook_server = @import("hook_server.zig");
 const hook_runner = @import("hook_runner.zig");
+const session_reconcile = @import("session_reconcile.zig");
 const agent_hooks = @import("agent_hooks.zig");
 const dsh_integration = @import("dsh_integration.zig");
 const plat = @import("plat.zig");
@@ -2141,6 +2142,9 @@ pub fn boot(model: *Model, fx: *Effects) void {
         }
         hook_server.start(boot_allocator, home) catch |err| {
             std.debug.print("petdex: hook server failed to start ({s})\n", .{@errorName(err)});
+        };
+        session_reconcile.start(boot_allocator, home) catch |err| {
+            std.debug.print("petdex: local session recovery failed to start ({s})\n", .{@errorName(err)});
         };
         startRemotes(model, fx);
     }
@@ -5036,6 +5040,16 @@ pub fn main(init: std.process.Init) !void {
     agent_hooks.env_qoder_cn_cli_home = init.environ_map.get("QODERCN_CLI_HOME");
     agent_hooks.env_hermes_home = init.environ_map.get("HERMES_HOME");
     dsh_integration.env_dsh_home = init.environ_map.get("DSH_HOME");
+    session_reconcile.env_claude_config_dir = init.environ_map.get("CLAUDE_CONFIG_DIR");
+    session_reconcile.env_kimi_code_home = init.environ_map.get("KIMI_CODE_HOME");
+    session_reconcile.env_kimi_share_dir = init.environ_map.get("KIMI_SHARE_DIR");
+    session_reconcile.env_pi_coding_agent_dir = init.environ_map.get("PI_CODING_AGENT_DIR");
+    session_reconcile.env_xdg_data_home = init.environ_map.get("XDG_DATA_HOME");
+    session_reconcile.env_qoder_config_dir = init.environ_map.get("QODER_CONFIG_DIR");
+    session_reconcile.env_qoder_cn_config_dir = init.environ_map.get("QODERCN_CONFIG_DIR");
+    session_reconcile.env_qoder_cli_home = init.environ_map.get("QODER_CLI_HOME");
+    session_reconcile.env_qoder_cn_cli_home = init.environ_map.get("QODERCN_CLI_HOME");
+    session_reconcile.env_hermes_home = init.environ_map.get("HERMES_HOME");
     // Hook hot path: `<binary> bubble <phase> [agent]` runs the
     // in-binary runner and exits before any UI machinery spins up.
     // initAllocator, not init: on Windows the command line arrives as
@@ -5467,6 +5481,7 @@ test {
     _ = agent_hooks;
     _ = hook_runner;
     _ = hook_server;
+    _ = session_reconcile;
     _ = installer;
     _ = plat;
     _ = remote_agents;

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -4067,7 +4067,14 @@ fn expireBubbles(model: *Model, now_ms: i64) bool {
         if (bubbleLifetimeExpired(model.bubble_expires_at_ms[i], now_ms, model.state)) {
             // Tell the server too: a slot the app stopped drawing must
             // not keep a session alive against the eviction policy.
-            hook_server.mailbox.dropBubble(model.bubbles[i].sessionSlice());
+            const expired = &model.bubbles[i];
+            hook_server.mailbox.dropBubbleIdentity(
+                expired.sessionSlice(),
+                expired.agent[0..expired.agent_len],
+                expired.hostnameSlice(),
+                expired.remote,
+                true,
+            );
             dropped = true;
             continue;
         }
@@ -4093,7 +4100,7 @@ fn syncBubbleDeadlines(model: *Model, previous: []const hook_server.Bubble, prev
         const fresh = bubbleExpiryMs(now_ms, model.bubble_lifetime_secs, model.bubbles[i].busy);
         model.bubble_expires_at_ms[i] = fresh;
         for (previous, previous_deadlines) |old, deadline| {
-            if (!std.mem.eql(u8, old.sessionSlice(), model.bubbles[i].sessionSlice())) continue;
+            if (!old.sameIdentity(&model.bubbles[i])) continue;
             if (old.counter == model.bubbles[i].counter) model.bubble_expires_at_ms[i] = deadline;
             break;
         }
@@ -6649,6 +6656,31 @@ test "expiry drops only the bubbles past their deadline" {
     try std.testing.expect(!expireBubbles(&model, 6000));
 }
 
+test "expiry drops only the matching agent and remote host" {
+    hook_server.mailbox.clearBubbles();
+    defer hook_server.mailbox.clearBubbles();
+    _ = hook_server.mailbox.setBubbleWithContext("shared", "Host A", "codex", "", .none, "", "", "host-a", "", true, false);
+    _ = hook_server.mailbox.setBubbleWithContext("shared", "Host B", "codex", "", .none, "", "", "host-b", "", true, false);
+    // Updating A leaves it in the first mailbox slot but makes B the oldest
+    // rendered card after the consumer's counter sort.
+    _ = hook_server.mailbox.setBubbleWithContext("shared", "Host A newest", "codex", "", .none, "", "", "host-a", "", true, false);
+
+    var drained: [hook_server.max_bubbles]hook_server.Bubble = @splat(.{});
+    const count = hook_server.mailbox.takeBubbles(&drained).?;
+    try std.testing.expectEqual(@as(usize, 2), count);
+    sortBubblesByCounter(drained[0..count]);
+    try std.testing.expectEqualStrings("host-b", drained[0].hostnameSlice());
+
+    var model: Model = .{};
+    @memcpy(model.bubbles[0..count], drained[0..count]);
+    model.bubbles_len = count;
+    model.bubble_expires_at_ms[0] = 5_000;
+    model.bubble_expires_at_ms[1] = 9_000;
+    try std.testing.expect(expireBubbles(&model, 6_000));
+    try std.testing.expectEqual(@as(usize, 1), hook_server.mailbox.bubbles_len);
+    try std.testing.expectEqualStrings("host-a", hook_server.mailbox.bubbles[0].hostnameSlice());
+}
+
 test "an unchanged bubble keeps its deadline when another one updates" {
     var model: Model = .{};
     model.bubble_lifetime_secs = 5;
@@ -6662,4 +6694,36 @@ test "an unchanged bubble keeps its deadline when another one updates" {
     syncBubbleDeadlines(&model, previous[0..2], previous_deadlines[0..2], 10_000);
     try std.testing.expectEqual(@as(i64, 4000), model.bubble_expires_at_ms[0]);
     try std.testing.expectEqual(@as(i64, 15_000), model.bubble_expires_at_ms[1]);
+}
+
+test "deadline reconciliation matches the full bubble identity" {
+    var model: Model = .{};
+    model.bubble_lifetime_secs = 5;
+    testPushBubble(&model, "shared", "Host A", false, 4_000);
+    testPushBubble(&model, "shared", "Host B", false, 5_000);
+    testPushBubble(&model, "shared", "Hermes A", false, 6_000);
+    const identities = [_]struct { agent: []const u8, hostname: []const u8 }{
+        .{ .agent = "codex", .hostname = "host-a" },
+        .{ .agent = "codex", .hostname = "host-b" },
+        .{ .agent = "hermes", .hostname = "host-a" },
+    };
+    for (identities, 0..) |identity, i| {
+        model.bubbles[i].agent_len = identity.agent.len;
+        @memcpy(model.bubbles[i].agent[0..identity.agent.len], identity.agent);
+        model.bubbles[i].hostname_len = identity.hostname.len;
+        @memcpy(model.bubbles[i].hostname[0..identity.hostname.len], identity.hostname);
+        model.bubbles[i].remote = true;
+    }
+    const previous = model.bubbles;
+    const previous_deadlines = model.bubble_expires_at_ms;
+
+    // A fresh mailbox drain may arrive in a different order from the prior
+    // rendered stack. Each unchanged sibling must retain its own lease.
+    model.bubbles[0] = previous[2];
+    model.bubbles[1] = previous[1];
+    model.bubbles[2] = previous[0];
+    syncBubbleDeadlines(&model, previous[0..3], previous_deadlines[0..3], 10_000);
+    try std.testing.expectEqual(@as(i64, 6_000), model.bubble_expires_at_ms[0]);
+    try std.testing.expectEqual(@as(i64, 5_000), model.bubble_expires_at_ms[1]);
+    try std.testing.expectEqual(@as(i64, 4_000), model.bubble_expires_at_ms[2]);
 }

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -1948,6 +1948,7 @@ fn registerFlockFrames(fx: *Effects) void {
 
 const poll_timer_key: u64 = 2;
 const poll_interval_ms: u32 = 100;
+const stale_running_grace_ms: i64 = 30_000;
 const min_dwell_ms: u32 = 250;
 
 /// Transient states whose duration is intrinsic to the animation;
@@ -3166,6 +3167,7 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             if (!model.sheet_loaded) return;
             if (model.settings_open and thumbs_built < catalog_mod.catalog_len) buildNextThumb(fx);
             const now = fx.wallMs();
+            _ = hook_server.mailbox.suppressStaleRunning(now, stale_running_grace_ms);
             var drained: [hook_server.max_bubbles]hook_server.Bubble = undefined;
             if (hook_server.mailbox.takeBubbles(&drained)) |raw_count| {
                 if (model.settings_open) {

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -2141,13 +2141,19 @@ pub fn boot(model: *Model, fx: *Effects) void {
         if (migration.failed > 0) {
             std.debug.print("petdex: {d} legacy hook configuration(s) could not be migrated; repair the config and update the affected agent in Settings\n", .{migration.failed});
         }
-        hook_server.start(boot_allocator, home) catch |err| {
+        var owns_hook_listener = false;
+        if (hook_server.start(boot_allocator, home)) |result| {
+            owns_hook_listener = result.ownsListener();
+        } else |err| {
             std.debug.print("petdex: hook server failed to start ({s})\n", .{@errorName(err)});
-        };
+        }
         session_reconcile.start(boot_allocator, home) catch |err| {
             std.debug.print("petdex: local session recovery failed to start ({s})\n", .{@errorName(err)});
         };
-        startRemotes(model, fx);
+        // Remote credentials live in the hook listener's process-local
+        // registry. A secondary desktop forwarding to the first process must
+        // not supervise tunnels with credentials that listener cannot know.
+        if (owns_hook_listener) startRemotes(model, fx);
     }
     loadAuthSession(model, fx);
     fx.startTimer(.{

--- a/packages/petdex-desktop-native/src/plat.zig
+++ b/packages/petdex-desktop-native/src/plat.zig
@@ -22,7 +22,226 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
+const macos_fsevents = @import("macos_fsevents.zig");
 
+pub const DirectoryWatchSignal = enum { none, dirty, overflow };
+
+/// A bounded, coalescing directory-change signal. Native backends report only
+/// that reconciliation work is needed; the reconciliation layer remains the
+/// source of truth and performs bounded scans. Queue overflow deliberately
+/// collapses to one stronger signal instead of retaining unbounded paths.
+pub const DirectoryWatch = struct {
+    const max_path = 1024;
+    const linux_max_dirs = 512;
+    path: [max_path]u8 = @splat(0),
+    path_len: usize = 0,
+    dirty: std.atomic.Value(bool) = .init(false),
+    overflow: std.atomic.Value(bool) = .init(false),
+    cursor: std.atomic.Value(u64) = .init(0),
+    failures: std.atomic.Value(u8) = .init(0),
+
+    pub fn init(path: []const u8) ?DirectoryWatch {
+        if (path.len == 0 or path.len > max_path or !std.unicode.utf8ValidateSlice(path)) return null;
+        var result: DirectoryWatch = .{};
+        result.path_len = path.len;
+        @memcpy(result.path[0..path.len], path);
+        return result;
+    }
+
+    pub fn start(self: *DirectoryWatch) bool {
+        const thread = std.Thread.spawn(.{}, watchThread, .{self}) catch return false;
+        thread.detach();
+        return true;
+    }
+
+    pub fn root(self: *const DirectoryWatch) []const u8 {
+        return self.path[0..self.path_len];
+    }
+
+    pub fn take(self: *DirectoryWatch) DirectoryWatchSignal {
+        if (self.overflow.swap(false, .acq_rel)) {
+            _ = self.dirty.swap(false, .acq_rel);
+            return .overflow;
+        }
+        return if (self.dirty.swap(false, .acq_rel)) .dirty else .none;
+    }
+
+    fn publish(self: *DirectoryWatch, signal: DirectoryWatchSignal) void {
+        switch (signal) {
+            .none => return,
+            .dirty => self.dirty.store(true, .release),
+            .overflow => self.overflow.store(true, .release),
+        }
+        _ = self.cursor.fetchAdd(1, .acq_rel);
+    }
+
+    fn watchThread(self: *DirectoryWatch) void {
+        var delay_ms: i64 = 250;
+        while (true) {
+            self.backendLoop() catch {
+                const prior = self.failures.load(.acquire);
+                const count = prior +| 1;
+                self.failures.store(count, .release);
+                delay_ms = directoryWatchBackoff(count);
+                self.publish(.overflow);
+                var scope = Scope.init();
+                std.Io.sleep(scope.io(), std.Io.Duration.fromMilliseconds(delay_ms), .awake) catch {};
+                scope.deinit();
+                continue;
+            };
+            delay_ms = 250;
+        }
+    }
+
+    fn backendLoop(self: *DirectoryWatch) !void {
+        return switch (builtin.os.tag) {
+            .windows => self.windowsLoop(),
+            .linux => self.linuxLoop(),
+            .macos => self.fseventsLoop(),
+            else => error.UnsupportedDirectoryWatch,
+        };
+    }
+
+    fn windowsLoop(self: *DirectoryWatch) !void {
+        const windows = std.os.windows;
+        const path_w = try std.unicode.utf8ToUtf16LeAllocZ(std.heap.page_allocator, self.path[0..self.path_len]);
+        defer std.heap.page_allocator.free(path_w);
+        const handle = CreateFileW(path_w.ptr, 0x0001, 0x00000001 | 0x00000002 | 0x00000004, null, 3, 0x02000000, null);
+        if (handle == windows.INVALID_HANDLE_VALUE) return error.OpenDirectoryWatchFailed;
+        defer windows.CloseHandle(handle);
+        var buffer: [64 * 1024]u8 align(@alignOf(u32)) = undefined;
+        while (true) {
+            var bytes: windows.DWORD = 0;
+            if (ReadDirectoryChangesW(handle, &buffer, buffer.len, windows.BOOL.TRUE, 0x00000001 | 0x00000002 | 0x00000008 | 0x00000010 | 0x00000020, &bytes, null, null) == .FALSE) return error.DirectoryWatchReadFailed;
+            self.failures.store(0, .release);
+            self.publish(if (bytes == 0) .overflow else .dirty);
+        }
+    }
+
+    fn linuxAddTree(self: *DirectoryWatch, io: std.Io, fd: std.posix.fd_t, path: []const u8, depth: u8, count: *usize) void {
+        if (depth > 12 or count.* >= linux_max_dirs) {
+            self.publish(.overflow);
+            return;
+        }
+        const path_z = std.heap.page_allocator.dupeZ(u8, path) catch {
+            self.publish(.overflow);
+            return;
+        };
+        defer std.heap.page_allocator.free(path_z);
+        const mask = std.os.linux.IN.CLOSE_WRITE | std.os.linux.IN.CREATE | std.os.linux.IN.DELETE |
+            std.os.linux.IN.MOVED_FROM | std.os.linux.IN.MOVED_TO | std.os.linux.IN.DELETE_SELF | std.os.linux.IN.MOVE_SELF;
+        const add_result = std.os.linux.inotify_add_watch(fd, path_z, mask);
+        if (std.posix.errno(add_result) != .SUCCESS) {
+            self.publish(.overflow);
+            return;
+        }
+        count.* += 1;
+        var dir = std.Io.Dir.openDirAbsolute(io, path, .{ .iterate = true }) catch {
+            self.publish(.overflow);
+            return;
+        };
+        defer dir.close(io);
+        var it = dir.iterate();
+        while (it.next(io) catch null) |entry| {
+            if (entry.kind != .directory) continue;
+            if (count.* >= linux_max_dirs) {
+                self.publish(.overflow);
+                continue;
+            }
+            const child = std.fs.path.join(std.heap.page_allocator, &.{ path, entry.name }) catch {
+                self.publish(.overflow);
+                continue;
+            };
+            defer std.heap.page_allocator.free(child);
+            self.linuxAddTree(io, fd, child, depth + 1, count);
+        }
+    }
+
+    fn linuxLoop(self: *DirectoryWatch) !void {
+        var scope = Scope.init();
+        defer scope.deinit();
+        const io = scope.io();
+        const init_result = std.os.linux.inotify_init1(std.os.linux.IN.CLOEXEC);
+        if (std.posix.errno(init_result) != .SUCCESS) return error.InotifyInitFailed;
+        const fd: std.posix.fd_t = @intCast(init_result);
+        defer std.Io.Threaded.closeFd(fd);
+        var count: usize = 0;
+        self.linuxAddTree(io, fd, self.path[0..self.path_len], 0, &count);
+        if (count == 0) return error.InotifyWatchFailed;
+        var buffer: [16 * 1024]u8 align(@alignOf(std.os.linux.inotify_event)) = undefined;
+        while (true) {
+            const used = try std.posix.read(fd, &buffer);
+            var offset: usize = 0;
+            var overflowed = false;
+            while (offset + @sizeOf(std.os.linux.inotify_event) <= used) {
+                const event: *align(1) const std.os.linux.inotify_event = @ptrCast(buffer[offset..].ptr);
+                if (event.mask & std.os.linux.IN.Q_OVERFLOW != 0) overflowed = true;
+                const next = @sizeOf(std.os.linux.inotify_event) + event.len;
+                if (next == 0 or offset + next > used) break;
+                offset += next;
+            }
+            self.failures.store(0, .release);
+            self.publish(if (overflowed) .overflow else .dirty);
+            count = 0;
+            self.linuxAddTree(io, fd, self.path[0..self.path_len], 0, &count);
+        }
+    }
+
+    fn fseventsPublish(raw: *anyopaque, signal: macos_fsevents.Signal) void {
+        const self: *DirectoryWatch = @ptrCast(@alignCast(raw));
+        self.failures.store(0, .release);
+        self.publish(switch (signal) {
+            .dirty => .dirty,
+            .overflow => .overflow,
+        });
+    }
+
+    fn fseventsLoop(self: *DirectoryWatch) !void {
+        return macos_fsevents.run(self.path[0..self.path_len], .{
+            .context = self,
+            .publish = fseventsPublish,
+        });
+    }
+};
+
+fn directoryWatchBackoff(failures: u8) i64 {
+    const shift: u6 = @intCast(@min(failures, 7));
+    return @min(@as(i64, 30_000), @as(i64, 250) << shift);
+}
+
+test "directory watch signals coalesce overflow and bound retry backoff" {
+    var watch = DirectoryWatch.init("safe-root").?;
+    watch.publish(.dirty);
+    watch.publish(.dirty);
+    try std.testing.expectEqual(DirectoryWatchSignal.dirty, watch.take());
+    try std.testing.expectEqual(DirectoryWatchSignal.none, watch.take());
+    watch.publish(.dirty);
+    watch.publish(.overflow);
+    try std.testing.expectEqual(DirectoryWatchSignal.overflow, watch.take());
+    try std.testing.expectEqual(DirectoryWatchSignal.none, watch.take());
+    try std.testing.expectEqual(@as(i64, 500), directoryWatchBackoff(1));
+    try std.testing.expectEqual(@as(i64, 30_000), directoryWatchBackoff(20));
+}
+
+extern "kernel32" fn CreateFileW(
+    name: [*:0]const u16,
+    access: std.os.windows.DWORD,
+    share: std.os.windows.DWORD,
+    security: ?*anyopaque,
+    creation: std.os.windows.DWORD,
+    flags: std.os.windows.DWORD,
+    template: ?std.os.windows.HANDLE,
+) callconv(.winapi) std.os.windows.HANDLE;
+extern "kernel32" fn ReadDirectoryChangesW(
+    directory: std.os.windows.HANDLE,
+    buffer: *anyopaque,
+    buffer_len: std.os.windows.DWORD,
+    subtree: std.os.windows.BOOL,
+    filter: std.os.windows.DWORD,
+    bytes: *std.os.windows.DWORD,
+    overlapped: ?*anyopaque,
+    completion: ?*anyopaque,
+) callconv(.winapi) std.os.windows.BOOL;
 /// One Io per calling thread. Cheap to build (no worker threads spin
 /// up until an async call asks for them) and never shared, so the
 /// blocking helpers below are safe from any thread.
@@ -121,6 +340,51 @@ pub fn writeFileMode(path: []const u8, bytes: []const u8, mode: u16) bool {
     return writeFileIo(scope.io(), path, bytes, mode);
 }
 
+/// Append one bounded record and retain one rotated generation. A sibling
+/// advisory lock serializes concurrent hook processes across size, rotation,
+/// and write operations.
+pub fn appendFileModeRotating(path: []const u8, bytes: []const u8, mode: u16, rotate_at: u64) bool {
+    if (bytes.len == 0 or @as(u64, @intCast(bytes.len)) > rotate_at) return false;
+    var scope = Scope.init();
+    defer scope.deinit();
+    const io = scope.io();
+    var cwd = std.Io.Dir.cwd();
+
+    var lock_path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}.lock", .{path}) catch return false;
+    var lock_file = cwd.createFile(io, lock_path, .{
+        .read = true,
+        .truncate = false,
+        .lock = .exclusive,
+        .permissions = permissionsFromMode(mode),
+    }) catch return false;
+    defer lock_file.close(io);
+
+    var current_size: u64 = 0;
+    if (cwd.statFile(io, path, .{})) |stat| {
+        if (stat.kind != .file) return false;
+        current_size = stat.size;
+    } else |_| {}
+
+    if (current_size + @as(u64, @intCast(bytes.len)) > rotate_at) {
+        var previous_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+        const previous = std.fmt.bufPrint(&previous_buf, "{s}.1", .{path}) catch return false;
+        cwd.deleteFile(io, previous) catch {};
+        cwd.rename(path, cwd, previous, io) catch return false;
+        current_size = 0;
+    }
+
+    var file = cwd.createFile(io, path, .{
+        .read = true,
+        .truncate = false,
+        .permissions = permissionsFromMode(mode),
+    }) catch return false;
+    defer file.close(io);
+    file.writePositionalAll(io, bytes, current_size) catch return false;
+    file.sync(io) catch return false;
+    return true;
+}
+
 fn writeFileIo(io: std.Io, path: []const u8, bytes: []const u8, mode: ?u16) bool {
     // Replacing a symlink path atomically replaces the link itself. Runtime
     // files are user-managed, and a symlink is a supported way to relocate
@@ -160,6 +424,22 @@ fn permissionsFromMode(mode: ?u16) std.Io.File.Permissions {
     const m = mode orelse return .default_file;
     if (builtin.os.tag == .windows) return .default_file;
     return @enumFromInt(m);
+}
+
+test "rotating append retains one private previous generation" {
+    const dir = ".zig-cache/petdex-plat-append";
+    const path = dir ++ "/journal.jsonl";
+    makeDir(dir);
+    deleteFile(path);
+    deleteFile(path ++ ".1");
+    deleteFile(path ++ ".lock");
+    try std.testing.expect(appendFileModeRotating(path, "one\n", 0o600, 9));
+    try std.testing.expect(appendFileModeRotating(path, "two\n", 0o600, 9));
+    try std.testing.expect(appendFileModeRotating(path, "three\n", 0o600, 9));
+    var current_buf: [32]u8 = undefined;
+    var prior_buf: [32]u8 = undefined;
+    try std.testing.expectEqualStrings("three\n", readFile(path, &current_buf).?);
+    try std.testing.expectEqualStrings("one\ntwo\n", readFile(path ++ ".1", &prior_buf).?);
 }
 
 pub fn makeDir(path: []const u8) void {
@@ -445,6 +725,14 @@ pub fn nowMs() i64 {
     return @intCast(@divTrunc(ns, std.time.ns_per_ms));
 }
 
+/// Process-local monotonic time for leases, rate limits, and deadlines.
+pub fn monotonicMs() i64 {
+    var scope = Scope.init();
+    defer scope.deinit();
+    const ns = std.Io.Timestamp.now(scope.io(), .boot).nanoseconds;
+    return @intCast(@divTrunc(ns, std.time.ns_per_ms));
+}
+
 pub fn nowSeconds() i64 {
     return @divTrunc(nowMs(), 1000);
 }
@@ -551,6 +839,32 @@ pub fn processId() u32 {
     };
 }
 
+/// Short machine name for session provenance. Invalid or unavailable host
+/// metadata is ignored by the caller.
+pub fn hostName(buf: []u8) ?[]const u8 {
+    if (comptime builtin.os.tag == .windows) {
+        const Win = struct {
+            extern "kernel32" fn GetComputerNameA(buffer: [*]u8, size: *u32) callconv(.winapi) c_int;
+        };
+        if (buf.len == 0 or buf.len > std.math.maxInt(u32)) return null;
+        var length: u32 = @intCast(buf.len);
+        if (Win.GetComputerNameA(buf.ptr, &length) == 0 or length == 0) return null;
+        const name = buf[0..length];
+        for (name) |ch| {
+            if (!std.ascii.isAlphanumeric(ch) and ch != '-' and ch != '_' and ch != '.') return null;
+        }
+        return name;
+    }
+    var raw: [std.posix.HOST_NAME_MAX]u8 = undefined;
+    const name = std.posix.gethostname(&raw) catch return null;
+    if (name.len == 0 or name.len > buf.len) return null;
+    for (name) |ch| {
+        if (!std.ascii.isAlphanumeric(ch) and ch != '-' and ch != '_' and ch != '.') return null;
+    }
+    @memcpy(buf[0..name.len], name);
+    return buf[0..name.len];
+}
+
 /// GUI application that owns the terminal hosting the latest agent event.
 /// Hook metadata is allowlisted and never becomes an arbitrary bundle id.
 pub const OriginApplication = enum(u8) {
@@ -561,21 +875,24 @@ pub const OriginApplication = enum(u8) {
     /// terminal rows this is intentionally not a bundle identifier: the
     /// active HTTP handler is resolved at click time on macOS.
     default_browser,
+    codex,
 
     pub fn fromTermProgram(value: ?[]const u8) OriginApplication {
         const name = value orelse return .none;
-        if (std.mem.eql(u8, name, "Apple_Terminal")) return .terminal;
-        if (std.mem.eql(u8, name, "vscode")) return .vscode;
-        if (std.mem.eql(u8, name, "default_browser")) return .default_browser;
+        if (std.mem.eql(u8, name, "Apple_Terminal") or std.ascii.eqlIgnoreCase(name, "Windows_Terminal") or std.ascii.eqlIgnoreCase(name, "WindowsTerminal")) return .terminal;
+        if (std.ascii.eqlIgnoreCase(name, "vscode") or std.ascii.eqlIgnoreCase(name, "Visual Studio Code")) return .vscode;
+        if (std.ascii.eqlIgnoreCase(name, "default_browser")) return .default_browser;
+        if (std.ascii.eqlIgnoreCase(name, "codex") or std.ascii.eqlIgnoreCase(name, "ChatGPT")) return .codex;
         return .none;
     }
 
     pub fn wireName(self: OriginApplication) []const u8 {
         return switch (self) {
             .none => "",
-            .terminal => "Apple_Terminal",
+            .terminal => if (builtin.os.tag == .windows) "Windows_Terminal" else "Apple_Terminal",
             .vscode => "vscode",
             .default_browser => "default_browser",
+            .codex => "codex",
         };
     }
 
@@ -585,9 +902,18 @@ pub const OriginApplication = enum(u8) {
             .terminal => "com.apple.Terminal",
             .vscode => "com.microsoft.VSCode",
             .default_browser => null,
+            .codex => "com.openai.codex",
         };
     }
 };
+
+test "origin metadata recognizes allowlisted desktop application hints" {
+    try std.testing.expectEqual(OriginApplication.terminal, OriginApplication.fromTermProgram("Windows_Terminal"));
+    try std.testing.expectEqual(OriginApplication.vscode, OriginApplication.fromTermProgram("Visual Studio Code"));
+    try std.testing.expectEqual(OriginApplication.codex, OriginApplication.fromTermProgram("ChatGPT"));
+    try std.testing.expectEqual(OriginApplication.none, OriginApplication.fromTermProgram("untrusted.exe"));
+    try std.testing.expectEqualStrings("com.openai.codex", OriginApplication.codex.bundleIdentifier().?);
+}
 
 pub const BrowserActivation = enum {
     unsupported,
@@ -649,12 +975,28 @@ pub fn safeSourceTty(value: ?[]const u8) ?[]const u8 {
 
 pub fn safeSourceCwd(value: ?[]const u8) ?[]const u8 {
     const cwd = value orelse return null;
-    if (cwd.len == 0 or cwd.len > 511 or cwd[0] != '/') return null;
+    if (cwd.len == 0 or cwd.len > 511) return null;
+    const absolute = if (builtin.os.tag == .windows)
+        (cwd.len >= 3 and std.ascii.isAlphabetic(cwd[0]) and cwd[1] == ':' and (cwd[2] == '/' or cwd[2] == '\\')) or
+            (cwd.len >= 3 and (std.mem.startsWith(u8, cwd, "//") or std.mem.startsWith(u8, cwd, "\\\\")))
+    else
+        cwd[0] == '/';
+    if (!absolute) return null;
     if (!std.unicode.utf8ValidateSlice(cwd)) return null;
     for (cwd) |ch| {
-        if (ch < 0x20 or ch == '"' or ch == '\\') return null;
+        if (ch < 0x20 or ch == '"' or (builtin.os.tag != .windows and ch == '\\')) return null;
     }
     return cwd;
+}
+
+test "source cwd accepts only native absolute paths" {
+    if (builtin.os.tag == .windows) {
+        try std.testing.expectEqualStrings("C:\\work\\petdex", safeSourceCwd("C:\\work\\petdex").?);
+        try std.testing.expectEqualStrings("\\\\server\\share", safeSourceCwd("\\\\server\\share").?);
+    } else {
+        try std.testing.expectEqualStrings("/work/petdex", safeSourceCwd("/work/petdex").?);
+        try std.testing.expect(safeSourceCwd("C:\\work\\petdex") == null);
+    }
 }
 
 pub fn safeHerdrPaneId(value: ?[]const u8) ?[]const u8 {

--- a/packages/petdex-desktop-native/src/remote_runtime.zig
+++ b/packages/petdex-desktop-native/src/remote_runtime.zig
@@ -15,6 +15,7 @@ const agent_hooks = @import("agent_hooks.zig");
 const remote_agents = @import("remote_agents.zig");
 const remote_ssh = @import("remote_ssh.zig");
 const remote_writeback = @import("remote_writeback.zig");
+const hook_server = @import("hook_server.zig");
 const plat = @import("plat.zig");
 
 const AgentKind = agent_hooks.AgentKind;
@@ -274,6 +275,7 @@ fn probeAction(slot: *Slot) Action {
 }
 
 fn quiesceAction(slot: *Slot) Action {
+    hook_server.revokeRemoteCredential(slot.nameSlice());
     slot.op = .quiesce;
     slot.tunnel_ready = false;
     slot.sync_complete = false;
@@ -301,11 +303,11 @@ fn fetchAction(slot: *Slot) Action {
 fn tokenAction(slot: *Slot, slot_idx: usize, home: []const u8) Action {
     var path_buf: [512]u8 = undefined;
     const token_path = std.fmt.bufPrint(&path_buf, "{s}/.petdex/runtime/update-token", .{home}) catch return retry(slot, true);
-    const bytes = plat.readFile(token_path, &token_bufs[slot_idx]) orelse return retry(slot, true);
-    if (bytes.len > max_token_len) return retry(slot, true);
-    const trimmed = std.mem.trim(u8, bytes, " \t\r\n");
-    token_lens[slot_idx] = trimmed.len;
-    if (trimmed.len == 0) return retry(slot, true);
+    var probe: [max_token_len + 1]u8 = undefined;
+    const bytes = plat.readFile(token_path, &probe) orelse return retry(slot, true);
+    if (bytes.len > max_token_len or std.mem.trim(u8, bytes, " \t\r\n").len == 0) return retry(slot, true);
+    const scoped = hook_server.issueRemoteCredential(slot.nameSlice(), &token_bufs[slot_idx]) orelse return retry(slot, true);
+    token_lens[slot_idx] = scoped.len;
     slot.op = .token;
     return .{ .spawn = .{ .op = .token, .path = remote_ssh.remote_token_file, .stdin = token_bufs[slot_idx][0..token_lens[slot_idx]] } };
 }
@@ -542,6 +544,7 @@ pub fn onSpawnExitDetailed(slot: *Slot, slot_idx: usize, op: Op, code: i32, outp
         },
         .token => {
             if (code != 0) {
+                hook_server.revokeRemoteCredential(slot.nameSlice());
                 std.debug.print("petdex: remote '{s}': token gate open failed (ssh exit {d}); retrying\n", .{ slot.nameSlice(), code });
                 return retry(slot, true);
             }
@@ -555,6 +558,7 @@ pub fn onSpawnExitDetailed(slot: *Slot, slot_idx: usize, op: Op, code: i32, outp
             return tokenAction(slot, slot_idx, home);
         },
         .tunnel => {
+            hook_server.revokeRemoteCredential(slot.nameSlice());
             // Any tunnel exit is a reconnect: ssh only exits when the
             // connection dropped (ExitOnForwardFailure makes a taken
             // port a fast exit too).
@@ -860,7 +864,8 @@ test "driver gates feed until tunnel-ready patch pass completes" {
     try t.expect(act == .spawn and act.spawn.op == .watcher);
     act = onSpawnExit(&slot, idx, .watcher, 0, "", home);
     try t.expect(act == .spawn and act.spawn.op == .token);
-    try t.expectEqualStrings("tok-abc", act.spawn.stdin);
+    try t.expect(std.mem.startsWith(u8, act.spawn.stdin, "remote:rogue:"));
+    try t.expectEqual(@as(usize, "remote:rogue:".len + 64), act.spawn.stdin.len);
     act = onSpawnExit(&slot, idx, .token, 0, "", home);
     try t.expect(act == .none);
     try t.expect(slot.tunnel_ready);

--- a/packages/petdex-desktop-native/src/remote_ssh.zig
+++ b/packages/petdex-desktop-native/src/remote_ssh.zig
@@ -44,6 +44,8 @@ pub const remote_hook_script = "~/.petdex/bin/petdex-hook";
 pub const remote_codex_watcher = "~/.petdex/bin/petdex-codex-watch";
 pub const remote_hermes_watcher = "~/.petdex/bin/petdex-hermes-watch";
 pub const remote_token_file = "~/.petdex/runtime/update-token";
+/// Configured remote name embedded in the scoped credential. Every helper
+/// publishes this principal instead of the machine's unrelated OS hostname.
 pub const remote_host_file = "~/.petdex/runtime/remote-host";
 pub const remote_hermes_home_file = "~/.petdex/runtime/hermes-home";
 pub const remote_lease_file = "~/.petdex/runtime/tunnel-lease";
@@ -96,6 +98,7 @@ pub const Scratch = struct {
     quote_c: [512]u8 = undefined,
     quote_d: [512]u8 = undefined,
     quote_e: [512]u8 = undefined,
+    quote_f: [512]u8 = undefined,
     cmd: [4096]u8 = undefined,
 };
 
@@ -311,7 +314,8 @@ pub fn tokenArgv(buf: *[max_argv][]const u8, scratch: *Scratch, remote: *const R
     const host_file = shQuote(&scratch.quote_c, remote_host_file) orelse return null;
     const hermes_home_file = shQuote(&scratch.quote_d, remote_hermes_home_file) orelse return null;
     const hermes_home = shQuote(&scratch.quote_e, remote.agents.hermes.home orelse remote_agents.default_hermes_home) orelse return null;
-    buf[n] = std.fmt.bufPrint(&scratch.cmd, "umask 077; mkdir -p {s} || exit; tmp=\"$HOME/.petdex/runtime/update-token.tmp.$$\"; trap 'rm -f \"$tmp\"' 0 1 2 15; hermes_home={s}; cat > \"$tmp\" && chmod 600 \"$tmp\" && hostname > {s} && printf '%s\\n' \"$hermes_home\" > {s} && mv -f \"$tmp\" {s}", .{ dir, hermes_home, host_file, hermes_home_file, quoted }) catch return null;
+    const remote_name = shQuote(&scratch.quote_f, remote.name) orelse return null;
+    buf[n] = std.fmt.bufPrint(&scratch.cmd, "umask 077; mkdir -p {s} || exit; tmp=\"$HOME/.petdex/runtime/update-token.tmp.$$\"; trap 'rm -f \"$tmp\"' 0 1 2 15; hermes_home={s}; remote_name={s}; cat > \"$tmp\" && chmod 600 \"$tmp\" && printf '%s\\n' \"$remote_name\" > {s} && printf '%s\\n' \"$hermes_home\" > {s} && mv -f \"$tmp\" {s}", .{ dir, hermes_home, remote_name, host_file, hermes_home_file, quoted }) catch return null;
     return buf[0 .. n + 1];
 }
 
@@ -530,7 +534,8 @@ test "tokenArgv lands the token 0600 under ~/.petdex" {
     const command = argv[argv.len - 1];
     try t.expect(std.mem.indexOf(u8, command, "update-token.tmp.$$") != null);
     try t.expect(std.mem.indexOf(u8, command, "chmod 600") != null);
-    try t.expect(std.mem.indexOf(u8, command, "hostname > \"$HOME\"/'.petdex/runtime/remote-host'") != null);
+    try t.expect(std.mem.indexOf(u8, command, "remote_name='rogue'") != null);
+    try t.expect(std.mem.indexOf(u8, command, "printf '%s\\n' \"$remote_name\" > \"$HOME\"/'.petdex/runtime/remote-host'") != null);
     try t.expect(std.mem.indexOf(u8, command, "mv -f \"$tmp\" \"$HOME\"/'.petdex/runtime/update-token'") != null);
 }
 

--- a/packages/petdex-desktop-native/src/remote_writeback.zig
+++ b/packages/petdex-desktop-native/src/remote_writeback.zig
@@ -341,6 +341,9 @@ test "remote hook preserves Codex conversation metadata and rich updates" {
     try t.expect(std.mem.indexOf(u8, hook_script, "not bool(row.get(\"session_key\"))") != null);
     try t.expect(std.mem.indexOf(u8, hook_script, "[ \"$session_kind\" = \"subagent\" ]") != null);
     try t.expect(std.mem.indexOf(u8, hook_script, "child_summary") != null);
+    // A successful/terminal bubble following a tool failure must overwrite
+    // the exact conversation's temporary failed Flock state.
+    try t.expect(std.mem.indexOf(u8, hook_script, "agent_state=$state") != null);
 }
 
 test "hermes writeback preserves foreign YAML and allowlist entries" {

--- a/packages/petdex-desktop-native/src/session_reconcile.zig
+++ b/packages/petdex-desktop-native/src/session_reconcile.zig
@@ -1,0 +1,2337 @@
+//! Provider-neutral local session reconciliation.
+//!
+//! Hooks and embedded plugins remain the low-latency path. This bounded,
+//! in-process registry recovers their private journal and provider-owned local
+//! stores so sessions that predate Petdex still feed the same mailbox without
+//! a sidecar, Petdex database, Python runtime, cloud call, or state mutation.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const directory_watch = @import("directory_watch.zig");
+const hook_server = @import("hook_server.zig");
+const plat = @import("plat.zig");
+
+const discovery_ms: i64 = 2_000;
+const follow_ms: i64 = 250;
+const provider_discovery_max_ms: i64 = 60_000;
+const provider_discovery_budget_ms: i64 = 20;
+const max_index_bytes: usize = 4 * 1024 * 1024;
+const max_rollout_bytes: usize = 4 * 1024 * 1024;
+const max_meta_bytes: usize = 64 * 1024;
+const max_recent: usize = 32;
+const max_watches: usize = hook_server.max_bubbles;
+const initial_running_max_age_ms: i64 = 15 * 60 * 1_000;
+const max_path_bytes: usize = 1024;
+const max_discovery_entries: usize = 4096;
+const max_directory_watch_roots: usize = 12;
+const journal_version_marker = "\"journal_version\":1";
+
+pub const AdapterCapabilities = packed struct(u8) {
+    explicit_parentage: bool = false,
+    input_correlation: bool = false,
+    authoritative_titles: bool = false,
+    origin_activation: bool = false,
+    subagents: bool = false,
+    _reserved: u3 = 0,
+};
+
+pub const StoreKind = enum { codex_rollout, transcript_json, sqlite, hooks_only };
+
+pub const ProviderSchema = enum { claude, codex, gemini, opencode, qoder, kimi, codebuddy, omp, hermes };
+
+/// Static registry for every local AgentKind. Adapters share scheduling and
+/// lowering but keep provider-specific roots/capabilities explicit so a schema
+/// fallback can never silently masquerade as another provider.
+pub const AgentSessionAdapter = struct {
+    agent: []const u8,
+    schema: ProviderSchema,
+    roots: []const []const u8,
+    store: StoreKind,
+    capabilities: AdapterCapabilities,
+};
+
+const claude_roots = [_][]const u8{".claude/projects"};
+const codex_roots = [_][]const u8{".codex/sessions"};
+const gemini_roots = [_][]const u8{ ".gemini/tmp", ".gemini/sessions" };
+const opencode_roots = [_][]const u8{ ".local/share/opencode/storage", ".opencode/storage" };
+const qoder_roots = [_][]const u8{ ".qoder/projects", ".qoder-cn/projects" };
+const kimi_roots = [_][]const u8{ ".kimi-code", ".kimi" };
+const codebuddy_roots = [_][]const u8{".codebuddy/projects"};
+const omp_roots = [_][]const u8{ ".omp/agent/sessions", ".omp/sessions" };
+const hermes_roots = [_][]const u8{".hermes"};
+
+pub const adapters = [_]AgentSessionAdapter{
+    .{ .agent = "claude-code", .schema = .claude, .roots = &claude_roots, .store = .transcript_json, .capabilities = .{ .origin_activation = true } },
+    .{ .agent = "codex", .schema = .codex, .roots = &codex_roots, .store = .codex_rollout, .capabilities = .{ .explicit_parentage = true, .input_correlation = true, .authoritative_titles = true, .origin_activation = true, .subagents = true } },
+    .{ .agent = "gemini", .schema = .gemini, .roots = &gemini_roots, .store = .transcript_json, .capabilities = .{ .explicit_parentage = true, .authoritative_titles = true, .origin_activation = true, .subagents = true } },
+    // These providers remain fully supported through their installed hooks,
+    // but their durable stores are proprietary or multi-file/SQLite layouts
+    // without a stable versioned contract. Fail closed instead of inventing a
+    // flat transcript vocabulary that can silently misidentify sessions.
+    .{ .agent = "opencode", .schema = .opencode, .roots = &opencode_roots, .store = .hooks_only, .capabilities = .{} },
+    .{ .agent = "qoder", .schema = .qoder, .roots = &qoder_roots, .store = .hooks_only, .capabilities = .{} },
+    .{ .agent = "kimi-code", .schema = .kimi, .roots = &kimi_roots, .store = .hooks_only, .capabilities = .{} },
+    .{ .agent = "codebuddy", .schema = .codebuddy, .roots = &codebuddy_roots, .store = .hooks_only, .capabilities = .{} },
+    .{ .agent = "omp", .schema = .omp, .roots = &omp_roots, .store = .transcript_json, .capabilities = .{ .explicit_parentage = true, .authoritative_titles = true, .origin_activation = true, .subagents = true } },
+    .{ .agent = "hermes", .schema = .hermes, .roots = &hermes_roots, .store = .sqlite, .capabilities = .{ .explicit_parentage = true, .authoritative_titles = true, .subagents = true } },
+};
+
+/// Snapshotted by main alongside the hook installer override. Keeping recovery
+/// on the same resolved Hermes home prevents hooks and state.db from describing
+/// different installations.
+pub var env_hermes_home: ?[]const u8 = null;
+pub var env_claude_config_dir: ?[]const u8 = null;
+pub var env_kimi_code_home: ?[]const u8 = null;
+pub var env_kimi_share_dir: ?[]const u8 = null;
+pub var env_pi_coding_agent_dir: ?[]const u8 = null;
+pub var env_xdg_data_home: ?[]const u8 = null;
+pub var env_qoder_config_dir: ?[]const u8 = null;
+pub var env_qoder_cn_config_dir: ?[]const u8 = null;
+pub var env_qoder_cli_home: ?[]const u8 = null;
+pub var env_qoder_cn_cli_home: ?[]const u8 = null;
+
+const Status = enum { idle, running, needs_input, completed, failed };
+const MessageKind = enum { status, prompt, reasoning, assistant };
+
+const SmallText = struct {
+    bytes: [200]u8 = @splat(0),
+    len: usize = 0,
+
+    fn slice(self: *const SmallText) []const u8 {
+        return self.bytes[0..self.len];
+    }
+
+    fn set(self: *SmallText, value: []const u8) void {
+        self.* = .{};
+        var out: usize = 0;
+        var pending_space = false;
+        for (value) |byte| {
+            if (std.ascii.isWhitespace(byte)) {
+                pending_space = out > 0;
+                continue;
+            }
+            if (pending_space and out < self.bytes.len) {
+                self.bytes[out] = ' ';
+                out += 1;
+            }
+            pending_space = false;
+            if (out == self.bytes.len) break;
+            self.bytes[out] = byte;
+            out += 1;
+        }
+        self.len = out;
+        while (self.len > 0 and !std.unicode.utf8ValidateSlice(self.bytes[0..self.len])) self.len -= 1;
+    }
+};
+
+const TitleText = struct {
+    bytes: [96]u8 = @splat(0),
+    len: usize = 0,
+
+    fn slice(self: *const TitleText) []const u8 {
+        return self.bytes[0..self.len];
+    }
+
+    fn set(self: *TitleText, value: []const u8) void {
+        self.* = .{};
+        var compact: SmallText = .{};
+        compact.set(value);
+        const n = @min(compact.len, self.bytes.len);
+        @memcpy(self.bytes[0..n], compact.bytes[0..n]);
+        self.len = n;
+        while (self.len > 0 and !std.unicode.utf8ValidateSlice(self.bytes[0..self.len])) self.len -= 1;
+    }
+};
+
+const CwdText = struct {
+    bytes: [512]u8 = @splat(0),
+    len: usize = 0,
+
+    fn slice(self: *const CwdText) []const u8 {
+        return self.bytes[0..self.len];
+    }
+
+    fn set(self: *CwdText, value: []const u8) void {
+        self.* = .{};
+        const n = @min(value.len, self.bytes.len);
+        @memcpy(self.bytes[0..n], value[0..n]);
+        self.len = n;
+        while (self.len > 0 and !std.unicode.utf8ValidateSlice(self.bytes[0..self.len])) self.len -= 1;
+    }
+};
+
+test "bounded provider text preserves utf8 boundaries" {
+    var text: SmallText = .{};
+    var input: [202]u8 = @splat('a');
+    input[199] = 0xf0;
+    input[200] = 0x9f;
+    input[201] = 0x98;
+    text.set(&input);
+    try std.testing.expect(std.unicode.utf8ValidateSlice(text.slice()));
+    try std.testing.expectEqual(@as(usize, 199), text.len);
+
+    var title: TitleText = .{};
+    var title_input: [99]u8 = @splat('b');
+    title_input[95] = 0xe2;
+    title_input[96] = 0x82;
+    title_input[97] = 0xac;
+    title_input[98] = '!';
+    title.set(&title_input);
+    try std.testing.expect(std.unicode.utf8ValidateSlice(title.slice()));
+    try std.testing.expectEqual(@as(usize, 95), title.len);
+}
+
+const Pending = struct {
+    active: bool = false,
+    id: [96]u8 = @splat(0),
+    id_len: usize = 0,
+    text: SmallText = .{},
+
+    fn idSlice(self: *const Pending) []const u8 {
+        return self.id[0..self.id_len];
+    }
+};
+
+const RolloutState = struct {
+    status: Status = .idle,
+    text: SmallText = .{},
+    fallback_title: TitleText = .{},
+    cwd: CwdText = .{},
+    message_kind: MessageKind = .status,
+    lifecycle: bool = false,
+    subagent: bool = false,
+    pending: [8]Pending = @splat(.{}),
+
+    fn setPending(self: *RolloutState, id: []const u8, prompt: []const u8) void {
+        var target: ?*Pending = null;
+        for (&self.pending) |*entry| {
+            if (entry.active and std.mem.eql(u8, entry.idSlice(), id)) {
+                target = entry;
+                break;
+            }
+            if (!entry.active and target == null) target = entry;
+        }
+        const entry = target orelse &self.pending[self.pending.len - 1];
+        entry.* = .{ .active = true };
+        entry.id_len = @min(id.len, entry.id.len);
+        @memcpy(entry.id[0..entry.id_len], id[0..entry.id_len]);
+        entry.text.set(prompt);
+    }
+
+    fn resolvePending(self: *RolloutState, id: []const u8) void {
+        for (&self.pending) |*entry| {
+            if (entry.active and std.mem.eql(u8, entry.idSlice(), id)) entry.active = false;
+        }
+    }
+
+    fn newestPending(self: *const RolloutState) ?*const Pending {
+        var newest: ?*const Pending = null;
+        for (&self.pending) |*entry| if (entry.active) {
+            newest = entry;
+        };
+        return newest;
+    }
+};
+
+const Event = struct {
+    status: Status,
+    text: SmallText,
+    title: TitleText,
+    cwd: CwdText,
+    busy: bool,
+
+    fn terminal(self: *const Event) bool {
+        return self.status == .completed or self.status == .failed;
+    }
+
+    fn digest(self: *const Event) u64 {
+        var hash = std.hash.Wyhash.init(0);
+        hash.update(self.text.slice());
+        hash.update(self.title.slice());
+        hash.update(self.cwd.slice());
+        hash.update(&.{ @intFromEnum(self.status), @intFromBool(self.busy) });
+        return hash.final();
+    }
+};
+
+const TitleEntry = struct {
+    session: [64]u8 = @splat(0),
+    session_len: usize = 0,
+    title: TitleText = .{},
+
+    fn sessionSlice(self: *const TitleEntry) []const u8 {
+        return self.session[0..self.session_len];
+    }
+};
+
+const Titles = struct {
+    entries: [max_recent]TitleEntry = @splat(.{}),
+    len: usize = 0,
+
+    fn put(self: *Titles, session: []const u8, title: []const u8) void {
+        var existing: ?usize = null;
+        for (self.entries[0..self.len], 0..) |*entry, index| {
+            if (std.mem.eql(u8, entry.sessionSlice(), session)) existing = index;
+        }
+        if (existing) |index| {
+            std.mem.copyForwards(TitleEntry, self.entries[index .. self.len - 1], self.entries[index + 1 .. self.len]);
+            self.len -= 1;
+        } else if (self.len == self.entries.len) {
+            std.mem.copyForwards(TitleEntry, self.entries[0 .. self.len - 1], self.entries[1..self.len]);
+            self.len -= 1;
+        }
+        var entry: TitleEntry = .{};
+        entry.session_len = @min(session.len, entry.session.len);
+        @memcpy(entry.session[0..entry.session_len], session[0..entry.session_len]);
+        entry.title.set(title);
+        self.entries[self.len] = entry;
+        self.len += 1;
+    }
+
+    fn get(self: *const Titles, session: []const u8) []const u8 {
+        var index = self.len;
+        while (index > 0) {
+            index -= 1;
+            if (std.mem.eql(u8, self.entries[index].sessionSlice(), session)) return self.entries[index].title.slice();
+        }
+        return "";
+    }
+};
+
+const Candidate = struct {
+    session: [64]u8 = @splat(0),
+    session_len: usize = 0,
+    path: [max_path_bytes]u8 = @splat(0),
+    path_len: usize = 0,
+    size: u64 = 0,
+    mtime_ms: i64 = 0,
+
+    fn sessionSlice(self: *const Candidate) []const u8 {
+        return self.session[0..self.session_len];
+    }
+
+    fn pathSlice(self: *const Candidate) []const u8 {
+        return self.path[0..self.path_len];
+    }
+};
+
+const Catalog = struct {
+    entries: [max_recent]Candidate = @splat(.{}),
+    len: usize = 0,
+
+    fn add(self: *Catalog, candidate: Candidate) void {
+        if (self.len < self.entries.len) {
+            self.entries[self.len] = candidate;
+            self.len += 1;
+        } else {
+            var oldest: usize = 0;
+            for (self.entries[1..], 1..) |entry, index| if (entry.mtime_ms < self.entries[oldest].mtime_ms) {
+                oldest = index;
+            };
+            if (candidate.mtime_ms <= self.entries[oldest].mtime_ms) return;
+            self.entries[oldest] = candidate;
+        }
+    }
+
+    fn sortNewest(self: *Catalog) void {
+        var i: usize = 1;
+        while (i < self.len) : (i += 1) {
+            const value = self.entries[i];
+            var j = i;
+            while (j > 0 and value.mtime_ms > self.entries[j - 1].mtime_ms) : (j -= 1) {
+                self.entries[j] = self.entries[j - 1];
+            }
+            self.entries[j] = value;
+        }
+    }
+};
+
+const Watch = struct {
+    used: bool = false,
+    session: [64]u8 = @splat(0),
+    session_len: usize = 0,
+    path: [max_path_bytes]u8 = @splat(0),
+    path_len: usize = 0,
+    size: u64 = 0,
+    mtime_ms: i64 = 0,
+    delivered: u64 = 0,
+    title: TitleText = .{},
+    force: bool = true,
+
+    fn sessionSlice(self: *const Watch) []const u8 {
+        return self.session[0..self.session_len];
+    }
+
+    fn pathSlice(self: *const Watch) []const u8 {
+        return self.path[0..self.path_len];
+    }
+};
+
+const JournalWatch = struct {
+    used: bool = false,
+    path: [max_path_bytes]u8 = @splat(0),
+    path_len: usize = 0,
+    size: u64 = 0,
+    mtime_ms: i64 = 0,
+
+    fn pathSlice(self: *const JournalWatch) []const u8 {
+        return self.path[0..self.path_len];
+    }
+};
+
+const ProviderEvent = struct {
+    status: Status = .idle,
+    text: SmallText = .{},
+    title: TitleText = .{},
+    cwd: CwdText = .{},
+    session: [hook_server.bubble_session_capacity]u8 = @splat(0),
+    session_len: usize = 0,
+    parent: [hook_server.bubble_session_capacity]u8 = @splat(0),
+    parent_len: usize = 0,
+    message_id: [hook_server.bubble_message_id_capacity]u8 = @splat(0),
+    message_id_len: usize = 0,
+    request_id: [hook_server.bubble_message_id_capacity]u8 = @splat(0),
+    request_id_len: usize = 0,
+    resolves_request_id: [hook_server.bubble_message_id_capacity]u8 = @splat(0),
+    resolves_request_id_len: usize = 0,
+    label: [48]u8 = @splat(0),
+    label_len: usize = 0,
+    message_kind: hook_server.MessageKind = .status,
+    title_source: hook_server.TitleSource = .unknown,
+    subagent: bool = false,
+    explicit_lifecycle: bool = false,
+
+    fn sessionSlice(self: *const ProviderEvent) []const u8 {
+        return self.session[0..self.session_len];
+    }
+    fn parentSlice(self: *const ProviderEvent) []const u8 {
+        return self.parent[0..self.parent_len];
+    }
+    fn messageIdSlice(self: *const ProviderEvent) []const u8 {
+        return self.message_id[0..self.message_id_len];
+    }
+    fn requestIdSlice(self: *const ProviderEvent) []const u8 {
+        return self.request_id[0..self.request_id_len];
+    }
+    fn resolvesRequestIdSlice(self: *const ProviderEvent) []const u8 {
+        return self.resolves_request_id[0..self.resolves_request_id_len];
+    }
+    fn labelSlice(self: *const ProviderEvent) []const u8 {
+        return self.label[0..self.label_len];
+    }
+    fn digest(self: *const ProviderEvent) u64 {
+        var hash = std.hash.Wyhash.init(0);
+        hash.update(self.sessionSlice());
+        hash.update(self.parentSlice());
+        hash.update(self.text.slice());
+        hash.update(self.title.slice());
+        hash.update(self.messageIdSlice());
+        hash.update(self.requestIdSlice());
+        hash.update(self.resolvesRequestIdSlice());
+        hash.update(&.{ @intFromEnum(self.status), @intFromBool(self.subagent) });
+        return hash.final();
+    }
+};
+
+const ProviderWatch = struct {
+    used: bool = false,
+    adapter_index: u8 = 0,
+    path: [max_path_bytes]u8 = @splat(0),
+    path_len: usize = 0,
+    size: u64 = 0,
+    mtime_ms: i64 = 0,
+    delivered: u64 = 0,
+
+    fn pathSlice(self: *const ProviderWatch) []const u8 {
+        return self.path[0..self.path_len];
+    }
+};
+
+const HermesSeen = struct {
+    used: bool = false,
+    session: [hook_server.bubble_session_capacity]u8 = @splat(0),
+    session_len: usize = 0,
+    digest: u64 = 0,
+
+    fn sessionSlice(self: *const HermesSeen) []const u8 {
+        return self.session[0..self.session_len];
+    }
+};
+
+const Watcher = struct {
+    allocator: std.mem.Allocator,
+    home: []const u8,
+    watches: [max_watches]Watch = @splat(.{}),
+    journal_watches: [max_recent]JournalWatch = @splat(.{}),
+    provider_watches: [max_recent]ProviderWatch = @splat(.{}),
+    hermes_seen: [max_recent]HermesSeen = @splat(.{}),
+    hermes_initialized: bool = false,
+    hermes_db_stamp: u64 = 0,
+    last_discovery_ms: i64 = 0,
+    directory_scan_pending: bool = false,
+    provider_next_discovery_ms: i64 = 0,
+    provider_discovery_interval_ms: i64 = discovery_ms,
+    provider_adapter_cursor: usize = 0,
+    rollout_scan: DirectoryTraversal = .{},
+    journal_scan: DirectoryTraversal = .{},
+    provider_scans: [adapters.len]ProviderScanCursor = @splat(.{}),
+    directory_changes: [max_directory_watch_roots]?directory_watch.Controller = @splat(null),
+    directory_changes_len: usize = 0,
+};
+
+pub fn start(allocator: std.mem.Allocator, home: []const u8) !void {
+    const watcher = try allocator.create(Watcher);
+    watcher.* = .{ .allocator = allocator, .home = try allocator.dupe(u8, home) };
+    const thread = try std.Thread.spawn(.{}, run, .{watcher});
+    thread.detach();
+}
+
+fn addDirectoryWatch(watcher: *Watcher, path: ?[]const u8) void {
+    const root = path orelse return;
+    if (root.len == 0 or !std.fs.path.isAbsolute(root) or watcher.directory_changes_len == watcher.directory_changes.len) return;
+    for (watcher.directory_changes[0..watcher.directory_changes_len]) |candidate| {
+        if (candidate) |controller| if (std.mem.eql(u8, controller.root(), root)) return;
+    }
+    const slot = &watcher.directory_changes[watcher.directory_changes_len];
+    slot.* = directory_watch.Controller.init(root) orelse return;
+    watcher.directory_changes_len += 1;
+    if (slot.*) |*controller| controller.start();
+}
+
+fn addJoinedDirectoryWatch(watcher: *Watcher, base: []const u8, suffix: []const u8) void {
+    const root = std.fs.path.join(watcher.allocator, &.{ base, suffix }) catch return;
+    defer watcher.allocator.free(root);
+    addDirectoryWatch(watcher, root);
+}
+
+fn configureDirectoryWatches(watcher: *Watcher) void {
+    // Watch only provider roots with an evidenced durable adapter. Watching
+    // all of home makes unrelated browser/download churn rescan transcripts,
+    // and can exhaust Linux's bounded recursive watch set. Fixed-size storage
+    // bounds both detached watcher count and memory for hostile environments.
+    addJoinedDirectoryWatch(watcher, watcher.home, ".codex");
+    addJoinedDirectoryWatch(watcher, watcher.home, ".gemini");
+    addJoinedDirectoryWatch(watcher, watcher.home, ".petdex");
+    // Discovery retains the provider defaults alongside optional overrides,
+    // so native notifications must cover both sets as well. Watching these
+    // shallow parents catches transcript leaves created after startup.
+    addJoinedDirectoryWatch(watcher, watcher.home, ".claude");
+    addJoinedDirectoryWatch(watcher, watcher.home, ".omp");
+    if (env_claude_config_dir) |root| addDirectoryWatch(watcher, root);
+    if (env_pi_coding_agent_dir) |root| addDirectoryWatch(watcher, root);
+    if (env_hermes_home) |root|
+        addDirectoryWatch(watcher, root)
+    else
+        addJoinedDirectoryWatch(watcher, watcher.home, ".hermes");
+}
+
+fn pollDirectoryWatches(watcher: *Watcher, monotonic_now: i64) directory_watch.Trigger {
+    var result: directory_watch.Trigger = .none;
+    for (watcher.directory_changes[0..watcher.directory_changes_len]) |*candidate| {
+        const trigger = if (candidate.*) |*controller| controller.poll(monotonic_now) else .none;
+        if (trigger == .overflow) return .overflow;
+        if (trigger == .changed or (trigger == .safety and result == .none)) result = trigger;
+    }
+    return result;
+}
+
+fn run(watcher: *Watcher) void {
+    var scope = plat.Scope.init();
+    defer scope.deinit();
+    const io = scope.io();
+    configureDirectoryWatches(watcher);
+    while (true) {
+        const now = plat.nowMs();
+        const monotonic_now = plat.monotonicMs();
+        const directory_trigger = pollDirectoryWatches(watcher, monotonic_now);
+        if (directory_trigger == .changed) watcher.directory_scan_pending = true;
+        const legacy_poll_due = watcher.directory_changes_len == 0 and
+            (watcher.last_discovery_ms == 0 or monotonic_now - watcher.last_discovery_ms >= discovery_ms);
+        const pending_scan_due = watcher.directory_scan_pending and
+            (watcher.last_discovery_ms == 0 or monotonic_now - watcher.last_discovery_ms >= discovery_ms);
+        const urgent_scan_due = directory_trigger == .overflow or directory_trigger == .safety;
+        if (legacy_poll_due or pending_scan_due or urgent_scan_due) {
+            if (directory_trigger == .overflow) resetDiscoveryCursors(watcher, io);
+            // Rollouts and hook journals get independent hard budgets so a
+            // large provider tree cannot starve crash-recovery journals.
+            var rollout_budget: ProviderDiscoveryBudget = .{ .deadline_ms = monotonic_now + provider_discovery_budget_ms };
+            discover(watcher, io, now, &rollout_budget);
+            var journal_budget: ProviderDiscoveryBudget = .{ .deadline_ms = plat.monotonicMs() + provider_discovery_budget_ms };
+            discoverJournals(watcher, io, now, &journal_budget);
+            watcher.last_discovery_ms = monotonic_now;
+            const changed = watcher.directory_scan_pending or directory_trigger == .overflow;
+            // An exhausted traversal owns open directory cursors and resumes
+            // after the debounce interval. Never clear it merely because this
+            // bounded slice of work completed.
+            watcher.directory_scan_pending = rollout_budget.exhausted or journal_budget.exhausted;
+            if (changed) watcher.provider_next_discovery_ms = 0;
+            if (directory_trigger == .overflow) watcher.provider_adapter_cursor = 0;
+        }
+        if (watcher.provider_next_discovery_ms == 0 or monotonic_now >= watcher.provider_next_discovery_ms) {
+            const result = discoverProviders(watcher, io, now);
+            watcher.provider_discovery_interval_ms = nextProviderDiscoveryInterval(watcher.provider_discovery_interval_ms, result);
+            watcher.provider_next_discovery_ms = monotonic_now + watcher.provider_discovery_interval_ms;
+        }
+        follow(watcher, io, now);
+        followJournals(watcher, io, now);
+        followProviders(watcher, io, now);
+        reconcileHermes(watcher, io, now, false);
+        std.Io.sleep(io, std.Io.Duration.fromMilliseconds(follow_ms), .awake) catch {};
+    }
+}
+
+fn readBounded(io: std.Io, allocator: std.mem.Allocator, path: []const u8, max: usize, tail: bool) ?[]u8 {
+    var file = std.Io.Dir.openFileAbsolute(io, path, .{}) catch return null;
+    defer file.close(io);
+    const stat = file.stat(io) catch return null;
+    if (stat.size == 0) return null;
+    const want: usize = @intCast(@min(stat.size, max));
+    const offset: u64 = if (tail) stat.size - want else 0;
+    const bytes = allocator.alloc(u8, want) catch return null;
+    const got = file.readPositionalAll(io, bytes, offset) catch {
+        allocator.free(bytes);
+        return null;
+    };
+    if (got == 0) {
+        allocator.free(bytes);
+        return null;
+    }
+    return allocator.realloc(bytes, got) catch bytes[0..got];
+}
+
+fn fileInfo(io: std.Io, path: []const u8) ?struct { size: u64, mtime_ms: i64 } {
+    var file = std.Io.Dir.openFileAbsolute(io, path, .{}) catch return null;
+    defer file.close(io);
+    const stat = file.stat(io) catch return null;
+    return .{ .size = stat.size, .mtime_ms = @intCast(@divTrunc(stat.mtime.nanoseconds, std.time.ns_per_ms)) };
+}
+
+fn valueString(value: std.json.Value, key: []const u8) ?[]const u8 {
+    if (value != .object) return null;
+    const item = value.object.get(key) orelse return null;
+    return if (item == .string) item.string else null;
+}
+
+fn messageContentText(payload: std.json.Value, kind: []const u8) ?[]const u8 {
+    if (payload != .object) return null;
+    const content = payload.object.get("content") orelse return null;
+    if (content != .array) return null;
+    for (content.array.items) |item| {
+        if (!std.mem.eql(u8, valueString(item, "type") orelse "", kind)) continue;
+        if (valueString(item, "text")) |text| return text;
+    }
+    return null;
+}
+
+fn loadTitles(io: std.Io, allocator: std.mem.Allocator, home: []const u8) Titles {
+    var out: Titles = .{};
+    const path = std.fs.path.join(allocator, &.{ home, ".codex", "session_index.jsonl" }) catch return out;
+    defer allocator.free(path);
+    const bytes = readBounded(io, allocator, path, max_index_bytes, true) orelse return out;
+    defer allocator.free(bytes);
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    var lines = std.mem.splitScalar(u8, bytes, '\n');
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+        _ = arena.reset(.retain_capacity);
+        const root = std.json.parseFromSliceLeaky(std.json.Value, arena.allocator(), line, .{}) catch continue;
+        const session = valueString(root, "id") orelse valueString(root, "session_id") orelse continue;
+        if (!validSessionId(session)) continue;
+        const title = valueString(root, "thread_name") orelse valueString(root, "title") orelse "";
+        out.put(session, title);
+    }
+    return out;
+}
+
+fn validSessionId(value: []const u8) bool {
+    if (value.len != 36) return false;
+    for (value, 0..) |byte, index| {
+        if (index == 8 or index == 13 or index == 18 or index == 23) {
+            if (byte != '-') return false;
+        } else if (!std.ascii.isHex(byte)) return false;
+    }
+    return true;
+}
+
+const ProviderDiscoveryBudget = struct {
+    visited: usize = 0,
+    deadline_ms: i64,
+    max_entries: usize = max_discovery_entries,
+    exhausted: bool = false,
+
+    fn take(self: *ProviderDiscoveryBudget) bool {
+        if (self.exhausted) return false;
+        if (self.visited >= self.max_entries or
+            (self.visited > 0 and self.visited % 64 == 0 and plat.monotonicMs() >= self.deadline_ms))
+        {
+            self.exhausted = true;
+            return false;
+        }
+        self.visited += 1;
+        return true;
+    }
+};
+
+/// Persistent bounded DFS. Directory iterators and handles survive scheduling
+/// ticks, so an exhausted pass resumes after its last entry rather than
+/// repeatedly enumerating the same filesystem prefix.
+const DirectoryTraversal = struct {
+    const max_frames = 9;
+    const Frame = struct {
+        dir: std.Io.Dir = undefined,
+        iterator: std.Io.Dir.Iterator = undefined,
+        path: [max_path_bytes]u8 = @splat(0),
+        path_len: usize = 0,
+        depth: u8 = 0,
+    };
+    const Entry = struct {
+        path: []const u8,
+        name: []const u8,
+        kind: std.Io.File.Kind,
+        depth: u8,
+    };
+
+    frames: [max_frames]Frame = undefined,
+    frames_len: usize = 0,
+    path_buf: [max_path_bytes]u8 = @splat(0),
+
+    fn active(self: *const DirectoryTraversal) bool {
+        return self.frames_len > 0;
+    }
+
+    fn reset(self: *DirectoryTraversal, io: std.Io) void {
+        while (self.frames_len > 0) {
+            self.frames_len -= 1;
+            self.frames[self.frames_len].dir.close(io);
+        }
+    }
+
+    fn begin(self: *DirectoryTraversal, io: std.Io, root: []const u8) bool {
+        self.reset(io);
+        if (root.len == 0 or root.len > max_path_bytes) return false;
+        var dir = std.Io.Dir.openDirAbsolute(io, root, .{ .iterate = true }) catch return false;
+        var frame: Frame = .{ .dir = dir, .iterator = dir.iterate() };
+        frame.path_len = root.len;
+        @memcpy(frame.path[0..root.len], root);
+        self.frames[0] = frame;
+        self.frames_len = 1;
+        return true;
+    }
+
+    fn next(self: *DirectoryTraversal, io: std.Io, max_directory_depth: u8) !?Entry {
+        while (self.frames_len > 0) {
+            const frame = &self.frames[self.frames_len - 1];
+            const entry = (try frame.iterator.next(io)) orelse {
+                frame.dir.close(io);
+                self.frames_len -= 1;
+                continue;
+            };
+            const base = frame.path[0..frame.path_len];
+            const separator = if (base.len > 0 and (base[base.len - 1] == '/' or base[base.len - 1] == '\\')) "" else std.fs.path.sep_str;
+            const full = std.fmt.bufPrint(&self.path_buf, "{s}{s}{s}", .{ base, separator, entry.name }) catch continue;
+            const depth = frame.depth + 1;
+            if (entry.kind == .directory and frame.depth < max_directory_depth and self.frames_len < self.frames.len) {
+                const child_dir = frame.dir.openDir(io, entry.name, .{ .iterate = true }) catch null;
+                if (child_dir) |dir| {
+                    var child: Frame = .{ .dir = dir, .iterator = dir.iterate(), .depth = depth };
+                    child.path_len = full.len;
+                    @memcpy(child.path[0..full.len], full);
+                    self.frames[self.frames_len] = child;
+                    self.frames_len += 1;
+                }
+            }
+            return .{ .path = full, .name = entry.name, .kind = entry.kind, .depth = depth };
+        }
+        return null;
+    }
+};
+
+const ProviderScanCursor = struct {
+    traversal: DirectoryTraversal = .{},
+    root_index: usize = 0,
+
+    fn reset(self: *ProviderScanCursor, io: std.Io) void {
+        self.traversal.reset(io);
+        self.root_index = 0;
+    }
+};
+
+fn resetDiscoveryCursors(watcher: *Watcher, io: std.Io) void {
+    watcher.rollout_scan.reset(io);
+    watcher.journal_scan.reset(io);
+    for (&watcher.provider_scans) |*cursor| cursor.reset(io);
+}
+
+fn collectCatalog(io: std.Io, allocator: std.mem.Allocator, home: []const u8, traversal: *DirectoryTraversal, budget: *ProviderDiscoveryBudget) Catalog {
+    var out: Catalog = .{};
+    const path = std.fs.path.join(allocator, &.{ home, ".codex", "sessions" }) catch return out;
+    defer allocator.free(path);
+    if (!traversal.active() and !traversal.begin(io, path)) return out;
+    while (budget.take()) {
+        const entry = traversal.next(io, 3) catch {
+            traversal.reset(io);
+            budget.exhausted = true;
+            break;
+        } orelse break;
+        if (entry.depth != 4 or entry.kind != .file or
+            !std.mem.startsWith(u8, entry.name, "rollout-") or !std.mem.endsWith(u8, entry.name, ".jsonl")) continue;
+        if (entry.name.len < 42) continue;
+        const session = entry.name[entry.name.len - 42 .. entry.name.len - 6];
+        if (!validSessionId(session)) continue;
+        const info = fileInfo(io, entry.path) orelse continue;
+        var candidate: Candidate = .{ .size = info.size, .mtime_ms = info.mtime_ms };
+        candidate.session_len = session.len;
+        @memcpy(candidate.session[0..session.len], session);
+        candidate.path_len = entry.path.len;
+        @memcpy(candidate.path[0..entry.path.len], entry.path);
+        out.add(candidate);
+    }
+    out.sortNewest();
+    return out;
+}
+
+fn collectJournalCatalog(io: std.Io, allocator: std.mem.Allocator, home: []const u8, traversal: *DirectoryTraversal, budget: *ProviderDiscoveryBudget) Catalog {
+    var out: Catalog = .{};
+    const root = std.fs.path.join(allocator, &.{ home, ".petdex", "runtime", "session-journal" }) catch return out;
+    defer allocator.free(root);
+    if (!traversal.active() and !traversal.begin(io, root)) return out;
+    while (budget.take()) {
+        const entry = traversal.next(io, 0) catch {
+            traversal.reset(io);
+            budget.exhausted = true;
+            break;
+        } orelse break;
+        if (entry.kind != .file or !std.mem.endsWith(u8, entry.name, ".jsonl")) continue;
+        const info = fileInfo(io, entry.path) orelse continue;
+        var candidate: Candidate = .{ .size = info.size, .mtime_ms = info.mtime_ms };
+        candidate.path_len = entry.path.len;
+        @memcpy(candidate.path[0..entry.path.len], entry.path);
+        out.add(candidate);
+    }
+    out.sortNewest();
+    return out;
+}
+
+fn journalEvent(line_raw: []const u8) ?[]const u8 {
+    const line = std.mem.trim(u8, line_raw, " \t\r");
+    if (line.len < 3 or !std.unicode.utf8ValidateSlice(line)) return null;
+    if (std.mem.indexOf(u8, line, journal_version_marker) == null) return null;
+    const marker = "\"event\":";
+    const at = std.mem.indexOf(u8, line, marker) orelse return null;
+    const event = std.mem.trim(u8, line[at + marker.len .. line.len - 1], " \t\r");
+    if (event.len < 2 or event[0] != '{' or event[event.len - 1] != '}') return null;
+    return event;
+}
+
+fn journalStatus(bytes: []const u8) ?hook_server.SessionStatus {
+    var result: ?hook_server.SessionStatus = null;
+    var lines = std.mem.splitScalar(u8, bytes, '\n');
+    while (lines.next()) |line| {
+        const event = journalEvent(line) orelse continue;
+        if (!std.mem.eql(u8, hook_server.jsonStringPub(event, "session_kind") orelse "primary", "primary")) continue;
+        if (hook_server.jsonStringPub(event, "status")) |raw| {
+            result = hook_server.SessionStatus.fromWire(raw) orelse continue;
+        } else {
+            result = if (std.mem.indexOf(u8, event, "\"busy\":true") != null) .running else .idle;
+        }
+    }
+    return result;
+}
+
+fn journalPublishable(bytes: []const u8, mtime_ms: i64, now_ms: i64) bool {
+    const status = journalStatus(bytes) orelse return false;
+    if (status == .needs_input) return true;
+    if (status != .running) return false;
+    return @max(@as(i64, 0), now_ms - mtime_ms) <= initial_running_max_age_ms;
+}
+
+fn replayJournalBytes(target: *hook_server.Mailbox, bytes: []const u8) void {
+    var lines = std.mem.splitScalar(u8, bytes, '\n');
+    while (lines.next()) |line| {
+        const event = journalEvent(line) orelse continue;
+        _ = hook_server.applyBubbleJson(target, event, .journal);
+    }
+}
+
+fn replayJournalFile(io: std.Io, allocator: std.mem.Allocator, path: []const u8) void {
+    // A rotated generation precedes the current one so nested messages retain
+    // provider order. Missing/corrupt/unsupported records are passive skips;
+    // the provider store remains the authoritative rebuild source.
+    var previous_buf: [max_path_bytes + 2]u8 = undefined;
+    if (std.fmt.bufPrint(&previous_buf, "{s}.1", .{path})) |previous| {
+        if (readBounded(io, allocator, previous, max_rollout_bytes, true)) |bytes| {
+            defer allocator.free(bytes);
+            replayJournalBytes(&hook_server.mailbox, bytes);
+        }
+    } else |_| {}
+    if (readBounded(io, allocator, path, max_rollout_bytes, true)) |bytes| {
+        defer allocator.free(bytes);
+        replayJournalBytes(&hook_server.mailbox, bytes);
+    }
+}
+
+fn findJournalWatch(watcher: *Watcher, path: []const u8) ?*JournalWatch {
+    for (&watcher.journal_watches) |*watch| if (watch.used and std.mem.eql(u8, watch.pathSlice(), path)) return watch;
+    return null;
+}
+
+fn freeJournalWatch(watcher: *Watcher) ?*JournalWatch {
+    for (&watcher.journal_watches) |*watch| if (!watch.used) return watch;
+    return null;
+}
+
+fn discoverJournals(watcher: *Watcher, io: std.Io, now_ms: i64, budget: *ProviderDiscoveryBudget) void {
+    const catalog = collectJournalCatalog(io, watcher.allocator, watcher.home, &watcher.journal_scan, budget);
+    for (catalog.entries[0..catalog.len]) |candidate| {
+        if (findJournalWatch(watcher, candidate.pathSlice()) != null) continue;
+        const bytes = readBounded(io, watcher.allocator, candidate.pathSlice(), max_rollout_bytes, true) orelse continue;
+        defer watcher.allocator.free(bytes);
+        if (!journalPublishable(bytes, candidate.mtime_ms, now_ms)) continue;
+        const slot = freeJournalWatch(watcher) orelse break;
+        slot.* = .{ .used = true, .size = candidate.size, .mtime_ms = candidate.mtime_ms };
+        slot.path_len = candidate.path_len;
+        @memcpy(slot.path[0..candidate.path_len], candidate.pathSlice());
+        replayJournalFile(io, watcher.allocator, slot.pathSlice());
+    }
+}
+
+fn followJournals(watcher: *Watcher, io: std.Io, now_ms: i64) void {
+    _ = now_ms;
+    for (&watcher.journal_watches) |*watch| {
+        if (!watch.used) continue;
+        const info = fileInfo(io, watch.pathSlice()) orelse continue;
+        if (info.size == watch.size and info.mtime_ms == watch.mtime_ms) continue;
+        watch.size = info.size;
+        watch.mtime_ms = info.mtime_ms;
+        const bytes = readBounded(io, watcher.allocator, watch.pathSlice(), max_rollout_bytes, true) orelse continue;
+        defer watcher.allocator.free(bytes);
+        replayJournalBytes(&hook_server.mailbox, bytes);
+        const status = journalStatus(bytes) orelse continue;
+        if (status != .running and status != .needs_input) watch.used = false;
+    }
+}
+
+const ProviderCandidate = struct {
+    adapter_index: u8,
+    candidate: Candidate,
+};
+
+fn selectProviderCandidates(catalogs: *const [adapters.len]Catalog, out: *[max_recent]ProviderCandidate) usize {
+    // Admit one newest conversation from every detected provider before
+    // recency competes for the remaining slots. A single noisy transcript
+    // tree therefore cannot starve quieter agents at startup.
+    var positions: [adapters.len]usize = @splat(0);
+    var count: usize = 0;
+    for (catalogs, 0..) |catalog, index| {
+        if (catalog.len == 0 or count == out.len) continue;
+        out[count] = .{ .adapter_index = @intCast(index), .candidate = catalog.entries[0] };
+        count += 1;
+        positions[index] = 1;
+    }
+    while (count < out.len) {
+        var best: ?usize = null;
+        for (catalogs, 0..) |catalog, index| {
+            if (positions[index] >= catalog.len) continue;
+            if (best == null or catalog.entries[positions[index]].mtime_ms > catalogs[best.?].entries[positions[best.?]].mtime_ms)
+                best = index;
+        }
+        const index = best orelse break;
+        out[count] = .{ .adapter_index = @intCast(index), .candidate = catalogs[index].entries[positions[index]] };
+        count += 1;
+        positions[index] += 1;
+    }
+    return count;
+}
+
+fn providerFileAllowed(name: []const u8) bool {
+    if (!(std.mem.endsWith(u8, name, ".jsonl") or std.mem.endsWith(u8, name, ".json"))) return false;
+    return !std.mem.eql(u8, name, "settings.json") and
+        !std.mem.eql(u8, name, "config.json") and
+        !std.mem.eql(u8, name, "session_index.jsonl");
+}
+
+test "provider discovery enforces entry and elapsed-work budgets" {
+    var expired: ProviderDiscoveryBudget = .{ .deadline_ms = plat.monotonicMs() - 1 };
+    var accepted: usize = 0;
+    while (expired.take()) accepted += 1;
+    try std.testing.expectEqual(@as(usize, 64), accepted);
+    try std.testing.expect(expired.exhausted);
+
+    var entry_limited: ProviderDiscoveryBudget = .{ .deadline_ms = plat.monotonicMs() + 60_000 };
+    accepted = 0;
+    while (entry_limited.take()) accepted += 1;
+    try std.testing.expectEqual(max_discovery_entries, accepted);
+    try std.testing.expect(entry_limited.exhausted);
+}
+
+test "bounded traversal resumes past its first scheduling budget" {
+    const root_relative = ".zig-cache/petdex-session-continuation";
+    plat.makeDir(root_relative);
+    for (0..7) |index| {
+        var path_buf: [256]u8 = undefined;
+        const path = try std.fmt.bufPrint(&path_buf, "{s}/entry-{d}.json", .{ root_relative, index });
+        try std.testing.expect(plat.writeFile(path, "{}"));
+    }
+
+    var scope = plat.Scope.init();
+    defer scope.deinit();
+    const io = scope.io();
+    var absolute_buf: [max_path_bytes]u8 = undefined;
+    const absolute_len = try std.Io.Dir.cwd().realPathFile(io, root_relative, &absolute_buf);
+    var traversal: DirectoryTraversal = .{};
+    defer traversal.reset(io);
+    try std.testing.expect(traversal.begin(io, absolute_buf[0..absolute_len]));
+
+    var seen: [7]bool = @splat(false);
+    var ticks: usize = 0;
+    while (traversal.active() and ticks < 16) : (ticks += 1) {
+        var budget: ProviderDiscoveryBudget = .{
+            .deadline_ms = plat.monotonicMs() + 60_000,
+            .max_entries = 2,
+        };
+        while (budget.take()) {
+            const entry = (try traversal.next(io, 0)) orelse break;
+            for (0..seen.len) |index| {
+                var expected_buf: [32]u8 = undefined;
+                const expected = try std.fmt.bufPrint(&expected_buf, "entry-{d}.json", .{index});
+                if (std.mem.eql(u8, entry.name, expected)) seen[index] = true;
+            }
+        }
+    }
+    try std.testing.expect(ticks >= 3);
+    try std.testing.expect(!traversal.active());
+    for (seen) |found| try std.testing.expect(found);
+}
+
+fn providerRootPath(allocator: std.mem.Allocator, home: []const u8, adapter: AgentSessionAdapter, ordinal: usize) ?[]u8 {
+    var index = ordinal;
+    const Custom = struct {
+        fn take(allocator_inner: std.mem.Allocator, candidate: ?[]const u8, suffix: []const u8, index_inner: *usize) ?[]u8 {
+            const base = candidate orelse return null;
+            if (index_inner.* > 0) {
+                index_inner.* -= 1;
+                return null;
+            }
+            index_inner.* = std.math.maxInt(usize);
+            if (base.len == 0 or !std.fs.path.isAbsolute(base)) return allocator_inner.alloc(u8, 0) catch null;
+            return if (suffix.len > 0)
+                std.fs.path.join(allocator_inner, &.{ base, suffix }) catch null
+            else
+                allocator_inner.dupe(u8, base) catch null;
+        }
+    };
+    const configured: ?[]u8 = switch (adapter.schema) {
+        .claude => Custom.take(allocator, env_claude_config_dir, "projects", &index),
+        .kimi => Custom.take(allocator, env_kimi_code_home, "", &index) orelse
+            Custom.take(allocator, env_kimi_share_dir, "", &index),
+        .omp => Custom.take(allocator, env_pi_coding_agent_dir, "sessions", &index),
+        .opencode => Custom.take(allocator, env_xdg_data_home, "opencode/storage", &index),
+        .qoder => Custom.take(allocator, env_qoder_config_dir, "", &index) orelse
+            Custom.take(allocator, env_qoder_cn_config_dir, "", &index) orelse
+            Custom.take(allocator, env_qoder_cli_home, "", &index) orelse
+            Custom.take(allocator, env_qoder_cn_cli_home, "", &index),
+        else => null,
+    };
+    if (configured) |root| return root;
+    if (index == std.math.maxInt(usize)) index = 0;
+    if (index >= adapter.roots.len) return null;
+    return std.fs.path.join(allocator, &.{ home, adapter.roots[index] }) catch null;
+}
+
+fn collectProviderCatalog(io: std.Io, allocator: std.mem.Allocator, home: []const u8, adapter: AgentSessionAdapter, cursor: *ProviderScanCursor, budget: *ProviderDiscoveryBudget) Catalog {
+    var out: Catalog = .{};
+    while (!budget.exhausted) {
+        if (!cursor.traversal.active()) {
+            const root = providerRootPath(allocator, home, adapter, cursor.root_index) orelse {
+                cursor.root_index = 0;
+                break;
+            };
+            cursor.root_index += 1;
+            const started = root.len > 0 and cursor.traversal.begin(io, root);
+            allocator.free(root);
+            if (!started) continue;
+        }
+        while (budget.take()) {
+            const entry = cursor.traversal.next(io, 7) catch {
+                cursor.traversal.reset(io);
+                budget.exhausted = true;
+                break;
+            } orelse break;
+            if (entry.kind != .file or !providerFileAllowed(entry.name)) continue;
+            const info = fileInfo(io, entry.path) orelse continue;
+            var candidate: Candidate = .{ .size = info.size, .mtime_ms = info.mtime_ms };
+            candidate.path_len = entry.path.len;
+            @memcpy(candidate.path[0..entry.path.len], entry.path);
+            out.add(candidate);
+        }
+        if (cursor.traversal.active()) break;
+    }
+    out.sortNewest();
+    return out;
+}
+
+fn objectString(value: std.json.Value, key: []const u8) ?[]const u8 {
+    if (value != .object) return null;
+    const field = value.object.get(key) orelse return null;
+    return if (field == .string) field.string else null;
+}
+
+fn contentText(value: std.json.Value, depth: u8) ?[]const u8 {
+    if (depth > 4) return null;
+    if (value == .string) return value.string;
+    if (value == .array) {
+        for (value.array.items) |item| if (contentText(item, depth + 1)) |text| return text;
+        return null;
+    }
+    if (value != .object) return null;
+    inline for (.{ "text", "content" }) |key| {
+        if (value.object.get(key)) |nested| if (contentText(nested, depth + 1)) |text| return text;
+    }
+    return null;
+}
+
+fn setBounded(destination: []u8, len: *usize, value: []const u8) void {
+    @memset(destination, 0);
+    len.* = @min(destination.len, value.len);
+    @memcpy(destination[0..len.*], value[0..len.*]);
+}
+
+fn providerPathFallback(path: []const u8) []const u8 {
+    const base = std.fs.path.basename(path);
+    const stem = if (std.mem.lastIndexOfScalar(u8, base, '.')) |dot| base[0..dot] else base;
+    if (std.mem.eql(u8, stem, "wire") or std.mem.eql(u8, stem, "state") or std.mem.eql(u8, stem, "messages") or std.mem.eql(u8, stem, "chat")) {
+        if (std.fs.path.dirname(path)) |parent| return std.fs.path.basename(parent);
+    }
+    return stem;
+}
+
+fn eventIs(value: []const u8, expected: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(value, expected);
+}
+
+fn objectValue(value: std.json.Value, key: []const u8) ?std.json.Value {
+    if (value != .object) return null;
+    return value.object.get(key);
+}
+
+fn objectBool(value: std.json.Value, key: []const u8) ?bool {
+    const field = objectValue(value, key) orelse return null;
+    return if (field == .bool) field.bool else null;
+}
+
+fn parentDirectoryName(path: []const u8) []const u8 {
+    const dir = std.fs.path.dirname(path) orelse return "";
+    return std.fs.path.basename(dir);
+}
+
+fn componentParent(path: []const u8, component: []const u8) []const u8 {
+    var marker_buf: [64]u8 = undefined;
+    for ([_]u8{ '/', '\\' }) |separator| {
+        const marker = std.fmt.bufPrint(&marker_buf, "{c}{s}{c}", .{ separator, component, separator }) catch return "";
+        if (std.mem.indexOf(u8, path, marker)) |at| return std.fs.path.basename(path[0..at]);
+    }
+    return "";
+}
+
+fn applyClaudeRecord(state: *ProviderEvent, root: std.json.Value) void {
+    if (root != .object) return;
+    if (objectString(root, "sessionId")) |value| setBounded(&state.session, &state.session_len, value);
+    if (objectString(root, "cwd")) |value| state.cwd.set(value);
+    if (objectString(root, "uuid")) |value| setBounded(&state.message_id, &state.message_id_len, value);
+    if (objectBool(root, "isSidechain") orelse false) state.subagent = true;
+    const event_type = objectString(root, "type") orelse return;
+    const message = objectValue(root, "message") orelse root;
+    const role = objectString(message, "role") orelse event_type;
+    const content = if (objectValue(message, "content")) |value| contentText(value, 0) else null;
+    if (eventIs(role, "user")) {
+        if (content) |value| if (state.title.len == 0) {
+            state.title.set(value);
+            state.title_source = .prompt;
+        };
+        state.status = .running;
+    } else if (eventIs(role, "assistant")) {
+        if (objectString(message, "id")) |value| setBounded(&state.message_id, &state.message_id_len, value);
+        if (content) |value| state.text.set(value);
+        state.message_kind = .assistant;
+        const stop_reason = objectString(message, "stop_reason") orelse "";
+        state.status = if (eventIs(stop_reason, "end_turn") or eventIs(stop_reason, "stop_sequence")) .completed else .running;
+    } else if (eventIs(event_type, "result")) {
+        if (objectString(root, "result")) |value| state.text.set(value);
+        state.status = if (objectBool(root, "is_error") orelse false) .failed else .completed;
+        state.explicit_lifecycle = true;
+    }
+}
+
+fn applyGeminiRecord(state: *ProviderEvent, root: std.json.Value) void {
+    if (root != .object) return;
+    if (objectValue(root, "messages")) |messages| {
+        if (messages == .array) for (messages.array.items) |message| applyGeminiRecord(state, message);
+    }
+    if (objectString(root, "sessionId")) |value| setBounded(&state.session, &state.session_len, value);
+    if (objectString(root, "summary")) |value| {
+        state.title.set(value);
+        state.title_source = .server;
+    }
+    if (objectString(root, "kind")) |value| {
+        if (eventIs(value, "subagent")) state.subagent = true;
+    }
+    if (objectValue(root, "directories")) |directories| {
+        if (directories == .array and directories.array.items.len > 0 and directories.array.items[0] == .string)
+            state.cwd.set(directories.array.items[0].string);
+    }
+    if (objectString(root, "id")) |value| setBounded(&state.message_id, &state.message_id_len, value);
+    const event_type = objectString(root, "type") orelse return;
+    const content = if (objectValue(root, "content")) |value| contentText(value, 0) else null;
+    if (eventIs(event_type, "user")) {
+        if (content) |value| if (state.title.len == 0) {
+            state.title.set(value);
+            state.title_source = .prompt;
+        };
+        state.status = .running;
+    } else if (eventIs(event_type, "gemini")) {
+        if (content) |value| state.text.set(value);
+        state.message_kind = .assistant;
+        const has_tool_calls = if (objectValue(root, "toolCalls")) |calls| calls == .array and calls.array.items.len > 0 else false;
+        state.status = if (has_tool_calls) .running else .completed;
+    }
+}
+
+fn applyOmpRecord(state: *ProviderEvent, path: []const u8, root: std.json.Value) void {
+    if (root != .object) return;
+    const event_type = objectString(root, "type") orelse return;
+    if (eventIs(event_type, "session")) {
+        setBounded(&state.session, &state.session_len, providerPathFallback(path));
+        if (objectString(root, "cwd")) |value| state.cwd.set(value);
+        if (objectString(root, "parentSession")) |value| {
+            setBounded(&state.parent, &state.parent_len, providerPathFallback(value));
+            state.subagent = true;
+        }
+        return;
+    }
+    if (eventIs(event_type, "session_info")) {
+        if (objectString(root, "name")) |value| {
+            state.title.set(value);
+            state.title_source = .server;
+        }
+        return;
+    }
+    if (!eventIs(event_type, "message")) return;
+    if (objectString(root, "id")) |value| setBounded(&state.message_id, &state.message_id_len, value);
+    const message = objectValue(root, "message") orelse return;
+    const role = objectString(message, "role") orelse return;
+    const content = if (objectValue(message, "content")) |value| contentText(value, 0) else null;
+    if (eventIs(role, "user")) {
+        if (content) |value| if (state.title.len == 0) {
+            state.title.set(value);
+            state.title_source = .prompt;
+        };
+        state.status = .running;
+    } else if (eventIs(role, "assistant")) {
+        if (content) |value| state.text.set(value);
+        state.message_kind = .assistant;
+        state.status = .completed;
+    } else if (eventIs(role, "toolResult")) {
+        state.status = .running;
+    }
+}
+
+fn applyProviderRecord(state: *ProviderEvent, schema: ProviderSchema, path: []const u8, root: std.json.Value) void {
+    switch (schema) {
+        .claude => applyClaudeRecord(state, root),
+        .gemini => applyGeminiRecord(state, root),
+        .omp => applyOmpRecord(state, path, root),
+        else => {},
+    }
+}
+
+fn parseProviderBytes(allocator: std.mem.Allocator, schema: ProviderSchema, path: []const u8, prefix: []const u8, tail: []const u8) ?ProviderEvent {
+    if (schema != .claude and schema != .gemini and schema != .omp) return null;
+    var state: ProviderEvent = .{};
+    const normalized_path = path;
+    state.subagent = std.mem.indexOf(u8, normalized_path, "/subagents/") != null or
+        std.mem.indexOf(u8, normalized_path, "\\subagents\\") != null or
+        std.mem.indexOf(u8, normalized_path, "/agents/") != null or
+        std.mem.indexOf(u8, normalized_path, "\\agents\\") != null;
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    for ([_][]const u8{ prefix, tail }) |bytes| {
+        var lines = std.mem.splitScalar(u8, bytes, '\n');
+        while (lines.next()) |line| {
+            if (line.len == 0 or !std.unicode.utf8ValidateSlice(line)) continue;
+            _ = arena.reset(.retain_capacity);
+            const root = std.json.parseFromSliceLeaky(std.json.Value, arena.allocator(), line, .{}) catch continue;
+            applyProviderRecord(&state, schema, path, root);
+        }
+    }
+    // Gemini and several OpenCode store versions write one pretty-printed JSON
+    // document rather than JSONL. Parse the bounded document as a whole after
+    // the line pass; duplicate records are harmless state assignments.
+    const trimmed_tail = std.mem.trim(u8, tail, " \t\r\n");
+    const first_line_end = std.mem.indexOfScalar(u8, trimmed_tail, '\n') orelse trimmed_tail.len;
+    const first_line = std.mem.trim(u8, trimmed_tail[0..first_line_end], " \t\r");
+    if (std.mem.eql(u8, first_line, "{") or std.mem.eql(u8, first_line, "[")) {
+        _ = arena.reset(.retain_capacity);
+        if (std.json.parseFromSliceLeaky(std.json.Value, arena.allocator(), tail, .{})) |root| {
+            applyProviderRecord(&state, schema, path, root);
+        } else |_| {}
+    }
+    if (state.session_len == 0) setBounded(&state.session, &state.session_len, providerPathFallback(path));
+    if (state.subagent and state.parent_len == 0) {
+        const parent = switch (schema) {
+            .claude => componentParent(path, "subagents"),
+            .gemini => parentDirectoryName(path),
+            else => "",
+        };
+        if (parent.len > 0) setBounded(&state.parent, &state.parent_len, parent);
+    }
+    if (state.parent_len > 0 and !std.mem.eql(u8, state.sessionSlice(), state.parentSlice())) state.subagent = true;
+    if (state.subagent and state.parent_len == 0) return null;
+    if (state.text.len == 0) state.text.set(switch (state.status) {
+        .running => "Thinking…",
+        .needs_input => "Waiting for you…",
+        .completed => "Done.",
+        .failed => "Session failed.",
+        .idle => "",
+    });
+    if (state.status == .idle or state.session_len == 0) return null;
+    return state;
+}
+
+fn parseProviderFile(io: std.Io, allocator: std.mem.Allocator, adapter: AgentSessionAdapter, path: []const u8) ?ProviderEvent {
+    const prefix = readBounded(io, allocator, path, max_meta_bytes, false) orelse return null;
+    defer allocator.free(prefix);
+    const tail = readBounded(io, allocator, path, max_rollout_bytes, true) orelse return null;
+    defer allocator.free(tail);
+    return parseProviderBytes(allocator, adapter.schema, path, prefix, tail);
+}
+
+fn providerInitialPublishable(event: ProviderEvent, mtime_ms: i64, now_ms: i64) bool {
+    if (event.subagent) return @max(@as(i64, 0), now_ms - mtime_ms) <= initial_running_max_age_ms;
+    if (event.status == .needs_input) return true;
+    if (event.status != .running) return false;
+    return @max(@as(i64, 0), now_ms - mtime_ms) <= initial_running_max_age_ms;
+}
+
+fn providerBubbleUpdate(adapter: AgentSessionAdapter, event: *const ProviderEvent) hook_server.BubbleUpdate {
+    return .{
+        .conversation_key = if (event.subagent) event.parentSlice() else event.sessionSlice(),
+        .source_session = event.sessionSlice(),
+        .parent_session = event.parentSlice(),
+        .text = event.text.slice(),
+        .agent = adapter.agent,
+        .title = event.title.slice(),
+        .source_cwd = event.cwd.slice(),
+        .message_id = event.messageIdSlice(),
+        .request_id = event.requestIdSlice(),
+        .resolves_request_id = event.resolvesRequestIdSlice(),
+        .event_kind = if (event.subagent) "subagent" else "native-store",
+        .subagent_label = event.labelSlice(),
+        .busy = event.status == .running,
+        .status = switch (event.status) {
+            .idle => .idle,
+            .running => .running,
+            .needs_input => .needs_input,
+            .completed => .completed,
+            .failed => .failed,
+        },
+        .session_kind = if (event.subagent) .subagent else .primary,
+        .message_kind = event.message_kind,
+        .title_source = event.title_source,
+        .feed_source = .native_store,
+    };
+}
+
+fn publishProvider(watch: *ProviderWatch, event: ProviderEvent) void {
+    const digest = event.digest();
+    if (digest == watch.delivered) return;
+    const adapter = adapters[watch.adapter_index];
+    _ = hook_server.mailbox.applyBubbleUpdate(providerBubbleUpdate(adapter, &event));
+    watch.delivered = digest;
+    if (!event.subagent and (event.status == .completed or event.status == .failed)) watch.used = false;
+}
+
+fn findProviderWatch(watcher: *Watcher, adapter_index: u8, path: []const u8) ?*ProviderWatch {
+    for (&watcher.provider_watches) |*watch|
+        if (watch.used and watch.adapter_index == adapter_index and std.mem.eql(u8, watch.pathSlice(), path)) return watch;
+    return null;
+}
+
+fn freeProviderWatch(watcher: *Watcher) ?*ProviderWatch {
+    for (&watcher.provider_watches) |*watch| if (!watch.used) return watch;
+    return null;
+}
+
+const ProviderDiscoveryResult = struct { added: bool = false, budget_exhausted: bool = false };
+
+fn nextProviderDiscoveryInterval(previous_ms: i64, result: ProviderDiscoveryResult) i64 {
+    if (result.added or result.budget_exhausted) return discovery_ms;
+    return @min(provider_discovery_max_ms, previous_ms * 2);
+}
+
+test "provider discovery backs off only after a complete unchanged pass" {
+    try std.testing.expectEqual(discovery_ms, nextProviderDiscoveryInterval(16_000, .{ .added = true }));
+    try std.testing.expectEqual(discovery_ms, nextProviderDiscoveryInterval(16_000, .{ .budget_exhausted = true }));
+    try std.testing.expectEqual(@as(i64, 4_000), nextProviderDiscoveryInterval(discovery_ms, .{}));
+    try std.testing.expectEqual(provider_discovery_max_ms, nextProviderDiscoveryInterval(provider_discovery_max_ms, .{}));
+}
+
+fn discoverProviders(watcher: *Watcher, io: std.Io, now_ms: i64) ProviderDiscoveryResult {
+    var result: ProviderDiscoveryResult = .{};
+    var catalogs: [adapters.len]Catalog = @splat(.{});
+    var budget: ProviderDiscoveryBudget = .{ .deadline_ms = plat.monotonicMs() + provider_discovery_budget_ms };
+    for (0..adapters.len) |offset| {
+        const index = (watcher.provider_adapter_cursor + offset) % adapters.len;
+        const adapter = adapters[index];
+        if (adapter.store == .codex_rollout or adapter.store == .sqlite or adapter.store == .hooks_only) continue;
+        catalogs[index] = collectProviderCatalog(io, watcher.allocator, watcher.home, adapter, &watcher.provider_scans[index], &budget);
+        if (budget.exhausted) break;
+    }
+    watcher.provider_adapter_cursor = (watcher.provider_adapter_cursor + 1) % adapters.len;
+    result.budget_exhausted = budget.exhausted;
+
+    var selected: [max_recent]ProviderCandidate = undefined;
+    const selected_len = selectProviderCandidates(&catalogs, &selected);
+
+    // Parents first resolves child-before-parent races within one discovery
+    // pass. The second pass adds only explicit nested assistant summaries.
+    inline for (.{ false, true }) |subagents| {
+        for (selected[0..selected_len]) |item| {
+            const candidate = item.candidate;
+            if (findProviderWatch(watcher, item.adapter_index, candidate.pathSlice()) != null) continue;
+            const event = parseProviderFile(io, watcher.allocator, adapters[item.adapter_index], candidate.pathSlice()) orelse continue;
+            if (event.subagent != subagents or !providerInitialPublishable(event, candidate.mtime_ms, now_ms)) continue;
+            const slot = freeProviderWatch(watcher) orelse return result;
+            slot.* = .{ .used = true, .adapter_index = item.adapter_index, .size = candidate.size, .mtime_ms = candidate.mtime_ms };
+            slot.path_len = candidate.path_len;
+            @memcpy(slot.path[0..candidate.path_len], candidate.pathSlice());
+            publishProvider(slot, event);
+            result.added = true;
+        }
+    }
+    return result;
+}
+
+fn followProviders(watcher: *Watcher, io: std.Io, now_ms: i64) void {
+    _ = now_ms;
+    for (&watcher.provider_watches) |*watch| {
+        if (!watch.used) continue;
+        const info = fileInfo(io, watch.pathSlice()) orelse continue;
+        if (info.size == watch.size and info.mtime_ms == watch.mtime_ms) continue;
+        watch.size = info.size;
+        watch.mtime_ms = info.mtime_ms;
+        const event = parseProviderFile(io, watcher.allocator, adapters[watch.adapter_index], watch.pathSlice()) orelse continue;
+        publishProvider(watch, event);
+    }
+}
+
+const WindowsLibrary = struct {
+    handle: *anyopaque,
+
+    extern "kernel32" fn LoadLibraryA(name: [*:0]const u8) callconv(.winapi) ?*anyopaque;
+    extern "kernel32" fn GetProcAddress(module: *anyopaque, name: [*:0]const u8) callconv(.winapi) ?*anyopaque;
+    extern "kernel32" fn FreeLibrary(module: *anyopaque) callconv(.winapi) c_int;
+
+    fn open(name: []const u8) !WindowsLibrary {
+        var buffer: [260]u8 = undefined;
+        if (name.len >= buffer.len) return error.NameTooLong;
+        @memcpy(buffer[0..name.len], name);
+        buffer[name.len] = 0;
+        return .{ .handle = LoadLibraryA(@ptrCast(&buffer)) orelse return error.NotFound };
+    }
+    fn close(self: *WindowsLibrary) void {
+        _ = FreeLibrary(self.handle);
+    }
+    fn lookup(self: *WindowsLibrary, comptime T: type, name: [:0]const u8) ?T {
+        return @ptrCast(GetProcAddress(self.handle, name.ptr) orelse return null);
+    }
+};
+
+const DynamicLibrary = if (builtin.target.os.tag == .windows) WindowsLibrary else std.DynLib;
+
+const SqliteApi = struct {
+    lib: DynamicLibrary,
+    open_v2: *const fn ([*:0]const u8, *?*anyopaque, c_int, ?[*:0]const u8) callconv(.c) c_int,
+    close_v2: *const fn (?*anyopaque) callconv(.c) c_int,
+    busy_timeout: *const fn (?*anyopaque, c_int) callconv(.c) c_int,
+    prepare_v2: *const fn (?*anyopaque, [*:0]const u8, c_int, *?*anyopaque, ?*?[*:0]const u8) callconv(.c) c_int,
+    step: *const fn (?*anyopaque) callconv(.c) c_int,
+    finalize: *const fn (?*anyopaque) callconv(.c) c_int,
+    column_text: *const fn (?*anyopaque, c_int) callconv(.c) ?[*:0]const u8,
+    column_double: *const fn (?*anyopaque, c_int) callconv(.c) f64,
+
+    fn load() ?SqliteApi {
+        const names: []const []const u8 = switch (builtin.target.os.tag) {
+            .windows => &.{ "winsqlite3.dll", "sqlite3.dll" },
+            .macos => &.{ "libsqlite3.dylib", "/usr/lib/libsqlite3.dylib" },
+            else => &.{ "libsqlite3.so.0", "libsqlite3.so" },
+        };
+        for (names) |name| {
+            var lib = DynamicLibrary.open(name) catch continue;
+            const open_v2 = lib.lookup(@TypeOf(@as(SqliteApi, undefined).open_v2), "sqlite3_open_v2") orelse {
+                lib.close();
+                continue;
+            };
+            const close_v2 = lib.lookup(@TypeOf(@as(SqliteApi, undefined).close_v2), "sqlite3_close_v2") orelse {
+                lib.close();
+                continue;
+            };
+            const busy_timeout = lib.lookup(@TypeOf(@as(SqliteApi, undefined).busy_timeout), "sqlite3_busy_timeout") orelse {
+                lib.close();
+                continue;
+            };
+            const prepare_v2 = lib.lookup(@TypeOf(@as(SqliteApi, undefined).prepare_v2), "sqlite3_prepare_v2") orelse {
+                lib.close();
+                continue;
+            };
+            const step = lib.lookup(@TypeOf(@as(SqliteApi, undefined).step), "sqlite3_step") orelse {
+                lib.close();
+                continue;
+            };
+            const finalize = lib.lookup(@TypeOf(@as(SqliteApi, undefined).finalize), "sqlite3_finalize") orelse {
+                lib.close();
+                continue;
+            };
+            const column_text = lib.lookup(@TypeOf(@as(SqliteApi, undefined).column_text), "sqlite3_column_text") orelse {
+                lib.close();
+                continue;
+            };
+            const column_double = lib.lookup(@TypeOf(@as(SqliteApi, undefined).column_double), "sqlite3_column_double") orelse {
+                lib.close();
+                continue;
+            };
+            return .{ .lib = lib, .open_v2 = open_v2, .close_v2 = close_v2, .busy_timeout = busy_timeout, .prepare_v2 = prepare_v2, .step = step, .finalize = finalize, .column_text = column_text, .column_double = column_double };
+        }
+        return null;
+    }
+};
+
+fn sqliteText(api: *const SqliteApi, statement: ?*anyopaque, column: c_int) []const u8 {
+    const value = api.column_text(statement, column) orelse return "";
+    return std.mem.span(value);
+}
+
+fn hermesSeen(watcher: *Watcher, session: []const u8) ?*HermesSeen {
+    for (&watcher.hermes_seen) |*seen| if (seen.used and std.mem.eql(u8, seen.sessionSlice(), session)) return seen;
+    return null;
+}
+
+fn rememberHermes(watcher: *Watcher, session: []const u8) ?*HermesSeen {
+    if (hermesSeen(watcher, session)) |seen| return seen;
+    for (&watcher.hermes_seen) |*seen| if (!seen.used) {
+        seen.* = .{ .used = true };
+        setBounded(&seen.session, &seen.session_len, session);
+        return seen;
+    };
+    return null;
+}
+
+fn publishHermes(watcher: *Watcher, event: ProviderEvent, initial: bool) void {
+    const terminal = event.status == .completed or event.status == .failed;
+    if (!event.subagent) {
+        const prior = hermesSeen(watcher, event.sessionSlice());
+        if (terminal and (initial or prior == null)) return;
+        const seen = prior orelse rememberHermes(watcher, event.sessionSlice()) orelse return;
+        const digest = event.digest();
+        if (seen.digest == digest) return;
+        seen.digest = digest;
+        if (terminal) seen.used = false;
+    }
+    _ = hook_server.mailbox.applyBubbleUpdate(.{
+        .conversation_key = if (event.subagent) event.parentSlice() else event.sessionSlice(),
+        .source_session = event.sessionSlice(),
+        .parent_session = event.parentSlice(),
+        .text = event.text.slice(),
+        .agent = "hermes",
+        .title = event.title.slice(),
+        .message_id = event.messageIdSlice(),
+        .event_kind = if (event.subagent) "subagent" else "native-store",
+        .subagent_label = event.labelSlice(),
+        .busy = event.status == .running,
+        .status = switch (event.status) {
+            .idle => .idle,
+            .running => .running,
+            .needs_input => .needs_input,
+            .completed => .completed,
+            .failed => .failed,
+        },
+        .session_kind = if (event.subagent) .subagent else .primary,
+        .message_kind = if (event.subagent) .assistant else .status,
+        .title_source = .server,
+        .feed_source = .native_store,
+    });
+}
+
+fn sqliteMillis(value: f64) i64 {
+    if (!std.math.isFinite(value) or value <= 0) return 0;
+    return if (value < 10_000_000_000) @intFromFloat(value * 1000) else @intFromFloat(value);
+}
+
+fn hermesSessionStatus(ended: bool, needs_input: bool, end_reason: []const u8) Status {
+    const failed = std.mem.indexOf(u8, end_reason, "fail") != null or
+        std.mem.indexOf(u8, end_reason, "error") != null or
+        std.mem.indexOf(u8, end_reason, "interrupt") != null;
+    return if (failed) .failed else if (ended) .completed else if (needs_input) .needs_input else .running;
+}
+
+fn hermesSessionIsSubagent(enriched_schema: bool, source: []const u8, model_config: []const u8, parent: []const u8, session_key: []const u8) bool {
+    return eventIs(source, "subagent") or eventIs(source, "delegate") or eventIs(source, "worker") or
+        std.mem.indexOf(u8, model_config, "_delegate_from") != null or
+        (enriched_schema and parent.len > 0 and session_key.len == 0);
+}
+
+const HermesRow = struct {
+    enriched_schema: bool,
+    id: []const u8,
+    session_key: []const u8,
+    title: []const u8,
+    source: []const u8,
+    model_config: []const u8,
+    parent_session_id: []const u8,
+    started_ms: i64,
+    activity_ms: i64,
+    description: []const u8,
+    ended: bool,
+    end_reason: []const u8,
+};
+
+fn hermesEventFromRow(row: HermesRow) ProviderEvent {
+    const input_prefix = "petdex:needs-input:";
+    const needs_input = std.mem.startsWith(u8, row.description, input_prefix);
+    const description = if (needs_input) row.description[input_prefix.len..] else row.description;
+    const subagent = hermesSessionIsSubagent(row.enriched_schema, row.source, row.model_config, row.parent_session_id, row.session_key);
+    const status = hermesSessionStatus(row.ended, needs_input, row.end_reason);
+    var event: ProviderEvent = .{ .status = status, .subagent = subagent, .explicit_lifecycle = true, .title_source = .server };
+    setBounded(&event.session, &event.session_len, if (!subagent and row.session_key.len > 0) row.session_key else row.id);
+    if (row.parent_session_id.len > 0) setBounded(&event.parent, &event.parent_len, row.parent_session_id);
+    event.title.set(if (row.title.len > 0) row.title else "Hermes session");
+    event.text.set(if (description.len > 0) description else if (status == .failed) "Session failed." else if (row.ended) "Done." else if (needs_input) "Waiting for you…" else "Thinking…");
+    event.message_kind = if (subagent) .assistant else .status;
+    var id_buf: [64]u8 = undefined;
+    const modified_ms = if (row.activity_ms > 0) row.activity_ms else row.started_ms;
+    const message_id = std.fmt.bufPrint(&id_buf, "hermes-{d}", .{modified_ms}) catch "";
+    setBounded(&event.message_id, &event.message_id_len, message_id);
+    if (subagent) setBounded(&event.label, &event.label_len, row.title);
+    return event;
+}
+
+fn reconcileHermes(watcher: *Watcher, io: std.Io, now_ms: i64, force: bool) void {
+    if (comptime builtin.target.os.tag != .windows and builtin.target.os.tag != .macos and builtin.target.os.tag != .linux) return;
+    const root_owned: ?[]u8 = if (env_hermes_home) |configured|
+        (if (configured.len > 0) watcher.allocator.dupe(u8, configured) catch return else null)
+    else
+        null;
+    defer if (root_owned) |root| watcher.allocator.free(root);
+    const default_root = std.fs.path.join(watcher.allocator, &.{ watcher.home, ".hermes" }) catch return;
+    defer watcher.allocator.free(default_root);
+    const root = root_owned orelse default_root;
+    const db_path = std.fs.path.join(watcher.allocator, &.{ root, "state.db" }) catch return;
+    defer watcher.allocator.free(db_path);
+    const db_info = fileInfo(io, db_path) orelse return;
+    var stamp = db_info.size ^ @as(u64, @bitCast(db_info.mtime_ms));
+    const wal_path = std.fmt.allocPrint(watcher.allocator, "{s}-wal", .{db_path}) catch return;
+    defer watcher.allocator.free(wal_path);
+    if (fileInfo(io, wal_path)) |wal| stamp ^= wal.size *% 1099511628211 ^ @as(u64, @bitCast(wal.mtime_ms));
+    if (!force and watcher.hermes_db_stamp == stamp) return;
+    watcher.hermes_db_stamp = stamp;
+
+    var api = SqliteApi.load() orelse return;
+    defer api.lib.close();
+    const path_z = watcher.allocator.dupeZ(u8, db_path) catch return;
+    defer watcher.allocator.free(path_z);
+    var database: ?*anyopaque = null;
+    if (api.open_v2(path_z.ptr, &database, 0x00000001, null) != 0 or database == null) return;
+    defer _ = api.close_v2(database);
+    _ = api.busy_timeout(database, 1_500);
+    const enriched_sql = "SELECT id,session_key,title,source,model_config,parent_session_id,started_at,last_activity_at,last_activity_description,ended_at,LOWER(COALESCE(end_reason,'')) FROM sessions ORDER BY COALESCE(last_activity_at,started_at) DESC LIMIT 32";
+    // Current Hermes documents the portable sessions/messages schema. Some
+    // installations additionally carry routing-index columns (session_key and
+    // last_activity_*). Prefer those when present, then fall back to a pure
+    // read-only/WAL-visible query over the documented provider-owned tables.
+    const portable_sql =
+        "SELECT s.id,s.id,COALESCE(s.title,''),s.source,COALESCE(s.model_config,''),COALESCE(s.parent_session_id,''),s.started_at," ++
+        "COALESCE((SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id=s.id),s.started_at)," ++
+        "CASE WHEN COALESCE((SELECT m.role FROM messages m WHERE m.session_id=s.id ORDER BY m.timestamp DESC,m.id DESC LIMIT 1),'')='assistant' AND (" ++
+        "LOWER(COALESCE((SELECT m.tool_name FROM messages m WHERE m.session_id=s.id ORDER BY m.timestamp DESC,m.id DESC LIMIT 1),'')) IN ('request_user_input','ask_user','clarify') OR " ++
+        "LOWER(COALESCE((SELECT m.tool_calls FROM messages m WHERE m.session_id=s.id ORDER BY m.timestamp DESC,m.id DESC LIMIT 1),'')) LIKE '%request_user_input%' OR " ++
+        "LOWER(COALESCE((SELECT m.tool_calls FROM messages m WHERE m.session_id=s.id ORDER BY m.timestamp DESC,m.id DESC LIMIT 1),'')) LIKE '%ask_user%') " ++
+        "THEN 'petdex:needs-input:' || COALESCE((SELECT m.content FROM messages m WHERE m.session_id=s.id ORDER BY m.timestamp DESC,m.id DESC LIMIT 1),'Waiting for you') " ++
+        "ELSE COALESCE((SELECT m.content FROM messages m WHERE m.session_id=s.id AND m.content IS NOT NULL ORDER BY m.timestamp DESC,m.id DESC LIMIT 1),'') END," ++
+        "s.ended_at,LOWER(COALESCE(s.end_reason,'')) FROM sessions s ORDER BY 8 DESC LIMIT 32";
+    var statement: ?*anyopaque = null;
+    const enriched_schema = api.prepare_v2(database, enriched_sql, -1, &statement, null) == 0 and statement != null;
+    if (!enriched_schema) {
+        if (statement != null) _ = api.finalize(statement);
+        statement = null;
+        if (api.prepare_v2(database, portable_sql, -1, &statement, null) != 0 or statement == null) return;
+    }
+    defer _ = api.finalize(statement);
+
+    var events: [max_recent]ProviderEvent = @splat(.{});
+    var raw_ids: [max_recent][hook_server.bubble_session_capacity]u8 = @splat(@splat(0));
+    var raw_id_lens: [max_recent]usize = @splat(0);
+    var len: usize = 0;
+    while (len < events.len and api.step(statement) == 100) {
+        const raw_id = sqliteText(&api, statement, 0);
+        if (raw_id.len == 0) continue;
+        const session_key = sqliteText(&api, statement, 1);
+        const title = sqliteText(&api, statement, 2);
+        const source = sqliteText(&api, statement, 3);
+        const model_config = sqliteText(&api, statement, 4);
+        const parent = sqliteText(&api, statement, 5);
+        const started_ms = sqliteMillis(api.column_double(statement, 6));
+        const activity_ms = sqliteMillis(api.column_double(statement, 7));
+        const raw_description = sqliteText(&api, statement, 8);
+        const ended = sqliteText(&api, statement, 9).len > 0;
+        const end_reason = sqliteText(&api, statement, 10);
+        const modified_ms = if (activity_ms > 0) activity_ms else started_ms;
+        const fresh = modified_ms > 0 and @max(@as(i64, 0), now_ms - modified_ms) <= initial_running_max_age_ms;
+        const needs_input = std.mem.startsWith(u8, raw_description, "petdex:needs-input:");
+        if (!ended and !needs_input and !fresh) continue;
+        setBounded(&raw_ids[len], &raw_id_lens[len], raw_id);
+        events[len] = hermesEventFromRow(.{ .enriched_schema = enriched_schema, .id = raw_id, .session_key = session_key, .title = title, .source = source, .model_config = model_config, .parent_session_id = parent, .started_ms = started_ms, .activity_ms = activity_ms, .description = raw_description, .ended = ended, .end_reason = end_reason });
+        len += 1;
+    }
+
+    // Resolve delegated parent ids to the parent's canonical session_key.
+    for (events[0..len]) |*event| {
+        if (!event.subagent) continue;
+        for (raw_ids[0..len], raw_id_lens[0..len], events[0..len]) |raw, raw_len, parent_event| {
+            if (std.mem.eql(u8, event.parentSlice(), raw[0..raw_len])) {
+                setBounded(&event.parent, &event.parent_len, parent_event.sessionSlice());
+                break;
+            }
+        }
+    }
+    for (events[0..len]) |event| if (!event.subagent) publishHermes(watcher, event, !watcher.hermes_initialized);
+    for (events[0..len]) |event| if (event.subagent) publishHermes(watcher, event, !watcher.hermes_initialized);
+    watcher.hermes_initialized = true;
+}
+
+fn requestPrompt(arguments: std.json.Value, output: *SmallText) void {
+    if (arguments != .object) {
+        output.set("Waiting for you…");
+        return;
+    }
+    if (arguments.object.get("questions")) |questions| {
+        if (questions == .array) for (questions.array.items) |question| {
+            if (valueString(question, "question")) |text| {
+                output.set(text);
+                return;
+            }
+        };
+    }
+    inline for (.{ "question", "justification", "prompt", "reason", "message" }) |key| {
+        if (valueString(arguments, key)) |text| {
+            output.set(text);
+            return;
+        }
+    }
+    output.set("Waiting for you…");
+}
+
+fn parseMetaPrefix(state: *RolloutState, bytes: []const u8) void {
+    const marker = std.mem.indexOf(u8, bytes, "\"type\":\"session_meta\"") orelse return;
+    const meta = bytes[marker..];
+    if (hook_server.jsonStringPub(meta, "cwd")) |cwd| {
+        var decoded: [512]u8 = undefined;
+        state.cwd.set(decodeJsonString(cwd, &decoded));
+    }
+    const thread_source = hook_server.jsonStringPub(meta, "thread_source") orelse "";
+    const source = hook_server.jsonStringPub(meta, "source") orelse "";
+    state.subagent = std.mem.eql(u8, thread_source, "subagent") or std.mem.eql(u8, source, "subagent") or
+        std.mem.indexOf(u8, meta, "\"source\":{\"subagent\"") != null or
+        (hook_server.jsonStringPub(meta, "parent_thread_id") != null and hook_server.jsonStringPub(meta, "agent_nickname") != null);
+}
+
+fn decodeJsonString(value: []const u8, output: []u8) []const u8 {
+    var read: usize = 0;
+    var written: usize = 0;
+    while (read < value.len and written < output.len) {
+        if (value[read] != '\\' or read + 1 >= value.len) {
+            output[written] = value[read];
+            read += 1;
+            written += 1;
+            continue;
+        }
+        const escaped = value[read + 1];
+        output[written] = switch (escaped) {
+            'n', 'r', 't' => ' ',
+            else => escaped,
+        };
+        read += 2;
+        written += 1;
+    }
+    return output[0..written];
+}
+
+fn applyEnvelope(state: *RolloutState, root: std.json.Value, arena: std.mem.Allocator) void {
+    if (root != .object) return;
+    const outer = valueString(root, "type") orelse "";
+    const payload = root.object.get("payload") orelse return;
+    if (payload != .object) return;
+    const event_type = valueString(payload, "type") orelse "";
+
+    if (std.mem.eql(u8, outer, "session_meta")) {
+        if (valueString(payload, "cwd")) |cwd| state.cwd.set(cwd);
+        const thread_source = valueString(payload, "thread_source") orelse "";
+        var source_kind = valueString(payload, "source") orelse "";
+        if (payload.object.get("source")) |source| if (source == .object) {
+            if (source.object.get("subagent") != null) source_kind = "subagent" else source_kind = valueString(source, "type") orelse valueString(source, "kind") orelse "";
+        };
+        state.subagent = std.mem.eql(u8, thread_source, "subagent") or std.mem.eql(u8, source_kind, "subagent") or
+            (valueString(payload, "parent_thread_id") != null and valueString(payload, "agent_nickname") != null);
+        return;
+    }
+    if (std.mem.eql(u8, event_type, "user_message") and state.fallback_title.len == 0) {
+        if (valueString(payload, "message")) |message| state.fallback_title.set(message);
+        return;
+    }
+    if (std.mem.eql(u8, outer, "response_item") and std.mem.eql(u8, event_type, "message")) {
+        const role = valueString(payload, "role") orelse "";
+        if (std.mem.eql(u8, role, "user") and state.fallback_title.len == 0) {
+            if (messageContentText(payload, "input_text")) |message| state.fallback_title.set(message);
+        } else if (std.mem.eql(u8, role, "assistant")) {
+            if (messageContentText(payload, "output_text")) |message| {
+                state.text.set(message);
+                state.message_kind = .assistant;
+            }
+        }
+        return;
+    }
+    if (std.mem.eql(u8, event_type, "task_started")) {
+        state.lifecycle = true;
+        state.status = .running;
+        state.text.set("");
+        state.message_kind = .status;
+        state.pending = @splat(.{});
+        return;
+    }
+    if (std.mem.eql(u8, event_type, "task_complete")) {
+        state.lifecycle = true;
+        state.status = .completed;
+        state.pending = @splat(.{});
+        const final_message = valueString(payload, "last_agent_message") orelse "";
+        if (std.mem.trim(u8, final_message, " \t\r\n").len > 0) {
+            const message = final_message;
+            state.text.set(message);
+            state.message_kind = .assistant;
+        } else if (state.message_kind != .assistant or std.mem.trim(u8, state.text.slice(), " \t\r\n").len == 0) {
+            // Codex may finish a turn without a final-message field. Never
+            // carry an in-progress prompt, reasoning, or “Thinking…” cue
+            // into a completed card; real assistant prose remains useful.
+            state.text.set("Done.");
+            state.message_kind = .status;
+        }
+        return;
+    }
+    if (std.mem.eql(u8, event_type, "turn_aborted") or std.mem.eql(u8, event_type, "task_failed")) {
+        state.lifecycle = true;
+        state.status = .failed;
+        state.pending = @splat(.{});
+        const reason = valueString(payload, "reason") orelse "";
+        state.text.set(if (std.mem.eql(u8, reason, "interrupted")) "Interrupted." else "Session failed.");
+        state.message_kind = .status;
+        return;
+    }
+    if (std.mem.eql(u8, outer, "response_item") and (std.mem.eql(u8, event_type, "function_call") or std.mem.eql(u8, event_type, "custom_tool_call"))) {
+        const name = valueString(payload, "name") orelse "";
+        const raw_arguments = valueString(payload, "arguments") orelse valueString(payload, "input") orelse "{}";
+        const arguments = std.json.parseFromSliceLeaky(std.json.Value, arena, raw_arguments, .{}) catch std.json.Value{ .object = std.json.ObjectMap.init(arena, &.{}, &.{}) catch return };
+        const approval = if (valueString(arguments, "sandbox_permissions")) |permission| std.mem.eql(u8, permission, "require_escalated") else false;
+        if (std.mem.endsWith(u8, name, "request_user_input") or approval) {
+            const id = valueString(payload, "call_id") orelse valueString(payload, "id") orelse "input-request";
+            var prompt: SmallText = .{};
+            requestPrompt(arguments, &prompt);
+            state.setPending(id, prompt.slice());
+            state.status = .needs_input;
+            state.text = prompt;
+            state.message_kind = .prompt;
+        }
+        return;
+    }
+    if (std.mem.eql(u8, outer, "response_item") and (std.mem.eql(u8, event_type, "function_call_output") or std.mem.eql(u8, event_type, "custom_tool_call_output"))) {
+        const id = valueString(payload, "call_id") orelse valueString(payload, "id") orelse "";
+        state.resolvePending(id);
+        if (state.newestPending() == null and state.status == .needs_input) {
+            state.status = .running;
+            state.text.set("Thinking…");
+            state.message_kind = .status;
+        }
+        return;
+    }
+    if (std.mem.eql(u8, event_type, "agent_message")) {
+        if (valueString(payload, "message")) |message| {
+            state.text.set(message);
+            state.message_kind = .assistant;
+        }
+        return;
+    }
+    if (std.mem.eql(u8, event_type, "agent_reasoning") and state.message_kind != .assistant) {
+        if (valueString(payload, "text")) |reasoning| {
+            state.text.set(reasoning);
+            state.message_kind = .reasoning;
+        }
+    }
+}
+
+fn parseRolloutBytes(allocator: std.mem.Allocator, prefix: []const u8, tail: []const u8, title: []const u8) ?Event {
+    var state: RolloutState = .{};
+    parseMetaPrefix(&state, prefix);
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    var lines = std.mem.splitScalar(u8, tail, '\n');
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+        _ = arena.reset(.retain_capacity);
+        const root = std.json.parseFromSliceLeaky(std.json.Value, arena.allocator(), line, .{}) catch continue;
+        applyEnvelope(&state, root, arena.allocator());
+    }
+    if (state.subagent) return null;
+    if (state.newestPending()) |pending| {
+        state.status = .needs_input;
+        state.text = pending.text;
+        state.message_kind = .prompt;
+    } else if (!state.lifecycle) {
+        if (state.text.len == 0) return null;
+        state.status = .running;
+    }
+    if (state.text.len == 0) state.text.set(if (state.status == .running) "Thinking…" else "Done.");
+    var resolved_title: TitleText = .{};
+    resolved_title.set(if (title.len > 0) title else state.fallback_title.slice());
+    return .{
+        .status = state.status,
+        .text = state.text,
+        .title = resolved_title,
+        .cwd = state.cwd,
+        .busy = state.status == .running,
+    };
+}
+
+fn parseRollout(io: std.Io, allocator: std.mem.Allocator, path: []const u8, title: []const u8) ?Event {
+    const prefix = readBounded(io, allocator, path, max_meta_bytes, false) orelse return null;
+    defer allocator.free(prefix);
+    const tail = readBounded(io, allocator, path, max_rollout_bytes, true) orelse return null;
+    defer allocator.free(tail);
+    return parseRolloutBytes(allocator, prefix, tail, title);
+}
+
+fn initialPublishable(event: Event, mtime_ms: i64, now_ms: i64) bool {
+    if (event.status == .needs_input) return true;
+    if (event.status != .running) return false;
+    return @max(@as(i64, 0), now_ms - mtime_ms) <= initial_running_max_age_ms;
+}
+
+fn findWatch(watcher: *Watcher, session: []const u8) ?*Watch {
+    for (&watcher.watches) |*watch| {
+        if (watch.used and std.mem.eql(u8, watch.sessionSlice(), session)) return watch;
+    }
+    return null;
+}
+
+fn freeWatch(watcher: *Watcher) ?*Watch {
+    for (&watcher.watches) |*watch| if (!watch.used) return watch;
+    return null;
+}
+
+fn publish(watch: *Watch, event: Event) void {
+    const digest = event.digest();
+    if (!watch.force and digest == watch.delivered) return;
+    _ = hook_server.mailbox.applyBubbleUpdate(.{
+        .conversation_key = watch.sessionSlice(),
+        .source_session = watch.sessionSlice(),
+        .text = event.text.slice(),
+        .agent = "codex",
+        .title = event.title.slice(),
+        .source_cwd = event.cwd.slice(),
+        .busy = event.busy,
+        .status = switch (event.status) {
+            .idle => .idle,
+            .running => .running,
+            .needs_input => .needs_input,
+            .completed => .completed,
+            .failed => .failed,
+        },
+        .message_kind = switch (event.status) {
+            .needs_input => .prompt,
+            else => .assistant,
+        },
+        .title_source = if (watch.title.len > 0) .server else .prompt,
+        .feed_source = .native_store,
+    });
+    watch.delivered = digest;
+    watch.force = false;
+    if (event.terminal()) watch.used = false;
+}
+
+fn discover(watcher: *Watcher, io: std.Io, now_ms: i64, budget: *ProviderDiscoveryBudget) void {
+    const titles = loadTitles(io, watcher.allocator, watcher.home);
+    const catalog = collectCatalog(io, watcher.allocator, watcher.home, &watcher.rollout_scan, budget);
+    for (&watcher.watches) |*watch| {
+        if (!watch.used) continue;
+        const title = titles.get(watch.sessionSlice());
+        if (!std.mem.eql(u8, watch.title.slice(), title)) {
+            watch.title.set(title);
+            watch.force = true;
+        }
+    }
+    for (catalog.entries[0..catalog.len]) |candidate| {
+        if (findWatch(watcher, candidate.sessionSlice())) |watch| {
+            if (!std.mem.eql(u8, watch.pathSlice(), candidate.pathSlice())) {
+                watch.path_len = candidate.path_len;
+                @memcpy(watch.path[0..candidate.path_len], candidate.pathSlice());
+                watch.force = true;
+            }
+            continue;
+        }
+        const slot = freeWatch(watcher) orelse break;
+        const title = titles.get(candidate.sessionSlice());
+        const event = parseRollout(io, watcher.allocator, candidate.pathSlice(), title) orelse continue;
+        if (!initialPublishable(event, candidate.mtime_ms, now_ms)) continue;
+        slot.* = .{ .used = true, .size = candidate.size, .mtime_ms = candidate.mtime_ms };
+        slot.session_len = candidate.session_len;
+        @memcpy(slot.session[0..candidate.session_len], candidate.sessionSlice());
+        slot.path_len = candidate.path_len;
+        @memcpy(slot.path[0..candidate.path_len], candidate.pathSlice());
+        slot.title.set(title);
+        publish(slot, event);
+    }
+}
+
+fn follow(watcher: *Watcher, io: std.Io, now_ms: i64) void {
+    _ = now_ms;
+    for (&watcher.watches) |*watch| {
+        if (!watch.used) continue;
+        const info = fileInfo(io, watch.pathSlice()) orelse continue;
+        if (!watch.force and info.size == watch.size and info.mtime_ms == watch.mtime_ms) continue;
+        watch.size = info.size;
+        watch.mtime_ms = info.mtime_ms;
+        const event = parseRollout(io, watcher.allocator, watch.pathSlice(), watch.title.slice()) orelse continue;
+        publish(watch, event);
+    }
+}
+
+test "running rollout becomes a busy titled bubble" {
+    const fixture =
+        \\{"type":"session_meta","payload":{"cwd":"C:\\work","thread_source":"user"}}
+        \\{"type":"event_msg","payload":{"type":"user_message","message":"Fallback title"}}
+        \\{"type":"event_msg","payload":{"type":"task_started"}}
+    ;
+    const event = parseRolloutBytes(std.testing.allocator, fixture, fixture, "Indexed title").?;
+    try std.testing.expectEqual(Status.running, event.status);
+    try std.testing.expect(event.busy);
+    try std.testing.expectEqualStrings("Thinking…", event.text.slice());
+    try std.testing.expectEqualStrings("Indexed title", event.title.slice());
+    try std.testing.expectEqualStrings("C:\\work", event.cwd.slice());
+}
+
+test "pending input survives initial reconciliation and resolves" {
+    const waiting =
+        \\{"type":"event_msg","payload":{"type":"task_started"}}
+        \\{"type":"response_item","payload":{"type":"function_call","name":"request_user_input","call_id":"q1","arguments":"{\"questions\":[{\"question\":\"Choose one?\"}]}"}}
+    ;
+    const event = parseRolloutBytes(std.testing.allocator, waiting, waiting, "").?;
+    try std.testing.expectEqual(Status.needs_input, event.status);
+    try std.testing.expect(!event.busy);
+    try std.testing.expectEqualStrings("Choose one?", event.text.slice());
+
+    const resolved = waiting ++
+        \\{"type":"response_item","payload":{"type":"function_call_output","call_id":"q1"}}
+        \\{"type":"event_msg","payload":{"type":"task_complete","last_agent_message":"Finished"}}
+    ;
+    const done = parseRolloutBytes(std.testing.allocator, resolved, resolved, "").?;
+    try std.testing.expectEqual(Status.completed, done.status);
+    try std.testing.expectEqualStrings("Finished", done.text.slice());
+}
+
+test "bare Codex completion clears transient copy but retains assistant prose" {
+    const waiting =
+        \\{"type":"event_msg","payload":{"type":"task_started"}}
+        \\{"type":"response_item","payload":{"type":"function_call","name":"request_user_input","call_id":"q1","arguments":"{\"questions\":[{\"question\":\"Choose one?\"}]}"}}
+        \\{"type":"response_item","payload":{"type":"function_call_output","call_id":"q1"}}
+        \\{"type":"event_msg","payload":{"type":"task_complete"}}
+    ;
+    const done = parseRolloutBytes(std.testing.allocator, waiting, waiting, "").?;
+    try std.testing.expectEqual(Status.completed, done.status);
+    try std.testing.expect(!done.busy);
+    try std.testing.expectEqualStrings("Done.", done.text.slice());
+
+    const prose =
+        \\{"type":"event_msg","payload":{"type":"task_started"}}
+        \\{"type":"event_msg","payload":{"type":"agent_message","message":"Useful final answer."}}
+        \\{"type":"event_msg","payload":{"type":"task_complete","last_agent_message":"   "}}
+    ;
+    const retained = parseRolloutBytes(std.testing.allocator, prose, prose, "").?;
+    try std.testing.expectEqual(Status.completed, retained.status);
+    try std.testing.expect(!retained.busy);
+    try std.testing.expectEqualStrings("Useful final answer.", retained.text.slice());
+}
+
+test "subagent and stale completed history are not published" {
+    const child =
+        \\{"type":"session_meta","payload":{"cwd":"C:\\work","thread_source":"subagent"}}
+        \\{"type":"event_msg","payload":{"type":"task_started"}}
+    ;
+    try std.testing.expect(parseRolloutBytes(std.testing.allocator, child, child, "Child") == null);
+
+    const complete =
+        \\{"type":"event_msg","payload":{"type":"task_started"}}
+        \\{"type":"event_msg","payload":{"type":"task_complete","last_agent_message":"Old answer"}}
+    ;
+    const event = parseRolloutBytes(std.testing.allocator, complete, complete, "Old").?;
+    try std.testing.expect(!initialPublishable(event, 0, initial_running_max_age_ms + 1));
+}
+
+test "partial final JSONL record is ignored" {
+    const fixture =
+        \\{"type":"event_msg","payload":{"type":"task_started"}}
+        \\{"type":"event_msg","payload":{"type":"task_complete"
+    ;
+    const event = parseRolloutBytes(std.testing.allocator, fixture, fixture, "Live").?;
+    try std.testing.expectEqual(Status.running, event.status);
+}
+
+test "failure is terminal and non-busy" {
+    const fixture =
+        \\{"type":"event_msg","payload":{"type":"task_started"}}
+        \\{"type":"event_msg","payload":{"type":"turn_aborted","reason":"interrupted"}}
+    ;
+    const event = parseRolloutBytes(std.testing.allocator, fixture, fixture, "Failed task").?;
+    try std.testing.expectEqual(Status.failed, event.status);
+    try std.testing.expect(!event.busy);
+    try std.testing.expect(event.terminal());
+    try std.testing.expectEqualStrings("Interrupted.", event.text.slice());
+}
+
+test "freshness includes old unresolved input but not abandoned running history" {
+    const running_fixture =
+        \\{"type":"event_msg","payload":{"type":"task_started"}}
+    ;
+    const running = parseRolloutBytes(std.testing.allocator, running_fixture, running_fixture, "Running").?;
+    const now = initial_running_max_age_ms * 3;
+    try std.testing.expect(initialPublishable(running, now - initial_running_max_age_ms, now));
+    try std.testing.expect(!initialPublishable(running, now - initial_running_max_age_ms - 1, now));
+
+    const waiting_fixture =
+        \\{"type":"event_msg","payload":{"type":"task_started"}}
+        \\{"type":"response_item","payload":{"type":"custom_tool_call","name":"functions.request_user_input","call_id":"q1","input":"{\"question\":\"Continue?\"}"}}
+    ;
+    const waiting = parseRolloutBytes(std.testing.allocator, waiting_fixture, waiting_fixture, "Waiting").?;
+    try std.testing.expect(initialPublishable(waiting, 0, now));
+}
+
+test "renamed and multiple active rollouts keep one stable mailbox slot per session" {
+    const fixture =
+        \\{"type":"session_meta","payload":{"cwd":"C:\\work","thread_source":"user"}}
+        \\{"type":"event_msg","payload":{"type":"task_started"}}
+    ;
+    const alpha = parseRolloutBytes(std.testing.allocator, fixture, fixture, "Alpha").?;
+    const beta = parseRolloutBytes(std.testing.allocator, fixture, fixture, "Beta").?;
+    var mailbox: hook_server.Mailbox = .{};
+    const alpha_counter = mailbox.applyBubbleUpdate(.{ .conversation_key = "session-alpha", .source_session = "session-alpha", .text = alpha.text.slice(), .agent = "codex", .title = alpha.title.slice(), .source_cwd = alpha.cwd.slice(), .busy = alpha.busy, .status = .running, .title_source = .server, .feed_source = .native_store });
+    _ = mailbox.applyBubbleUpdate(.{ .conversation_key = "session-beta", .source_session = "session-beta", .text = beta.text.slice(), .agent = "codex", .title = beta.title.slice(), .source_cwd = beta.cwd.slice(), .busy = beta.busy, .status = .running, .title_source = .server, .feed_source = .native_store });
+    const renamed = parseRolloutBytes(std.testing.allocator, fixture, fixture, "Alpha renamed").?;
+    const renamed_counter = mailbox.applyBubbleUpdate(.{ .conversation_key = "session-alpha", .source_session = "session-alpha", .text = renamed.text.slice(), .agent = "codex", .title = renamed.title.slice(), .source_cwd = renamed.cwd.slice(), .busy = renamed.busy, .status = .running, .title_source = .server, .feed_source = .native_store });
+    try std.testing.expect(renamed_counter > alpha_counter);
+    try std.testing.expectEqual(@as(usize, 2), mailbox.bubbles_len);
+    try std.testing.expectEqualStrings("session-alpha", mailbox.bubbles[0].sessionSlice());
+    try std.testing.expectEqualStrings("Alpha renamed", mailbox.bubbles[0].title[0..mailbox.bubbles[0].title_len]);
+    try std.testing.expectEqualStrings("session-beta", mailbox.bubbles[1].sessionSlice());
+}
+
+test "current response-item messages map user titles and assistant progress" {
+    const fixture =
+        \\{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Fix the bubble tracker"}]}}
+        \\{"type":"event_msg","payload":{"type":"task_started"}}
+        \\{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Inspecting window movement"}]}}
+    ;
+    const event = parseRolloutBytes(std.testing.allocator, fixture, fixture, "").?;
+    try std.testing.expectEqualStrings("Fix the bubble tracker", event.title.slice());
+    try std.testing.expectEqualStrings("Inspecting window movement", event.text.slice());
+    try std.testing.expect(event.busy);
+}
+
+test "adapter registry covers all nine agents and fails closed for unversioned stores" {
+    try std.testing.expectEqual(@as(usize, 9), adapters.len);
+    const expected = [_][]const u8{ "claude-code", "codex", "gemini", "opencode", "qoder", "kimi-code", "codebuddy", "omp", "hermes" };
+    for (adapters, expected) |adapter, name| {
+        try std.testing.expectEqualStrings(name, adapter.agent);
+        if (adapter.store == .hooks_only) {
+            try std.testing.expectEqual(AdapterCapabilities{}, adapter.capabilities);
+        } else if (adapter.schema == .hermes) {
+            try std.testing.expect(adapter.capabilities.authoritative_titles);
+            try std.testing.expect(!adapter.capabilities.input_correlation);
+            try std.testing.expect(!adapter.capabilities.origin_activation);
+        }
+    }
+    try std.testing.expect(!adapters[0].capabilities.authoritative_titles);
+    try std.testing.expect(adapters[2].capabilities.authoritative_titles);
+    try std.testing.expect(adapters[7].capabilities.authoritative_titles);
+}
+
+test "candidate admission seeds every detected provider before noisy recency" {
+    var catalogs: [adapters.len]Catalog = @splat(.{});
+    catalogs[0].len = max_recent;
+    for (catalogs[0].entries[0..max_recent], 0..) |*entry, index|
+        entry.mtime_ms = 10_000 - @as(i64, @intCast(index));
+    for (1..adapters.len) |index| {
+        catalogs[index].len = 1;
+        catalogs[index].entries[0].mtime_ms = @intCast(index);
+    }
+
+    var selected: [max_recent]ProviderCandidate = undefined;
+    const count = selectProviderCandidates(&catalogs, &selected);
+    try std.testing.expectEqual(max_recent, count);
+    for (0..adapters.len) |index|
+        try std.testing.expectEqual(@as(u8, @intCast(index)), selected[index].adapter_index);
+    try std.testing.expectEqual(@as(u8, 0), selected[adapters.len].adapter_index);
+}
+
+test "Hermes portable schema distinguishes continuations workers input and failure" {
+    // A documented parent_session_id can be a compression continuation; it
+    // is not a delegated worker without an explicit source/config marker.
+    try std.testing.expect(!hermesSessionIsSubagent(false, "cli", "{}", "previous", "current"));
+    try std.testing.expect(hermesSessionIsSubagent(false, "worker", "{}", "parent", "child"));
+    try std.testing.expect(hermesSessionIsSubagent(false, "cli", "{\"_delegate_from\":\"parent\"}", "parent", "child"));
+    try std.testing.expect(hermesSessionIsSubagent(true, "cli", "{}", "parent", ""));
+
+    try std.testing.expectEqual(Status.needs_input, hermesSessionStatus(false, true, ""));
+    try std.testing.expectEqual(Status.completed, hermesSessionStatus(true, false, "complete"));
+    try std.testing.expectEqual(Status.failed, hermesSessionStatus(true, false, "interrupted"));
+}
+
+const ProviderFixtureCase = struct {
+    adapter_index: usize,
+    bytes: []const u8,
+    path: []const u8,
+    completion_marker: []const u8,
+    session: []const u8,
+    parent: []const u8,
+    title: []const u8,
+    title_source: hook_server.TitleSource,
+    final_text: []const u8,
+};
+
+test "versioned provider-owned fixtures exercise identity title parent completion and publication" {
+    const cases = [_]ProviderFixtureCase{
+        .{ .adapter_index = 0, .bytes = @embedFile("test-fixtures/session-reconcile/v1/claude.jsonl"), .path = "C:/fixture/projects/project/claude-primary.jsonl", .completion_marker = "{\"type\":\"assistant\"", .session = "claude-primary", .parent = "", .title = "Review the rounded bubble controls", .title_source = .prompt, .final_text = "Claude review complete" },
+        .{ .adapter_index = 2, .bytes = @embedFile("test-fixtures/session-reconcile/v1/gemini.jsonl"), .path = "C:/fixture/chats/gemini-parent/gemini-child.jsonl", .completion_marker = "{\"id\":\"gemini-model-1\"", .session = "gemini-child", .parent = "gemini-parent", .title = "Gemini authoritative title", .title_source = .server, .final_text = "Gemini research complete" },
+        .{ .adapter_index = 7, .bytes = @embedFile("test-fixtures/session-reconcile/v1/omp.jsonl"), .path = "C:/fixture/sessions/omp-child.jsonl", .completion_marker = "{\"type\":\"message\",\"id\":\"omp-assistant-1\"", .session = "omp-child", .parent = "omp-parent", .title = "OMP authoritative title", .title_source = .server, .final_text = "OMP review complete" },
+    };
+    for (cases) |case| {
+        const adapter = adapters[case.adapter_index];
+        const fixture_line_end = std.mem.indexOfScalar(u8, case.bytes, '\n') orelse return error.MissingFixtureMetadata;
+        const fixture_root = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, case.bytes[0..fixture_line_end], .{});
+        defer fixture_root.deinit();
+        const fixture = fixture_root.value.object.get("_fixture") orelse return error.MissingFixtureMetadata;
+        try std.testing.expectEqualStrings(adapter.agent, objectString(fixture, "provider") orelse "");
+        try std.testing.expect(objectBool(fixture, "sanitized") orelse false);
+        const fixture_source = objectString(fixture, "source") orelse return error.MissingFixtureMetadata;
+        try std.testing.expect(std.mem.startsWith(u8, fixture_source, "provider-owned"));
+        try std.testing.expect(objectValue(fixture, "version") != null);
+        const checkpoint = std.mem.indexOf(u8, case.bytes, case.completion_marker) orelse return error.MissingFixtureCheckpoint;
+        const running = parseProviderBytes(std.testing.allocator, adapter.schema, case.path, case.bytes[0..checkpoint], case.bytes[0..checkpoint]).?;
+        try std.testing.expectEqual(Status.running, running.status);
+        try std.testing.expectEqualStrings(case.session, running.sessionSlice());
+        try std.testing.expectEqualStrings(case.parent, running.parentSlice());
+        try std.testing.expectEqualStrings(case.title, running.title.slice());
+        try std.testing.expectEqual(case.title_source, running.title_source);
+
+        const completed = parseProviderBytes(std.testing.allocator, adapter.schema, case.path, case.bytes, case.bytes).?;
+        try std.testing.expectEqual(Status.completed, completed.status);
+        try std.testing.expectEqual(case.parent.len > 0, completed.subagent);
+        try std.testing.expectEqualStrings(case.final_text, completed.text.slice());
+        const update = providerBubbleUpdate(adapter, &completed);
+        try std.testing.expectEqualStrings(if (case.parent.len > 0) case.parent else case.session, update.conversation_key);
+        try std.testing.expectEqualStrings(case.session, update.source_session);
+        try std.testing.expectEqual(if (case.parent.len > 0) hook_server.SessionKind.subagent else hook_server.SessionKind.primary, update.session_kind);
+        try std.testing.expectEqual(hook_server.SessionStatus.completed, update.status.?);
+        try std.testing.expectEqual(hook_server.FeedSource.native_store, update.feed_source);
+    }
+}
+
+test "provider contracts reject another provider identity vocabulary" {
+    const foreign = "{\"event\":\"task_started\",\"session_id\":\"must-not-cross\"}";
+    try std.testing.expect(parseProviderBytes(std.testing.allocator, .claude, "C:/fixture/unknown.jsonl", foreign, foreign) == null);
+    try std.testing.expect(parseProviderBytes(std.testing.allocator, .opencode, "C:/fixture/session.json", foreign, foreign) == null);
+}
+
+test "Hermes versioned row fixture lowers through SQLite row adapter and publication" {
+    const waiting_parsed = try std.json.parseFromSlice(HermesRow, std.testing.allocator, @embedFile("test-fixtures/session-reconcile/v1/hermes-waiting.json"), .{ .ignore_unknown_fields = true });
+    defer waiting_parsed.deinit();
+    const waiting = hermesEventFromRow(waiting_parsed.value);
+    try std.testing.expectEqual(Status.needs_input, waiting.status);
+    try std.testing.expectEqualStrings("Choose a deployment target", waiting.text.slice());
+    try std.testing.expectEqual(@as(usize, 0), waiting.request_id_len);
+
+    const parsed = try std.json.parseFromSlice(HermesRow, std.testing.allocator, @embedFile("test-fixtures/session-reconcile/v1/hermes.json"), .{ .ignore_unknown_fields = true });
+    defer parsed.deinit();
+    const event = hermesEventFromRow(parsed.value);
+    try std.testing.expectEqualStrings("hermes-child", event.sessionSlice());
+    try std.testing.expectEqualStrings("hermes-parent", event.parentSlice());
+    try std.testing.expectEqualStrings("Hermes authoritative title", event.title.slice());
+    try std.testing.expectEqualStrings("Hermes review complete", event.text.slice());
+    try std.testing.expect(event.subagent);
+    try std.testing.expectEqual(Status.completed, event.status);
+    const update = providerBubbleUpdate(adapters[8], &event);
+    try std.testing.expectEqualStrings("hermes-parent", update.conversation_key);
+    try std.testing.expectEqual(hook_server.SessionKind.subagent, update.session_kind);
+    try std.testing.expectEqual(hook_server.FeedSource.native_store, update.feed_source);
+}
+
+test "journal replay deduplicates hook overlap and keeps richer hook metadata" {
+    const source_cwd = if (builtin.os.tag == .windows) "C:/rich" else "/rich";
+    var parent_body_buf: [1024]u8 = undefined;
+    const parent_body = try std.fmt.bufPrint(
+        &parent_body_buf,
+        "{{\"text\":\"Working\",\"busy\":true,\"agent_source\":\"claude-code\",\"session_id\":\"parent\",\"conversation_key\":\"parent\",\"source_session_id\":\"parent\",\"session_kind\":\"primary\",\"source_cwd\":\"{s}\",\"message_id\":\"m1\",\"event_kind\":\"assistant\",\"message_kind\":\"assistant\",\"feed_source\":\"hook\",\"status\":\"running\"}}",
+        .{source_cwd},
+    );
+    const child_body =
+        \\{"text":"Nested result","busy":false,"agent_source":"claude-code","session_id":"child","conversation_key":"parent","source_session_id":"child","parent_session_id":"parent","session_kind":"subagent","subagent_label":"Reviewer","message_id":"c1","event_kind":"subagent-stop","message_kind":"assistant","feed_source":"hook","status":"completed"}
+    ;
+    var hook_mailbox: hook_server.Mailbox = .{};
+    const hook_counter = hook_server.applyBubbleJson(&hook_mailbox, parent_body, .hook).?;
+    var journal_buf: [4096]u8 = undefined;
+    const journal = try std.fmt.bufPrint(
+        &journal_buf,
+        "{{\"journal_version\":1,\"event\":{s}}}\n{{\"journal_version\":1,\"event\":{s}}}\n",
+        .{ parent_body, child_body },
+    );
+    replayJournalBytes(&hook_mailbox, journal);
+    const after_first = hook_mailbox.bubble_counter;
+    try std.testing.expect(after_first > hook_counter);
+    try std.testing.expectEqual(@as(usize, 1), hook_mailbox.bubbles_len);
+    try std.testing.expectEqual(@as(usize, 1), hook_mailbox.bubbles[0].child_messages_len);
+    try std.testing.expectEqual(hook_server.FeedSource.hook, hook_mailbox.bubbles[0].feed_source);
+    try std.testing.expectEqualStrings(source_cwd, hook_mailbox.bubbles[0].cwdSlice());
+    replayJournalBytes(&hook_mailbox, journal);
+    try std.testing.expectEqual(after_first, hook_mailbox.bubble_counter);
+}
+
+test "journal skips partial invalid UTF-8 corrupt and unsupported records" {
+    const unsupported = "{\"journal_version\":2,\"event\":{\"text\":\"bad\",\"agent_source\":\"codex\"}}";
+    const partial = "{\"journal_version\":1,\"event\":{\"text\":\"partial\"";
+    const invalid = [_]u8{ '{', '"', 'j', 'o', 'u', 'r', 'n', 'a', 'l', '_', 'v', 'e', 'r', 's', 'i', 'o', 'n', '"', ':', '1', ',', '"', 'e', 'v', 'e', 'n', 't', '"', ':', '{', '"', 't', 'e', 'x', 't', '"', ':', '"', 0xff, '"', '}', '}' };
+    try std.testing.expect(journalEvent(unsupported) == null);
+    try std.testing.expect(journalEvent(partial) == null);
+    try std.testing.expect(journalEvent(&invalid) == null);
+}
+
+test "pretty printed recorded chat is accepted without JSONL framing" {
+    const chat =
+        \\{
+        \\  "sessionId": "gemini-session",
+        \\  "projectHash": "fixture-project",
+        \\  "summary": "Recorded chat",
+        \\  "messages": [
+        \\    {"id":"user-1","type":"user","content":[{"text":"Question"}]},
+        \\    {"id":"model-1","type":"gemini","content":[{"text":"Current answer"}]}
+        \\  ]
+        \\}
+    ;
+    const event = parseProviderBytes(std.testing.allocator, .gemini, "C:/gemini/chats/session.json", chat, chat).?;
+    try std.testing.expectEqualStrings("gemini-session", event.sessionSlice());
+    try std.testing.expectEqualStrings("Current answer", event.text.slice());
+    try std.testing.expectEqual(Status.completed, event.status);
+}

--- a/packages/petdex-desktop-native/src/session_reconcile.zig
+++ b/packages/petdex-desktop-native/src/session_reconcile.zig
@@ -1380,15 +1380,29 @@ fn publishProvider(watch: *ProviderWatch, event: ProviderEvent) void {
     if (event.status == .completed or event.status == .failed) watch.used = false;
 }
 
-fn findProviderWatch(watcher: *Watcher, adapter_index: u8, path: []const u8) ?*ProviderWatch {
-    for (&watcher.provider_watches) |*watch|
-        if (watch.used and watch.adapter_index == adapter_index and std.mem.eql(u8, watch.pathSlice(), path)) return watch;
+/// Active watches and unchanged terminal tombstones both suppress discovery.
+/// A terminal event keeps its bounded path/stamp after releasing the live
+/// watch slot, preventing the same recent multi-megabyte transcript from being
+/// reparsed every two seconds. A changed stamp clears the tombstone so a file
+/// that legitimately resumes can be admitted again.
+fn findProviderWatch(watcher: *Watcher, adapter_index: u8, path: []const u8, size: u64, mtime_ms: i64) ?*ProviderWatch {
+    for (&watcher.provider_watches) |*watch| {
+        if (watch.adapter_index != adapter_index or !std.mem.eql(u8, watch.pathSlice(), path)) continue;
+        if (watch.used or (watch.size == size and watch.mtime_ms == mtime_ms)) return watch;
+        watch.* = .{};
+        return null;
+    }
     return null;
 }
 
 fn freeProviderWatch(watcher: *Watcher) ?*ProviderWatch {
-    for (&watcher.provider_watches) |*watch| if (!watch.used) return watch;
-    return null;
+    var tombstone: ?*ProviderWatch = null;
+    for (&watcher.provider_watches) |*watch| {
+        if (watch.used) continue;
+        if (watch.path_len == 0) return watch;
+        if (tombstone == null) tombstone = watch;
+    }
+    return tombstone;
 }
 
 const ProviderDiscoveryResult = struct { added: bool = false, budget_exhausted: bool = false };
@@ -1427,7 +1441,7 @@ fn discoverProviders(watcher: *Watcher, io: std.Io, now_ms: i64) ProviderDiscove
     inline for (.{ false, true }) |subagents| {
         for (selected[0..selected_len]) |item| {
             const candidate = item.candidate;
-            if (findProviderWatch(watcher, item.adapter_index, candidate.pathSlice()) != null) continue;
+            if (findProviderWatch(watcher, item.adapter_index, candidate.pathSlice(), candidate.size, candidate.mtime_ms) != null) continue;
             const event = parseProviderFile(io, watcher.allocator, adapters[item.adapter_index], candidate.pathSlice()) orelse continue;
             if (event.subagent != subagents or !providerInitialPublishable(event, candidate.mtime_ms, now_ms)) continue;
             const slot = freeProviderWatch(watcher) orelse return result;
@@ -2281,14 +2295,33 @@ test "candidate admission seeds every detected provider before noisy recency" {
 
 test "terminal subagent provider watches release their slots" {
     var event: ProviderEvent = .{ .status = .completed, .subagent = true };
-    var watch: ProviderWatch = .{ .used = true, .adapter_index = 0 };
+    var watch: ProviderWatch = .{ .used = true, .adapter_index = 0, .size = 4096, .mtime_ms = 42 };
+    setBounded(&watch.path, &watch.path_len, "claude/child.jsonl");
     publishProvider(&watch, event);
     try std.testing.expect(!watch.used);
+    try std.testing.expectEqualStrings("claude/child.jsonl", watch.pathSlice());
+    try std.testing.expectEqual(@as(u64, 4096), watch.size);
+    try std.testing.expectEqual(@as(i64, 42), watch.mtime_ms);
 
     event.status = .running;
     watch = .{ .used = true, .adapter_index = 0 };
     publishProvider(&watch, event);
     try std.testing.expect(watch.used);
+}
+
+test "unchanged terminal provider tombstones suppress rediscovery" {
+    var watcher: Watcher = .{ .allocator = std.testing.allocator, .home = "" };
+    const terminal = &watcher.provider_watches[0];
+    terminal.* = .{ .adapter_index = 2, .size = 4096, .mtime_ms = 42 };
+    setBounded(&terminal.path, &terminal.path_len, "gemini/child.jsonl");
+
+    try std.testing.expect(findProviderWatch(&watcher, 2, "gemini/child.jsonl", 4096, 42) == terminal);
+    // Prefer a genuinely empty slot so tombstones survive until capacity is
+    // actually needed.
+    try std.testing.expect(freeProviderWatch(&watcher) == &watcher.provider_watches[1]);
+
+    try std.testing.expect(findProviderWatch(&watcher, 2, "gemini/child.jsonl", 4100, 43) == null);
+    try std.testing.expectEqual(@as(usize, 0), watcher.provider_watches[0].path_len);
 }
 
 test "Hermes portable schema distinguishes continuations workers input and failure" {

--- a/packages/petdex-desktop-native/src/session_reconcile.zig
+++ b/packages/petdex-desktop-native/src/session_reconcile.zig
@@ -1369,40 +1369,11 @@ fn providerBubbleUpdate(adapter: AgentSessionAdapter, event: *const ProviderEven
     };
 }
 
-fn recoveredAgentState(status: Status) []const u8 {
-    return switch (status) {
-        .running => "running",
-        .needs_input => "waiting",
-        .failed => "failed",
-        .idle, .completed => "",
-    };
-}
-
-/// Native stores are authoritative recovery evidence for both the bubble
-/// lifecycle and its Flock body. Lower them together so a missed hook cannot
-/// leave an older failed/review sprite attached to progress or completion.
-/// Child events only contribute prose to their parent and must never replace
-/// the parent's own attention state.
-fn applyRecoveredBubble(target: *hook_server.Mailbox, update: hook_server.BubbleUpdate, status: Status) u64 {
-    const counter = target.applyBubbleUpdate(update);
-    if (update.session_kind == .primary) {
-        target.setBubbleAgentStateIdentity(
-            update.conversation_key,
-            recoveredAgentState(status),
-            update.agent,
-            update.hostname,
-            update.remote,
-            true,
-        );
-    }
-    return counter;
-}
-
 fn publishProvider(watch: *ProviderWatch, event: ProviderEvent) void {
     const digest = event.digest();
     if (digest == watch.delivered) return;
     const adapter = adapters[watch.adapter_index];
-    _ = applyRecoveredBubble(&hook_server.mailbox, providerBubbleUpdate(adapter, &event), event.status);
+    _ = hook_server.mailbox.applyBubbleUpdateWithDerivedAgentState(providerBubbleUpdate(adapter, &event));
     watch.delivered = digest;
     if (event.status == .completed or event.status == .failed) watch.used = false;
 }
@@ -1620,7 +1591,7 @@ fn publishHermes(watcher: *Watcher, event: ProviderEvent, initial: bool) void {
         seen.digest = digest;
         if (terminal) seen.used = false;
     }
-    _ = applyRecoveredBubble(&hook_server.mailbox, .{
+    _ = hook_server.mailbox.applyBubbleUpdateWithDerivedAgentState(.{
         .conversation_key = if (event.subagent) event.parentSlice() else event.sessionSlice(),
         .source_session = event.sessionSlice(),
         .parent_session = event.parentSlice(),
@@ -1642,7 +1613,7 @@ fn publishHermes(watcher: *Watcher, event: ProviderEvent, initial: bool) void {
         .message_kind = if (event.subagent) .assistant else .status,
         .title_source = .server,
         .feed_source = .native_store,
-    }, event.status);
+    });
 }
 
 fn sqliteMillis(value: f64) i64 {
@@ -2036,7 +2007,7 @@ fn freeWatch(watcher: *Watcher) ?*Watch {
 fn publish(watch: *Watch, event: Event) void {
     const digest = event.digest();
     if (!watch.force and digest == watch.delivered) return;
-    _ = applyRecoveredBubble(&hook_server.mailbox, .{
+    _ = hook_server.mailbox.applyBubbleUpdateWithDerivedAgentState(.{
         .conversation_key = watch.sessionSlice(),
         .source_session = watch.sessionSlice(),
         .text = event.text.slice(),
@@ -2057,7 +2028,7 @@ fn publish(watch: *Watch, event: Event) void {
         },
         .title_source = if (watch.title.len > 0) .server else .prompt,
         .feed_source = .native_store,
-    }, event.status);
+    });
     watch.delivered = digest;
     watch.force = false;
     if (event.terminal()) watch.used = false;
@@ -2288,92 +2259,97 @@ test "renamed and multiple active rollouts keep one stable mailbox slot per sess
     try std.testing.expectEqualStrings("session-beta", mailbox.bubbles[1].sessionSlice());
 }
 
-test "native store recovery replaces primary Flock state for every lifecycle" {
+test "native store recovery derives Flock state from canonical reconciled lifecycle" {
     var mailbox: hook_server.Mailbox = .{};
-    const identity = hook_server.BubbleIdentity{
-        .conversation_key = "recovered-primary",
-        .agent = "claude-code",
-        .hostname = "",
-        .remote = false,
-    };
+    const raw_identity = "provider/session/with:unsafe/components/and/a/conversation-key-longer-than-the-mailbox-storage-boundary/recovered-primary";
+    const agent = "claude-code";
 
     _ = mailbox.applyBubbleUpdate(.{
-        .conversation_key = identity.conversation_key,
-        .source_session = identity.conversation_key,
-        .text = "Hook is reviewing",
-        .agent = identity.agent,
-        .busy = true,
-        .status = .running,
-        .message_kind = .assistant,
-        .feed_source = .hook,
-    });
-    mailbox.setBubbleAgentStateIdentity(identity.conversation_key, "review", identity.agent, identity.hostname, identity.remote, true);
-
-    _ = applyRecoveredBubble(&mailbox, .{
-        .conversation_key = identity.conversation_key,
-        .source_session = identity.conversation_key,
-        .text = "Waiting for you…",
-        .agent = identity.agent,
+        .conversation_key = raw_identity,
+        .source_session = raw_identity,
+        .text = "Approve the recovered action",
+        .agent = agent,
+        .request_id = "approval-1",
         .busy = false,
         .status = .needs_input,
         .message_kind = .prompt,
-        .feed_source = .native_store,
-    }, .needs_input);
-    try std.testing.expectEqual(hook_server.SessionStatus.needs_input, mailbox.bubbles[0].status);
-    try std.testing.expectEqualStrings("waiting", mailbox.bubbles[0].agentStateSlice());
+        .feed_source = .hook,
+    });
+    try std.testing.expectEqual(@as(usize, std.crypto.hash.sha2.Sha256.digest_length * 2), mailbox.bubbles[0].session_len);
+    try std.testing.expect(!std.mem.eql(u8, raw_identity, mailbox.bubbles[0].sessionSlice()));
+    mailbox.setBubbleAgentStateIdentity(mailbox.bubbles[0].sessionSlice(), "review", agent, "", false, true);
 
-    _ = applyRecoveredBubble(&mailbox, .{
-        .conversation_key = identity.conversation_key,
-        .source_session = identity.conversation_key,
-        .text = "Recovered progress",
-        .agent = identity.agent,
-        .message_id = "assistant-2",
+    // Generic progress cannot resolve a keyed approval. The recovered state
+    // must follow the accepted needs_input status, not the proposed running
+    // status, and must find the normalized long provider identity.
+    _ = mailbox.applyBubbleUpdateWithDerivedAgentState(.{
+        .conversation_key = raw_identity,
+        .source_session = raw_identity,
+        .text = "Recovered progress without approval correlation",
+        .agent = agent,
+        .message_id = "assistant-1",
         .event_kind = "native-store",
         .busy = true,
         .status = .running,
         .message_kind = .assistant,
         .feed_source = .native_store,
-    }, .running);
+    });
+    try std.testing.expectEqual(hook_server.SessionStatus.needs_input, mailbox.bubbles[0].status);
+    try std.testing.expectEqualStrings("waiting", mailbox.bubbles[0].agentStateSlice());
+
+    _ = mailbox.applyBubbleUpdateWithDerivedAgentState(.{
+        .conversation_key = raw_identity,
+        .source_session = raw_identity,
+        .text = "Recovered progress",
+        .agent = agent,
+        .message_id = "assistant-2",
+        .resolves_request_id = "approval-1",
+        .event_kind = "native-store",
+        .busy = true,
+        .status = .running,
+        .message_kind = .assistant,
+        .feed_source = .native_store,
+    });
     try std.testing.expectEqual(hook_server.SessionStatus.running, mailbox.bubbles[0].status);
     try std.testing.expectEqualStrings("running", mailbox.bubbles[0].agentStateSlice());
 
-    _ = applyRecoveredBubble(&mailbox, .{
-        .conversation_key = identity.conversation_key,
-        .source_session = identity.conversation_key,
+    _ = mailbox.applyBubbleUpdateWithDerivedAgentState(.{
+        .conversation_key = raw_identity,
+        .source_session = raw_identity,
         .text = "Session failed.",
-        .agent = identity.agent,
+        .agent = agent,
         .busy = false,
         .status = .failed,
         .feed_source = .native_store,
-    }, .failed);
+    });
     try std.testing.expectEqualStrings("failed", mailbox.bubbles[0].agentStateSlice());
 
-    _ = applyRecoveredBubble(&mailbox, .{
-        .conversation_key = identity.conversation_key,
-        .source_session = identity.conversation_key,
+    _ = mailbox.applyBubbleUpdateWithDerivedAgentState(.{
+        .conversation_key = raw_identity,
+        .source_session = raw_identity,
         .text = "Done.",
-        .agent = identity.agent,
+        .agent = agent,
         .busy = false,
         .status = .completed,
         .feed_source = .native_store,
-    }, .completed);
+    });
     try std.testing.expectEqual(hook_server.SessionStatus.completed, mailbox.bubbles[0].status);
     try std.testing.expectEqual(@as(usize, 0), mailbox.bubbles[0].agent_state_len);
 
-    mailbox.setBubbleAgentStateIdentity(identity.conversation_key, "review", identity.agent, identity.hostname, identity.remote, true);
-    _ = applyRecoveredBubble(&mailbox, .{
-        .conversation_key = identity.conversation_key,
+    mailbox.setBubbleAgentStateIdentity(mailbox.bubbles[0].sessionSlice(), "review", agent, "", false, true);
+    _ = mailbox.applyBubbleUpdateWithDerivedAgentState(.{
+        .conversation_key = raw_identity,
         .source_session = "recovered-child",
-        .parent_session = identity.conversation_key,
+        .parent_session = raw_identity,
         .text = "Child summary",
-        .agent = identity.agent,
+        .agent = agent,
         .message_id = "child-1",
         .busy = false,
         .status = .completed,
         .session_kind = .subagent,
         .message_kind = .assistant,
         .feed_source = .native_store,
-    }, .completed);
+    });
     try std.testing.expectEqualStrings("review", mailbox.bubbles[0].agentStateSlice());
 }
 

--- a/packages/petdex-desktop-native/src/session_reconcile.zig
+++ b/packages/petdex-desktop-native/src/session_reconcile.zig
@@ -192,6 +192,40 @@ const Pending = struct {
     }
 };
 
+const CorrelationId = struct {
+    bytes: [hook_server.bubble_message_id_capacity]u8 = @splat(0),
+    len: usize = 0,
+
+    fn slice(self: *const CorrelationId) []const u8 {
+        return self.bytes[0..self.len];
+    }
+
+    fn set(self: *CorrelationId, value: []const u8) void {
+        self.* = .{};
+        self.len = @min(value.len, self.bytes.len);
+        @memcpy(self.bytes[0..self.len], value[0..self.len]);
+        while (self.len > 0 and !std.unicode.utf8ValidateSlice(self.bytes[0..self.len])) self.len -= 1;
+    }
+};
+
+const CorrelationIds = struct {
+    entries: [8]CorrelationId = @splat(.{}),
+    len: usize = 0,
+
+    fn append(self: *CorrelationIds, value: []const u8) void {
+        if (value.len == 0) return;
+        for (self.entries[0..self.len]) |*entry| {
+            if (std.mem.eql(u8, entry.slice(), value)) return;
+        }
+        if (self.len == self.entries.len) {
+            std.mem.copyForwards(CorrelationId, self.entries[0 .. self.len - 1], self.entries[1..self.len]);
+            self.len -= 1;
+        }
+        self.entries[self.len].set(value);
+        self.len += 1;
+    }
+};
+
 const RolloutState = struct {
     status: Status = .idle,
     text: SmallText = .{},
@@ -201,6 +235,7 @@ const RolloutState = struct {
     lifecycle: bool = false,
     subagent: bool = false,
     pending: [8]Pending = @splat(.{}),
+    resolved: CorrelationIds = .{},
 
     fn removePendingAt(self: *RolloutState, index: usize) void {
         var cursor = index;
@@ -235,14 +270,15 @@ const RolloutState = struct {
         entry.text.set(prompt);
     }
 
-    fn resolvePending(self: *RolloutState, id: []const u8) void {
+    fn resolvePending(self: *RolloutState, id: []const u8) bool {
         for (&self.pending, 0..) |*entry, index| {
-            if (!entry.active) return;
+            if (!entry.active) return false;
             if (std.mem.eql(u8, entry.idSlice(), id)) {
                 self.removePendingAt(index);
-                return;
+                return true;
             }
         }
+        return false;
     }
 
     fn newestPending(self: *const RolloutState) ?*const Pending {
@@ -260,6 +296,12 @@ const Event = struct {
     title: TitleText,
     cwd: CwdText,
     busy: bool,
+    request_id: CorrelationId = .{},
+    resolved: CorrelationIds = .{},
+
+    fn requestIdSlice(self: *const Event) []const u8 {
+        return self.request_id.slice();
+    }
 
     fn terminal(self: *const Event) bool {
         return self.status == .completed or self.status == .failed;
@@ -270,6 +312,12 @@ const Event = struct {
         hash.update(self.text.slice());
         hash.update(self.title.slice());
         hash.update(self.cwd.slice());
+        hash.update(std.mem.asBytes(&self.request_id.len));
+        hash.update(self.requestIdSlice());
+        for (self.resolved.entries[0..self.resolved.len]) |*entry| {
+            hash.update(std.mem.asBytes(&entry.len));
+            hash.update(entry.slice());
+        }
         hash.update(&.{ @intFromEnum(self.status), @intFromBool(self.busy) });
         return hash.final();
     }
@@ -1591,7 +1639,11 @@ fn publishHermes(watcher: *Watcher, event: ProviderEvent, initial: bool) void {
         seen.digest = digest;
         if (terminal) seen.used = false;
     }
-    _ = hook_server.mailbox.applyBubbleUpdateWithDerivedAgentState(.{
+    _ = hook_server.mailbox.applyBubbleUpdateWithDerivedAgentState(hermesBubbleUpdate(&event));
+}
+
+fn hermesBubbleUpdate(event: *const ProviderEvent) hook_server.BubbleUpdate {
+    return .{
         .conversation_key = if (event.subagent) event.parentSlice() else event.sessionSlice(),
         .source_session = event.sessionSlice(),
         .parent_session = event.parentSlice(),
@@ -1599,6 +1651,7 @@ fn publishHermes(watcher: *Watcher, event: ProviderEvent, initial: bool) void {
         .agent = "hermes",
         .title = event.title.slice(),
         .message_id = event.messageIdSlice(),
+        .resolves_unkeyed_input = !event.subagent and event.status == .running,
         .event_kind = if (event.subagent) "subagent" else "native-store",
         .subagent_label = event.labelSlice(),
         .busy = event.status == .running,
@@ -1613,7 +1666,7 @@ fn publishHermes(watcher: *Watcher, event: ProviderEvent, initial: bool) void {
         .message_kind = if (event.subagent) .assistant else .status,
         .title_source = .server,
         .feed_source = .native_store,
-    });
+    };
 }
 
 fn sqliteMillis(value: f64) i64 {
@@ -1664,7 +1717,10 @@ fn hermesEventFromRow(row: HermesRow) ProviderEvent {
     var id_buf: [64]u8 = undefined;
     const modified_ms = if (row.activity_ms > 0) row.activity_ms else row.started_ms;
     const message_id = std.fmt.bufPrint(&id_buf, "hermes-{d}", .{modified_ms}) catch "";
-    setBounded(&event.message_id, &event.message_id_len, message_id);
+    // Hermes exposes attention as session state, not a request/response pair.
+    // Leaving this update unkeyed lets the next authoritative running row
+    // release it without pretending the row timestamp is a correlation id.
+    if (!needs_input) setBounded(&event.message_id, &event.message_id_len, message_id);
     if (subagent) setBounded(&event.label, &event.label_len, row.title);
     return event;
 }
@@ -1875,6 +1931,7 @@ fn applyEnvelope(state: *RolloutState, root: std.json.Value, arena: std.mem.Allo
         state.text.set("");
         state.message_kind = .status;
         state.pending = @splat(.{});
+        state.resolved = .{};
         return;
     }
     if (std.mem.eql(u8, event_type, "task_complete")) {
@@ -1922,7 +1979,9 @@ fn applyEnvelope(state: *RolloutState, root: std.json.Value, arena: std.mem.Allo
     }
     if (std.mem.eql(u8, outer, "response_item") and (std.mem.eql(u8, event_type, "function_call_output") or std.mem.eql(u8, event_type, "custom_tool_call_output"))) {
         const id = valueString(payload, "call_id") orelse valueString(payload, "id") orelse "";
-        state.resolvePending(id);
+        if (state.resolvePending(id)) {
+            state.resolved.append(id);
+        }
         if (state.newestPending() == null and state.status == .needs_input) {
             state.status = .running;
             state.text.set("Thinking…");
@@ -1958,10 +2017,12 @@ fn parseRolloutBytes(allocator: std.mem.Allocator, prefix: []const u8, tail: []c
         applyEnvelope(&state, root, arena.allocator());
     }
     if (state.subagent) return null;
+    var request_id: CorrelationId = .{};
     if (state.newestPending()) |pending| {
         state.status = .needs_input;
         state.text = pending.text;
         state.message_kind = .prompt;
+        request_id.set(pending.idSlice());
     } else if (!state.lifecycle) {
         if (state.text.len == 0) return null;
         state.status = .running;
@@ -1975,6 +2036,8 @@ fn parseRolloutBytes(allocator: std.mem.Allocator, prefix: []const u8, tail: []c
         .title = resolved_title,
         .cwd = state.cwd,
         .busy = state.status == .running,
+        .request_id = request_id,
+        .resolved = state.resolved,
     };
 }
 
@@ -2004,16 +2067,16 @@ fn freeWatch(watcher: *Watcher) ?*Watch {
     return null;
 }
 
-fn publish(watch: *Watch, event: Event) void {
-    const digest = event.digest();
-    if (!watch.force and digest == watch.delivered) return;
-    _ = hook_server.mailbox.applyBubbleUpdateWithDerivedAgentState(.{
+fn codexBubbleUpdate(watch: *const Watch, event: *const Event, resolves_request_id: []const u8) hook_server.BubbleUpdate {
+    return .{
         .conversation_key = watch.sessionSlice(),
         .source_session = watch.sessionSlice(),
         .text = event.text.slice(),
         .agent = "codex",
         .title = event.title.slice(),
         .source_cwd = event.cwd.slice(),
+        .request_id = event.requestIdSlice(),
+        .resolves_request_id = resolves_request_id,
         .busy = event.busy,
         .status = switch (event.status) {
             .idle => .idle,
@@ -2028,7 +2091,19 @@ fn publish(watch: *Watch, event: Event) void {
         },
         .title_source = if (watch.title.len > 0) .server else .prompt,
         .feed_source = .native_store,
-    });
+    };
+}
+
+fn publish(watch: *Watch, event: Event) void {
+    const digest = event.digest();
+    if (!watch.force and digest == watch.delivered) return;
+    if (event.resolved.len == 0) {
+        _ = hook_server.mailbox.applyBubbleUpdateWithDerivedAgentState(codexBubbleUpdate(watch, &event, ""));
+    } else {
+        for (event.resolved.entries[0..event.resolved.len]) |*resolved| {
+            _ = hook_server.mailbox.applyBubbleUpdateWithDerivedAgentState(codexBubbleUpdate(watch, &event, resolved.slice()));
+        }
+    }
     watch.delivered = digest;
     watch.force = false;
     if (event.terminal()) watch.used = false;
@@ -2107,24 +2182,57 @@ test "pending input survives initial reconciliation and resolves" {
     try std.testing.expectEqual(Status.needs_input, event.status);
     try std.testing.expect(!event.busy);
     try std.testing.expectEqualStrings("Choose one?", event.text.slice());
+    try std.testing.expectEqualStrings("q1", event.requestIdSlice());
 
-    const resolved = waiting ++
+    const resolved = waiting ++ "\n" ++
         \\{"type":"response_item","payload":{"type":"function_call_output","call_id":"q1"}}
         \\{"type":"event_msg","payload":{"type":"task_complete","last_agent_message":"Finished"}}
     ;
     const done = parseRolloutBytes(std.testing.allocator, resolved, resolved, "").?;
     try std.testing.expectEqual(Status.completed, done.status);
     try std.testing.expectEqualStrings("Finished", done.text.slice());
+    try std.testing.expectEqual(@as(usize, 1), done.resolved.len);
+    try std.testing.expectEqualStrings("q1", done.resolved.entries[0].slice());
+}
+
+test "Codex rollout recovery publishes the matched approval resolution" {
+    const waiting_rollout =
+        \\{"type":"event_msg","payload":{"type":"task_started"}}
+        \\{"type":"response_item","payload":{"type":"function_call","name":"request_user_input","call_id":"approval-1","arguments":"{\"questions\":[{\"question\":\"Approve deployment?\"}]}"}}
+    ;
+    const waiting = parseRolloutBytes(std.testing.allocator, waiting_rollout, waiting_rollout, "").?;
+
+    var watch: Watch = .{};
+    setBounded(&watch.session, &watch.session_len, "codex-session");
+    var mailbox: hook_server.Mailbox = .{};
+    _ = mailbox.applyBubbleUpdateWithDerivedAgentState(codexBubbleUpdate(&watch, &waiting, ""));
+    try std.testing.expectEqual(hook_server.SessionStatus.needs_input, mailbox.bubbles[0].status);
+    try std.testing.expectEqual(@as(usize, 1), mailbox.bubbles[0].pending_input_ids_len);
+    try std.testing.expectEqualStrings("waiting", mailbox.bubbles[0].agentStateSlice());
+
+    const resumed_rollout = waiting_rollout ++ "\n" ++
+        \\{"type":"response_item","payload":{"type":"function_call_output","call_id":"approval-1"}}
+    ;
+    const resumed = parseRolloutBytes(std.testing.allocator, resumed_rollout, resumed_rollout, "").?;
+    try std.testing.expectEqual(Status.running, resumed.status);
+    try std.testing.expectEqual(@as(usize, 1), resumed.resolved.len);
+    const resolution = resumed.resolved.entries[0].slice();
+    try std.testing.expectEqualStrings("approval-1", resolution);
+
+    _ = mailbox.applyBubbleUpdateWithDerivedAgentState(codexBubbleUpdate(&watch, &resumed, resolution));
+    try std.testing.expectEqual(hook_server.SessionStatus.running, mailbox.bubbles[0].status);
+    try std.testing.expectEqual(@as(usize, 0), mailbox.bubbles[0].pending_input_ids_len);
+    try std.testing.expectEqualStrings("running", mailbox.bubbles[0].agentStateSlice());
 }
 
 test "resolving an older request keeps later pending prompts ordered" {
     var state: RolloutState = .{};
     state.setPending("q1", "First question");
     state.setPending("q2", "Second question");
-    state.resolvePending("q1");
+    try std.testing.expect(state.resolvePending("q1"));
     state.setPending("q3", "Newest question");
     try std.testing.expectEqualStrings("Newest question", state.newestPending().?.text.slice());
-    state.resolvePending("q3");
+    try std.testing.expect(state.resolvePending("q3"));
     try std.testing.expectEqualStrings("Second question", state.newestPending().?.text.slice());
 }
 
@@ -2134,7 +2242,7 @@ test "updating a pending request moves it to the newest position" {
     state.setPending("q2", "Second question");
     state.setPending("q1", "Updated first question");
     try std.testing.expectEqualStrings("Updated first question", state.newestPending().?.text.slice());
-    state.resolvePending("q1");
+    try std.testing.expect(state.resolvePending("q1"));
     try std.testing.expectEqualStrings("Second question", state.newestPending().?.text.slice());
 }
 
@@ -2550,6 +2658,26 @@ test "Hermes versioned row fixture lowers through SQLite row adapter and publica
     try std.testing.expectEqual(Status.needs_input, waiting.status);
     try std.testing.expectEqualStrings("Choose a deployment target", waiting.text.slice());
     try std.testing.expectEqual(@as(usize, 0), waiting.request_id_len);
+    try std.testing.expectEqual(@as(usize, 0), waiting.message_id_len);
+
+    var mailbox: hook_server.Mailbox = .{};
+    const waiting_update = hermesBubbleUpdate(&waiting);
+    try std.testing.expect(!waiting_update.resolves_unkeyed_input);
+    _ = mailbox.applyBubbleUpdateWithDerivedAgentState(waiting_update);
+    try std.testing.expectEqual(hook_server.SessionStatus.needs_input, mailbox.bubbles[0].status);
+    try std.testing.expect(mailbox.bubbles[0].pending_unkeyed_input);
+    try std.testing.expectEqual(@as(usize, 0), mailbox.bubbles[0].pending_input_ids_len);
+
+    var resumed_row = waiting_parsed.value;
+    resumed_row.activity_ms += 1;
+    resumed_row.description = "Planning deployment";
+    const resumed = hermesEventFromRow(resumed_row);
+    const resumed_update = hermesBubbleUpdate(&resumed);
+    try std.testing.expect(resumed_update.resolves_unkeyed_input);
+    _ = mailbox.applyBubbleUpdateWithDerivedAgentState(resumed_update);
+    try std.testing.expectEqual(hook_server.SessionStatus.running, mailbox.bubbles[0].status);
+    try std.testing.expect(!mailbox.bubbles[0].pending_unkeyed_input);
+    try std.testing.expectEqualStrings("running", mailbox.bubbles[0].agentStateSlice());
 
     const parsed = try std.json.parseFromSlice(HermesRow, std.testing.allocator, @embedFile("test-fixtures/session-reconcile/v1/hermes.json"), .{ .ignore_unknown_fields = true });
     defer parsed.deinit();

--- a/packages/petdex-desktop-native/src/session_reconcile.zig
+++ b/packages/petdex-desktop-native/src/session_reconcile.zig
@@ -1348,7 +1348,7 @@ fn publishProvider(watch: *ProviderWatch, event: ProviderEvent) void {
     const adapter = adapters[watch.adapter_index];
     _ = hook_server.mailbox.applyBubbleUpdate(providerBubbleUpdate(adapter, &event));
     watch.delivered = digest;
-    if (!event.subagent and (event.status == .completed or event.status == .failed)) watch.used = false;
+    if (event.status == .completed or event.status == .failed) watch.used = false;
 }
 
 fn findProviderWatch(watcher: *Watcher, adapter_index: u8, path: []const u8) ?*ProviderWatch {
@@ -1615,6 +1615,15 @@ fn hermesEventFromRow(row: HermesRow) ProviderEvent {
     return event;
 }
 
+const sqlite_row: c_int = 100;
+const sqlite_done: c_int = 101;
+
+fn commitHermesStampAfterScan(watcher: *Watcher, stamp: u64, step_result: c_int) bool {
+    if (step_result != sqlite_done) return false;
+    watcher.hermes_db_stamp = stamp;
+    return true;
+}
+
 fn reconcileHermes(watcher: *Watcher, io: std.Io, now_ms: i64, force: bool) void {
     if (comptime builtin.target.os.tag != .windows and builtin.target.os.tag != .macos and builtin.target.os.tag != .linux) return;
     const root_owned: ?[]u8 = if (env_hermes_home) |configured|
@@ -1633,7 +1642,6 @@ fn reconcileHermes(watcher: *Watcher, io: std.Io, now_ms: i64, force: bool) void
     defer watcher.allocator.free(wal_path);
     if (fileInfo(io, wal_path)) |wal| stamp ^= wal.size *% 1099511628211 ^ @as(u64, @bitCast(wal.mtime_ms));
     if (!force and watcher.hermes_db_stamp == stamp) return;
-    watcher.hermes_db_stamp = stamp;
 
     var api = SqliteApi.load() orelse return;
     defer api.lib.close();
@@ -1671,7 +1679,15 @@ fn reconcileHermes(watcher: *Watcher, io: std.Io, now_ms: i64, force: bool) void
     var raw_ids: [max_recent][hook_server.bubble_session_capacity]u8 = @splat(@splat(0));
     var raw_id_lens: [max_recent]usize = @splat(0);
     var len: usize = 0;
-    while (len < events.len and api.step(statement) == 100) {
+    while (true) {
+        const step_result = api.step(statement);
+        if (step_result != sqlite_row) {
+            if (!commitHermesStampAfterScan(watcher, stamp, step_result)) return;
+            break;
+        }
+        // Both queries are currently bounded to max_recent, but retain this
+        // guard if their SQL limit changes before the fixed storage does.
+        if (len == events.len) continue;
         const raw_id = sqliteText(&api, statement, 0);
         if (raw_id.len == 0) continue;
         const session_key = sqliteText(&api, statement, 1);
@@ -2187,6 +2203,18 @@ test "candidate admission seeds every detected provider before noisy recency" {
     try std.testing.expectEqual(@as(u8, 0), selected[adapters.len].adapter_index);
 }
 
+test "terminal subagent provider watches release their slots" {
+    var event: ProviderEvent = .{ .status = .completed, .subagent = true };
+    var watch: ProviderWatch = .{ .used = true, .adapter_index = 0 };
+    publishProvider(&watch, event);
+    try std.testing.expect(!watch.used);
+
+    event.status = .running;
+    watch = .{ .used = true, .adapter_index = 0 };
+    publishProvider(&watch, event);
+    try std.testing.expect(watch.used);
+}
+
 test "Hermes portable schema distinguishes continuations workers input and failure" {
     // A documented parent_session_id can be a compression continuation; it
     // is not a delegated worker without an explicit source/config marker.
@@ -2198,6 +2226,15 @@ test "Hermes portable schema distinguishes continuations workers input and failu
     try std.testing.expectEqual(Status.needs_input, hermesSessionStatus(false, true, ""));
     try std.testing.expectEqual(Status.completed, hermesSessionStatus(true, false, "complete"));
     try std.testing.expectEqual(Status.failed, hermesSessionStatus(true, false, "interrupted"));
+}
+
+test "Hermes DB stamp advances only after a completed SQLite scan" {
+    var watcher: Watcher = .{ .allocator = std.testing.allocator, .home = "" };
+    watcher.hermes_db_stamp = 17;
+    try std.testing.expect(!commitHermesStampAfterScan(&watcher, 42, 5));
+    try std.testing.expectEqual(@as(u64, 17), watcher.hermes_db_stamp);
+    try std.testing.expect(commitHermesStampAfterScan(&watcher, 42, sqlite_done));
+    try std.testing.expectEqual(@as(u64, 42), watcher.hermes_db_stamp);
 }
 
 const ProviderFixtureCase = struct {

--- a/packages/petdex-desktop-native/src/session_reconcile.zig
+++ b/packages/petdex-desktop-native/src/session_reconcile.zig
@@ -1461,11 +1461,24 @@ fn followProviders(watcher: *Watcher, io: std.Io, now_ms: i64) void {
         if (!watch.used) continue;
         const info = fileInfo(io, watch.pathSlice()) orelse continue;
         if (info.size == watch.size and info.mtime_ms == watch.mtime_ms) continue;
-        watch.size = info.size;
-        watch.mtime_ms = info.mtime_ms;
-        const event = parseProviderFile(io, watcher.allocator, adapters[watch.adapter_index], watch.pathSlice()) orelse continue;
+        const event = acceptProviderParse(
+            watch,
+            info.size,
+            info.mtime_ms,
+            parseProviderFile(io, watcher.allocator, adapters[watch.adapter_index], watch.pathSlice()),
+        ) orelse continue;
         publishProvider(watch, event);
     }
+}
+
+/// A failed read is not evidence that a changed provider file was consumed.
+/// Keep the last successfully parsed stamp so the next poll retries the same
+/// bytes instead of suppressing them as already observed.
+fn acceptProviderParse(watch: *ProviderWatch, size: u64, mtime_ms: i64, event: ?ProviderEvent) ?ProviderEvent {
+    const parsed = event orelse return null;
+    watch.size = size;
+    watch.mtime_ms = mtime_ms;
+    return parsed;
 }
 
 const WindowsLibrary = struct {
@@ -2322,6 +2335,20 @@ test "unchanged terminal provider tombstones suppress rediscovery" {
 
     try std.testing.expect(findProviderWatch(&watcher, 2, "gemini/child.jsonl", 4100, 43) == null);
     try std.testing.expectEqual(@as(usize, 0), watcher.provider_watches[0].path_len);
+}
+
+test "provider stamps advance only after a successful parse" {
+    var watch: ProviderWatch = .{ .used = true, .size = 1024, .mtime_ms = 10 };
+
+    try std.testing.expectEqual(@as(?ProviderEvent, null), acceptProviderParse(&watch, 2048, 20, null));
+    try std.testing.expectEqual(@as(u64, 1024), watch.size);
+    try std.testing.expectEqual(@as(i64, 10), watch.mtime_ms);
+
+    const event: ProviderEvent = .{ .status = .running };
+    const accepted = acceptProviderParse(&watch, 2048, 20, event) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(Status.running, accepted.status);
+    try std.testing.expectEqual(@as(u64, 2048), watch.size);
+    try std.testing.expectEqual(@as(i64, 20), watch.mtime_ms);
 }
 
 test "Hermes portable schema distinguishes continuations workers input and failure" {

--- a/packages/petdex-desktop-native/src/session_reconcile.zig
+++ b/packages/petdex-desktop-native/src/session_reconcile.zig
@@ -202,16 +202,33 @@ const RolloutState = struct {
     subagent: bool = false,
     pending: [8]Pending = @splat(.{}),
 
-    fn setPending(self: *RolloutState, id: []const u8, prompt: []const u8) void {
-        var target: ?*Pending = null;
-        for (&self.pending) |*entry| {
-            if (entry.active and std.mem.eql(u8, entry.idSlice(), id)) {
-                target = entry;
-                break;
-            }
-            if (!entry.active and target == null) target = entry;
+    fn removePendingAt(self: *RolloutState, index: usize) void {
+        var cursor = index;
+        while (cursor + 1 < self.pending.len and self.pending[cursor + 1].active) : (cursor += 1) {
+            self.pending[cursor] = self.pending[cursor + 1];
         }
-        const entry = target orelse &self.pending[self.pending.len - 1];
+        self.pending[cursor] = .{};
+    }
+
+    fn setPending(self: *RolloutState, id: []const u8, prompt: []const u8) void {
+        var active_len: usize = 0;
+        var existing: ?usize = null;
+        for (&self.pending, 0..) |*entry, index| {
+            if (!entry.active) break;
+            active_len = index + 1;
+            if (entry.active and std.mem.eql(u8, entry.idSlice(), id)) {
+                existing = index;
+            }
+        }
+        if (existing) |index| {
+            self.removePendingAt(index);
+            active_len -= 1;
+        } else if (active_len == self.pending.len) {
+            // Bound the queue by evicting the oldest unresolved request.
+            self.removePendingAt(0);
+            active_len -= 1;
+        }
+        const entry = &self.pending[active_len];
         entry.* = .{ .active = true };
         entry.id_len = @min(id.len, entry.id.len);
         @memcpy(entry.id[0..entry.id_len], id[0..entry.id_len]);
@@ -219,8 +236,12 @@ const RolloutState = struct {
     }
 
     fn resolvePending(self: *RolloutState, id: []const u8) void {
-        for (&self.pending) |*entry| {
-            if (entry.active and std.mem.eql(u8, entry.idSlice(), id)) entry.active = false;
+        for (&self.pending, 0..) |*entry, index| {
+            if (!entry.active) return;
+            if (std.mem.eql(u8, entry.idSlice(), id)) {
+                self.removePendingAt(index);
+                return;
+            }
         }
     }
 
@@ -425,10 +446,18 @@ const ProviderEvent = struct {
         hash.update(self.parentSlice());
         hash.update(self.text.slice());
         hash.update(self.title.slice());
+        hash.update(self.cwd.slice());
         hash.update(self.messageIdSlice());
         hash.update(self.requestIdSlice());
         hash.update(self.resolvesRequestIdSlice());
-        hash.update(&.{ @intFromEnum(self.status), @intFromBool(self.subagent) });
+        hash.update(self.labelSlice());
+        hash.update(&.{
+            @intFromEnum(self.status),
+            @intFromEnum(self.message_kind),
+            @intFromEnum(self.title_source),
+            @intFromBool(self.subagent),
+            @intFromBool(self.explicit_lifecycle),
+        });
         return hash.final();
     }
 };
@@ -2058,6 +2087,53 @@ test "pending input survives initial reconciliation and resolves" {
     const done = parseRolloutBytes(std.testing.allocator, resolved, resolved, "").?;
     try std.testing.expectEqual(Status.completed, done.status);
     try std.testing.expectEqualStrings("Finished", done.text.slice());
+}
+
+test "resolving an older request keeps later pending prompts ordered" {
+    var state: RolloutState = .{};
+    state.setPending("q1", "First question");
+    state.setPending("q2", "Second question");
+    state.resolvePending("q1");
+    state.setPending("q3", "Newest question");
+    try std.testing.expectEqualStrings("Newest question", state.newestPending().?.text.slice());
+    state.resolvePending("q3");
+    try std.testing.expectEqualStrings("Second question", state.newestPending().?.text.slice());
+}
+
+test "updating a pending request moves it to the newest position" {
+    var state: RolloutState = .{};
+    state.setPending("q1", "First question");
+    state.setPending("q2", "Second question");
+    state.setPending("q1", "Updated first question");
+    try std.testing.expectEqualStrings("Updated first question", state.newestPending().?.text.slice());
+    state.resolvePending("q1");
+    try std.testing.expectEqualStrings("Second question", state.newestPending().?.text.slice());
+}
+
+test "provider digest includes presentation-only metadata" {
+    var baseline: ProviderEvent = .{ .status = .running };
+    setBounded(&baseline.session, &baseline.session_len, "session");
+    const original = baseline.digest();
+
+    var changed = baseline;
+    changed.cwd.set("/new/cwd");
+    try std.testing.expect(original != changed.digest());
+
+    changed = baseline;
+    setBounded(&changed.label, &changed.label_len, "Reviewer");
+    try std.testing.expect(original != changed.digest());
+
+    changed = baseline;
+    changed.message_kind = .assistant;
+    try std.testing.expect(original != changed.digest());
+
+    changed = baseline;
+    changed.title_source = .server;
+    try std.testing.expect(original != changed.digest());
+
+    changed = baseline;
+    changed.explicit_lifecycle = true;
+    try std.testing.expect(original != changed.digest());
 }
 
 test "bare Codex completion clears transient copy but retains assistant prose" {

--- a/packages/petdex-desktop-native/src/session_reconcile.zig
+++ b/packages/petdex-desktop-native/src/session_reconcile.zig
@@ -1369,11 +1369,40 @@ fn providerBubbleUpdate(adapter: AgentSessionAdapter, event: *const ProviderEven
     };
 }
 
+fn recoveredAgentState(status: Status) []const u8 {
+    return switch (status) {
+        .running => "running",
+        .needs_input => "waiting",
+        .failed => "failed",
+        .idle, .completed => "",
+    };
+}
+
+/// Native stores are authoritative recovery evidence for both the bubble
+/// lifecycle and its Flock body. Lower them together so a missed hook cannot
+/// leave an older failed/review sprite attached to progress or completion.
+/// Child events only contribute prose to their parent and must never replace
+/// the parent's own attention state.
+fn applyRecoveredBubble(target: *hook_server.Mailbox, update: hook_server.BubbleUpdate, status: Status) u64 {
+    const counter = target.applyBubbleUpdate(update);
+    if (update.session_kind == .primary) {
+        target.setBubbleAgentStateIdentity(
+            update.conversation_key,
+            recoveredAgentState(status),
+            update.agent,
+            update.hostname,
+            update.remote,
+            true,
+        );
+    }
+    return counter;
+}
+
 fn publishProvider(watch: *ProviderWatch, event: ProviderEvent) void {
     const digest = event.digest();
     if (digest == watch.delivered) return;
     const adapter = adapters[watch.adapter_index];
-    _ = hook_server.mailbox.applyBubbleUpdate(providerBubbleUpdate(adapter, &event));
+    _ = applyRecoveredBubble(&hook_server.mailbox, providerBubbleUpdate(adapter, &event), event.status);
     watch.delivered = digest;
     if (event.status == .completed or event.status == .failed) watch.used = false;
 }
@@ -1591,7 +1620,7 @@ fn publishHermes(watcher: *Watcher, event: ProviderEvent, initial: bool) void {
         seen.digest = digest;
         if (terminal) seen.used = false;
     }
-    _ = hook_server.mailbox.applyBubbleUpdate(.{
+    _ = applyRecoveredBubble(&hook_server.mailbox, .{
         .conversation_key = if (event.subagent) event.parentSlice() else event.sessionSlice(),
         .source_session = event.sessionSlice(),
         .parent_session = event.parentSlice(),
@@ -1613,7 +1642,7 @@ fn publishHermes(watcher: *Watcher, event: ProviderEvent, initial: bool) void {
         .message_kind = if (event.subagent) .assistant else .status,
         .title_source = .server,
         .feed_source = .native_store,
-    });
+    }, event.status);
 }
 
 fn sqliteMillis(value: f64) i64 {
@@ -2007,7 +2036,7 @@ fn freeWatch(watcher: *Watcher) ?*Watch {
 fn publish(watch: *Watch, event: Event) void {
     const digest = event.digest();
     if (!watch.force and digest == watch.delivered) return;
-    _ = hook_server.mailbox.applyBubbleUpdate(.{
+    _ = applyRecoveredBubble(&hook_server.mailbox, .{
         .conversation_key = watch.sessionSlice(),
         .source_session = watch.sessionSlice(),
         .text = event.text.slice(),
@@ -2028,7 +2057,7 @@ fn publish(watch: *Watch, event: Event) void {
         },
         .title_source = if (watch.title.len > 0) .server else .prompt,
         .feed_source = .native_store,
-    });
+    }, event.status);
     watch.delivered = digest;
     watch.force = false;
     if (event.terminal()) watch.used = false;
@@ -2257,6 +2286,95 @@ test "renamed and multiple active rollouts keep one stable mailbox slot per sess
     try std.testing.expectEqualStrings("session-alpha", mailbox.bubbles[0].sessionSlice());
     try std.testing.expectEqualStrings("Alpha renamed", mailbox.bubbles[0].title[0..mailbox.bubbles[0].title_len]);
     try std.testing.expectEqualStrings("session-beta", mailbox.bubbles[1].sessionSlice());
+}
+
+test "native store recovery replaces primary Flock state for every lifecycle" {
+    var mailbox: hook_server.Mailbox = .{};
+    const identity = hook_server.BubbleIdentity{
+        .conversation_key = "recovered-primary",
+        .agent = "claude-code",
+        .hostname = "",
+        .remote = false,
+    };
+
+    _ = mailbox.applyBubbleUpdate(.{
+        .conversation_key = identity.conversation_key,
+        .source_session = identity.conversation_key,
+        .text = "Hook is reviewing",
+        .agent = identity.agent,
+        .busy = true,
+        .status = .running,
+        .message_kind = .assistant,
+        .feed_source = .hook,
+    });
+    mailbox.setBubbleAgentStateIdentity(identity.conversation_key, "review", identity.agent, identity.hostname, identity.remote, true);
+
+    _ = applyRecoveredBubble(&mailbox, .{
+        .conversation_key = identity.conversation_key,
+        .source_session = identity.conversation_key,
+        .text = "Waiting for you…",
+        .agent = identity.agent,
+        .busy = false,
+        .status = .needs_input,
+        .message_kind = .prompt,
+        .feed_source = .native_store,
+    }, .needs_input);
+    try std.testing.expectEqual(hook_server.SessionStatus.needs_input, mailbox.bubbles[0].status);
+    try std.testing.expectEqualStrings("waiting", mailbox.bubbles[0].agentStateSlice());
+
+    _ = applyRecoveredBubble(&mailbox, .{
+        .conversation_key = identity.conversation_key,
+        .source_session = identity.conversation_key,
+        .text = "Recovered progress",
+        .agent = identity.agent,
+        .message_id = "assistant-2",
+        .event_kind = "native-store",
+        .busy = true,
+        .status = .running,
+        .message_kind = .assistant,
+        .feed_source = .native_store,
+    }, .running);
+    try std.testing.expectEqual(hook_server.SessionStatus.running, mailbox.bubbles[0].status);
+    try std.testing.expectEqualStrings("running", mailbox.bubbles[0].agentStateSlice());
+
+    _ = applyRecoveredBubble(&mailbox, .{
+        .conversation_key = identity.conversation_key,
+        .source_session = identity.conversation_key,
+        .text = "Session failed.",
+        .agent = identity.agent,
+        .busy = false,
+        .status = .failed,
+        .feed_source = .native_store,
+    }, .failed);
+    try std.testing.expectEqualStrings("failed", mailbox.bubbles[0].agentStateSlice());
+
+    _ = applyRecoveredBubble(&mailbox, .{
+        .conversation_key = identity.conversation_key,
+        .source_session = identity.conversation_key,
+        .text = "Done.",
+        .agent = identity.agent,
+        .busy = false,
+        .status = .completed,
+        .feed_source = .native_store,
+    }, .completed);
+    try std.testing.expectEqual(hook_server.SessionStatus.completed, mailbox.bubbles[0].status);
+    try std.testing.expectEqual(@as(usize, 0), mailbox.bubbles[0].agent_state_len);
+
+    mailbox.setBubbleAgentStateIdentity(identity.conversation_key, "review", identity.agent, identity.hostname, identity.remote, true);
+    _ = applyRecoveredBubble(&mailbox, .{
+        .conversation_key = identity.conversation_key,
+        .source_session = "recovered-child",
+        .parent_session = identity.conversation_key,
+        .text = "Child summary",
+        .agent = identity.agent,
+        .message_id = "child-1",
+        .busy = false,
+        .status = .completed,
+        .session_kind = .subagent,
+        .message_kind = .assistant,
+        .feed_source = .native_store,
+    }, .completed);
+    try std.testing.expectEqualStrings("review", mailbox.bubbles[0].agentStateSlice());
 }
 
 test "current response-item messages map user titles and assistant progress" {

--- a/packages/petdex-desktop-native/src/session_reconcile.zig
+++ b/packages/petdex-desktop-native/src/session_reconcile.zig
@@ -931,12 +931,10 @@ fn followJournals(watcher: *Watcher, io: std.Io, now_ms: i64) void {
         if (!watch.used) continue;
         const info = fileInfo(io, watch.pathSlice()) orelse continue;
         if (info.size == watch.size and info.mtime_ms == watch.mtime_ms) continue;
-        watch.size = info.size;
-        watch.mtime_ms = info.mtime_ms;
         const bytes = readBounded(io, watcher.allocator, watch.pathSlice(), max_rollout_bytes, true) orelse continue;
         defer watcher.allocator.free(bytes);
+        const status = acceptParsedStamp(watch, info.size, info.mtime_ms, journalStatus(bytes)) orelse continue;
         replayJournalBytes(&hook_server.mailbox, bytes);
-        const status = journalStatus(bytes) orelse continue;
         if (status != .running and status != .needs_input) watch.used = false;
     }
 }
@@ -1461,7 +1459,7 @@ fn followProviders(watcher: *Watcher, io: std.Io, now_ms: i64) void {
         if (!watch.used) continue;
         const info = fileInfo(io, watch.pathSlice()) orelse continue;
         if (info.size == watch.size and info.mtime_ms == watch.mtime_ms) continue;
-        const event = acceptProviderParse(
+        const event = acceptParsedStamp(
             watch,
             info.size,
             info.mtime_ms,
@@ -1474,8 +1472,8 @@ fn followProviders(watcher: *Watcher, io: std.Io, now_ms: i64) void {
 /// A failed read is not evidence that a changed provider file was consumed.
 /// Keep the last successfully parsed stamp so the next poll retries the same
 /// bytes instead of suppressing them as already observed.
-fn acceptProviderParse(watch: *ProviderWatch, size: u64, mtime_ms: i64, event: ?ProviderEvent) ?ProviderEvent {
-    const parsed = event orelse return null;
+fn acceptParsedStamp(watch: anytype, size: u64, mtime_ms: i64, parsed_result: anytype) @TypeOf(parsed_result) {
+    const parsed = parsed_result orelse return null;
     watch.size = size;
     watch.mtime_ms = mtime_ms;
     return parsed;
@@ -2076,9 +2074,12 @@ fn follow(watcher: *Watcher, io: std.Io, now_ms: i64) void {
         if (!watch.used) continue;
         const info = fileInfo(io, watch.pathSlice()) orelse continue;
         if (!watch.force and info.size == watch.size and info.mtime_ms == watch.mtime_ms) continue;
-        watch.size = info.size;
-        watch.mtime_ms = info.mtime_ms;
-        const event = parseRollout(io, watcher.allocator, watch.pathSlice(), watch.title.slice()) orelse continue;
+        const event = acceptParsedStamp(
+            watch,
+            info.size,
+            info.mtime_ms,
+            parseRollout(io, watcher.allocator, watch.pathSlice(), watch.title.slice()),
+        ) orelse continue;
         publish(watch, event);
     }
 }
@@ -2337,18 +2338,37 @@ test "unchanged terminal provider tombstones suppress rediscovery" {
     try std.testing.expectEqual(@as(usize, 0), watcher.provider_watches[0].path_len);
 }
 
-test "provider stamps advance only after a successful parse" {
+test "file watch stamps advance only after a successful parse" {
     var watch: ProviderWatch = .{ .used = true, .size = 1024, .mtime_ms = 10 };
 
-    try std.testing.expectEqual(@as(?ProviderEvent, null), acceptProviderParse(&watch, 2048, 20, null));
+    try std.testing.expectEqual(@as(?ProviderEvent, null), acceptParsedStamp(&watch, 2048, 20, @as(?ProviderEvent, null)));
     try std.testing.expectEqual(@as(u64, 1024), watch.size);
     try std.testing.expectEqual(@as(i64, 10), watch.mtime_ms);
 
     const event: ProviderEvent = .{ .status = .running };
-    const accepted = acceptProviderParse(&watch, 2048, 20, event) orelse return error.TestUnexpectedResult;
+    const accepted = acceptParsedStamp(&watch, 2048, 20, @as(?ProviderEvent, event)) orelse return error.TestUnexpectedResult;
     try std.testing.expectEqual(Status.running, accepted.status);
     try std.testing.expectEqual(@as(u64, 2048), watch.size);
     try std.testing.expectEqual(@as(i64, 20), watch.mtime_ms);
+
+    var rollout: Watch = .{ .used = true, .size = 4096, .mtime_ms = 30 };
+    try std.testing.expectEqual(@as(?Event, null), acceptParsedStamp(&rollout, 8192, 40, @as(?Event, null)));
+    try std.testing.expectEqual(@as(u64, 4096), rollout.size);
+    try std.testing.expectEqual(@as(i64, 30), rollout.mtime_ms);
+
+    const rollout_event: Event = .{ .status = .running, .text = .{}, .title = .{}, .cwd = .{}, .busy = true };
+    _ = acceptParsedStamp(&rollout, 8192, 40, @as(?Event, rollout_event)) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(@as(u64, 8192), rollout.size);
+    try std.testing.expectEqual(@as(i64, 40), rollout.mtime_ms);
+
+    var journal: JournalWatch = .{ .used = true, .size = 16_384, .mtime_ms = 50 };
+    try std.testing.expectEqual(@as(?Status, null), acceptParsedStamp(&journal, 32_768, 60, @as(?Status, null)));
+    try std.testing.expectEqual(@as(u64, 16_384), journal.size);
+    try std.testing.expectEqual(@as(i64, 50), journal.mtime_ms);
+
+    try std.testing.expectEqual(Status.running, acceptParsedStamp(&journal, 32_768, 60, @as(?Status, .running)).?);
+    try std.testing.expectEqual(@as(u64, 32_768), journal.size);
+    try std.testing.expectEqual(@as(i64, 60), journal.mtime_ms);
 }
 
 test "Hermes portable schema distinguishes continuations workers input and failure" {

--- a/packages/petdex-desktop-native/src/test-fixtures/session-reconcile/v1/claude.jsonl
+++ b/packages/petdex-desktop-native/src/test-fixtures/session-reconcile/v1/claude.jsonl
@@ -1,0 +1,3 @@
+{"_fixture":{"schema":"claude-code-jsonl","version":"2.1","provider":"claude-code","sanitized":true,"source":"provider-owned transcript"}}
+{"type":"user","sessionId":"claude-primary","uuid":"claude-user-1","parentUuid":null,"isSidechain":false,"cwd":"C:/fixture/project","message":{"role":"user","content":"Review the rounded bubble controls"}}
+{"type":"assistant","sessionId":"claude-primary","uuid":"claude-assistant-entry-1","parentUuid":"claude-user-1","isSidechain":false,"cwd":"C:/fixture/project","message":{"id":"claude-assistant-1","role":"assistant","content":[{"type":"text","text":"Claude review complete"}],"stop_reason":"end_turn"}}

--- a/packages/petdex-desktop-native/src/test-fixtures/session-reconcile/v1/gemini.jsonl
+++ b/packages/petdex-desktop-native/src/test-fixtures/session-reconcile/v1/gemini.jsonl
@@ -1,0 +1,4 @@
+{"_fixture":{"schema":"gemini-chat-recording-jsonl","version":"0.38","provider":"gemini","sanitized":true,"source":"provider-owned chats/session JSONL"}}
+{"sessionId":"gemini-child","projectHash":"fixture-project-hash","startTime":"2026-08-14T00:00:00.000Z","lastUpdated":"2026-08-14T00:00:01.000Z","summary":"Gemini authoritative title","kind":"subagent","directories":["C:/fixture/project"]}
+{"id":"gemini-user-1","timestamp":"2026-08-14T00:00:00.100Z","type":"user","content":[{"text":"Research native bubble accessibility"}]}
+{"id":"gemini-model-1","timestamp":"2026-08-14T00:00:01.000Z","type":"gemini","content":[{"text":"Gemini research complete"}],"model":"gemini-fixture"}

--- a/packages/petdex-desktop-native/src/test-fixtures/session-reconcile/v1/hermes-waiting.json
+++ b/packages/petdex-desktop-native/src/test-fixtures/session-reconcile/v1/hermes-waiting.json
@@ -1,0 +1,20 @@
+{
+  "_fixture": {
+    "schema": "petdex-hermes-row",
+    "version": 1,
+    "provider": "hermes",
+    "sanitized": true
+  },
+  "enriched_schema": true,
+  "id": "hermes-parent",
+  "session_key": "hermes-parent",
+  "title": "Hermes input title",
+  "source": "cli",
+  "model_config": "{}",
+  "parent_session_id": "",
+  "started_ms": 1700000000000,
+  "activity_ms": 1700000001000,
+  "description": "petdex:needs-input:Choose a deployment target",
+  "ended": false,
+  "end_reason": ""
+}

--- a/packages/petdex-desktop-native/src/test-fixtures/session-reconcile/v1/hermes.json
+++ b/packages/petdex-desktop-native/src/test-fixtures/session-reconcile/v1/hermes.json
@@ -1,0 +1,20 @@
+{
+  "_fixture": {
+    "schema": "petdex-hermes-row",
+    "version": 1,
+    "provider": "hermes",
+    "sanitized": true
+  },
+  "enriched_schema": true,
+  "id": "hermes-child",
+  "session_key": "",
+  "title": "Hermes authoritative title",
+  "source": "worker",
+  "model_config": "{}",
+  "parent_session_id": "hermes-parent",
+  "started_ms": 1700000000000,
+  "activity_ms": 1700000001000,
+  "description": "Hermes review complete",
+  "ended": true,
+  "end_reason": "complete"
+}

--- a/packages/petdex-desktop-native/src/test-fixtures/session-reconcile/v1/omp.jsonl
+++ b/packages/petdex-desktop-native/src/test-fixtures/session-reconcile/v1/omp.jsonl
@@ -1,0 +1,5 @@
+{"_fixture":{"schema":"pi-session-jsonl","version":3,"provider":"omp","sanitized":true,"source":"provider-owned session file"}}
+{"type":"session","version":3,"id":"omp-child-source-id","timestamp":"2026-08-14T00:00:00.000Z","cwd":"C:/fixture/project","parentSession":"C:/fixture/sessions/omp-parent.jsonl"}
+{"type":"session_info","id":"omp-info-1","parentId":null,"timestamp":"2026-08-14T00:00:00.010Z","name":"OMP authoritative title"}
+{"type":"message","id":"omp-user-1","parentId":"omp-info-1","timestamp":"2026-08-14T00:00:00.100Z","message":{"role":"user","content":"Review popup behavior","timestamp":1786665600100}}
+{"type":"message","id":"omp-assistant-1","parentId":"omp-user-1","timestamp":"2026-08-14T00:00:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"OMP review complete"}],"timestamp":1786665601000,"provider":"fixture","model":"fixture"}}

--- a/packages/petdex-desktop-native/tests/journal_process_check.mjs
+++ b/packages/petdex-desktop-native/tests/journal_process_check.mjs
@@ -1,0 +1,76 @@
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const fixture = join(root, ".zig-cache", `journal-process-${process.pid}`);
+const executable = join(
+  fixture,
+  process.platform === "win32" ? "journal-writer.exe" : "journal-writer",
+);
+const journal = join(fixture, "journal.jsonl");
+
+function run(argv) {
+  return new Promise((resolveExit, reject) => {
+    const child = spawn(argv[0], argv.slice(1), {
+      cwd: root,
+      stdio: "inherit",
+    });
+    child.once("error", reject);
+    child.once("exit", (code, signal) =>
+      resolveExit(signal ? 128 : (code ?? 1)),
+    );
+  });
+}
+
+rmSync(fixture, { recursive: true, force: true });
+mkdirSync(fixture, { recursive: true });
+
+try {
+  const buildCode = await run([
+    "zig",
+    "build-exe",
+    "-ODebug",
+    "--dep",
+    "plat",
+    `-Mroot=${join(root, "tests", "journal_process_writer.zig")}`,
+    `-Mplat=${join(root, "src", "plat.zig")}`,
+    `-femit-bin=${executable}`,
+  ]);
+  if (buildCode !== 0)
+    throw new Error("journal writer helper failed to compile");
+
+  const writers = ["a", "b", "c", "d"];
+  const exits = await Promise.all(
+    writers.map((writer) => run([executable, journal, writer])),
+  );
+  if (exits.some((code) => code !== 0))
+    throw new Error(`journal writer exited unsuccessfully: ${exits.join(",")}`);
+
+  const current = readFileSync(journal, "utf8");
+  const previous = readFileSync(`${journal}.1`, "utf8");
+  if (current.length + previous.length !== 72)
+    throw new Error("rotated generations did not retain all 72 bytes");
+  const ordered = previous + current;
+  for (const writer of writers) {
+    let last = -1;
+    for (let sequence = 0; sequence < 3; sequence++) {
+      const record = `${writer}:${sequence}xx\n`;
+      const first = ordered.indexOf(record);
+      const second = ordered.indexOf(record, first + 1);
+      if (first < 0 || second >= 0)
+        throw new Error(`${record.trim()} was not present exactly once`);
+      if (first <= last)
+        throw new Error(
+          `${writer} records were reordered across processes/rotation`,
+        );
+      last = first;
+    }
+  }
+  console.log(
+    "journal process test: 12/12 records exactly once and ordered across one rotation",
+  );
+} finally {
+  if (existsSync(fixture)) rmSync(fixture, { recursive: true, force: true });
+}

--- a/packages/petdex-desktop-native/tests/journal_process_check.mjs
+++ b/packages/petdex-desktop-native/tests/journal_process_check.mjs
@@ -3,6 +3,9 @@ import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { journalStem as ompJournalStem } from "../src/assets/omp-extension.ts";
+import { journalStem as opencodeJournalStem } from "../src/assets/opencode-plugin.js";
+
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const fixture = join(root, ".zig-cache", `journal-process-${process.pid}`);
 const executable = join(
@@ -10,6 +13,29 @@ const executable = join(
   process.platform === "win32" ? "journal-writer.exe" : "journal-writer",
 );
 const journal = join(fixture, "journal.jsonl");
+
+const stemCases = [
+  [
+    "team/a",
+    "65f838a2fbff37d81a09242f44268f116e339d56e03dec44785d0badda4b1341",
+  ],
+  [
+    "team:a",
+    "5752fddeb3d6826d1281d4ecd54493c1eca7c0d93bf64bae0ff098c833f1fee3",
+  ],
+  ["", "d43eaed1b24b2617fb850c9c81dd86891d3b64edbb62712c94f08b8b32279ebf"],
+];
+for (const stem of [ompJournalStem, opencodeJournalStem]) {
+  for (const [value, expected] of stemCases) {
+    const actual = stem(value, "unkeyed");
+    if (actual !== expected)
+      throw new Error(
+        `journal stem mismatch for ${JSON.stringify(value)}: ${actual}`,
+      );
+  }
+  if (stem("team/a", "unkeyed") === stem("team:a", "unkeyed"))
+    throw new Error("punctuation-distinct journal identities collided");
+}
 
 function run(argv) {
   return new Promise((resolveExit, reject) => {

--- a/packages/petdex-desktop-native/tests/journal_process_writer.zig
+++ b/packages/petdex-desktop-native/tests/journal_process_writer.zig
@@ -1,0 +1,13 @@
+const std = @import("std");
+const plat = @import("plat");
+
+pub fn main(init: std.process.Init) !void {
+    const args = try init.minimal.args.toSlice(std.heap.page_allocator);
+    if (args.len != 3 or args[2].len != 1) return error.InvalidArguments;
+    const writer = args[2][0];
+    for (0..3) |sequence| {
+        var record_buf: [6]u8 = undefined;
+        const record = try std.fmt.bufPrint(&record_buf, "{c}:{d}xx\n", .{ writer, sequence });
+        if (!plat.appendFileModeRotating(args[1], record, 0o600, 64)) return error.AppendFailed;
+    }
+}

--- a/packages/petdex-desktop-native/tests/remote_hook_test.sh
+++ b/packages/petdex-desktop-native/tests/remote_hook_test.sh
@@ -200,3 +200,20 @@ payload='{"session_id":"00000000-0000-0000-0000-000000000001","last_assistant_me
 printf '%s' "$payload" | HOME="$fixture/home" PATH="$fixture/bin:/usr/bin:/bin" \
     PETDEX_CAPTURE="$fixture/capture" sh "$root/src/assets/petdex-remote-hook.sh" bubble stop codex
 tail -n 1 "$fixture/capture" | grep -q '"title":"Parent conversation"'
+
+# A failed tool is intermediate: keep the session busy/running while the
+# per-agent failed state drives only the temporary sprite.
+payload='{"session_id":"gemini-tool-failure","tool_name":"shell"}'
+printf '%s' "$payload" | HOME="$fixture/home" PATH="$fixture/bin:$test_path" \
+    PETDEX_CAPTURE="$fixture/capture" sh "$root/src/assets/petdex-remote-hook.sh" bubble tool-failure gemini
+failure_body=$(tail -n 1 "$fixture/capture")
+printf '%s\n' "$failure_body" | grep -q '"busy":true'
+printf '%s\n' "$failure_body" | grep -q '"status":"running"'
+printf '%s\n' "$failure_body" | grep -q '"agent_state":"failed"'
+
+# Gemini's final turn event names its assistant prose prompt_response.
+payload='{"session_id":"gemini-final","prompt_response":"Gemini answer"}'
+printf '%s' "$payload" | HOME="$fixture/home" PATH="$fixture/bin:$test_path" \
+    PETDEX_CAPTURE="$fixture/capture" sh "$root/src/assets/petdex-remote-hook.sh" bubble assistant gemini
+answer_body=$(tail -n 1 "$fixture/capture")
+printf '%s\n' "$answer_body" | grep -q '"text":"Gemini answer"'

--- a/packages/petdex-desktop-native/tests/remote_hook_test.sh
+++ b/packages/petdex-desktop-native/tests/remote_hook_test.sh
@@ -6,6 +6,7 @@ fixture=$(mktemp -d)
 trap 'rm -rf "$fixture"' 0 1 2 15
 mkdir -p "$fixture/home/.petdex/runtime" "$fixture/bin"
 printf 'test-token\n' > "$fixture/home/.petdex/runtime/update-token"
+printf 'configured-alias\n' > "$fixture/home/.petdex/runtime/remote-host"
 python3_path=$(command -v python3 || true)
 if [ -n "$python3_path" ]; then
     test_path="$(dirname "$python3_path"):/usr/bin:/bin"
@@ -44,6 +45,7 @@ printf '%s' "$payload" | HOME="$fixture/home" PATH="$fixture/bin:$test_path" \
 grep -Eq '"session_id":"[0-9a-f]{64}"' "$fixture/capture"
 grep -q '"source_session_id":"raw-turn"' "$fixture/capture"
 grep -q '"session_kind":"primary"' "$fixture/capture"
+grep -q '"hostname":"configured-alias"' "$fixture/capture"
 
 # A host may keep the stdin write end open after the JSON is complete. The
 # remote hook must return within its bounded drain window instead of waiting

--- a/packages/petdex-desktop-native/tests/remote_watchers_test.py
+++ b/packages/petdex-desktop-native/tests/remote_watchers_test.py
@@ -68,6 +68,58 @@ class CodexWatcherTests(unittest.TestCase):
             self.assertEqual(size, offset)
             self.assertEqual("Done now", event["text"])
 
+    def test_bare_completion_replaces_transient_copy_and_keeps_prose(self) -> None:
+        watcher = load("petdex_codex_completion_test", "petdex-codex-watch.py")
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            transient = root / "rollout-00000000-0000-0000-0000-000000000010.jsonl"
+            transient_rows = [
+                {"type": "event_msg", "payload": {"type": "task_started"}},
+                {
+                    "type": "response_item",
+                    "payload": {
+                        "type": "function_call",
+                        "name": "request_user_input",
+                        "call_id": "q1",
+                        "arguments": json.dumps({"questions": [{"question": "Continue?"}]}),
+                    },
+                },
+                {
+                    "type": "response_item",
+                    "payload": {"type": "function_call_output", "call_id": "q1"},
+                },
+                {"type": "event_msg", "payload": {"type": "task_complete"}},
+            ]
+            transient.write_text(
+                "".join(json.dumps(row) + "\n" for row in transient_rows),
+                encoding="utf-8",
+            )
+            event = watcher.parse_rollout(transient, "Transient")
+            self.assertEqual("completed", event["status"])
+            self.assertFalse(event["busy"])
+            self.assertEqual("Done.", event["text"])
+
+            prose = root / "rollout-00000000-0000-0000-0000-000000000011.jsonl"
+            prose_rows = [
+                {"type": "event_msg", "payload": {"type": "task_started"}},
+                {
+                    "type": "event_msg",
+                    "payload": {"type": "agent_message", "message": "Useful final answer."},
+                },
+                {
+                    "type": "event_msg",
+                    "payload": {"type": "task_complete", "last_agent_message": "   "},
+                },
+            ]
+            prose.write_text(
+                "".join(json.dumps(row) + "\n" for row in prose_rows),
+                encoding="utf-8",
+            )
+            retained = watcher.parse_rollout(prose, "Prose")
+            self.assertEqual("completed", retained["status"])
+            self.assertFalse(retained["busy"])
+            self.assertEqual("Useful final answer.", retained["text"])
+
     def test_subagent_rollouts_do_not_hide_an_older_primary(self) -> None:
         watcher = load("petdex_codex_subagent_test", "petdex-codex-watch.py")
         with tempfile.TemporaryDirectory() as directory:

--- a/packages/petdex-desktop-native/tests/remote_watchers_test.py
+++ b/packages/petdex-desktop-native/tests/remote_watchers_test.py
@@ -275,5 +275,25 @@ class WatcherOwnershipTests(unittest.TestCase):
                     release.join()
 
 
+class RemoteIdentityTests(unittest.TestCase):
+    def test_watchers_publish_the_configured_remote_principal(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            remote_host = Path(directory) / "remote-host"
+            remote_host.write_text("configured-alias\n", encoding="utf-8")
+            watchers = []
+            for name, filename in (
+                ("codex_remote_identity_test", "petdex-codex-watch.py"),
+                ("hermes_remote_identity_test", "petdex-hermes-watch.py"),
+            ):
+                watcher = load(name, filename)
+                watcher.REMOTE_HOST = remote_host
+                watchers.append(watcher)
+                self.assertEqual("configured-alias", watcher.remote_hostname())
+
+            remote_host.unlink()
+            for watcher in watchers:
+                self.assertEqual("", watcher.remote_hostname())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds durable, cross-provider recovery for Codex, Claude, Gemini, OMP, and Hermes sessions. The session event contract it relies on is intentionally included here so this PR merges directly into `main` as one complete deliverable.

- normalizes legacy hook payloads into optional identity, provenance, status, child-message, and origin fields
- reconciles journals and provider directories, including missing and rotated journals
- keeps directory watching behind a polling fallback on every supported platform
- scopes remote credentials and preserves mailbox ordering/at-most-once semantics
- adds provider fixtures and process-boundary regression coverage
- corrects bare Codex `task_complete` events so terminal cards retain real assistant prose or show `Done.`, never stale `Thinking…` copy

## Scope and impact

This changes only the desktop runtime. It introduces no web, database, or CLI contract changes. Legacy hook payloads remain accepted.

`Refs #694` — this supplies the session identity/status plumbing, but deliberately does **not** implement hidden-task filtering.

## Root cause

Codex can finish without `last_agent_message`. Each active Codex producer previously changed the status to completed while retaining an earlier status/prompt/reasoning message. The correction applies the same terminal-copy rule to local recovery, hook-tail parsing, and the embedded SSH watcher.

## Size

23 files changed: +6,531 / -378.

## Validation

- `git diff --check upstream/main...HEAD`
- Native SDK ReleaseFast build
- `native test .` — 277/277 passed
- `python3 tests/remote_watchers_test.py` — 7/7 passed
- `bun tests/journal_process_check.mjs` — 12/12 records delivered exactly once and in order across rotation

## Merge readiness

This is an independently mergeable, single-commit PR targeting `main`. It is kept as a draft pending review, not because any known regression is deferred.