### PR TITLE
fix: keep a blocked Upstash database from returning 500 on every route

### DIFF
--- a/src/lib/public-traffic-guard.test.ts
+++ b/src/lib/public-traffic-guard.test.ts
@@ -7,6 +7,21 @@ import {
 } from "@/lib/public-traffic-guard";
 
 describe("public traffic guard", () => {
+  it("leaves /api/manifest unguarded because it is a cached static redirect", () => {
+    expect(
+      publicTrafficGuardRule({ method: "GET", pathname: "/api/manifest" }),
+    ).toBeNull();
+    expect(
+      publicTrafficGuardRule({ method: "HEAD", pathname: "/api/manifest" }),
+    ).toBeNull();
+  });
+
+  it("still guards the manifest routes that do read the database", () => {
+    expect(
+      publicTrafficGuardRule({ method: "GET", pathname: "/api/pets/search" }),
+    ).toBe("catalog");
+  });
+
   it("targets public asset exports and catalog enumeration routes", () => {
     expect(
       publicTrafficGuardRule({
@@ -26,9 +41,6 @@ describe("public traffic guard", () => {
         pathname: "/api/pets/nukey/wastickers",
       }),
     ).toBe("pack");
-    expect(
-      publicTrafficGuardRule({ method: "GET", pathname: "/api/manifest" }),
-    ).toBe("catalog");
     expect(
       publicTrafficGuardRule({ method: "GET", pathname: "/api/pets/random" }),
     ).toBe("catalog");

--- a/src/lib/public-traffic-guard.ts
+++ b/src/lib/public-traffic-guard.ts
@@ -22,7 +22,11 @@ export function publicTrafficGuardRule(input: {
     return "sticker";
   }
   if (/^\/api\/pets\/[^/]+\/wastickers\/?$/.test(pathname)) return "pack";
-  if (pathname === "/api/manifest") return "catalog";
+  // /api/manifest is a static 307 to the R2 object with a 300s CDN cache and
+  // no database read, so rate limiting it spends a Redis round trip to guard
+  // a redirect. It is also the single most requested path, which made it the
+  // largest contributor to the command volume that got the Upstash database
+  // blocked. Leave it out of the guard.
   if (pathname === "/api/pets/random") return "catalog";
   if (pathname === "/api/pets/search") return "catalog";
   if (pathname === "/api/me/header-state") return "state";

--- a/src/lib/ratelimit-factory.test.ts
+++ b/src/lib/ratelimit-factory.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+
+// Reproduces the production failure at the factory boundary: a limiter whose
+// underlying call throws must still answer with an allow verdict, so no route
+// turns a limiter outage into a 500.
+describe("fail-open limiter factory", () => {
+  it("allows the request when .limit() throws the Upstash blocked-database TypeError", async () => {
+    const { failOpenForTest } = await import("@/lib/ratelimit");
+    const limiter = failOpenForTest({
+      limit: async () => {
+        throw new TypeError("r.map is not a function");
+      },
+    });
+    const result = await limiter.limit("1.2.3.4");
+    expect(result.success).toBe(true);
+  });
+
+  it("preserves a real deny verdict", async () => {
+    const { failOpenForTest } = await import("@/lib/ratelimit");
+    const limiter = failOpenForTest({
+      limit: async () => ({ success: false, reset: 42 }),
+    });
+    const result = await limiter.limit("1.2.3.4");
+    expect(result.success).toBe(false);
+    expect(result.reset).toBe(42);
+  });
+});

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -7,19 +7,55 @@ const redis = Redis.fromEnv();
 
 type RatelimitConfig = ConstructorParameters<typeof Ratelimit>[0];
 
+const ALLOW_WHEN_LIMITER_IS_DOWN = {
+  success: true,
+  limit: Number.POSITIVE_INFINITY,
+  remaining: Number.POSITIVE_INFINITY,
+  reset: 0,
+  pending: Promise.resolve(),
+};
+
+// A rate limiter protects the site, so it must never be what takes the site
+// down. Upstash answers a temporarily-blocked database with HTTP 200 and an
+// `{"error": ...}` body; the SDK reads that as a success and calls .map() on
+// what it assumed was a pipeline result array, throwing `TypeError: r.map is
+// not a function` out of .limit(). Uncaught, that turned every rate-limited
+// route into a 500, including routes whose handlers never touch Redis.
+//
+// Wrapping the factory rather than each of the 27 call sites means a limiter
+// added later inherits the same fail-open behaviour without anyone
+// remembering to ask for it.
+function failOpen(limiter: Ratelimit): Ratelimit {
+  const inner = limiter.limit.bind(limiter);
+  const wrapped: Ratelimit["limit"] = async (identifier, req) => {
+    try {
+      return await inner(identifier, req);
+    } catch {
+      return ALLOW_WHEN_LIMITER_IS_DOWN;
+    }
+  };
+  return new Proxy(limiter, {
+    get(target, prop, receiver) {
+      if (prop === "limit") return wrapped;
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}
+
+// Exported for tests: exercises the wrapper without a live Upstash client.
+export function failOpenForTest(limiter: {
+  limit: (identifier: string) => Promise<{ success: boolean; reset?: number }>;
+}): Ratelimit {
+  return failOpen(limiter as unknown as Ratelimit);
+}
+
 function createRatelimit(config: RatelimitConfig): Ratelimit {
   if (IS_MOCK) {
     return {
-      limit: async () => ({
-        success: true,
-        limit: Number.POSITIVE_INFINITY,
-        remaining: Number.POSITIVE_INFINITY,
-        reset: 0,
-        pending: Promise.resolve(),
-      }),
+      limit: async () => ALLOW_WHEN_LIMITER_IS_DOWN,
     } as unknown as Ratelimit;
   }
-  return new Ratelimit(config);
+  return failOpen(new Ratelimit(config));
 }
 
 export const submitRatelimit = createRatelimit({

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -156,6 +156,9 @@ async function guardPublicTraffic(
   });
   if (!rule) return null;
 
+  // Every limiter fails open (see createRatelimit in @/lib/ratelimit), so a
+  // limiter outage degrades to "allow" here instead of throwing into the
+  // middleware and turning each matched route into a 500.
   const key = publicTrafficGuardKey(req.headers);
   const burst = await publicTrafficBurstRatelimit.limit(key);
   if (!burst.success) return rateLimitedResponse(burst.reset);


### PR DESCRIPTION
## What broke

`/api/manifest` returned 500 for hours, taking down the CLI, the desktop app and the 21 projects on `/built-with`. Issues #736, #733 and #741 are all the same bug.

Upstash had temporarily blocked the database. It signals that with **HTTP 200** and an `{"error": ...}` body, so the SDK reads the 200 as success and calls `.map()` on what it assumed was a pipeline result array:

```
TypeError: r.map is not a function
  at fS.exec                  <- @upstash/redis pipeline
  at fT.withAutoPipeline
  at Object.limit             <- @upstash/ratelimit
  at N.getRatelimitResponse
  at async mt                 <- src/proxy.ts middleware
```

Nothing caught it, so the throw escaped `guardPublicTraffic` in the middleware and every matched route 500'd, including `/api/manifest`, whose handler is a static redirect to R2 that never touches Redis.

## The fix

Wrap the limiter factory so every limiter fails open. Done at the factory rather than at the 27 call sites, so a limiter added later inherits it without anyone remembering to ask.

A limiter that is down now lets traffic through instead of taking the site down, which is the opposite of what a rate limiter is for.

Also drop `/api/manifest` from the public traffic guard: it is a 307 to an R2 object with a 300s CDN cache and no database read, so guarding it spent a Redis round trip to protect a redirect, and as the most requested path it was the largest contributor to the command volume that got the database blocked.

## Verification

Pointed the **real SDK** at a server reproducing the blocked-database response:

```
RAW  -> throws: TypeError | res.map is not a function
WRAP -> success: true
```

Removing the fix makes 3 of the 5 new tests fail, so they discriminate.

- `biome check` clean
- `tsc --noEmit` exit 0
- 440/440 tests pass

## Follow-up (not in this PR)

Measured cost is 1 Redis command per `.limit()`, 2 with `analytics: true`, and `guardPublicTraffic` makes 2 calls per request. At current traffic that projects to ~25M commands/month against a 500K free tier. Cutting the guarded surface is tracked separately.