### PR TITLE
fix: answer 401 instead of 404 on protected API routes

### DIFF
--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+
+// The proxy itself pulls in Clerk and next-intl, so we assert on its
+// source instead of importing it. What matters is an ordering the type
+// system cannot express: /api must return before auth.protect() runs.
+// Comments are stripped first, otherwise prose mentioning auth.protect()
+// would be read as the call site and the assertion would measure itself.
+const source = readFileSync(new URL("./proxy.ts", import.meta.url), "utf8")
+  .replace(/\/\*[\s\S]*?\*\//g, "")
+  .replace(/\/\/.*$/gm, "");
+
+describe("protected API routes bypass auth.protect", () => {
+  it("returns for /api before calling auth.protect", () => {
+    // Scope to the Clerk-backed middleware. The anonymous middleware
+    // above it has its own /api early return, and matching that one
+    // would pass no matter how the Clerk branch is ordered.
+    const start = source.indexOf("const clerkBackedMiddleware");
+    expect(start).toBeGreaterThan(-1);
+    const body = source.slice(start);
+
+    const apiReturn = body.indexOf('pathname.startsWith("/api")');
+    const protect = body.indexOf("auth.protect()");
+
+    expect(apiReturn).toBeGreaterThan(-1);
+    expect(protect).toBeGreaterThan(-1);
+    // auth.protect() answers a fetch() with notFound(), so an API route
+    // reaching it returns 404 to an expired session instead of 401 (#717).
+    expect(apiReturn).toBeLessThan(protect);
+  });
+});
+
+describe("every proxy-protected API route rejects on its own", () => {
+  // Mirrors the /api entries of isProtected. Each must answer 401
+  // itself, because the proxy no longer guards them.
+  const routes = [
+    "src/app/api/submit/route.ts",
+    "src/app/api/r2/presign/route.ts",
+    "src/app/api/my-pets/approved/route.ts",
+    "src/app/api/my-pets/claim/route.ts",
+    "src/app/api/my-pets/[id]/edit/route.ts",
+    "src/app/api/my-pets/[id]/edit-presign/route.ts",
+    "src/app/api/my-pets/[id]/withdraw/route.ts",
+  ];
+
+  for (const route of routes) {
+    it(`${route} answers 401 without a session`, () => {
+      const body = readFileSync(route, "utf8");
+      expect(body).toContain("await auth()");
+      expect(body).toMatch(/if \(!userId\)/);
+      expect(body).toContain("status: 401");
+    });
+  }
+});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -46,6 +46,9 @@ const LEGACY_REDIRECT_HOSTS = new Set([
   "www.petdex.crafter.run",
 ]);
 
+// The /api entries are unreachable while the /api early return above
+// runs first, and they stay as a backstop in case that order changes.
+// Every route they name already answers 401 on its own.
 const isProtected = createRouteMatcher([
   "/submit",
   "/submit/(.*)",
@@ -96,12 +99,17 @@ const clerkBackedMiddleware = clerkMiddleware(async (auth, req, event) => {
   const guard = await guardPublicTraffic(req);
   if (guard) return guard;
 
-  if (isProtected(req)) {
-    await auth.protect();
-  }
-
+  // API routes authenticate themselves and answer 401. Running
+  // auth.protect() here instead sends them down Clerk's page path,
+  // which redirects a document request but calls notFound() for a
+  // fetch(), so /api/r2/presign answered 404 to an expired session
+  // and the submit form reported "presign 404" (#717).
   if (req.nextUrl.pathname.startsWith("/api")) {
     return NextResponse.next();
+  }
+
+  if (isProtected(req)) {
+    await auth.protect();
   }
 
   return handleI18nRoutingWithoutLocaleCookie(req);


### PR DESCRIPTION
## Problem

Signed-out or expired requests to `/api/r2/presign` get a 404, so the submit form reports `presign 404` and the upload dies. Reported in #717 (and #716, a duplicate of it).

`auth.protect()` ran at `src/proxy.ts:99`, before the `/api` early return on line 103. That sends protected API routes down Clerk's page-oriented path, which redirects a document request but calls `notFound()` for a `fetch()`. The presign route never runs, so its own 401 never gets a chance.

Verified against production:

```
POST /api/r2/presign         -> 404   (in isProtected)
POST /api/submit             -> 404   (in isProtected)
POST /api/pet-requests/image -> 401   (not in isProtected, correct)

POST /api/r2/presign, Sec-Fetch-Dest: empty    -> 404
POST /api/r2/presign, Sec-Fetch-Dest: document -> 307 to sign-in
```

Same URL and same second on the last pair, so one request header is the only variable. `/api/submit` and `/api/my-pets/*` carried the same defect.

## Change

Return for `/api` before `auth.protect()` runs. `/submit` is a page and keeps its redirect to sign-in.

This removes no protection. All seven routes the matcher named already call `auth()` and return 401 without a session, so they now emit that instead of a 404. The `/api` entries stay in `isProtected` as a backstop in case the ordering changes again.

## Not the cause

The reports came from `zh` users, so locale and geography both looked plausible. Neither holds. The submit form calls the unprefixed `/api/r2/presign`, and `上传失败` only identifies the UI language. Reproduced from Buenos Aires.

#655 is a different bug. Its error is `Failed to fetch` from the R2 PUT loop, not `presign 404`. The shared catch in `pet-submit-form.tsx:533` is what makes the two look alike.

## Test plan

- [x] `bun test src/proxy.test.ts`, 8 new tests
- [x] force-red: restoring the old order turns the ordering test red, and the fix turns it green
- [x] `bun run i18n:check`
- [x] Biome on changed files and `git diff --check`
- [x] `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build`
- [x] `bun test --env-file=.env.mock`, 441 pass. The 2 CLI asset allowlist failures reproduce on a clean tree with the same command, so they are not from this branch.

## Follow-up, not in this PR

`pet-submit-form.tsx:473-481` prints the raw status. A 401 there should prompt re-auth instead.