### PR TITLE
fix: restore profile pages for new users

### DIFF
--- a/src/app/[locale]/my-feedback/layout.tsx
+++ b/src/app/[locale]/my-feedback/layout.tsx
@@ -1,0 +1,9 @@
+import { FullAuthProviders } from "@/components/auth/auth-providers";
+
+export default function MyFeedbackLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <FullAuthProviders>{children}</FullAuthProviders>;
+}

--- a/src/app/[locale]/my-feedback/not-found.tsx
+++ b/src/app/[locale]/my-feedback/not-found.tsx
@@ -1,0 +1,1 @@
+export { default } from "../not-found";

--- a/src/app/[locale]/u/[handle]/page.tsx
+++ b/src/app/[locale]/u/[handle]/page.tsx
@@ -22,7 +22,6 @@ import { buildLocaleAlternates } from "@/lib/locale-routing";
 import { type PetWithMetrics, rowToPet } from "@/lib/pets";
 import { toCurrentR2PublicUrl } from "@/lib/r2-public-url";
 
-import { FullAuthProviders } from "@/components/auth/auth-providers";
 import { JsonLd } from "@/components/layout/json-ld";
 import type { Submission } from "@/components/profile/my-pets-view";
 import { ProfileExternalLink } from "@/components/profile/profile-external-link";
