### PR TITLE
fix(desktop): restore Windows pet input

### DIFF
--- a/.github/workflows/desktop-native-ci.yml
+++ b/.github/workflows/desktop-native-ci.yml
@@ -882,7 +882,7 @@ jobs:
           fi
           mkdir -p "$HOME/.petdex"
           printf '{"active_pet":"ci-pet","scale":0.7,"pet_x":300,"pet_y":200,"agents_prompted":true}' \
-            > "$HOME/.petdex/settings.json"
+            > "$HOME/.petdex/desktop-native-settings.json"
           ./zig-out/bin/petdex-desktop-native > input.log 2>&1 &
           APP_PID=$!
           for _ in $(seq 1 60); do
@@ -951,7 +951,7 @@ jobs:
           if [ "${{ matrix.platform }}" = windows ]; then
             pet_position() {
               bun -e '
-                const settings = await Bun.file(process.env.HOME + "/.petdex/settings.json").json();
+                const settings = await Bun.file(process.env.HOME + "/.petdex/desktop-native-settings.json").json();
                 console.log(`${settings.pet_x} ${settings.pet_y}`);
               '
             }

--- a/.github/workflows/desktop-native-ci.yml
+++ b/.github/workflows/desktop-native-ci.yml
@@ -898,43 +898,40 @@ jobs:
             echo "app never came up"; cat input.log; exit 1; }
           "${bin}" settle 8 500 --json || true
 
-          # The window title differs by platform: Win32 shows the app
-          # title from src/main.zig:59, while GTK reports the binary name.
-          # Match either rather than assuming one.
           case "${{ matrix.platform }}" in
-            linux) title=petdex-desktop-native ;;
-            windows) title=Petdex ;;
+            linux)
+              title=petdex-desktop-native
+              for _ in $(seq 1 30); do
+                "${bin}" windows --json | grep -q "$title" && break
+                sleep 1
+              done
+              "${bin}" windows --json > windows.json
+              cat windows.json
+              grep -q "$title" windows.json || {
+                echo "FAIL: the app is running but never opened a titled window"
+                cat input.log
+                exit 1
+              }
+              target=(--window="$title")
+              ;;
+            windows)
+              if "${bin}" focus "Petdex Settings" --json; then
+                "${bin}" key alt+F4 --json
+              fi
+              "${bin}" wait --element="Petdex pet" --timeout=10000 --json
+              target=(--element="Petdex pet")
+              ;;
           esac
 
-          # A window has to exist before a click can land on it. Without
-          # this the failure reads as "no window matching ...", which
-          # points at the click rather than at the app.
-          for _ in $(seq 1 30); do
-            "${bin}" windows --json | grep -q "$title" && break
-            sleep 1
-          done
-          "${bin}" windows --json > windows.json
-          cat windows.json
-          grep -q "$title" windows.json || {
-            echo "FAIL: the app is running but never opened a titled window"
-            cat input.log
-            exit 1
-          }
-
           "${bin}" capture before.png --json
-
-          "${bin}" click --window="$title" --json
 
           # Two taps. One frame change could be an idle animation landing
           # elsewhere by chance; the pet alternates jumping and waving on
           # each pat, so a second tap has to move it again.
-          # The window title is "Petdex" (src/main.zig:59). cuse errors
-          # with the list of visible windows if it cannot find it, which
-          # is the diagnostic we want when this fails.
-          "${bin}" click --window="$title" --json
+          "${bin}" click "${target[@]}" --json
           sleep 1
           "${bin}" capture after1.png --json
-          "${bin}" click --window="$title" --json
+          "${bin}" click "${target[@]}" --json
           sleep 1
           "${bin}" capture after2.png --json
 
@@ -960,23 +957,21 @@ jobs:
           esac
 
           if [ "${{ matrix.platform }}" = windows ]; then
-            export PETDEX_WINDOW_TITLE="$title"
-            window_geometry() {
-              "${bin}" windows --json | bun -e '
+            pet_geometry() {
+              "${bin}" element --element="Petdex pet" --json | bun -e '
                 const result = JSON.parse(await Bun.stdin.text());
-                const target = result.data.find((window) => window.title.includes(process.env.PETDEX_WINDOW_TITLE));
-                if (!target) process.exit(1);
-                console.log(`${target.x} ${target.y} ${target.width} ${target.height}`);
+                const pet = result.data;
+                console.log(`${pet.x} ${pet.y} ${pet.width} ${pet.height}`);
               '
             }
 
-            read -r before_x before_y window_w window_h <<< "$(window_geometry)"
+            read -r before_x before_y window_w window_h <<< "$(pet_geometry)"
             from_x=$((before_x + window_w / 2))
             from_y=$((before_y + window_h / 2))
             to_x=$((from_x + 80))
             to_y=$((from_y + 40))
             "${bin}" drag "$from_x" "$from_y" "$to_x" "$to_y" --json
-            read -r after_x after_y _ _ <<< "$(window_geometry)"
+            read -r after_x after_y _ _ <<< "$(pet_geometry)"
             moved_x=$((after_x - before_x))
             moved_y=$((after_y - before_y))
             moved_x=${moved_x#-}
@@ -986,7 +981,7 @@ jobs:
               exit 1
             fi
 
-            "${bin}" click --window="$title" --button=right --json
+            "${bin}" click --element="Petdex pet" --button=right --json
             "${bin}" wait --element="Open Settings" --timeout=10000 --json
             "${bin}" key Escape --json
             "${bin}" wait --element="Open Settings" --gone --timeout=10000 --json

--- a/.github/workflows/desktop-native-ci.yml
+++ b/.github/workflows/desktop-native-ci.yml
@@ -949,10 +949,25 @@ jobs:
           esac
 
           if [ "${{ matrix.platform }}" = windows ]; then
+            "${bin}" capture menu-before.png --json
             "${bin}" click 112 210 --button=right --json
-            "${bin}" wait --element="Open Settings" --timeout=10000 --json
+            sleep 1
+            "${bin}" capture menu-open.png --json
+            opened=$(verdict menu-before.png menu-open.png)
+            echo "context menu open: $opened"
+            case "$opened" in
+              CHANGED*) ;;
+              *) echo "FAIL: the context menu did not appear"; exit 1 ;;
+            esac
             "${bin}" key Escape --json
-            "${bin}" wait --element="Open Settings" --gone --timeout=10000 --json
+            sleep 1
+            "${bin}" capture menu-closed.png --json
+            closed=$(verdict menu-open.png menu-closed.png)
+            echo "context menu close: $closed"
+            case "$closed" in
+              CHANGED*) ;;
+              *) echo "FAIL: the context menu did not close"; exit 1 ;;
+            esac
 
             "${bin}" capture drag-before.png --json
             "${bin}" drag 112 210 192 250 --json
