### PR TITLE
fix: stop sprite frames bleeding their neighbor at fractional scales

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -619,13 +619,16 @@ input {
      matter how many rows exist below the ones we animate. */
   background-size: var(--sprite-sheet-width) auto;
   image-rendering: pixelated;
-  /* translateZ(0) forces a GPU-composited layer so background-image
-     decode + animation stay on the compositor thread instead of being
-     re-rasterized on each scroll-induced repaint. Combined with
-     contain:paint on the parent, the WebP stays decoded. */
-  transform: scale(var(--pet-scale)) translateZ(0);
-  transform-origin: top left;
-  will-change: background-position;
+  /* zoom, not transform: scale(). Scaling a pixelated layer by a
+     fractional factor makes the nearest-neighbour sampler reach past
+     the frame it is drawing, so a card at 0.7 showed a sliver of the
+     next column (a hat tip, a braid) beside the pet (#660). zoom
+     scales the box before the background is sampled, so every frame
+     stays inside its own 192x208 cell. translateZ(0) is gone with the
+     transform, so will-change keeps the layer promoted and the WebP
+     decoded across scrolls. */
+  zoom: var(--pet-scale);
+  will-change: transform, background-position;
   animation: pet-state var(--sprite-duration) steps(var(--sprite-frames))
     infinite;
 }
@@ -662,8 +665,8 @@ input {
   background-size: 1536px auto;
   background-position: 0 var(--sprite-y);
   image-rendering: pixelated;
-  transform: scale(var(--pet-scale, 1));
-  transform-origin: top left;
+  /* Same nearest-neighbour bleed as .pet-sprite, see #660. */
+  zoom: var(--pet-scale, 1);
 }
 
 /* Tap-me hint ring on the interactive PetFloater. A brand-tinted glow


### PR DESCRIPTION
## Problem

Pet cards show a sliver of the neighboring animation frame beside the character, reported in #660 as a hat tip or braid appearing at the edge. The reporter confirmed their atlas is correct: 1536x1872, 8x9 grid, all 57 frames clean locally, and the same sheet renders fine in the local Codex app.

The cause is `image-rendering: pixelated` combined with `transform: scale()` at a fractional factor. The nearest-neighbour sampler runs on the scaled layer, so it reaches past the 192x208 cell it is drawing and picks up the adjacent column.

## Evidence

Measured with the reporter's own spritesheet, same browser and same file, at the six idle frames. Columns carrying pixel mass that the fixed version does not have:

```
frame 0: transform 7 columns   zoom 1
frame 1: transform 7           zoom 1
frame 2: transform 4           zoom 1
frame 3: transform 6           zoom 1
frame 4: transform 7           zoom 1
frame 5: transform 7           zoom 2
```

Isolating the properties one at a time, `image-rendering: auto` was clean at every scale while `pixelated` bled, and `translateZ(0)` made no difference either way. Scale 1 was clean in both, which matches the report: the detail page renders through `PetFloater` at a fixed 110px box, while the card surfaces pass 0.7, 0.65, 0.45 and 0.32.

## Change

Use `zoom` instead of `transform: scale()` on `.pet-sprite` and `.static-pet-sprite`. `zoom` scales the box before the background is sampled, so each frame stays inside its own cell and `pixelated` is preserved.

`translateZ(0)` goes away with the transform. It was there to keep the layer GPU-composited so the WebP stays decoded across scrolls, so `will-change` now carries `transform` to keep that promotion.

## Why it looked unreproducible

@henryjing96 could not reproduce it, which fits: the artifact depends on device pixel ratio and on which scale the surface passes, so the same page differs between machines.

## Test plan

- [x] verified in the compiled production CSS: both rules emit `zoom:var(--pet-scale)`, zero occurrences of the old `transform:scale(var(--pet-scale))`
- [x] measured before and after on the reporter's sheet at all six frames, numbers above
- [x] Biome on the changed file and `git diff --check`
- [x] `TELEMETRY_RATELIMIT_SECRET=mock-telemetry-secret bun --env-file=.env.mock run build`
- [x] `bun test --env-file=.env.mock`, 444 pass. The 2 CLI asset allowlist failures reproduce on a clean tree with the same command, so they are not from this branch.

Worth a look on the preview across a few cards, since this touches every sprite surface.