@@ -274,183 +273,181 @@ export default async function UserProfilePage({ params }: PageProps) {
   };
 
   return (
-    <FullAuthProviders>
-      <main className="min-h-dvh bg-background text-foreground">
-        <JsonLd data={jsonLd} />
+    <main className="min-h-dvh bg-background text-foreground">
+      <JsonLd data={jsonLd} />
 
-        <SiteHeader />
-        <section className="petdex-hero relative -mt-14 overflow-clip pt-14">
-          <div className="relative mx-auto flex w-full max-w-[1440px] flex-col px-5 pb-10 md:px-8">
-            <header className="mt-10 grid gap-8 md:mt-14 lg:grid-cols-[auto_1fr_auto] lg:items-start">
-              {/* Avatar */}
-              <div className="flex justify-center lg:block">
-                {avatarUrl ? (
-                  // biome-ignore lint/performance/noImgElement: Clerk-hosted avatar
-                  <img
-                    src={avatarUrl}
-                    alt={displayName ?? `@${publicHandle}`}
-                    className="size-28 rounded-3xl object-cover ring-1 ring-black/10 md:size-32"
-                  />
-                ) : (
-                  <div className="grid size-28 place-items-center rounded-3xl bg-surface font-mono text-3xl font-semibold text-muted-2 ring-1 ring-black/10 md:size-32">
-                    {fallbackInitial}
-                  </div>
-                )}
+      <SiteHeader />
+      <section className="petdex-hero relative -mt-14 overflow-clip pt-14">
+        <div className="relative mx-auto flex w-full max-w-[1440px] flex-col px-5 pb-10 md:px-8">
+          <header className="mt-10 grid gap-8 md:mt-14 lg:grid-cols-[auto_1fr_auto] lg:items-start">
+            {/* Avatar */}
+            <div className="flex justify-center lg:block">
+              {avatarUrl ? (
+                // biome-ignore lint/performance/noImgElement: Clerk-hosted avatar
+                <img
+                  src={avatarUrl}
+                  alt={displayName ?? `@${publicHandle}`}
+                  className="size-28 rounded-3xl object-cover ring-1 ring-black/10 md:size-32"
+                />
+              ) : (
+                <div className="grid size-28 place-items-center rounded-3xl bg-surface font-mono text-3xl font-semibold text-muted-2 ring-1 ring-black/10 md:size-32">
+                  {fallbackInitial}
+                </div>
+              )}
+            </div>
+
+            {/* Identity */}
+            <div className="text-center lg:text-left">
+              <div className="flex flex-wrap items-center justify-center gap-2 lg:justify-start">
+                <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
+                  {t("creatorBadge")}
+                </p>
+                {catchProgress ? (
+                  <p className="font-mono text-xs tracking-[0.22em] text-muted-3 uppercase">
+                    {t("yourAlbum", {
+                      caught: catchProgress.caught,
+                      total: catchProgress.total,
+                      pct: catchProgress.pct,
+                    })}
+                  </p>
+                ) : null}
+                {isOwnerAdmin ? (
+                  <span
+                    className="inline-flex items-center gap-1 rounded-full bg-brand px-2 py-0.5 font-mono text-[10px] tracking-[0.15em] text-white uppercase"
+                    title="One of the people who built Petdex"
+                  >
+                    <Trophy className="size-3" />
+                    {t("creatorOfPetdex")}
+                  </span>
+                ) : rank ? (
+                  <Link
+                    href="/leaderboard"
+                    className="inline-flex items-center gap-1 rounded-full bg-chip-warning-bg px-2 py-0.5 font-mono text-[10px] tracking-[0.15em] text-chip-warning-fg uppercase transition hover:opacity-80"
+                    title={`Ranked #${rank.rank} of ${rank.total} by approved pets. See the full leaderboard`}
+                  >
+                    <Trophy className="size-3" />#{rank.rank} most pets
+                  </Link>
+                ) : null}
               </div>
+              <h1 className="mt-3 text-balance text-[40px] leading-[1] font-semibold tracking-tight md:text-[56px]">
+                {displayName ?? `@${publicHandle}`}
+              </h1>
+              {displayName ? (
+                <p className="mt-2 font-mono text-sm tracking-[0.08em] text-muted-3">
+                  @{publicHandle}
+                </p>
+              ) : null}
+              {bio ? (
+                <p className="mt-4 max-w-xl text-balance text-base leading-7 text-muted-1 md:text-lg">
+                  {bio}
+                </p>
+              ) : null}
 
-              {/* Identity */}
-              <div className="text-center lg:text-left">
-                <div className="flex flex-wrap items-center justify-center gap-2 lg:justify-start">
-                  <p className="font-mono text-xs tracking-[0.22em] text-brand uppercase">
-                    {t("creatorBadge")}
-                  </p>
-                  {catchProgress ? (
-                    <p className="font-mono text-xs tracking-[0.22em] text-muted-3 uppercase">
-                      {t("yourAlbum", {
-                        caught: catchProgress.caught,
-                        total: catchProgress.total,
-                        pct: catchProgress.pct,
-                      })}
-                    </p>
-                  ) : null}
-                  {isOwnerAdmin ? (
-                    <span
-                      className="inline-flex items-center gap-1 rounded-full bg-brand px-2 py-0.5 font-mono text-[10px] tracking-[0.15em] text-white uppercase"
-                      title="One of the people who built Petdex"
-                    >
-                      <Trophy className="size-3" />
-                      {t("creatorOfPetdex")}
-                    </span>
-                  ) : rank ? (
-                    <Link
-                      href="/leaderboard"
-                      className="inline-flex items-center gap-1 rounded-full bg-chip-warning-bg px-2 py-0.5 font-mono text-[10px] tracking-[0.15em] text-chip-warning-fg uppercase transition hover:opacity-80"
-                      title={`Ranked #${rank.rank} of ${rank.total} by approved pets. See the full leaderboard`}
-                    >
-                      <Trophy className="size-3" />#{rank.rank} most pets
-                    </Link>
-                  ) : null}
-                </div>
-                <h1 className="mt-3 text-balance text-[40px] leading-[1] font-semibold tracking-tight md:text-[56px]">
-                  {displayName ?? `@${publicHandle}`}
-                </h1>
-                {displayName ? (
-                  <p className="mt-2 font-mono text-sm tracking-[0.08em] text-muted-3">
-                    @{publicHandle}
-                  </p>
+              {/* Stats row */}
+              <div className="mt-5 flex flex-wrap items-center justify-center gap-x-5 gap-y-2 font-mono text-[11px] tracking-[0.18em] text-muted-3 uppercase lg:justify-start">
+                <span>{t("petsCount", { count: pets.length })}</span>
+                {totalLikes > 0 ? (
+                  <span className="inline-flex items-center gap-1.5">
+                    <Heart className="size-3" />
+                    {formatLocalizedNumber(totalLikes, locale)}
+                  </span>
                 ) : null}
-                {bio ? (
-                  <p className="mt-4 max-w-xl text-balance text-base leading-7 text-muted-1 md:text-lg">
-                    {bio}
-                  </p>
+                {totalInstalls > 0 ? (
+                  <span className="inline-flex items-center gap-1.5">
+                    <TerminalSquare className="size-3" />
+                    {t("installs", {
+                      count: formatLocalizedNumber(totalInstalls, locale),
+                    })}
+                  </span>
                 ) : null}
-
-                {/* Stats row */}
-                <div className="mt-5 flex flex-wrap items-center justify-center gap-x-5 gap-y-2 font-mono text-[11px] tracking-[0.18em] text-muted-3 uppercase lg:justify-start">
-                  <span>{t("petsCount", { count: pets.length })}</span>
-                  {totalLikes > 0 ? (
-                    <span className="inline-flex items-center gap-1.5">
-                      <Heart className="size-3" />
-                      {formatLocalizedNumber(totalLikes, locale)}
-                    </span>
-                  ) : null}
-                  {totalInstalls > 0 ? (
-                    <span className="inline-flex items-center gap-1.5">
-                      <TerminalSquare className="size-3" />
-                      {t("installs", {
-                        count: formatLocalizedNumber(totalInstalls, locale),
-                      })}
-                    </span>
-                  ) : null}
-                  {memberSince ? (
-                    <span>
-                      {t("joined", {
-                        date: new Date(memberSince).toLocaleDateString(
-                          locale === "zh"
-                            ? "zh-Hans-CN"
-                            : locale === "es"
-                              ? "es"
-                              : "en",
-                          { month: "long", year: "numeric" },
-                        ),
-                      })}
-                    </span>
-                  ) : null}
-                </div>
-
-                {/* External links */}
-                {externalUrls.length > 0 ? (
-                  <div className="mt-4 flex flex-wrap items-center justify-center gap-2 lg:justify-start">
-                    {externalUrls.map((e) => (
-                      <ProfileExternalLink
-                        key={e.url}
-                        handle={publicHandle}
-                        url={e.url}
-                        label={e.label}
-                      />
-                    ))}
-                  </div>
+                {memberSince ? (
+                  <span>
+                    {t("joined", {
+                      date: new Date(memberSince).toLocaleDateString(
+                        locale === "zh"
+                          ? "zh-Hans-CN"
+                          : locale === "es"
+                            ? "es"
+                            : "en",
+                        { month: "long", year: "numeric" },
+                      ),
+                    })}
+                  </span>
                 ) : null}
               </div>
 
-              {/* Owner + visitor actions. Share is on for everyone so a
+              {/* External links */}
+              {externalUrls.length > 0 ? (
+                <div className="mt-4 flex flex-wrap items-center justify-center gap-2 lg:justify-start">
+                  {externalUrls.map((e) => (
+                    <ProfileExternalLink
+                      key={e.url}
+                      handle={publicHandle}
+                      url={e.url}
+                      label={e.label}
+                    />
+                  ))}
+                </div>
+              ) : null}
+            </div>
+
+            {/* Owner + visitor actions. Share is on for everyone so a
                 fan can spread a profile they liked, the same growth
                 motion as the creator promoting their own page. */}
-              <div className="flex flex-wrap items-center justify-center gap-2 lg:justify-end">
-                <ProfileShareButton
+            <div className="flex flex-wrap items-center justify-center gap-2 lg:justify-end">
+              <ProfileShareButton
+                handle={publicHandle}
+                displayName={displayName}
+              />
+              {isOwner ? (
+                <ProfileInlineEditor
                   handle={publicHandle}
-                  displayName={displayName}
+                  initialDisplayName={displayName}
+                  initialBio={bio}
+                  initialFeaturedSlugs={featuredSlugs}
+                  approvedPets={pets.map((p) => ({
+                    slug: p.slug,
+                    displayName: p.displayName,
+                  }))}
                 />
-                {isOwner ? (
-                  <ProfileInlineEditor
-                    handle={publicHandle}
-                    initialDisplayName={displayName}
-                    initialBio={bio}
-                    initialFeaturedSlugs={featuredSlugs}
-                    approvedPets={pets.map((p) => ({
-                      slug: p.slug,
-                      displayName: p.displayName,
-                    }))}
-                  />
-                ) : null}
-              </div>
-            </header>
-          </div>
-        </section>
+              ) : null}
+            </div>
+          </header>
+        </div>
+      </section>
 
-        <section className="mx-auto flex w-full max-w-[1440px] flex-col gap-8 px-5 py-12 md:px-8 md:py-16">
-          <ProfilePinningSurface
-            isOwner={isOwner}
-            publicHandle={publicHandle}
-            pets={pets}
-            initialPinnedSlugs={featuredSlugs}
-            ownerSubmissions={ownerSubmissions}
-            likedPets={likedPets}
-            collection={
-              collection
-                ? {
-                    slug: collection.slug,
-                    title: collection.title,
-                    description: collection.description,
-                    externalUrl: collection.externalUrl,
-                    coverPetSlug: collection.coverPetSlug,
-                    petSlugs: collection.pets.map((pet) => pet.slug),
-                  }
-                : null
-            }
-            canManageCollections={canManageOwnCollection}
-            collectionApprovedPets={pets.map((p) => ({
-              slug: p.slug,
-              displayName: p.displayName,
-              spritesheetUrl: p.spritesheetPath,
-            }))}
-            ownerCollections={ownerCollectionsForTabs}
-            maxOwnerCollections={MAX_OWNER_COLLECTIONS}
-          />
-        </section>
+      <section className="mx-auto flex w-full max-w-[1440px] flex-col gap-8 px-5 py-12 md:px-8 md:py-16">
+        <ProfilePinningSurface
+          isOwner={isOwner}
+          publicHandle={publicHandle}
+          pets={pets}
+          initialPinnedSlugs={featuredSlugs}
+          ownerSubmissions={ownerSubmissions}
+          likedPets={likedPets}
+          collection={
+            collection
+              ? {
+                  slug: collection.slug,
+                  title: collection.title,
+                  description: collection.description,
+                  externalUrl: collection.externalUrl,
+                  coverPetSlug: collection.coverPetSlug,
+                  petSlugs: collection.pets.map((pet) => pet.slug),
+                }
+              : null
+          }
+          canManageCollections={canManageOwnCollection}
+          collectionApprovedPets={pets.map((p) => ({
+            slug: p.slug,
+            displayName: p.displayName,
+            spritesheetUrl: p.spritesheetPath,
+          }))}
+          ownerCollections={ownerCollectionsForTabs}
+          maxOwnerCollections={MAX_OWNER_COLLECTIONS}
+        />
+      </section>
 
-        <SiteFooter />
-      </main>
-    </FullAuthProviders>
+      <SiteFooter />
+    </main>
   );
 }

--- a/src/app/[locale]/u/[handle]/page.tsx
+++ b/src/app/[locale]/u/[handle]/page.tsx
@@ -16,7 +16,7 @@ import { getOwnerCollections } from "@/lib/collections";
 import { db, schema } from "@/lib/db/client";
 import { getMetricsBySlugs } from "@/lib/db/metrics";
 import { formatLocalizedNumber } from "@/lib/format-number";
-import { userIdForHandle } from "@/lib/handles";
+import { userIdForHandle, viewerIdForFallbackHandle } from "@/lib/handles";
 import { getOwnerRank } from "@/lib/leaderboard";
 import { buildLocaleAlternates } from "@/lib/locale-routing";
 import { type PetWithMetrics, rowToPet } from "@/lib/pets";
@@ -41,7 +41,11 @@ type PageProps = { params: Promise<{ handle: string; locale: string }> };
 
 export async function generateMetadata({ params }: PageProps) {
   const { handle, locale } = await params;
-  const userId = await userIdForHandle(handle);
+  const requestedHandle = handle.toLowerCase();
+  const { userId: viewerId } = await auth();
+  const userId =
+    viewerIdForFallbackHandle(requestedHandle, viewerId) ??
+    (await userIdForHandle(handle));
   if (!userId) return { title: "Profile not found", robots: { index: false } };
   let displayName = `@${handle}`;
   const profile = await db.query.userProfiles.findFirst({
@@ -87,7 +91,10 @@ export default async function UserProfilePage({ params }: PageProps) {
   const { handle, locale } = await params;
   const t = await getTranslations({ locale, namespace: "profile" });
   const requestedHandle = handle.toLowerCase();
-  const ownerId = await userIdForHandle(handle);
+  const { userId: viewerId } = await auth();
+  const ownerId =
+    viewerIdForFallbackHandle(requestedHandle, viewerId) ??
+    (await userIdForHandle(handle));
   if (!ownerId) notFound();
 
   // Pull Clerk profile.
@@ -142,7 +149,6 @@ export default async function UserProfilePage({ params }: PageProps) {
 
   // Viewer detection runs ahead of the pets query so the owner sees
   // their pending + rejected rows alongside the approved gallery.
-  const { userId: viewerId } = await auth();
   const isOwner = viewerId === ownerId;
 
   // Pets owned by this user. Visitors only see approved rows; the owner

--- a/src/app/[locale]/u/layout.tsx
+++ b/src/app/[locale]/u/layout.tsx
@@ -1,0 +1,9 @@
+import { FullAuthProviders } from "@/components/auth/auth-providers";
+
+export default function UserProfileLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <FullAuthProviders>{children}</FullAuthProviders>;
+}

--- a/src/app/[locale]/u/not-found.tsx
+++ b/src/app/[locale]/u/not-found.tsx
@@ -1,0 +1,1 @@
+export { default } from "../not-found";

--- a/src/lib/handles.test.ts
+++ b/src/lib/handles.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+
+import { fallbackHandle, findUserIdByFallbackHandle } from "./handles";
+
+describe("profile fallback handles", () => {
+  it("resolves a Clerk user without a Petdex database row", async () => {
+    const userId = "user_2abc1234target42";
+    const calls: number[] = [];
+
+    const result = await findUserIdByFallbackHandle(
+      fallbackHandle(userId),
+      async ({ offset }) => {
+        calls.push(offset);
+        return offset === 0
+          ? { data: [{ id: "user_unrelated" }], totalCount: 2 }
+          : { data: [{ id: userId }], totalCount: 2 };
+      },
+    );
+
+    expect(result).toBe(userId);
+    expect(calls).toEqual([0, 1]);
+  });
+
+  it("rejects ambiguous fallback handles", async () => {
+    const suffix = "same1234";
+    const result = await findUserIdByFallbackHandle(suffix, async () => ({
+      data: [{ id: `user_first${suffix}` }, { id: `user_second${suffix}` }],
+      totalCount: 2,
+    }));
+
+    expect(result).toBeNull();
+  });
+
+  it("ignores Clerk query matches from other user fields", async () => {
+    const result = await findUserIdByFallbackHandle("arthaey1", async () => ({
+      data: [{ id: "user_different" }],
+      totalCount: 1,
+    }));
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/handles.test.ts
+++ b/src/lib/handles.test.ts
@@ -1,42 +1,26 @@
 import { describe, expect, it } from "bun:test";
 
-import { fallbackHandle, findUserIdByFallbackHandle } from "./handles";
+import { fallbackHandle, viewerIdForFallbackHandle } from "./handles";
 
 describe("profile fallback handles", () => {
-  it("resolves a Clerk user without a Petdex database row", async () => {
+  it("resolves the signed-in viewer without a Petdex database row", () => {
     const userId = "user_2abc1234target42";
-    const calls: number[] = [];
 
-    const result = await findUserIdByFallbackHandle(
-      fallbackHandle(userId),
-      async ({ offset }) => {
-        calls.push(offset);
-        return offset === 0
-          ? { data: [{ id: "user_unrelated" }], totalCount: 2 }
-          : { data: [{ id: userId }], totalCount: 2 };
-      },
+    expect(viewerIdForFallbackHandle(fallbackHandle(userId), userId)).toBe(
+      userId,
     );
-
-    expect(result).toBe(userId);
-    expect(calls).toEqual([0, 1]);
   });
 
-  it("rejects ambiguous fallback handles", async () => {
-    const suffix = "same1234";
-    const result = await findUserIdByFallbackHandle(suffix, async () => ({
-      data: [{ id: `user_first${suffix}` }, { id: `user_second${suffix}` }],
-      totalCount: 2,
-    }));
-
-    expect(result).toBeNull();
+  it("does not resolve another viewer or an anonymous request", () => {
+    expect(
+      viewerIdForFallbackHandle("target42", "user_2abc1234different"),
+    ).toBeNull();
+    expect(viewerIdForFallbackHandle("target42", null)).toBeNull();
   });
 
-  it("ignores Clerk query matches from other user fields", async () => {
-    const result = await findUserIdByFallbackHandle("arthaey1", async () => ({
-      data: [{ id: "user_different" }],
-      totalCount: 1,
-    }));
-
-    expect(result).toBeNull();
+  it("normalizes the requested fallback handle", () => {
+    expect(
+      viewerIdForFallbackHandle(" TARGET42 ", "user_2abc1234target42"),
+    ).toBe("user_2abc1234target42");
   });
 });

--- a/src/lib/handles.ts
+++ b/src/lib/handles.ts
@@ -13,9 +13,46 @@ import {
 
 export const FALLBACK_HANDLE_LENGTH = 8;
 const HANDLE_CACHE_TTL_SECONDS = 300;
+const CLERK_USER_PAGE_SIZE = 500;
+
+type ClerkUserListPage = {
+  data: Array<{ id: string }>;
+  totalCount: number;
+};
+
+type GetClerkUsers = (params: {
+  limit: number;
+  offset: number;
+  query: string;
+}) => Promise<ClerkUserListPage>;
 
 export function fallbackHandle(userId: string): string {
   return userId.slice(-FALLBACK_HANDLE_LENGTH).toLowerCase();
+}
+
+export async function findUserIdByFallbackHandle(
+  normalized: string,
+  getUsers: GetClerkUsers,
+): Promise<string | null> {
+  let offset = 0;
+  let match: string | null = null;
+
+  while (true) {
+    const page = await getUsers({
+      limit: CLERK_USER_PAGE_SIZE,
+      offset,
+      query: normalized,
+    });
+
+    for (const user of page.data) {
+      if (fallbackHandle(user.id) !== normalized) continue;
+      if (match && match !== user.id) return null;
+      match = user.id;
+    }
+
+    offset += page.data.length;
+    if (page.data.length === 0 || offset >= page.totalCount) return match;
+  }
 }
 
 // Forward: userId -> handle. Used to build /u/<handle> URLs from a
@@ -121,6 +158,17 @@ async function resolveUserIdForHandle(
     normalized.length === FALLBACK_HANDLE_LENGTH &&
     /^[a-z0-9]+$/.test(normalized)
   ) {
+    try {
+      const client = await clerkClient();
+      const clerkUserId = await findUserIdByFallbackHandle(
+        normalized,
+        (params) => client.users.getUserList(params),
+      );
+      if (clerkUserId) return clerkUserId;
+    } catch {
+      if (cacheableOnly) return null;
+    }
+
     try {
       const { db, schema } = await import("@/lib/db/client");
       const { sql } = await import("drizzle-orm");

--- a/src/lib/handles.ts
+++ b/src/lib/handles.ts
@@ -13,46 +13,19 @@ import {
 
 export const FALLBACK_HANDLE_LENGTH = 8;
 const HANDLE_CACHE_TTL_SECONDS = 300;
-const CLERK_USER_PAGE_SIZE = 500;
-
-type ClerkUserListPage = {
-  data: Array<{ id: string }>;
-  totalCount: number;
-};
-
-type GetClerkUsers = (params: {
-  limit: number;
-  offset: number;
-  query: string;
-}) => Promise<ClerkUserListPage>;
 
 export function fallbackHandle(userId: string): string {
   return userId.slice(-FALLBACK_HANDLE_LENGTH).toLowerCase();
 }
 
-export async function findUserIdByFallbackHandle(
-  normalized: string,
-  getUsers: GetClerkUsers,
-): Promise<string | null> {
-  let offset = 0;
-  let match: string | null = null;
-
-  while (true) {
-    const page = await getUsers({
-      limit: CLERK_USER_PAGE_SIZE,
-      offset,
-      query: normalized,
-    });
-
-    for (const user of page.data) {
-      if (fallbackHandle(user.id) !== normalized) continue;
-      if (match && match !== user.id) return null;
-      match = user.id;
-    }
-
-    offset += page.data.length;
-    if (page.data.length === 0 || offset >= page.totalCount) return match;
-  }
+export function viewerIdForFallbackHandle(
+  handle: string,
+  viewerId: string | null,
+): string | null {
+  if (!viewerId) return null;
+  return fallbackHandle(viewerId) === handle.trim().toLowerCase()
+    ? viewerId
+    : null;
 }
 
 // Forward: userId -> handle. Used to build /u/<handle> URLs from a
@@ -158,17 +131,6 @@ async function resolveUserIdForHandle(
     normalized.length === FALLBACK_HANDLE_LENGTH &&
     /^[a-z0-9]+$/.test(normalized)
   ) {
-    try {
-      const client = await clerkClient();
-      const clerkUserId = await findUserIdByFallbackHandle(
-        normalized,
-        (params) => client.users.getUserList(params),
-      );
-      if (clerkUserId) return clerkUserId;
-    } catch {
-      if (cacheableOnly) return null;
-    }
-
     try {
       const { db, schema } = await import("@/lib/db/client");
       const { sql } = await import("drizzle-orm");


### PR DESCRIPTION
## Summary
- keep the auth providers around profile and my-feedback pages, including their nested not-found boundaries
- resolve a fallback handle for the signed-in viewer instead of paginating the whole Clerk user list

Closes #713

## Why the Clerk sweep is gone
`/u/<handle>` links come from `owner-credit.ts`, which builds them from `submittedPets.ownerId`, so those users always have database rows and the existing sweep resolves them. The only case the Clerk pagination added was a signed-in user with no Petdex rows opening their own profile, and matching the viewer id covers that in constant time. As written, the sweep ran on every profile request and grew with total user count.

## Why my-feedback needs the layout
`my-feedback/[id]/page.tsx` calls `notFound()` at line 49, before the body applies `FullAuthProviders` at line 64. The route is on the eager-auth list, so `ConditionalAuthProviders` skips the root provider for it, and the not-found tree renders without one. `AuthBadge` lazy loads `useAuth`/`useClerk` whenever a Clerk session cookie is present, which is the same failure the issue reports on `/u/`.

## Test plan
- [x] `bun test src/lib/handles.test.ts`
- [x] `bun run i18n:check`
- [x] changed-file Biome check and `git diff --check`
- [x] `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build`
- [x] `bun test --env-file=.env.mock` (436 pass; the 2 CLI asset allowlist failures reproduce on a clean tree with the same command, so they are not from this branch)