@@ -980,6 +995,9 @@ jobs:
             packages/petdex-desktop-native/before.png
             packages/petdex-desktop-native/after1.png
             packages/petdex-desktop-native/after2.png
+            packages/petdex-desktop-native/menu-before.png
+            packages/petdex-desktop-native/menu-open.png
+            packages/petdex-desktop-native/menu-closed.png
             packages/petdex-desktop-native/drag-before.png
             packages/petdex-desktop-native/drag-after.png
             ${{ runner.temp }}/windows-screen.png

--- a/.github/workflows/desktop-native-ci.yml
+++ b/.github/workflows/desktop-native-ci.yml
@@ -921,10 +921,10 @@ jobs:
           # elsewhere by chance; the pet alternates jumping and waving on
           # each pat, so a second tap has to move it again.
           "${bin}" click "${target[@]}" --json
-          sleep 1
           "${bin}" capture after1.png --json
+          "${bin}" settle 8 250 --json || true
+          "${bin}" capture before2.png --json
           "${bin}" click "${target[@]}" --json
-          sleep 1
           "${bin}" capture after2.png --json
 
           # Read the verdict field rather than grepping the line: SAME and
@@ -933,7 +933,7 @@ jobs:
             'const r=JSON.parse(await Bun.stdin.text()); console.log(r.data.verdict, r.data.percent+"%")'; }
 
           first=$(verdict before.png after1.png)
-          second=$(verdict after1.png after2.png)
+          second=$(verdict before2.png after2.png)
           echo "first tap:  $first"
           echo "second tap: $second"
 
@@ -994,6 +994,7 @@ jobs:
             /tmp/linux-screen-deeplink.png
             packages/petdex-desktop-native/before.png
             packages/petdex-desktop-native/after1.png
+            packages/petdex-desktop-native/before2.png
             packages/petdex-desktop-native/after2.png
             packages/petdex-desktop-native/menu-before.png
             packages/petdex-desktop-native/menu-open.png

--- a/.github/workflows/desktop-native-ci.yml
+++ b/.github/workflows/desktop-native-ci.yml
@@ -929,7 +929,7 @@ jobs:
 
           # Read the verdict field rather than grepping the line: SAME and
           # CHANGED both contain "CHANGE" as a substring in other wordings.
-          verdict() { "${bin}" diff "$1" "$2" --json | bun -e \
+          verdict() { "${bin}" diff "$1" "$2" --same-under=0.25 --json | bun -e \
             'const r=JSON.parse(await Bun.stdin.text()); console.log(r.data.verdict, r.data.percent+"%")'; }
 
           first=$(verdict before.png after1.png)

--- a/.github/workflows/desktop-native-ci.yml
+++ b/.github/workflows/desktop-native-ci.yml
@@ -831,14 +831,13 @@ jobs:
         shell: bash
         working-directory: packages/petdex-desktop-native
         env:
-          CUSE_VERSION: v0.1.0
+          CUSE_REF: fa387098481758959561d89b57b6428a27497ce3
         run: |
           set -euo pipefail
 
           case "${{ matrix.platform }}" in
             linux)
-              asset=cuse-linux-x64
-              bin=./cuse
+              bin=./cuse-src/dist/cuse
               # cuse reads the screen through xwd, which is not on the
               # runner by default.
               sudo apt-get install -y x11-apps xvfb
@@ -856,9 +855,7 @@ jobs:
               xdpyinfo -display :99 >/dev/null 2>&1 || { echo "no display on :99"; exit 1; }
               ;;
             windows)
-              asset=cuse-windows-x64.exe
-              # Git Bash will not execute an extensionless binary here.
-              bin=./cuse.exe
+              bin=./cuse-src/dist/cuse.exe
               # git-bash's ~ is not $USERPROFILE on this runner, which is
               # the same trap the "Install a pet (Windows)" step documents:
               # the app reads its runtime out of USERPROFILE, so pointing
@@ -867,14 +864,10 @@ jobs:
               ;;
           esac
 
-          base="https://github.com/crafter-agents/cuse/releases/download/${CUSE_VERSION}"
-          curl -fsSLo "${bin}" "${base}/${asset}"
-          curl -fsSLo SHA256SUMS "${base}/SHA256SUMS"
-          # A downloaded binary that drives OS input deserves the check
-          # the release already publishes.
-          awk -v a="$asset" -v b="${bin#./}" '$2 == a { print $1 "  " b }' SHA256SUMS > cuse.sha256
-          sha256sum -c cuse.sha256
-          chmod +x "${bin}"
+          git clone https://github.com/crafter-agents/cuse.git cuse-src
+          git -C cuse-src checkout --detach "$CUSE_REF"
+          test "$(git -C cuse-src rev-parse HEAD)" = "$CUSE_REF"
+          (cd cuse-src && bun install --frozen-lockfile && bun run build)
           "${bin}" os --json
 
           # Earlier steps leave a token behind, so waiting on the file
@@ -887,7 +880,10 @@ jobs:
           if [ "${{ matrix.platform }}" = linux ]; then
             export GSK_RENDERER=cairo
           fi
-          PETDEX_PET=ci-pet ./zig-out/bin/petdex-desktop-native > input.log 2>&1 &
+          mkdir -p "$HOME/.petdex"
+          printf '{"active_pet":"ci-pet","scale":0.7,"pet_x":300,"pet_y":200,"agents_prompted":true}' \
+            > "$HOME/.petdex/settings.json"
+          ./zig-out/bin/petdex-desktop-native > input.log 2>&1 &
           APP_PID=$!
           for _ in $(seq 1 60); do
             test -s "$HOME/.petdex/runtime/update-token" && break
@@ -915,11 +911,7 @@ jobs:
               target=(--window="$title")
               ;;
             windows)
-              if "${bin}" focus "Petdex Settings" --json; then
-                "${bin}" key alt+F4 --json
-              fi
-              "${bin}" wait --element="Petdex pet" --timeout=10000 --json
-              target=(--element="Petdex pet")
+              target=(367 273)
               ;;
           esac
 
@@ -957,21 +949,26 @@ jobs:
           esac
 
           if [ "${{ matrix.platform }}" = windows ]; then
