### PR TITLE
perf: stop spending Redis commands on redirects and burst checks

### DIFF
--- a/src/lib/burst-guard.test.ts
+++ b/src/lib/burst-guard.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+
+import { checkBurst, resetBurstGuardForTest } from "@/lib/burst-guard";
+
+const LIMIT = 120;
+const WINDOW_MS = 60_000;
+
+describe("burst guard", () => {
+  beforeEach(() => {
+    resetBurstGuardForTest();
+  });
+
+  it("allows traffic up to the ceiling", () => {
+    const now = 1_000_000;
+    for (let i = 0; i < LIMIT; i++) {
+      expect(checkBurst("1.2.3.4", now).success).toBe(true);
+    }
+  });
+
+  it("denies the request that crosses the ceiling", () => {
+    const now = 1_000_000;
+    for (let i = 0; i < LIMIT; i++) checkBurst("1.2.3.4", now);
+    const over = checkBurst("1.2.3.4", now);
+    expect(over.success).toBe(false);
+    expect(over.reset).toBe(now + WINDOW_MS);
+  });
+
+  it("starts a fresh window once the old one expires", () => {
+    const now = 1_000_000;
+    for (let i = 0; i < LIMIT + 5; i++) checkBurst("1.2.3.4", now);
+    expect(checkBurst("1.2.3.4", now).success).toBe(false);
+    expect(checkBurst("1.2.3.4", now + WINDOW_MS).success).toBe(true);
+  });
+
+  it("keeps separate windows per key", () => {
+    const now = 1_000_000;
+    for (let i = 0; i < LIMIT + 5; i++) checkBurst("1.2.3.4", now);
+    expect(checkBurst("1.2.3.4", now).success).toBe(false);
+    expect(checkBurst("5.6.7.8", now).success).toBe(true);
+  });
+
+  it("bounds how many keys it tracks", () => {
+    const now = 1_000_000;
+    for (let i = 0; i < 10_050; i++) checkBurst(`ip-${i}`, now);
+    // The earliest keys were evicted, so the first one starts a fresh window
+    // instead of carrying its old count.
+    expect(checkBurst("ip-0", now).success).toBe(true);
+  });
+});

--- a/src/lib/burst-guard.ts
+++ b/src/lib/burst-guard.ts
@@ -1,0 +1,52 @@
+// In-process burst guard.
+//
+// The burst limit used to be an Upstash sliding window, which meant every
+// guarded request paid a Redis round trip for the burst check and a second
+// one for its per-rule limit. That doubled the command bill on the hot path
+// to catch a case a local counter catches just as well: a single client
+// hammering a single instance within one minute.
+//
+// This trades exactness for cost. Each serverless instance keeps its own
+// window, so a client spread across N instances gets up to N times the
+// ceiling before the per-rule limiter (still backed by Redis) stops it. That
+// is an acceptable ceiling for a burst guard whose job is absorbing spikes,
+// not enforcing a quota.
+
+const WINDOW_MS = 60_000;
+const MAX_HITS_PER_WINDOW = 120;
+// Bounds memory on an instance that sees many distinct IPs. Old entries are
+// evicted oldest-first, which at worst forgives a client mid-window.
+const MAX_TRACKED_KEYS = 10_000;
+
+type Window = { count: number; resetAt: number };
+
+const windows = new Map<string, Window>();
+
+export type BurstVerdict = { success: boolean; reset: number };
+
+export function checkBurst(key: string, now = Date.now()): BurstVerdict {
+  const existing = windows.get(key);
+
+  if (!existing || now >= existing.resetAt) {
+    const resetAt = now + WINDOW_MS;
+    // Re-inserting moves the key to the end of the Map's insertion order, so
+    // the eviction below stays oldest-first.
+    windows.delete(key);
+    windows.set(key, { count: 1, resetAt });
+    if (windows.size > MAX_TRACKED_KEYS) {
+      const oldest = windows.keys().next();
+      if (!oldest.done) windows.delete(oldest.value);
+    }
+    return { success: true, reset: resetAt };
+  }
+
+  existing.count += 1;
+  return {
+    success: existing.count <= MAX_HITS_PER_WINDOW,
+    reset: existing.resetAt,
+  };
+}
+
+export function resetBurstGuardForTest(): void {
+  windows.clear();
+}

