### PR TITLE
fix(db): declare the six migrations missing from the drizzle journal

### DIFF
--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,48 @@
       "when": 1778604000000,
       "tag": "0015_drop_ad_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1778918401000,
+      "tag": "0015_edit_pet_columns",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1778918402000,
+      "tag": "0016_route_cost_buckets",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1778918403000,
+      "tag": "0017_route_cost_sources",
+      "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1778918404000,
+      "tag": "0018_sprite_version_number",
+      "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1778918405000,
+      "tag": "0018_sticker_exports",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1778918406000,
+      "tag": "0020_pending_asset_gc_claims",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## The drift

The journal stopped at `0015_drop_ad_tables` while six `.sql` files sat on disk undeclared. Production had drifted the other way: DDL applied by hand without recording a hash.

```
migration files on disk:      22
declared in _journal.json:    16
recorded in __drizzle_migrations: 10
last hash recorded:           2026-05-06
```

Note there are **two files numbered 0018** (`0018_sprite_version_number`, `0018_sticker_exports`) and **no 0019**. That collision is how one of them got lost.

## What had actually never run

`0018_sticker_exports`, which creates `pet_export_approvals` and `pet_sticker_publications`. Without them, `/api/pets/[slug]/sticker` answered **500** with Postgres `42P01` (relation does not exist) from the day the route shipped in #648. Confirmed against the production database:

```
tables present: [ "submitted_pets" ]
missing: pet_export_approvals, pet_sticker_publications
```

## How it was applied

Every statement in that migration is `IF NOT EXISTS` or `ON CONFLICT DO NOTHING`, so redoing it was safe. Even so:

1. Created a Neon branch of production and ran it there. 40/40 statements, no errors.
2. Ran it a **second time** on the branch to confirm idempotence: 8 collection items both times, no duplicates.
3. Verified the exact query that was throwing `42P01` now returns a row.
4. Applied to production. 40/40 statements.

The other eleven migrations were each verified **already applied** by checking for the table, column, or enum value they create, before recording their hash. No hash claims work that was never done.

## Verification

`drizzle-kit migrate` on a fresh branch of production now applies nothing and reports:

```
migrations registered: 22 (was 10)
tables:                25
pets:                  4968 intact
claude collection:     8 items, no duplicates
```

Live: `/api/pets/homelander/sticker` went from **500** to **403** (`ineligible`, the correct answer for a pet with no export approval).

## Not addressed here

`/stickers/claude` still 404s because `STICKER_EXPLORER_ENABLED` is not set in production. That is a deliberate feature flag, not drift, so it is left alone.