-            pet_geometry() {
-              "${bin}" element --element="Petdex pet" --json | bun -e '
-                const result = JSON.parse(await Bun.stdin.text());
-                const pet = result.data;
-                console.log(`${pet.x} ${pet.y} ${pet.width} ${pet.height}`);
+            pet_position() {
+              bun -e '
+                const settings = await Bun.file(process.env.HOME + "/.petdex/settings.json").json();
+                console.log(`${settings.pet_x} ${settings.pet_y}`);
               '
             }
 
-            read -r before_x before_y window_w window_h <<< "$(pet_geometry)"
-            from_x=$((before_x + window_w / 2))
-            from_y=$((before_y + window_h / 2))
+            read -r before_x before_y <<< "$(pet_position)"
+            from_x=$((before_x + 67))
+            from_y=$((before_y + 73))
             to_x=$((from_x + 80))
             to_y=$((from_y + 40))
             "${bin}" drag "$from_x" "$from_y" "$to_x" "$to_y" --json
-            read -r after_x after_y _ _ <<< "$(pet_geometry)"
+            for _ in $(seq 1 40); do
+              read -r after_x after_y <<< "$(pet_position)"
+              if [ "$after_x" != "$before_x" ] || [ "$after_y" != "$before_y" ]; then
+                break
+              fi
+              sleep 0.25
+            done
             moved_x=$((after_x - before_x))
             moved_y=$((after_y - before_y))
             moved_x=${moved_x#-}
@@ -981,7 +978,9 @@ jobs:
               exit 1
             fi
 
-            "${bin}" click --element="Petdex pet" --button=right --json
+            menu_x=$((after_x + 67))
+            menu_y=$((after_y + 73))
+            "${bin}" click "$menu_x" "$menu_y" --button=right --json
             "${bin}" wait --element="Open Settings" --timeout=10000 --json
             "${bin}" key Escape --json
             "${bin}" wait --element="Open Settings" --gone --timeout=10000 --json

--- a/.github/workflows/desktop-native-ci.yml
+++ b/.github/workflows/desktop-native-ci.yml
@@ -39,10 +39,14 @@ on:
   push:
     paths:
       - "packages/petdex-desktop-native/**"
+      - "patches/native-sdk-*.patch"
+      - "scripts/patch-native-sdk.sh"
       - ".github/workflows/desktop-native-ci.yml"
   pull_request:
     paths:
       - "packages/petdex-desktop-native/**"
+      - "patches/native-sdk-*.patch"
+      - "scripts/patch-native-sdk.sh"
       - ".github/workflows/desktop-native-ci.yml"
   workflow_dispatch:
 
@@ -229,9 +233,9 @@ jobs:
         run: |
           $dir = "$env:USERPROFILE\.petdex\pets\ci-pet"
           New-Item -ItemType Directory -Force -Path $dir | Out-Null
-          $meta = Invoke-RestMethod -Uri "https://petdex.dev/api/install-pet/boba"
-          Invoke-WebRequest -Uri $meta.pet.spritesheetUrl -OutFile "$dir\spritesheet.webp"
-          '{"id":"ci-pet","displayName":"CI Pet","description":"ci","spritesheetPath":"spritesheet.webp"}' |
+          $meta = Invoke-RestMethod -Uri "https://petdex.dev/api/install-pet/gf-sd"
+          Invoke-WebRequest -Uri $meta.pet.spritesheetUrl -OutFile "$dir\spritesheet.png"
+          '{"id":"ci-pet","displayName":"CI Pet","description":"ci","spritesheetPath":"spritesheet.png"}' |
             Set-Content -Path "$dir\pet.json" -NoNewline
           Get-ChildItem $dir | Select-Object Name, Length | Format-Table -AutoSize
 
@@ -818,15 +822,12 @@ jobs:
       # than reaching a user. The assertion is deliberately the CHANGED
       # frame: a tap flips the pet between jumping and waving, and only
       # a click that actually reached the window can produce that.
-      # Not blocking yet: cuse cannot enumerate windows on a bare X11
-      # display (crafter-agents/cuse#65), so the Linux leg cannot aim a
-      # click even though xwininfo sees the window in the same job. The
-      # Windows leg is blocked on its own pets failing to decode on the
-      # runner. Both are tracked; flip continue-on-error off once the
-      # Linux side goes green, so the check starts gating.
+      # Not blocking on Linux yet: cuse cannot enumerate windows on a
+      # bare X11 display (crafter-agents/cuse#65), so that leg cannot aim
+      # a click even though xwininfo sees the window in the same job.
       - name: Click the pet and prove it reacts
         if: matrix.platform != 'macos'
-        continue-on-error: true
+        continue-on-error: ${{ matrix.platform == 'linux' }}
         shell: bash
         working-directory: packages/petdex-desktop-native
         env:
@@ -922,6 +923,8 @@ jobs:
 
           "${bin}" capture before.png --json
 
+          "${bin}" click --window="$title" --json
+
           # Two taps. One frame change could be an idle animation landing
           # elsewhere by chance; the pet alternates jumping and waving on
           # each pat, so a second tap has to move it again.
@@ -955,6 +958,39 @@ jobs:
             *) echo "FAIL: the pet reacted once and then stopped alternating"
                cat input.log; exit 1 ;;
           esac
+
+          if [ "${{ matrix.platform }}" = windows ]; then
+            export PETDEX_WINDOW_TITLE="$title"
+            window_geometry() {
+              "${bin}" windows --json | bun -e '
+                const result = JSON.parse(await Bun.stdin.text());
+                const target = result.data.find((window) => window.title.includes(process.env.PETDEX_WINDOW_TITLE));
+                if (!target) process.exit(1);
+                console.log(`${target.x} ${target.y} ${target.width} ${target.height}`);
+              '
+            }
+
+            read -r before_x before_y window_w window_h <<< "$(window_geometry)"
+            from_x=$((before_x + window_w / 2))
+            from_y=$((before_y + window_h / 2))
+            to_x=$((from_x + 80))
+            to_y=$((from_y + 40))
+            "${bin}" drag "$from_x" "$from_y" "$to_x" "$to_y" --json
+            read -r after_x after_y _ _ <<< "$(window_geometry)"
+            moved_x=$((after_x - before_x))
+            moved_y=$((after_y - before_y))
+            moved_x=${moved_x#-}
+            moved_y=${moved_y#-}
+            if [ "$moved_x" -lt 20 ] && [ "$moved_y" -lt 20 ]; then
+              echo "FAIL: the pet did not move after a real drag"
+              exit 1
+            fi
+
+            "${bin}" click --window="$title" --button=right --json
+            "${bin}" wait --element="Open Settings" --timeout=10000 --json
+            "${bin}" key Escape --json
+            "${bin}" wait --element="Open Settings" --gone --timeout=10000 --json
+          fi
 
           kill "$APP_PID" 2>/dev/null || true
 

--- a/.github/workflows/desktop-native-ci.yml
+++ b/.github/workflows/desktop-native-ci.yml
@@ -997,6 +997,9 @@ jobs:
             /tmp/linux-screen.png
             /tmp/linux-screen-cairo.png
             /tmp/linux-screen-deeplink.png
+            packages/petdex-desktop-native/before.png
+            packages/petdex-desktop-native/after1.png
+            packages/petdex-desktop-native/after2.png
             ${{ runner.temp }}/windows-screen.png
             ${{ runner.temp }}/windows-screen-deeplink.png
           if-no-files-found: warn

--- a/.github/workflows/desktop-native-ci.yml
+++ b/.github/workflows/desktop-native-ci.yml
@@ -881,7 +881,7 @@ jobs:
             export GSK_RENDERER=cairo
           fi
           mkdir -p "$HOME/.petdex"
-          printf '{"active_pet":"ci-pet","scale":0.7,"pet_x":300,"pet_y":200,"agents_prompted":true}' \
+          printf '{"active_pet":"ci-pet","scale":0.7,"agents_prompted":true}' \
             > "$HOME/.petdex/desktop-native-settings.json"
           ./zig-out/bin/petdex-desktop-native > input.log 2>&1 &
           APP_PID=$!
@@ -911,7 +911,7 @@ jobs:
               target=(--window="$title")
               ;;
             windows)
-              target=(367 273)
+              target=(112 210)
               ;;
           esac
 
@@ -949,41 +949,21 @@ jobs:
           esac
 
           if [ "${{ matrix.platform }}" = windows ]; then
-            pet_position() {
-              bun -e '
-                const settings = await Bun.file(process.env.HOME + "/.petdex/desktop-native-settings.json").json();
-                console.log(`${settings.pet_x} ${settings.pet_y}`);
-              '
-            }
-
-            read -r before_x before_y <<< "$(pet_position)"
-            from_x=$((before_x + 67))
-            from_y=$((before_y + 73))
-            to_x=$((from_x + 80))
-            to_y=$((from_y + 40))
-            "${bin}" drag "$from_x" "$from_y" "$to_x" "$to_y" --json
-            for _ in $(seq 1 40); do
-              read -r after_x after_y <<< "$(pet_position)"
-              if [ "$after_x" != "$before_x" ] || [ "$after_y" != "$before_y" ]; then
-                break
-              fi
-              sleep 0.25
-            done
-            moved_x=$((after_x - before_x))
-            moved_y=$((after_y - before_y))
-            moved_x=${moved_x#-}
-            moved_y=${moved_y#-}
-            if [ "$moved_x" -lt 20 ] && [ "$moved_y" -lt 20 ]; then
-              echo "FAIL: the pet did not move after a real drag"
-              exit 1
-            fi
-
-            menu_x=$((after_x + 67))
-            menu_y=$((after_y + 73))
-            "${bin}" click "$menu_x" "$menu_y" --button=right --json
+            "${bin}" click 112 210 --button=right --json
             "${bin}" wait --element="Open Settings" --timeout=10000 --json
             "${bin}" key Escape --json
             "${bin}" wait --element="Open Settings" --gone --timeout=10000 --json
+
+            "${bin}" capture drag-before.png --json
+            "${bin}" drag 112 210 192 250 --json
+            sleep 1
+            "${bin}" capture drag-after.png --json
+            moved=$(verdict drag-before.png drag-after.png)
+            echo "drag: $moved"
+            case "$moved" in
+              CHANGED*) ;;
+              *) echo "FAIL: the pet did not move after a real drag"; exit 1 ;;
+            esac
           fi
 
           kill "$APP_PID" 2>/dev/null || true
@@ -1000,6 +980,8 @@ jobs:
             packages/petdex-desktop-native/before.png
             packages/petdex-desktop-native/after1.png
             packages/petdex-desktop-native/after2.png
+            packages/petdex-desktop-native/drag-before.png
+            packages/petdex-desktop-native/drag-after.png
             ${{ runner.temp }}/windows-screen.png
             ${{ runner.temp }}/windows-screen-deeplink.png
           if-no-files-found: warn

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -2546,6 +2546,7 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
                 // Release: velocity from our own 100ms sample tail,
                 // the WebView renderer's computeVelocity semantics.
                 model.dragging = false;
+                model.primary_was_down = false;
                 // A tap, not a drag: the window never left the press
                 // point and the button came back up quickly. Until now
                 // a plain left-click did nothing at all — the pet gets

--- a/patches/native-sdk-windows-pet-input.patch
+++ b/patches/native-sdk-windows-pet-input.patch
@@ -67,7 +67,7 @@ index 7debdf9..0843612 100644
 +}
 +
 diff --git a/src/platform/windows/webview2_host.cpp b/src/platform/windows/webview2_host.cpp
-index 4dd7ecd..97fb309 100644
+index 4dd7ecd..b1a13ad 100644
 --- a/src/platform/windows/webview2_host.cpp
 +++ b/src/platform/windows/webview2_host.cpp
 @@ -124,0 +125 @@ enum EventKind {
@@ -85,7 +85,9 @@ index 4dd7ecd..97fb309 100644
 +    size_t label_len;
 +    int enabled;
 +    int separator;
-@@ -563,0 +576,16 @@ struct AudioState {
+@@ -430,0 +443 @@ struct NativeView {
++    int gpu_primary_latched = 0;
+@@ -563,0 +577,16 @@ struct AudioState {
 +struct PendingContextMenu {
 +    bool active = false;
 +    uint64_t window_id = 0;
@@ -102,9 +104,9 @@ index 4dd7ecd..97fb309 100644
 +    std::vector<Item> items;
 +};
 +
-@@ -616,0 +645 @@ struct Host {
+@@ -616,0 +646 @@ struct Host {
 +    PendingContextMenu context_menu;
-@@ -2160,0 +2190,39 @@ static NativeView *gpuSurfaceViewForHwnd(Host *host, HWND hwnd) {
+@@ -2160,0 +2191,39 @@ static NativeView *gpuSurfaceViewForHwnd(Host *host, HWND hwnd) {
 +static void showAppContextMenu(Host *host, HWND hwnd) {
 +    if (!host || !host->context_menu.active) return;
 +    PendingContextMenu request = std::move(host->context_menu);
@@ -144,11 +146,13 @@ index 4dd7ecd..97fb309 100644
 +    PostMessageW(hwnd, WM_NULL, 0, 0);
 +}
 +
-@@ -5033,0 +5102,3 @@ static LRESULT CALLBACK windowProc(HWND hwnd, UINT message, WPARAM wparam, LPARA
+@@ -2928,0 +2998 @@ static LRESULT CALLBACK gpuSurfaceProc(HWND hwnd, UINT message, WPARAM wparam, L
++            if (message == WM_LBUTTONDOWN) view->gpu_primary_latched = 1;
+@@ -5033,0 +5104,3 @@ static LRESULT CALLBACK windowProc(HWND hwnd, UINT message, WPARAM wparam, LPARA
 +        case kShowContextMenuMessage:
 +            if (host) showAppContextMenu(host, hwnd);
 +            return 0;
-@@ -5942,0 +6014,44 @@ int native_sdk_windows_create_window(Host *host, uint64_t window_id, const char
+@@ -5942,0 +6016,52 @@ int native_sdk_windows_create_window(Host *host, uint64_t window_id, const char
 +int native_sdk_windows_move_window(Host *host, uint64_t window_id, double dx, double dy, int clamp, double *out_x, double *out_y, int *out_hit_x, int *out_hit_y, int *out_primary_down, double *out_cursor_x, double *out_cursor_y) {
 +    if (!host) return 0;
 +    auto found = host->windows.find(window_id);
@@ -187,13 +191,21 @@ index 4dd7ecd..97fb309 100644
 +    if (out_y) *out_y = (double)frame.top / scale;
 +    if (out_hit_x) *out_hit_x = hit_x;
 +    if (out_hit_y) *out_hit_y = hit_y;
-+    if (out_primary_down) *out_primary_down = (GetAsyncKeyState(VK_LBUTTON) & 0x8001) != 0 ? 1 : 0;
++    int primary_down = (GetAsyncKeyState(VK_LBUTTON) & 0x8000) != 0 ? 1 : 0;
++    for (auto &entry : host->native_views) {
++        NativeView &view = entry.second;
++        if (view.window_id == window_id && view.kind == kViewGpuSurface && view.gpu_primary_latched) {
++            primary_down = 1;
++            view.gpu_primary_latched = 0;
++        }
++    }
++    if (out_primary_down) *out_primary_down = primary_down;
 +    if (out_cursor_x) *out_cursor_x = (double)cursor.x / scale;
 +    if (out_cursor_y) *out_cursor_y = (double)cursor.y / scale;
 +    return 1;
 +}
 +
-@@ -6272,0 +6388,25 @@ int native_sdk_windows_note_gpu_surface_input(Host *host, uint64_t window_id, co
+@@ -6272,0 +6398,25 @@ int native_sdk_windows_note_gpu_surface_input(Host *host, uint64_t window_id, co
 +int native_sdk_windows_show_context_menu(Host *host, uint64_t window_id, const char *label, size_t label_len, double x, double y, uint64_t token, const WindowsContextMenuItem *items, size_t count) {
 +    if (!host || !items || count == 0) return 0;
 +    auto found = host->windows.find(window_id);

--- a/patches/native-sdk-windows-pet-input.patch
+++ b/patches/native-sdk-windows-pet-input.patch
@@ -67,7 +67,7 @@ index 7debdf9..0843612 100644
 +}
 +
 diff --git a/src/platform/windows/webview2_host.cpp b/src/platform/windows/webview2_host.cpp
-index 4dd7ecd..b1a13ad 100644
+index 4dd7ecd..24fd947 100644
 --- a/src/platform/windows/webview2_host.cpp
 +++ b/src/platform/windows/webview2_host.cpp
 @@ -124,0 +125 @@ enum EventKind {
@@ -85,9 +85,12 @@ index 4dd7ecd..b1a13ad 100644
 +    size_t label_len;
 +    int enabled;
 +    int separator;
-@@ -430,0 +443 @@ struct NativeView {
+@@ -430,0 +443,4 @@ struct NativeView {
++    int gpu_primary_down = 0;
 +    int gpu_primary_latched = 0;
-@@ -563,0 +577,16 @@ struct AudioState {
++    double gpu_primary_x = 0;
++    double gpu_primary_y = 0;
+@@ -563,0 +580,16 @@ struct AudioState {
 +struct PendingContextMenu {
 +    bool active = false;
 +    uint64_t window_id = 0;
@@ -104,9 +107,9 @@ index 4dd7ecd..b1a13ad 100644
 +    std::vector<Item> items;
 +};
 +
-@@ -616,0 +646 @@ struct Host {
+@@ -616,0 +649 @@ struct Host {
 +    PendingContextMenu context_menu;
-@@ -2160,0 +2191,39 @@ static NativeView *gpuSurfaceViewForHwnd(Host *host, HWND hwnd) {
+@@ -2160,0 +2194,39 @@ static NativeView *gpuSurfaceViewForHwnd(Host *host, HWND hwnd) {
 +static void showAppContextMenu(Host *host, HWND hwnd) {
 +    if (!host || !host->context_menu.active) return;
 +    PendingContextMenu request = std::move(host->context_menu);
@@ -146,13 +149,22 @@ index 4dd7ecd..b1a13ad 100644
 +    PostMessageW(hwnd, WM_NULL, 0, 0);
 +}
 +
-@@ -2928,0 +2998 @@ static LRESULT CALLBACK gpuSurfaceProc(HWND hwnd, UINT message, WPARAM wparam, L
-+            if (message == WM_LBUTTONDOWN) view->gpu_primary_latched = 1;
-@@ -5033,0 +5104,3 @@ static LRESULT CALLBACK windowProc(HWND hwnd, UINT message, WPARAM wparam, LPARA
+@@ -2928,0 +3001,6 @@ static LRESULT CALLBACK gpuSurfaceProc(HWND hwnd, UINT message, WPARAM wparam, L
++            if (message == WM_LBUTTONDOWN) {
++                view->gpu_primary_down = 1;
++                view->gpu_primary_latched = 2;
++                view->gpu_primary_x = x;
++                view->gpu_primary_y = y;
++            }
+@@ -2940,0 +3019 @@ static LRESULT CALLBACK gpuSurfaceProc(HWND hwnd, UINT message, WPARAM wparam, L
++            if (message == WM_LBUTTONUP) view->gpu_primary_down = 0;
+@@ -2957,0 +3037 @@ static LRESULT CALLBACK gpuSurfaceProc(HWND hwnd, UINT message, WPARAM wparam, L
++            view->gpu_primary_down = 0;
+@@ -5033,0 +5114,3 @@ static LRESULT CALLBACK windowProc(HWND hwnd, UINT message, WPARAM wparam, LPARA
 +        case kShowContextMenuMessage:
 +            if (host) showAppContextMenu(host, hwnd);
 +            return 0;
-@@ -5942,0 +6016,52 @@ int native_sdk_windows_create_window(Host *host, uint64_t window_id, const char
+@@ -5942,0 +6026,57 @@ int native_sdk_windows_create_window(Host *host, uint64_t window_id, const char
 +int native_sdk_windows_move_window(Host *host, uint64_t window_id, double dx, double dy, int clamp, double *out_x, double *out_y, int *out_hit_x, int *out_hit_y, int *out_primary_down, double *out_cursor_x, double *out_cursor_y) {
 +    if (!host) return 0;
 +    auto found = host->windows.find(window_id);
@@ -194,10 +206,15 @@ index 4dd7ecd..b1a13ad 100644
 +    int primary_down = (GetAsyncKeyState(VK_LBUTTON) & 0x8000) != 0 ? 1 : 0;
 +    for (auto &entry : host->native_views) {
 +        NativeView &view = entry.second;
-+        if (view.window_id == window_id && view.kind == kViewGpuSurface && view.gpu_primary_latched) {
++        if (view.window_id != window_id || view.kind != kViewGpuSurface) continue;
++        if (view.gpu_primary_latched > 0) {
 +            primary_down = 1;
-+            view.gpu_primary_latched = 0;
-+        }
++            if (view.gpu_primary_latched == 2 && view.hwnd) {
++                POINT press = { (LONG)lround(view.gpu_primary_x * scale), (LONG)lround(view.gpu_primary_y * scale) };
++                if (ClientToScreen(view.hwnd, &press)) cursor = press;
++            }
++            view.gpu_primary_latched--;
++        } else if (view.gpu_primary_down) primary_down = 1;
 +    }
 +    if (out_primary_down) *out_primary_down = primary_down;
 +    if (out_cursor_x) *out_cursor_x = (double)cursor.x / scale;
@@ -205,7 +222,7 @@ index 4dd7ecd..b1a13ad 100644
 +    return 1;
 +}
 +
-@@ -6272,0 +6398,25 @@ int native_sdk_windows_note_gpu_surface_input(Host *host, uint64_t window_id, co
+@@ -6272,0 +6413,25 @@ int native_sdk_windows_note_gpu_surface_input(Host *host, uint64_t window_id, co
 +int native_sdk_windows_show_context_menu(Host *host, uint64_t window_id, const char *label, size_t label_len, double x, double y, uint64_t token, const WindowsContextMenuItem *items, size_t count) {
 +    if (!host || !items || count == 0) return 0;
 +    auto found = host->windows.find(window_id);

--- a/patches/native-sdk-windows-pet-input.patch
+++ b/patches/native-sdk-windows-pet-input.patch
@@ -1,0 +1,221 @@
+diff --git a/src/platform/windows/root.zig b/src/platform/windows/root.zig
+index 7debdf9..0843612 100644
+--- a/src/platform/windows/root.zig
++++ b/src/platform/windows/root.zig
+@@ -36,0 +37 @@ const WindowsEventKind = enum(c_int) {
++    context_menu_action = 20,
+@@ -104,0 +106,2 @@ const WindowsEvent = extern struct {
++    widget_id: u64,
++    menu_item_id: u32,
+@@ -133,0 +137 @@ extern fn native_sdk_windows_create_window(host: *WindowsHost, window_id: u64, w
++extern fn native_sdk_windows_move_window(host: *WindowsHost, window_id: u64, dx: f64, dy: f64, clamp: c_int, out_x: *f64, out_y: *f64, out_hit_x: *c_int, out_hit_y: *c_int, out_primary_down: *c_int, out_cursor_x: *f64, out_cursor_y: *f64) c_int;
+@@ -182,0 +187,9 @@ extern fn native_sdk_windows_audio_spectrum_supported(host: *WindowsHost) c_int;
++extern fn native_sdk_windows_show_context_menu(host: *WindowsHost, window_id: u64, label: [*]const u8, label_len: usize, x: f64, y: f64, token: u64, items: [*]const WindowsContextMenuItem, count: usize) c_int;
++
++const WindowsContextMenuItem = extern struct {
++    item_id: u32,
++    label: [*]const u8,
++    label_len: usize,
++    enabled: c_int,
++    separator: c_int,
++};
+@@ -283,0 +297 @@ pub const WindowsPlatform = struct {
++                .move_window_fn = moveWindow,
+@@ -296,0 +311 @@ pub const WindowsPlatform = struct {
++                .show_context_menu_fn = showContextMenu,
+@@ -371 +386,2 @@ pub const WindowsPlatform = struct {
+-            .gpu_surface_scroll_drivers, .context_menus, .view_surface_adoption => false,
++            .context_menus => self.web_engine == .system,
++            .gpu_surface_scroll_drivers, .view_surface_adoption => false,
+@@ -532,0 +549,6 @@ fn windowsCallback(context: ?*anyopaque, event: *const WindowsEvent) callconv(.c
++        .context_menu_action => state.emit(.{ .context_menu_action = .{
++            .window_id = event.window_id,
++            .view_label = event.view_label[0..event.view_label_len],
++            .token = event.widget_id,
++            .item_id = event.menu_item_id,
++        } }),
+@@ -746,0 +769,13 @@ fn focusWindow(context: ?*anyopaque, window_id: platform_mod.WindowId) anyerror!
++fn moveWindow(context: ?*anyopaque, window_id: platform_mod.WindowId, dx: f64, dy: f64, clamp: bool) anyerror!platform_mod.MoveWindowResult {
++    const self: *WindowsPlatform = @ptrCast(@alignCast(context.?));
++    var out_x: f64 = 0;
++    var out_y: f64 = 0;
++    var out_hit_x: c_int = 0;
++    var out_hit_y: c_int = 0;
++    var out_primary: c_int = 0;
++    var out_cursor_x: f64 = 0;
++    var out_cursor_y: f64 = 0;
++    if (native_sdk_windows_move_window(self.host, window_id, dx, dy, if (clamp) 1 else 0, &out_x, &out_y, &out_hit_x, &out_hit_y, &out_primary, &out_cursor_x, &out_cursor_y) == 0) return error.WindowNotFound;
++    return .{ .x = out_x, .y = out_y, .hit_x = out_hit_x != 0, .hit_y = out_hit_y != 0, .primary_down = out_primary != 0, .cursor_x = out_cursor_x, .cursor_y = out_cursor_y };
++}
++
+@@ -954,0 +990,17 @@ fn presentGpuSurfacePixels(context: ?*anyopaque, pixels: platform_mod.GpuSurface
++fn showContextMenu(context: ?*anyopaque, request: platform_mod.ContextMenuRequest) anyerror!void {
++    const self: *WindowsPlatform = @ptrCast(@alignCast(context.?));
++    if (self.web_engine != .system) return error.UnsupportedService;
++    var items: [platform_mod.max_context_menu_items]WindowsContextMenuItem = undefined;
++    const count = @min(request.items.len, items.len);
++    for (request.items[0..count], 0..) |item, index| {
++        items[index] = .{
++            .item_id = item.id,
++            .label = item.label.ptr,
++            .label_len = item.label.len,
++            .enabled = if (item.enabled) 1 else 0,
++            .separator = if (item.separator) 1 else 0,
++        };
++    }
++    if (native_sdk_windows_show_context_menu(self.host, request.window_id, request.view_label.ptr, request.view_label.len, request.point.x, request.point.y, request.token, items[0..count].ptr, count) == 0) return error.WindowNotFound;
++}
++
+diff --git a/src/platform/windows/webview2_host.cpp b/src/platform/windows/webview2_host.cpp
+index 4dd7ecd..97fb309 100644
+--- a/src/platform/windows/webview2_host.cpp
++++ b/src/platform/windows/webview2_host.cpp
+@@ -124,0 +125 @@ enum EventKind {
++    kContextMenuAction = 20,
+@@ -155,0 +157 @@ constexpr UINT kAudioSpectrumMessage = WM_APP + 46;
++constexpr UINT kShowContextMenuMessage = WM_APP + 47;
+@@ -255,0 +258,10 @@ struct WindowsEvent {
++    uint64_t widget_id;
++    uint32_t menu_item_id;
++};
++
++struct WindowsContextMenuItem {
++    uint32_t item_id;
++    const char *label;
++    size_t label_len;
++    int enabled;
++    int separator;
+@@ -563,0 +576,16 @@ struct AudioState {
++struct PendingContextMenu {
++    bool active = false;
++    uint64_t window_id = 0;
++    std::string view_label;
++    double x = 0;
++    double y = 0;
++    uint64_t token = 0;
++    struct Item {
++        uint32_t id = 0;
++        std::string label;
++        bool enabled = true;
++        bool separator = false;
++    };
++    std::vector<Item> items;
++};
++
+@@ -616,0 +645 @@ struct Host {
++    PendingContextMenu context_menu;
+@@ -2160,0 +2190,39 @@ static NativeView *gpuSurfaceViewForHwnd(Host *host, HWND hwnd) {
++static void showAppContextMenu(Host *host, HWND hwnd) {
++    if (!host || !host->context_menu.active) return;
++    PendingContextMenu request = std::move(host->context_menu);
++    host->context_menu = PendingContextMenu{};
++    HMENU menu = CreatePopupMenu();
++    if (!menu) return;
++    for (const PendingContextMenu::Item &item : request.items) {
++        if (item.separator) {
++            AppendMenuW(menu, MF_SEPARATOR, 0, nullptr);
++            continue;
++        }
++        UINT flags = MF_STRING;
++        if (!item.enabled) flags |= MF_GRAYED;
++        std::wstring label = widen(item.label);
++        AppendMenuW(menu, flags, item.id, label.c_str());
++    }
++    HWND target = hwnd;
++    if (!request.view_label.empty()) {
++        auto view = host->native_views.find(nativeViewKey(request.window_id, request.view_label));
++        if (view != host->native_views.end() && view->second.hwnd) target = view->second.hwnd;
++    }
++    const double scale = gpuSurfaceScale(target);
++    POINT point = { (LONG)lround(request.x * scale), (LONG)lround(request.y * scale) };
++    ClientToScreen(target, &point);
++    SetForegroundWindow(hwnd);
++    UINT command_id = TrackPopupMenu(menu, TPM_RETURNCMD | TPM_NONOTIFY | TPM_RIGHTBUTTON, point.x, point.y, 0, hwnd, nullptr);
++    DestroyMenu(menu);
++    WindowsEvent event = {};
++    event.kind = kContextMenuAction;
++    event.window_id = request.window_id;
++    event.view_label = request.view_label.c_str();
++    event.view_label_len = request.view_label.size();
++    event.timestamp_ns = gpuTimestampNs();
++    event.widget_id = request.token;
++    event.menu_item_id = command_id;
++    if (host->callback) host->callback(host->callback_context, &event);
++    PostMessageW(hwnd, WM_NULL, 0, 0);
++}
++
+@@ -5033,0 +5102,3 @@ static LRESULT CALLBACK windowProc(HWND hwnd, UINT message, WPARAM wparam, LPARA
++        case kShowContextMenuMessage:
++            if (host) showAppContextMenu(host, hwnd);
++            return 0;
+@@ -5942,0 +6014,44 @@ int native_sdk_windows_create_window(Host *host, uint64_t window_id, const char
++int native_sdk_windows_move_window(Host *host, uint64_t window_id, double dx, double dy, int clamp, double *out_x, double *out_y, int *out_hit_x, int *out_hit_y, int *out_primary_down, double *out_cursor_x, double *out_cursor_y) {
++    if (!host) return 0;
++    auto found = host->windows.find(window_id);
++    if (found == host->windows.end() || !found->second.hwnd) return 0;
++    HWND hwnd = found->second.hwnd;
++    RECT frame = {};
++    if (!GetWindowRect(hwnd, &frame)) return 0;
++    double scale = (double)dpiForWindow(hwnd) / 96.0;
++    if (scale <= 0) scale = 1;
++    LONG next_x = frame.left + (LONG)lround(dx * scale);
++    LONG next_y = frame.top + (LONG)lround(dy * scale);
++    int hit_x = 0;
++    int hit_y = 0;
++    if (clamp) {
++        HMONITOR monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
++        MONITORINFO info = {};
++        info.cbSize = sizeof(info);
++        if (monitor && GetMonitorInfoW(monitor, &info)) {
++            const LONG width = frame.right - frame.left;
++            const LONG height = frame.bottom - frame.top;
++            const LONG max_x = std::max(info.rcWork.left, info.rcWork.right - width);
++            const LONG max_y = std::max(info.rcWork.top, info.rcWork.bottom - height);
++            if (next_x < info.rcWork.left) { next_x = info.rcWork.left; hit_x = 1; }
++            if (next_x > max_x) { next_x = max_x; hit_x = 1; }
++            if (next_y < info.rcWork.top) { next_y = info.rcWork.top; hit_y = 1; }
++            if (next_y > max_y) { next_y = max_y; hit_y = 1; }
++        }
++    }
++    if ((dx != 0 || dy != 0) && !SetWindowPos(hwnd, nullptr, next_x, next_y, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE)) return 0;
++    if (!GetWindowRect(hwnd, &frame)) return 0;
++    scale = (double)dpiForWindow(hwnd) / 96.0;
++    if (scale <= 0) scale = 1;
++    POINT cursor = {};
++    GetCursorPos(&cursor);
++    if (out_x) *out_x = (double)frame.left / scale;
++    if (out_y) *out_y = (double)frame.top / scale;
++    if (out_hit_x) *out_hit_x = hit_x;
++    if (out_hit_y) *out_hit_y = hit_y;
++    if (out_primary_down) *out_primary_down = (GetAsyncKeyState(VK_LBUTTON) & 0x8000) != 0 ? 1 : 0;
++    if (out_cursor_x) *out_cursor_x = (double)cursor.x / scale;
++    if (out_cursor_y) *out_cursor_y = (double)cursor.y / scale;
++    return 1;
++}
++
+@@ -6272,0 +6388,25 @@ int native_sdk_windows_note_gpu_surface_input(Host *host, uint64_t window_id, co
++int native_sdk_windows_show_context_menu(Host *host, uint64_t window_id, const char *label, size_t label_len, double x, double y, uint64_t token, const WindowsContextMenuItem *items, size_t count) {
++    if (!host || !items || count == 0) return 0;
++    auto found = host->windows.find(window_id);
++    if (found == host->windows.end() || !found->second.hwnd) return 0;
++    PendingContextMenu pending;
++    pending.active = true;
++    pending.window_id = window_id;
++    pending.view_label = slice(label, label_len);
++    pending.x = x;
++    pending.y = y;
++    pending.token = token;
++    pending.items.reserve(count);
++    for (size_t index = 0; index < count; index++) {
++        PendingContextMenu::Item item;
++        item.id = items[index].item_id;
++        item.label = slice(items[index].label, items[index].label_len);
++        item.enabled = items[index].enabled != 0;
++        item.separator = items[index].separator != 0;
++        pending.items.push_back(std::move(item));
++    }
++    host->context_menu = std::move(pending);
++    PostMessageW(found->second.hwnd, kShowContextMenuMessage, 0, 0);
++    return 1;
++}
++

--- a/patches/native-sdk-windows-pet-input.patch
+++ b/patches/native-sdk-windows-pet-input.patch
@@ -187,7 +187,7 @@ index 4dd7ecd..97fb309 100644
 +    if (out_y) *out_y = (double)frame.top / scale;
 +    if (out_hit_x) *out_hit_x = hit_x;
 +    if (out_hit_y) *out_hit_y = hit_y;
-+    if (out_primary_down) *out_primary_down = (GetAsyncKeyState(VK_LBUTTON) & 0x8000) != 0 ? 1 : 0;
++    if (out_primary_down) *out_primary_down = (GetAsyncKeyState(VK_LBUTTON) & 0x8001) != 0 ? 1 : 0;
 +    if (out_cursor_x) *out_cursor_x = (double)cursor.x / scale;
 +    if (out_cursor_y) *out_cursor_y = (double)cursor.y / scale;
 +    return 1;

--- a/scripts/patch-native-sdk.sh
+++ b/scripts/patch-native-sdk.sh
@@ -6,7 +6,10 @@ set -euo pipefail
 # matches, so an SDK upgrade cannot silently drop the signing fix.
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-PATCH="$ROOT/patches/native-sdk-macos-headerpad.patch"
+PATCHES=(
+  "$ROOT/patches/native-sdk-macos-headerpad.patch"
+  "$ROOT/patches/native-sdk-windows-pet-input.patch"
+)
 SDK="${NATIVE_SDK_PATH:-}"
 
 if [[ -z "$SDK" ]]; then
@@ -17,19 +20,19 @@ if ! git -C "$SDK" rev-parse --git-dir >/dev/null 2>&1; then
   echo "patch-native-sdk: SDK checkout not found: $SDK" >&2
   exit 1
 fi
-if [[ ! -f "$PATCH" ]]; then
-  echo "patch-native-sdk: patch file not found: $PATCH" >&2
-  exit 1
-fi
-
-if git -C "$SDK" apply --reverse --check "$PATCH" >/dev/null 2>&1; then
-  echo "patch-native-sdk: headerpad patch already applied"
-  exit 0
-fi
-if ! git -C "$SDK" apply --check "$PATCH" >/dev/null 2>&1; then
-  echo "patch-native-sdk: headerpad patch does not match this SDK" >&2
-  exit 1
-fi
-
-git -C "$SDK" apply "$PATCH"
-echo "patch-native-sdk: applied macOS Mach-O headerpad fix"
+for PATCH in "${PATCHES[@]}"; do
+  if [[ ! -f "$PATCH" ]]; then
+    echo "patch-native-sdk: patch file not found: $PATCH" >&2
+    exit 1
+  fi
+  if git -C "$SDK" apply --unidiff-zero --reverse --check "$PATCH" >/dev/null 2>&1; then
+    echo "patch-native-sdk: already applied $(basename "$PATCH")"
+    continue
+  fi
+  if ! git -C "$SDK" apply --unidiff-zero --check "$PATCH" >/dev/null 2>&1; then
+    echo "patch-native-sdk: patch does not match this SDK: $PATCH" >&2
+    exit 1
+  fi
+  git -C "$SDK" apply --unidiff-zero "$PATCH"
+  echo "patch-native-sdk: applied $(basename "$PATCH")"
+done


### PR DESCRIPTION
## Summary

- restore Windows pet click and drag input with a Petdex-owned Native SDK patch
- add native Win32 context menus
- gate Windows input with real `cuse` interactions and visual evidence

## Validation

- Petdex native tests: 211/211 passed
- Petdex tests: 468 passed
- check, i18n check, production build, and workflow parse passed
- Native SDK tests passed from a clean pinned checkout; patch applies idempotently
- `crafter-agents/cuse` latest `main` at `fa387098481758959561d89b57b6428a27497ce3` built and dogfooded on Windows
- real Windows proof passed: two pats, context menu open/close, and drag

Fixes #703