--- a/src/lib/public-traffic-guard.test.ts
+++ b/src/lib/public-traffic-guard.test.ts
@@ -7,6 +7,17 @@ import {
 } from "@/lib/public-traffic-guard";
 
 describe("public traffic guard", () => {
+  it("leaves the sticker routes unguarded because they only redirect or 410", () => {
+    for (const pathname of [
+      "/api/pets/nukey/thumb",
+      "/api/pets/nukey/sticker",
+      "/api/pets/nukey/wastickers",
+    ]) {
+      expect(publicTrafficGuardRule({ method: "GET", pathname })).toBeNull();
+      expect(publicTrafficGuardRule({ method: "HEAD", pathname })).toBeNull();
+    }
+  });
+
   it("leaves /api/manifest unguarded because it is a cached static redirect", () => {
     expect(
       publicTrafficGuardRule({ method: "GET", pathname: "/api/manifest" }),
@@ -23,24 +34,6 @@ describe("public traffic guard", () => {
   });
 
   it("targets public asset exports and catalog enumeration routes", () => {
-    expect(
-      publicTrafficGuardRule({
-        method: "GET",
-        pathname: "/api/pets/nukey/thumb",
-      }),
-    ).toBe("sticker");
-    expect(
-      publicTrafficGuardRule({
-        method: "GET",
-        pathname: "/api/pets/nukey/sticker",
-      }),
-    ).toBe("sticker");
-    expect(
-      publicTrafficGuardRule({
-        method: "HEAD",
-        pathname: "/api/pets/nukey/wastickers",
-      }),
-    ).toBe("pack");
     expect(
       publicTrafficGuardRule({ method: "GET", pathname: "/api/pets/random" }),
     ).toBe("catalog");

--- a/src/lib/public-traffic-guard.ts
+++ b/src/lib/public-traffic-guard.ts
@@ -5,12 +5,7 @@ type HeaderBag =
 const BLOCKED_IPS = new Set(["133.106.50.116"]);
 const BLOCKED_USER_AGENTS = ["petoverlaycompose-pixelartclassifier"];
 
-export type PublicTrafficGuardRule =
-  | "catalog"
-  | "metadata"
-  | "pack"
-  | "state"
-  | "sticker";
+export type PublicTrafficGuardRule = "catalog" | "metadata" | "state";
 
 export function publicTrafficGuardRule(input: {
   method: string;
@@ -18,10 +13,11 @@ export function publicTrafficGuardRule(input: {
 }): PublicTrafficGuardRule | null {
   if (input.method !== "GET" && input.method !== "HEAD") return null;
   const pathname = input.pathname;
-  if (/^\/api\/pets\/[^/]+\/(?:thumb|sticker)\/?$/.test(pathname)) {
-    return "sticker";
-  }
-  if (/^\/api\/pets\/[^/]+\/wastickers\/?$/.test(pathname)) return "pack";
+  // The sticker routes are redirects to R2 objects (thumb 308, sticker 307)
+  // and wastickers is a constant 410, so none of them does work worth a Redis
+  // round trip. They were the single largest share of guarded traffic, which
+  // means the limiter spent most of its command budget guarding redirects.
+  // Abuse of the underlying objects is bounded by R2 and the CDN, not here.
   // /api/manifest is a static 307 to the R2 object with a 300s CDN cache and
   // no database read, so rate limiting it spends a Redis round trip to guard
   // a redirect. It is also the single most requested path, which made it the

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -106,27 +106,6 @@ export const trackZipRatelimit = createRatelimit({
   prefix: "petdex:track-zip",
 });
 
-// WhatsApp Sticker Pack generation. Each request fans out to 1 spritesheet
-// fetch + 9 animated WebP encodes + 1 ZIP — the heaviest unauthenticated
-// path in the app. Tighter ceiling so a loop can't burn CPU + R2 egress.
-export const wastickersRatelimit = createRatelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(8, "1 h"),
-  prefix: "petdex:wastickers",
-});
-
-export const stickerAssetRatelimit = createRatelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(60, "1 h"),
-  prefix: "petdex:sticker-asset",
-});
-
-export const packAssetRatelimit = createRatelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(8, "1 h"),
-  prefix: "petdex:pack-asset",
-});
-
 export const publicCatalogRatelimit = createRatelimit({
   redis,
   limiter: Ratelimit.slidingWindow(60, "1 h"),
@@ -145,11 +124,8 @@ export const publicMetadataRatelimit = createRatelimit({
   prefix: "petdex:public-metadata",
 });
 
-export const publicTrafficBurstRatelimit = createRatelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(120, "1 m"),
-  prefix: "petdex:public-burst",
-});
+// The burst ceiling now lives in @/lib/burst-guard, in process, so a spike
+// costs no Redis commands. Only the sustained limits below reach Upstash.
 
 // Public metrics reads — `/api/pets/[slug]/metrics`. Browser pages hit
 // this on every visit, and the CDN caches the response for 60s so the

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -7,6 +7,7 @@ import {
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import createMiddleware from "next-intl/middleware";
 
+import { checkBurst } from "@/lib/burst-guard";
 import { shouldBypassClerkMiddleware } from "@/lib/public-clerk-bypass";
 import {
   publicTrafficGuardKey,
@@ -14,12 +15,9 @@ import {
   shouldBlockKnownAbusiveClient,
 } from "@/lib/public-traffic-guard";
 import {
-  packAssetRatelimit,
   publicCatalogRatelimit,
   publicMetadataRatelimit,
   publicStateRatelimit,
-  publicTrafficBurstRatelimit,
-  stickerAssetRatelimit,
 } from "@/lib/ratelimit";
 import {
   buildRouteCostSample,
@@ -156,23 +154,21 @@ async function guardPublicTraffic(
   });
   if (!rule) return null;
 
+  // The burst check runs in process, so a spike costs no Redis commands. Only
+  // the sustained per-rule limit below reaches Upstash.
+  const key = publicTrafficGuardKey(req.headers);
+  const burst = checkBurst(key);
+  if (!burst.success) return rateLimitedResponse(burst.reset);
+
   // Every limiter fails open (see createRatelimit in @/lib/ratelimit), so a
   // limiter outage degrades to "allow" here instead of throwing into the
   // middleware and turning each matched route into a 500.
-  const key = publicTrafficGuardKey(req.headers);
-  const burst = await publicTrafficBurstRatelimit.limit(key);
-  if (!burst.success) return rateLimitedResponse(burst.reset);
-
   const limit =
-    rule === "sticker"
-      ? await stickerAssetRatelimit.limit(key)
-      : rule === "pack"
-        ? await packAssetRatelimit.limit(key)
-        : rule === "metadata"
-          ? await publicMetadataRatelimit.limit(key)
-          : rule === "state"
-            ? await publicStateRatelimit.limit(key)
-            : await publicCatalogRatelimit.limit(key);
+    rule === "metadata"
+      ? await publicMetadataRatelimit.limit(key)
+      : rule === "state"
+        ? await publicStateRatelimit.limit(key)
+        : await publicCatalogRatelimit.limit(key);
   if (limit.success) return null;
 
   return rateLimitedResponse(limit.reset);


### PR DESCRIPTION
Follow-up to #745. That fixed the crash; this cuts what caused Upstash to block the database.

## The measurement

Interception against the real SDK: each `.limit()` costs **one Redis command** (two with `analytics: true`), and `guardPublicTraffic` made **two calls per request**. On the traffic in the logs that projects to ~28M commands/month against a 500K free tier, roughly **56x over**.

## What changed

**Sticker routes leave the guard.** No feature is removed, the routes serve exactly as before:

| Route | What it actually does |
|---|---|
| `/api/pets/[slug]/thumb` | 308 to an R2 object, already cached a week |
| `/api/pets/[slug]/sticker` | 307 to an R2 object |
| `/api/pets/[slug]/wastickers` | constant 410, the pack was retired |

All three paid two Redis commands to guard work they no longer do, and together they were the largest share of guarded traffic.

**The burst ceiling moves in process.** It was a sliding window in Upstash, so every guarded request paid one round trip for the burst check and a second for its per-rule limit. A local counter catches the case that matters, one client hammering one instance inside a minute, without a network hop.

The tradeoff, stated plainly: each instance keeps its own window, so a client spread across N instances gets up to N times the ceiling before the per-rule limiter (still Redis-backed) stops it. Acceptable for a guard whose job is absorbing spikes rather than enforcing a quota.

**Four limiters had no callers left** and are gone, including `wastickersRatelimit`, already orphaned by the 410.

## Result

Measured on the same request sample:

| | commands/request | commands/month | vs free tier |
|---|---|---|---|
| before | 1.73 | 28.2M | 56.5x |
| after | 0.45 | 7.3M | 14.5x |

**74% reduction.**

## Still over, and why that is not fixed here

The remaining spend is **89% one route**: `/api/pets/search`. It sets `private, no-store` for the `curated` sort because the shuffle seed is per visitor, so the home page cannot be CDN-cached and every visit reaches the function.

Making that cacheable would land inside the free tier but changes how the catalog is discovered. That is a product call, not a perf cleanup, so it is deliberately out of scope.

## Verification

- 446/446 tests pass, 5 new for the burst guard
- `tsc --noEmit` exit 0
- `biome check` clean