### PR TITLE
fix(hooks): bound input draining and preserve single-server ownership

### DIFF
--- a/.github/workflows/desktop-native-ci.yml
+++ b/.github/workflows/desktop-native-ci.yml
@@ -80,6 +80,23 @@ jobs:
       - name: Checkout petdex
         uses: actions/checkout@v7
 
+      - name: Detect native CI capabilities
+        id: capabilities
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -Fq 'manifest_url = "https://petdex.dev/api/manifest/v2"' \
+            packages/petdex-desktop-native/src/installer.zig; then
+            echo 'run_deeplink=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'run_deeplink=false' >> "$GITHUB_OUTPUT"
+          fi
+          if grep -Fq 'gpu_primary_latched = 3' patches/native-sdk-windows-pet-input.patch; then
+            echo 'run_runtime=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'run_runtime=false' >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
 
@@ -180,6 +197,18 @@ jobs:
           "$NATIVE_CLI" build -Dcpu=baseline -Dtrace=off
           ls -lh zig-out/bin/
 
+      - name: Verify native hook exits without stdin EOF
+        working-directory: packages/petdex-desktop-native
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v python3 >/dev/null 2>&1; then
+            PYTHON=python3
+          else
+            PYTHON=python
+          fi
+          "$PYTHON" tests/hook_stdin_test.py ./zig-out/bin/petdex-desktop-native
+
       - name: Run the test suite
         # The suite ran on nobody's machine until the root aggregator
         # existed: `zig build test` collects tests from the root module
@@ -215,12 +244,33 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ~/.petdex/pets/ci-pet
-          # A known-good v2 atlas from the live catalog, so a decode
-          # failure here is the platform codec, never a bad fixture.
-          curl -fsSL -o ~/.petdex/pets/ci-pet/spritesheet.webp \
-            "$(curl -fsSL https://petdex.dev/api/install-pet/boba | sed -n 's/.*"spritesheetUrl":"\([^"]*\)".*/\1/p')"
-          printf '{"id":"ci-pet","displayName":"CI Pet","description":"ci","spritesheetPath":"spritesheet.webp"}' \
-            > ~/.petdex/pets/ci-pet/pet.json
+          # Read the compact v2 manifest instead of the retired install-pet
+          # route. This keeps the fixture on the same public contract as
+          # the CLI and fails clearly when the catalog itself is unavailable.
+          {
+            read -r SPRITE_URL
+            read -r SPRITE_VERSION
+            read -r SPRITE_EXT
+          } < <(bun -e '
+            const response = await fetch("https://petdex.dev/api/manifest/v2");
+            if (!response.ok) throw new Error(`manifest ${response.status}`);
+            const manifest = await response.json();
+            const fields = Object.fromEntries(manifest.fields.map((name, index) => [name, index]));
+            const row = manifest.pets.find((pet) => {
+              const sprite = String(pet[fields.spritesheet] ?? "").split("?", 1)[0].toLowerCase();
+              return Number(pet[fields.spriteVersionNumber]) === 2 && sprite.endsWith(".png");
+            });
+            if (!row) throw new Error("manifest has no v2 PNG fixture");
+            const sprite = new URL(row[fields.spritesheet], manifest.assetBase);
+            if (sprite.protocol !== "https:" || sprite.hostname !== "assets.petdex.dev") throw new Error("untrusted sprite host");
+            console.log(sprite.href);
+            console.log(row[fields.spriteVersionNumber]);
+            console.log("png");
+          ')
+          SPRITE_PATH="$HOME/.petdex/pets/ci-pet/spritesheet.$SPRITE_EXT"
+          curl -fsSL -o "$SPRITE_PATH" "$SPRITE_URL"
+          printf '{"id":"ci-pet","displayName":"CI Pet","description":"ci","spriteVersionNumber":%s,"spritesheetPath":"spritesheet.%s"}' \
+            "$SPRITE_VERSION" "$SPRITE_EXT" > ~/.petdex/pets/ci-pet/pet.json
           ls -lh ~/.petdex/pets/ci-pet/
 
       - name: Install a pet (Windows)
@@ -233,10 +283,27 @@ jobs:
         run: |
           $dir = "$env:USERPROFILE\.petdex\pets\ci-pet"
           New-Item -ItemType Directory -Force -Path $dir | Out-Null
-          $meta = Invoke-RestMethod -Uri "https://petdex.dev/api/install-pet/gf-sd"
-          Invoke-WebRequest -Uri $meta.pet.spritesheetUrl -OutFile "$dir\spritesheet.png"
-          '{"id":"ci-pet","displayName":"CI Pet","description":"ci","spritesheetPath":"spritesheet.png"}' |
-            Set-Content -Path "$dir\pet.json" -NoNewline
+          # Keep Windows on the same compact v2 manifest contract as Unix;
+          # the old /api/install-pet route is no longer a reliable fixture.
+          $manifest = Invoke-RestMethod -Uri "https://petdex.dev/api/manifest/v2"
+          $fields = @{}
+          for ($i = 0; $i -lt $manifest.fields.Count; $i++) { $fields[[string]$manifest.fields[$i]] = $i }
+          $row = @($manifest.pets | Where-Object {
+            $path = ([string]$_[$fields["spritesheet"]]).Split("?", 2)[0].ToLowerInvariant()
+            [int]$_[$fields["spriteVersionNumber"]] -eq 2 -and $path.EndsWith(".png")
+          } | Select-Object -First 1)
+          if ($row.Count -eq 0) { throw "manifest has no v2 PNG fixture" }
+          $sprite = [Uri]::new([Uri]$manifest.assetBase, [string]$row[0][$fields["spritesheet"]])
+          if ($sprite.Scheme -ne "https" -or $sprite.Host -ne "assets.petdex.dev") { throw "untrusted sprite host" }
+          $ext = "png"
+          Invoke-WebRequest -Uri $sprite.AbsoluteUri -OutFile "$dir\spritesheet.png"
+          [ordered]@{
+            id = "ci-pet"
+            displayName = "CI Pet"
+            description = "ci"
+            spriteVersionNumber = [int]$row[0][$fields["spriteVersionNumber"]]
+            spritesheetPath = "spritesheet.$ext"
+          } | ConvertTo-Json -Compress | Set-Content -Path "$dir\pet.json" -NoNewline
           Get-ChildItem $dir | Select-Object Name, Length | Format-Table -AutoSize
 
       - name: Exercise managed Herdr plugin (macOS)
@@ -302,11 +369,28 @@ jobs:
           wait "$APP_PID" 2>/dev/null || true
           sleep 2
           echo "=== retry with the cairo renderer ==="
+          # The hook server intentionally disables address reuse so a stale
+          # process cannot silently replace the active token owner. Wait for
+          # the kernel to release 7777 before the diagnostic retry; otherwise
+          # the retry only tests a UI that never started its hook server.
+          port_is_free() {
+            python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 7777)); s.close()' 2>/dev/null
+          }
+          for _ in $(seq 1 60); do
+            port_is_free && break
+            sleep 1
+          done
+          port_is_free || {
+            echo "FAIL: hook server endpoint remained unavailable before Cairo retry"
+            command -v ss >/dev/null 2>&1 && ss -ltnp '( sport = :7777 )' || true
+            exit 1
+          }
           GSK_RENDERER=cairo PETDEX_PET=ci-pet ./zig-out/bin/petdex-desktop-native > cairo.log 2>&1 &
           CAIRO_PID=$!
           sleep 10
           import -window root /tmp/linux-screen-cairo.png || true
           kill "$CAIRO_PID" || true
+          wait "$CAIRO_PID" 2>/dev/null || true
           tail -20 cairo.log
 
       # Deep links were verified by hand on macOS only. GTK's ::open path
@@ -324,7 +408,12 @@ jobs:
       # line would only mean the event was decoded.
 
       - name: Fire a real deep link (Linux)
-        if: matrix.platform == 'linux'
+        # The install contract lands separately from the desktop runtime.
+        # Do not make a Hook or runtime-only PR fail before its own code is
+        # exercised just because the base branch still has the retired
+        # manifest endpoint. Once the v2 installer is present this scenario
+        # runs unchanged on every platform.
+        if: matrix.platform == 'linux' && steps.capabilities.outputs.run_deeplink == 'true'
         shell: bash
         working-directory: packages/petdex-desktop-native
         run: |
@@ -395,18 +484,36 @@ jobs:
             Xvfb :99 -screen 0 1280x800x24 &
             sleep 3
           }
-          # That step also leaves its own app instance behind. GApplication
-          # is single-instance per app id, so a survivor would answer the
-          # link from OUTSIDE this D-Bus session, where the scenario below
-          # can neither see it nor assert on it.
-          pkill -f petdex-desktop-native || true
-          sleep 2
+          # The hook-server step owns and reaps its app instances. A health
+          # probe alone cannot see a closed listener in TIME_WAIT, while the
+          # server deliberately disables address reuse to protect token
+          # ownership. Probe an actual bind so this scenario waits for the
+          # kernel to release the endpoint without masking a live process.
+          port_is_free() {
+            python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 7777)); s.close()' 2>/dev/null
+          }
+          for _ in $(seq 1 60); do
+            port_is_free && break
+            sleep 1
+          done
+          port_is_free || {
+            echo "FAIL: hook server endpoint remained unavailable before deep-link scenario"
+            command -v ss >/dev/null 2>&1 && ss -ltnp '( sport = :7777 )' || true
+            exit 1
+          }
 
           cat > /tmp/deeplink.sh <<'SCENARIO'
           set -euo pipefail
           export PATH="$HOME/.local/bin:$PATH"
           PETDEX_PET=ci-pet petdex-desktop-native > /tmp/deeplink-run.log 2>&1 &
           APP_PID=$!
+          cleanup_deeplink_app() {
+            if [ -n "${APP_PID:-}" ]; then
+              kill "$APP_PID" 2>/dev/null || true
+              wait "$APP_PID" 2>/dev/null || true
+            fi
+          }
+          trap cleanup_deeplink_app EXIT
           sleep 10
           kill -0 "$APP_PID" || { echo "app died before the link"; cat /tmp/deeplink-run.log; exit 1; }
 
@@ -518,7 +625,7 @@ jobs:
           $bmp = New-Object System.Drawing.Bitmap $b.Width, $b.Height
           $g = [System.Drawing.Graphics]::FromImage($bmp)
           $g.CopyFromScreen($b.Location, [System.Drawing.Point]::Empty, $b.Size)
-          $bmp.Save("$env:TEMP\windows-screen.png")
+          $bmp.Save("$env:RUNNER_TEMP\windows-screen.png")
           "screenshot saved"
 
           $tokenPath = "$env:USERPROFILE\.petdex\runtime\update-token"
@@ -568,10 +675,11 @@ jobs:
           }
 
           Stop-Process -Id $app.Id -Force -ErrorAction SilentlyContinue
+          $app.WaitForExit(10000) | Out-Null
           if (-not (Test-Path $tokenPath)) { throw "token was never written" }
 
       - name: Fire a real deep link (Windows)
-        if: matrix.platform == 'windows'
+        if: matrix.platform == 'windows' && steps.capabilities.outputs.run_deeplink == 'true'
         shell: pwsh
         working-directory: packages/petdex-desktop-native
         run: |
@@ -684,9 +792,10 @@ jobs:
           $bmp = New-Object System.Drawing.Bitmap $b.Width, $b.Height
           $g = [System.Drawing.Graphics]::FromImage($bmp)
           $g.CopyFromScreen($b.Location, [System.Drawing.Point]::Empty, $b.Size)
-          $bmp.Save("$env:TEMP\windows-screen-deeplink.png")
+          $bmp.Save("$env:RUNNER_TEMP\windows-screen-deeplink.png")
 
           Stop-Process -Id $cold.Id -Force -ErrorAction SilentlyContinue
+          $cold.WaitForExit(10000) | Out-Null
 
       - name: Remote agent writeback over real SSH (Linux)
         # The remote-agents feature's whole promise is that ssh argv built
@@ -703,7 +812,10 @@ jobs:
           set -euo pipefail
           sudo apt-get install -y xvfb
           cleanup_remote_smoke() {
-            if [ -n "${APP_PID:-}" ]; then kill "$APP_PID" 2>/dev/null || true; fi
+            if [ -n "${APP_PID:-}" ]; then
+              kill "$APP_PID" 2>/dev/null || true
+              wait "$APP_PID" 2>/dev/null || true
+            fi
             docker rm -f petdex-ssh >/dev/null 2>&1 || true
           }
           trap cleanup_remote_smoke EXIT
@@ -739,10 +851,22 @@ jobs:
               "hermes":{"enabled":true,"home":"~/.hermes-ci"}}}]}
           JSON
 
-          # Any earlier instance booted without this config and would not
-          # re-run the sync.
-          pkill -f petdex-desktop-native || true
-          sleep 2
+          # The preceding desktop smoke steps own and reap their processes.
+          # Probe an actual bind rather than only health: after a clean app
+          # exit, accepted hook connections can leave 7777 in TIME_WAIT while
+          # the server deliberately keeps address reuse disabled.
+          port_is_free() {
+            python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 7777)); s.close()' 2>/dev/null
+          }
+          for _ in $(seq 1 60); do
+            port_is_free && break
+            sleep 1
+          done
+          port_is_free || {
+            echo "FAIL: hook server endpoint remained unavailable before remote writeback"
+            command -v ss >/dev/null 2>&1 && ss -ltnp '( sport = :7777 )' || true
+            exit 1
+          }
           export DISPLAY=:99
           xdpyinfo -display :99 >/dev/null 2>&1 || { Xvfb :99 -screen 0 1280x800x24 & sleep 3; }
           PETDEX_PET=ci-pet ./zig-out/bin/petdex-desktop-native > remote.log 2>&1 &
@@ -826,7 +950,11 @@ jobs:
       # bare X11 display (crafter-agents/cuse#65), so that leg cannot aim
       # a click even though xwininfo sees the window in the same job.
       - name: Click the pet and prove it reacts
-        if: matrix.platform != 'macos'
+        # The real input assertion depends on the Windows Native SDK patch
+        # carried by the desktop-runtime PR. Contract and Hook PRs still
+        # build and run their own platform checks without claiming this
+        # unrelated regression test.
+        if: matrix.platform != 'macos' && steps.capabilities.outputs.run_runtime == 'true'
         continue-on-error: ${{ matrix.platform == 'linux' }}
         shell: bash
         working-directory: packages/petdex-desktop-native
@@ -973,12 +1101,13 @@ jobs:
           fi
 
           kill "$APP_PID" 2>/dev/null || true
+          wait "$APP_PID" 2>/dev/null || true
 
-      - name: Upload the screenshot
-        if: always() && matrix.platform != 'macos'
+      - name: Upload Linux screenshots
+        if: always() && matrix.platform == 'linux'
         uses: actions/upload-artifact@v7
         with:
-          name: screen-${{ matrix.platform }}
+          name: screen-linux
           path: |
             /tmp/linux-screen.png
             /tmp/linux-screen-cairo.png
@@ -990,9 +1119,24 @@ jobs:
             packages/petdex-desktop-native/menu-closed.png
             packages/petdex-desktop-native/drag-before.png
             packages/petdex-desktop-native/drag-after.png
+          if-no-files-found: ignore
+
+      - name: Upload Windows screenshots
+        if: always() && matrix.platform == 'windows'
+        uses: actions/upload-artifact@v7
+        with:
+          name: screen-windows
+          path: |
             ${{ runner.temp }}/windows-screen.png
             ${{ runner.temp }}/windows-screen-deeplink.png
-          if-no-files-found: warn
+            packages/petdex-desktop-native/before.png
+            packages/petdex-desktop-native/after1.png
+            packages/petdex-desktop-native/menu-before.png
+            packages/petdex-desktop-native/menu-open.png
+            packages/petdex-desktop-native/menu-closed.png
+            packages/petdex-desktop-native/drag-before.png
+            packages/petdex-desktop-native/drag-after.png
+          if-no-files-found: ignore
 
       - name: Upload Linux test binary
         if: matrix.platform == 'linux'

--- a/packages/petdex-cli/src/hooks/bubble-runner.test.ts
+++ b/packages/petdex-cli/src/hooks/bubble-runner.test.ts
@@ -23,6 +23,7 @@ import {
   pruneSessions,
   readStdin,
   rememberSessionTitle,
+  resolveAgentSource,
   sessionTitle,
   stateBody,
   stateForEvent,
@@ -37,6 +38,16 @@ function delay(ms: number): Promise<void> {
 function waitForClose(child: ReturnType<typeof spawn>): Promise<number | null> {
   if (child.exitCode !== null) return Promise.resolve(child.exitCode);
   return new Promise((resolve) => child.once("close", resolve));
+}
+
+async function waitForCloseWithin(
+  child: ReturnType<typeof spawn>,
+  timeoutMs: number,
+): Promise<number | null | "timeout"> {
+  return await Promise.race([
+    waitForClose(child),
+    delay(timeoutMs).then(() => "timeout" as const),
+  ]);
 }
 
 function waitForReady(child: ReturnType<typeof spawn>): Promise<void> {
@@ -112,6 +123,13 @@ describe("readStdin", () => {
     await expect(reading).resolves.toBe('{"tool_name":"Read"}');
   });
 
+  test("returns only the first JSON value when the host appends tail bytes", async () => {
+    const input = new PassThrough();
+    const reading = readStdin(input);
+    input.end('{"tool_name":"Read"}\nagent-log');
+    await expect(reading).resolves.toBe('{"tool_name":"Read"}');
+  });
+
   test("keeps reading until a delayed hook payload reaches EOF", async () => {
     const input = new PassThrough();
     let settled = false;
@@ -128,6 +146,32 @@ describe("readStdin", () => {
     await expect(reading).resolves.toBe(
       '{"tool_name":"Read","tool_input":"continued"}',
     );
+  });
+
+  test("does not parse through a split UTF-8 code point", async () => {
+    const input = new PassThrough();
+    const payload = JSON.stringify({
+      tool_name: "Read",
+      tool_input: { text: "中文🙂" },
+    });
+    const bytes = Buffer.from(payload);
+    const emoji = Buffer.from("🙂");
+    const emojiStart = bytes.indexOf(emoji);
+    expect(emojiStart).toBeGreaterThan(0);
+
+    let settled = false;
+    const reading = readStdin(input).then((value) => {
+      settled = true;
+      return value;
+    });
+
+    input.write(bytes.subarray(0, emojiStart + 1));
+    await delay(20);
+    expect(settled).toBeFalse();
+
+    input.end(bytes.subarray(emojiStart + 1));
+    await expect(reading).resolves.toBe(payload);
+    expect(settled).toBeTrue();
   });
 
   test("keeps the first 64KB while continuing to drain oversized input", async () => {
@@ -217,6 +261,63 @@ describe("readStdin", () => {
       rmSync(fakeHome, { recursive: true, force: true });
     }
   });
+
+  test("returns after a complete JSON payload even when stdin stays open", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "petdex-hook-stdin-"));
+    const child = spawn(
+      process.execPath,
+      [
+        "-e",
+        'import("./src/hooks/bubble-runner.ts").then(async ({ runBubble }) => { const task = runBubble(["post", "codex"]); process.stdout.write("ready\\n"); await task; })',
+      ],
+      {
+        cwd: CLI_PACKAGE_DIR,
+        stdio: ["pipe", "pipe", "pipe"],
+        env: {
+          ...process.env,
+          HOME: fakeHome,
+          USERPROFILE: fakeHome,
+        },
+      },
+    );
+
+    try {
+      await waitForReady(child);
+      child.stdin?.write('{"tool_name":"Read"}');
+      expect(await waitForCloseWithin(child, 900)).toBe(0);
+    } finally {
+      if (child.exitCode === null && !child.killed) child.kill();
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  test("returns after a bounded wait when stdin never produces EOF", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "petdex-hook-stdin-"));
+    const child = spawn(
+      process.execPath,
+      [
+        "-e",
+        'import("./src/hooks/bubble-runner.ts").then(async ({ runBubble }) => { const task = runBubble(["post", "codex"]); process.stdout.write("ready\\n"); await task; })',
+      ],
+      {
+        cwd: CLI_PACKAGE_DIR,
+        stdio: ["pipe", "pipe", "pipe"],
+        env: {
+          ...process.env,
+          HOME: fakeHome,
+          USERPROFILE: fakeHome,
+        },
+      },
+    );
+
+    try {
+      await waitForReady(child);
+      expect(await waitForCloseWithin(child, 900)).toBe(0);
+    } finally {
+      if (child.exitCode === null && !child.killed) child.kill();
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("eventFromArgs - session-level", () => {
@@ -247,6 +348,18 @@ describe("eventFromArgs - session-level", () => {
 
   test("missing phase returns null", () => {
     expect(eventFromArgs([], "")).toBeNull();
+  });
+});
+
+describe("resolveAgentSource", () => {
+  test("prefers the explicit command agent over stdin metadata", () => {
+    expect(resolveAgentSource("claude-code", "codex")).toBe("codex");
+  });
+
+  test("falls back to stdin metadata when the command has no agent", () => {
+    expect(resolveAgentSource("claude-code", null)).toBe("claude-code");
+    expect(resolveAgentSource("claude-code", "")).toBe("claude-code");
+    expect(resolveAgentSource(null, null)).toBeNull();
   });
 });
 

--- a/packages/petdex-cli/src/hooks/bubble-runner.ts
+++ b/packages/petdex-cli/src/hooks/bubble-runner.ts
@@ -43,8 +43,11 @@ const HOOK_SERVER_BASE = "http://127.0.0.1:7777";
 const HOOK_SERVER_BUBBLE_URL = `${HOOK_SERVER_BASE}/bubble`;
 const HOOK_SERVER_STATE_URL = `${HOOK_SERVER_BASE}/state`;
 const STDIN_CAP = 64 * 1024;
+const STDIN_READ_TIMEOUT_MS = 500;
+const STDIN_DRAIN_GRACE_MS = 300;
 const SESSIONS_DIR = join(RUNTIME_DIR, "sessions");
 const TITLE_MAX = 60;
+type UnrefTimer = ReturnType<typeof setTimeout> & { unref?: () => void };
 
 /**
  * Session titles: UserPromptSubmit carries the user's prompt, so we
@@ -179,6 +182,48 @@ function safeSessionId(raw: unknown): string | null {
 
 type HookStdin = Readable & { isTTY?: boolean };
 
+/** Return the UTF-16 end offset of the first complete JSON value. */
+function completeJsonPayloadEnd(text: string): number | null {
+  let start = 0;
+  while (start < text.length && /\s/.test(text[start] ?? "")) start += 1;
+  const root = text[start];
+  if (root !== "{" && root !== "[") return null;
+
+  const stack: string[] = [root === "{" ? "}" : "]"];
+  let quoted = false;
+  let escaped = false;
+  for (let i = start + 1; i < text.length; i += 1) {
+    const char = text[i];
+    if (quoted) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') quoted = false;
+      continue;
+    }
+    if (char === '"') {
+      quoted = true;
+      continue;
+    }
+    if (char === "{" || char === "[") {
+      stack.push(char === "{" ? "}" : "]");
+      continue;
+    }
+    if (char !== "}" && char !== "]") continue;
+    if (stack.pop() !== char) return null;
+    if (stack.length !== 0) continue;
+
+    // Validate only the first complete value. A hook host may append a
+    // newline or other drain-only bytes after the payload.
+    try {
+      JSON.parse(text.slice(start, i + 1));
+      return i + 1;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
 function requiredUtf8ContinuationBytes(byte: number): number | null {
   if (byte <= 0x7f) return 0;
   if (byte >= 0xc2 && byte <= 0xdf) return 1;
@@ -206,6 +251,10 @@ function completeUtf8PrefixLength(prefix: Buffer): number {
     return leadIndex;
   }
   return prefix.length;
+}
+
+function decodeCompleteUtf8Prefix(prefix: Buffer): string {
+  return prefix.toString("utf8", 0, completeUtf8PrefixLength(prefix));
 }
 
 /**
@@ -293,40 +342,79 @@ export function bubbleBody(
 export async function readStdin(
   input: HookStdin = process.stdin,
 ): Promise<string> {
-  // Hooks pipe a single JSON payload. Preserve at most STDIN_CAP bytes for
-  // parsing, but keep draining until EOF or an input error. Returning early
-  // closes the read end of the pipe and can make a host that is still writing
-  // report EPIPE. The generated agent hook timeout bounds the process itself.
+  // Hooks pipe one JSON payload, but some hosts keep stdin open after writing
+  // it. Preserve at most STDIN_CAP bytes for parsing, deliver a complete JSON
+  // value without waiting for EOF, then drain briefly so a large writer does
+  // not see an avoidable EPIPE. An incomplete or silent host is bounded too.
   if (input.isTTY) return Promise.resolve("");
   return await new Promise((resolve) => {
     const prefix: Buffer[] = [];
     let prefixBytes = 0;
     let settled = false;
+    let readTimer: ReturnType<typeof setTimeout> | undefined;
+    let drainTimer: UnrefTimer | undefined;
+
+    const retainedText = () => {
+      const retained = Buffer.concat(prefix, prefixBytes);
+      const text = decodeCompleteUtf8Prefix(retained);
+      const end = completeJsonPayloadEnd(text);
+      // A host may append logging or framing bytes after its JSON payload.
+      // Return only the value that made us settle so parseStdin never sees
+      // unrelated tail data.
+      return end === null ? text : text.slice(0, end);
+    };
+
+    const cleanup = () => {
+      if (readTimer !== undefined) clearTimeout(readTimer);
+      if (drainTimer !== undefined) clearTimeout(drainTimer);
+      input.off("data", onData);
+      input.off("end", finish);
+      input.off("error", finish);
+      input.pause();
+    };
 
     const finish = () => {
       if (settled) return;
       settled = true;
-      input.off("data", onData);
-      input.off("end", finish);
-      input.off("error", finish);
-      const retained = Buffer.concat(prefix, prefixBytes);
-      resolve(retained.toString("utf8", 0, completeUtf8PrefixLength(retained)));
+      cleanup();
+      resolve(retainedText());
+    };
+
+    const settleComplete = () => {
+      if (settled) return;
+      settled = true;
+      if (readTimer !== undefined) clearTimeout(readTimer);
+      resolve(retainedText());
+      // Keep the data listener attached for a short bounded drain. This is
+      // enough for normal oversized hook writes while guaranteeing the child
+      // can exit when the host never closes stdin.
+      drainTimer = setTimeout(cleanup, STDIN_DRAIN_GRACE_MS) as UnrefTimer;
+      drainTimer.unref?.();
     };
 
     const onData = (chunk: Buffer | string) => {
-      if (settled) return;
       const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-      const remaining = STDIN_CAP - prefixBytes;
-      if (remaining <= 0) return;
-      const retained = Buffer.from(bytes.subarray(0, remaining));
-      prefix.push(retained);
-      prefixBytes += retained.length;
+      if (!settled) {
+        const remaining = STDIN_CAP - prefixBytes;
+        if (remaining > 0) {
+          const retained = Buffer.from(bytes.subarray(0, remaining));
+          prefix.push(retained);
+          prefixBytes += retained.length;
+          const text = decodeCompleteUtf8Prefix(
+            Buffer.concat(prefix, prefixBytes),
+          );
+          if (completeJsonPayloadEnd(text) !== null) {
+            settleComplete();
+          }
+        }
+      }
     };
 
     input.on("data", onData);
     input.on("end", finish);
     input.on("error", finish);
     input.resume();
+    readTimer = setTimeout(finish, STDIN_READ_TIMEOUT_MS);
   });
 }
 
@@ -505,7 +593,7 @@ export async function runBubble(args: string[]): Promise<void> {
     transcriptPath,
     lastAssistantMessage,
   } = parseStdin(stdin);
-  const agentSource = stdinSource ?? argSource;
+  const agentSource = resolveAgentSource(stdinSource, argSource);
   if (
     sessionId &&
     prompt &&
@@ -565,4 +653,13 @@ export async function runBubble(args: string[]): Promise<void> {
     );
   }
   await Promise.all(tasks);
+}
+
+/// The command argument identifies the agent that invoked this runner. Stdin
+/// metadata is only a compatibility fallback for callers without that arg.
+export function resolveAgentSource(
+  stdinSource: string | null,
+  argSource: string | null,
+): string | null {
+  return argSource && argSource.length > 0 ? argSource : stdinSource;
 }

--- a/packages/petdex-desktop-native/src/assets/petdex-remote-hook.sh
+++ b/packages/petdex-desktop-native/src/assets/petdex-remote-hook.sh
@@ -12,17 +12,84 @@
 
 runtime="$HOME/.petdex/runtime"
 
-# Keep a bounded useful prefix while draining the complete hook pipe. Tool
-# results can be many megabytes; retaining all of them delays the agent and
-# used to reparse the same payload once per extracted field.
+# Keep a bounded useful prefix and stop after the first complete JSON value.
+# Hosts are allowed to leave the write end of stdin open, so waiting for EOF
+# here would leave every remote hook process stuck. Python is a declared
+# dependency for remote Codex/Hermes reconciliation; on a minimal host without
+# it, use an optional one-block timeout and fail closed rather than waiting
+# forever.
 if command -v python3 >/dev/null 2>&1; then
-    payload=$(python3 -c 'import sys
-data = sys.stdin.buffer.read(65536)
-while sys.stdin.buffer.read(65536):
-    pass
-sys.stdout.buffer.write(data)' 2>/dev/null)
+    payload=$(python3 -c '
+import json
+import os
+import select
+import sys
+import time
+
+CAP = 65536
+READ_TIMEOUT = 0.5
+DRAIN_TIMEOUT = 0.3
+
+fd = sys.stdin.fileno()
+retained = bytearray()
+output = None
+drain_deadline = None
+deadline = time.monotonic() + READ_TIMEOUT
+decoder = json.JSONDecoder()
+
+
+def first_json_bytes():
+    # Ignore malformed bytes only for the probe; the normal parser below still
+    # rejects malformed payloads. This lets a valid JSON value followed by a
+    # partial UTF-8 tail settle without waiting for the tail to complete.
+    text = bytes(retained).decode("utf-8", "ignore")
+    start = len(text) - len(text.lstrip())
+    if start >= len(text) or text[start] not in "[{":
+        return None
+    try:
+        _, end = decoder.raw_decode(text, start)
+    except ValueError:
+        return None
+    return text[:end].encode("utf-8")
+
+
+while True:
+    until = drain_deadline if drain_deadline is not None else deadline
+    remaining = until - time.monotonic()
+    if remaining <= 0:
+        break
+    try:
+        readable, _, _ = select.select([fd], [], [], remaining)
+    except (OSError, ValueError):
+        break
+    if not readable:
+        break
+    try:
+        chunk = os.read(fd, 8192)
+    except OSError:
+        break
+    if not chunk:
+        break
+    if output is None:
+        remaining_capacity = CAP - len(retained)
+        if remaining_capacity > 0:
+            retained.extend(chunk[:remaining_capacity])
+        candidate = first_json_bytes()
+        if candidate is not None:
+            output = candidate
+            drain_deadline = time.monotonic() + DRAIN_TIMEOUT
+        elif len(retained) >= CAP:
+            output = bytes(retained)
+            drain_deadline = time.monotonic() + DRAIN_TIMEOUT
+
+if output is None:
+    output = bytes(retained)
+sys.stdout.buffer.write(output)
+' 2>/dev/null)
+elif command -v timeout >/dev/null 2>&1; then
+    payload=$(timeout 1s sh -c 'dd bs=65536 count=1 2>/dev/null' 2>/dev/null || true)
 else
-    payload=$({ dd bs=65536 count=1 2>/dev/null; cat >/dev/null 2>&1; })
+    payload=
 fi
 
 # Check the gate before doing any parsing. Draining remains unconditional so
@@ -366,8 +433,10 @@ normalize_key() {
     elif command -v python3 >/dev/null 2>&1; then
         printf '%s' "$value" | python3 -c 'import hashlib,sys; print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest())'
     else
-        set -- $(printf '%s' "$value" | cksum)
-        printf 'cksum-%s-%s' "$1" "$2"
+        cksum_result=$(printf '%s' "$value" | cksum)
+        cksum_sum=$(printf '%s\n' "$cksum_result" | awk '{print $1}')
+        cksum_length=$(printf '%s\n' "$cksum_result" | awk '{print $2}')
+        printf 'cksum-%s-%s' "$cksum_sum" "$cksum_length"
     fi
 }
 conversation_key=$(normalize_key "$conversation_key")
@@ -401,7 +470,7 @@ notification_kind=$(id_field notification_type)
 case "$phase" in
     pre|post)
         tool=$(id_field tool_name)
-        lower_tool=$(printf '%s' "$tool" | tr 'A-Z' 'a-z')
+        lower_tool=$(printf '%s' "$tool" | tr '[:upper:]' '[:lower:]')
         session_status=running
         message_kind=tool
         if [ "$lower_tool" = "clarify" ]; then

--- a/packages/petdex-desktop-native/src/dsh_integration.zig
+++ b/packages/petdex-desktop-native/src/dsh_integration.zig
@@ -302,17 +302,55 @@ test "DSH_HOME redirects profile detection" {
 }
 
 test "filesystem detection distinguishes restart from real event connection" {
-    const home = ".zig-cache/petdex-dsh-detect";
-    defer _ = plat.deleteTree(home);
-    plat.makeDir(home ++ "/.dsh/profiles/web");
-    plat.makeDir(home ++ "/.petdex/runtime");
+    // The production app populates this override from the process
+    // environment. Tests must use their isolated fixture home instead of a
+    // developer's real DSH_HOME, otherwise an installed host profile can
+    // make this assertion report connected or not_installed nondeterministically.
+    const saved_dsh_home = env_dsh_home;
+    env_dsh_home = null;
+    defer env_dsh_home = saved_dsh_home;
+
+    var test_dir = std.testing.tmpDir(.{});
+    defer test_dir.cleanup();
+    var home_buf: [128]u8 = undefined;
+    const home = std.fmt.bufPrint(
+        &home_buf,
+        ".zig-cache/tmp/{s}",
+        .{test_dir.sub_path[0..]},
+    ) catch unreachable;
+    var manifest_path_buf: [512]u8 = undefined;
+    const manifest_path = std.fmt.bufPrint(
+        &manifest_path_buf,
+        "{s}/.dsh/profiles/web/package.json",
+        .{home},
+    ) catch unreachable;
+    var handshake_path_buf: [512]u8 = undefined;
+    const handshake_path = std.fmt.bufPrint(
+        &handshake_path_buf,
+        "{s}/.petdex/runtime/dsh-handshake.json",
+        .{home},
+    ) catch unreachable;
+    var manifest_dir_buf: [512]u8 = undefined;
+    const manifest_dir = std.fmt.bufPrint(
+        &manifest_dir_buf,
+        "{s}/.dsh/profiles/web",
+        .{home},
+    ) catch unreachable;
+    var handshake_dir_buf: [512]u8 = undefined;
+    const handshake_dir = std.fmt.bufPrint(
+        &handshake_dir_buf,
+        "{s}/.petdex/runtime",
+        .{home},
+    ) catch unreachable;
+    plat.makeDir(manifest_dir);
+    plat.makeDir(handshake_dir);
     const manifest =
         \\{"dependencies":{"@petdex/dsh-plugin":"file:/stable/plugin.tgz"},"dsh":{"profile":{"bundles":["@petdex/dsh-plugin"]}}}
     ;
-    try std.testing.expect(plat.writeFile(home ++ "/.dsh/profiles/web/package.json", manifest));
+    try std.testing.expect(plat.writeFile(manifest_path, manifest));
     try std.testing.expectEqual(Status.restart_required, detect(std.testing.allocator, home));
     try std.testing.expect(plat.writeFile(
-        home ++ "/.petdex/runtime/dsh-handshake.json",
+        handshake_path,
         "{\"integrationVersion\":\"0.1.0\"}",
     ));
     try std.testing.expectEqual(Status.connected, detect(std.testing.allocator, home));

--- a/packages/petdex-desktop-native/src/hook_runner.zig
+++ b/packages/petdex-desktop-native/src/hook_runner.zig
@@ -52,7 +52,7 @@ pub fn run(phase: []const u8, arg_agent: ?[]const u8, origin_app: plat.OriginApp
     const token = std.mem.trim(u8, token_raw, " \t\r\n");
     if (token.len == 0) return;
 
-    const agent = jsonString(payload, "agent_source") orelse (arg_agent orelse "");
+    const agent = resolveAgent(payload, arg_agent);
     const source_app = origin_app.wireName();
     var tty_buf: [64]u8 = undefined;
     const source_tty = if (origin_app == .terminal) (plat.controllingTty(&tty_buf) orelse "") else "";
@@ -128,6 +128,16 @@ pub fn run(phase: []const u8, arg_agent: ?[]const u8, origin_app: plat.OriginApp
         }
     }
     waitForPosts(posts[0..post_count]);
+}
+
+/// The hook command identifies the agent that actually invoked this runner.
+/// Prefer that explicit argument over payload metadata, which may be nested,
+/// copied from another integration, or supplied by an agent subprocess.
+fn resolveAgent(payload: []const u8, arg_agent: ?[]const u8) []const u8 {
+    if (arg_agent) |agent| {
+        if (agent.len > 0) return agent;
+    }
+    return jsonString(payload, "agent_source") orelse "";
 }
 
 fn isPromptPhase(phase: []const u8) bool {
@@ -792,6 +802,19 @@ test "stateBody adds duration only for the failure phase" {
         "{\"state\":\"waving\",\"agent_source\":\"codex\"}",
         stateBody(&buf, "waving", 0, "codex").?,
     );
+}
+
+test "explicit hook agent wins over payload metadata" {
+    try t.expectEqualStrings(
+        "codex",
+        resolveAgent("{\"agent_source\":\"claude-code\"}", "codex"),
+    );
+    try t.expectEqualStrings(
+        "claude-code",
+        resolveAgent("{\"agent_source\":\"claude-code\"}", null),
+    );
+    try t.expectEqualStrings("", resolveAgent("{}", null));
+    try t.expectEqualStrings("codex", resolveAgent("{}", "codex"));
 }
 
 test "bubbleBody carries session_id, and omits it when there is none" {

--- a/packages/petdex-desktop-native/src/hook_server.zig
+++ b/packages/petdex-desktop-native/src/hook_server.zig
@@ -32,7 +32,39 @@ pub const max_pending = 50;
 const max_active_connections: u32 = 64;
 const max_request_bytes: usize = 8192;
 const connection_timeout_ms: i64 = 5_000;
+const response_drain_grace_ms: i64 = 300;
 
+/// Windows' std.Io stream reader intentionally waits for the AFD receive
+/// operation to complete, but it has no stream-level timeout API. Poll the
+/// socket with the native AFD control path first, then use the existing
+/// reader only after the kernel reports readable or closed state. This keeps
+/// the receive buffer and the platform-independent parser unchanged while
+/// making the connection deadline real on Windows too.
+const AfdPollHandle = extern struct {
+    handle: std.os.windows.HANDLE,
+    events: std.os.windows.ULONG,
+    status: std.os.windows.NTSTATUS,
+};
+
+const AfdPollInfo = extern struct {
+    timeout: std.os.windows.LARGE_INTEGER,
+    handle_count: std.os.windows.ULONG,
+    exclusive: std.os.windows.ULONG,
+    handles: [1]AfdPollHandle,
+};
+
+const afd_event_receive: std.os.windows.ULONG = 1 << 0;
+const afd_event_disconnect: std.os.windows.ULONG = 1 << 3;
+const afd_event_abort: std.os.windows.ULONG = 1 << 4;
+const afd_event_close: std.os.windows.ULONG = 1 << 5;
+const afd_readable_events = afd_event_receive |
+    afd_event_disconnect |
+    afd_event_abort |
+    afd_event_close;
+
+// AFD.POLL is issued directly on each accepted socket handle below. The AFD
+// endpoint is created by Winsock; opening a separate \Device\Afd child and
+// sending the ioctl to that control handle is rejected by Windows.
 pub const StateEvent = struct {
     state: [16]u8 = @splat(0),
     state_len: usize = 0,
@@ -348,12 +380,6 @@ pub fn start(allocator: std.mem.Allocator, home: []const u8) !void {
 }
 
 fn run(server: *Server) void {
-    writeRuntimeFile(server, "update-token", &server.token, 0o600) catch |err| {
-        std.debug.print("petdex: token write failed ({s})\n", .{@errorName(err)});
-        return;
-    };
-    mirrorState(server, "idle", 0) catch {};
-
     // This thread owns its Io for its whole life: the listener blocks
     // in accept() forever and must never touch the main thread's.
     var scope = plat.Scope.init();
@@ -363,7 +389,10 @@ fn run(server: *Server) void {
     const addr: std.Io.net.IpAddress = .{ .ip4 = .loopback(7777) };
     var listener = addr.listen(io, .{
         .kernel_backlog = 16,
-        .reuse_address = true,
+        // This endpoint is a single-owner service. Zig maps true to
+        // SO_REUSEPORT on POSIX, which would let a second desktop bind the
+        // same port and replace the first instance's token file.
+        .reuse_address = false,
         .mode = .stream,
         .protocol = .tcp,
     }) catch {
@@ -371,6 +400,16 @@ fn run(server: *Server) void {
         return;
     };
     defer listener.deinit(io);
+
+    // Bind before replacing the token file. A second desktop instance may
+    // fail to bind; it must not invalidate the token of the listener that is
+    // already serving hooks.
+    writeRuntimeFile(server, "update-token", &server.token, 0o600) catch |err| {
+        std.debug.print("petdex: token write failed ({s})\n", .{@errorName(err)});
+        return;
+    };
+    mirrorState(server, "idle", 0) catch {};
+
     // Installation is not connection. Each Petdex process requires a fresh
     // event from the plugin before Settings may show DSH as connected.
     deleteRuntimeFile(server, "dsh-handshake.json");
@@ -405,10 +444,14 @@ fn handleConnectionThread(server: *Server, stream: std.Io.net.Stream) void {
     handleConnection(server, &conn);
     stream.shutdown(io, .send) catch {};
     if (builtin.os.tag == .windows) {
-        var drain: [1]u8 = undefined;
+        var drain: [1024]u8 = undefined;
+        const timeout = (std.Io.Timeout{ .duration = .{
+            .raw = std.Io.Duration.fromMilliseconds(response_drain_grace_ms),
+            .clock = .awake,
+        } }).toDeadline(io);
         while (true) {
-            const message = stream.socket.receive(io, &drain) catch break;
-            if (message.data.len == 0) break;
+            const received = receiveWithTimeout(&conn, &drain, timeout) catch break;
+            if (received == 0) break;
         }
     }
     stream.close(io);
@@ -472,6 +515,7 @@ fn handleConnection(server: *Server, conn: *Conn) void {
 
 fn receiveWithTimeout(conn: *Conn, buffer: []u8, timeout: std.Io.Timeout) !usize {
     if (builtin.os.tag == .windows) {
+        try waitForWindowsReadable(conn, timeout);
         var reader = conn.stream.reader(conn.io, &.{});
         var data = [_][]u8{buffer};
         return reader.interface.readVec(&data) catch |err| switch (err) {
@@ -480,6 +524,65 @@ fn receiveWithTimeout(conn: *Conn, buffer: []u8, timeout: std.Io.Timeout) !usize
         };
     }
     return (try conn.stream.socket.receiveTimeout(conn.io, buffer, timeout)).data.len;
+}
+
+fn waitForWindowsReadable(conn: *Conn, timeout: std.Io.Timeout) !void {
+    if (comptime builtin.os.tag != .windows) return;
+
+    var poll = AfdPollInfo{
+        .timeout = windowsRelativeTimeout(timeout, conn.io),
+        .handle_count = 1,
+        .exclusive = 0,
+        .handles = .{.{
+            .handle = conn.stream.socket.handle,
+            .events = afd_readable_events,
+            .status = .SUCCESS,
+        }},
+    };
+    const bytes = std.mem.asBytes(&poll);
+    const result = (try conn.io.operate(.{
+        .device_io_control = .{
+            .file = .{
+                // AFD.POLL is an endpoint ioctl. Windows requires the
+                // endpoint socket handle as the NtDeviceIoControlFile
+                // target; a separately opened \Device\Afd control handle
+                // returns STATUS_INVALID_DEVICE_REQUEST.
+                .handle = conn.stream.socket.handle,
+                // AFD.POLL completes through the APC path when the request is
+                // pending. The synchronous flag would hit Zig's unreachable
+                // branch on STATUS_PENDING instead of honoring the deadline.
+                .flags = .{ .nonblocking = true },
+            },
+            .code = std.os.windows.IOCTL.AFD.POLL,
+            .in = bytes,
+            .out = bytes,
+        },
+    })).device_io_control;
+
+    switch (result.u.Status) {
+        .SUCCESS => {},
+        .TIMEOUT => return error.Timeout,
+        .CANCELLED => return error.Canceled,
+        else => |status| return std.os.windows.unexpectedStatus(status),
+    }
+    if (poll.handles[0].status != .SUCCESS) {
+        return std.os.windows.unexpectedStatus(poll.handles[0].status);
+    }
+    if (poll.handles[0].events & afd_readable_events == 0) {
+        return error.Unexpected;
+    }
+}
+
+fn windowsRelativeTimeout(timeout: std.Io.Timeout, io: std.Io) std.os.windows.LARGE_INTEGER {
+    const duration = timeout.toDurationFromNow(io) orelse return std.math.minInt(std.os.windows.LARGE_INTEGER);
+    return windowsRelativeTimeoutFromNanoseconds(duration.raw.toNanoseconds());
+}
+
+fn windowsRelativeTimeoutFromNanoseconds(nanoseconds: i96) std.os.windows.LARGE_INTEGER {
+    if (nanoseconds <= 0) return 0;
+    const ticks: i128 = @divTrunc(@as(i128, nanoseconds) + 99, 100);
+    const bounded = @min(ticks, @as(i128, std.math.maxInt(std.os.windows.LARGE_INTEGER)));
+    return -@as(std.os.windows.LARGE_INTEGER, @intCast(bounded));
 }
 
 fn route(server: *Server, conn: *Conn, method: []const u8, path: []const u8, head: []const u8, body: []const u8) void {
@@ -929,6 +1032,33 @@ test "json string scanner rejects malformed mirror input" {
     try std.testing.expect(jsonString("{\"text\":\"unterminated}", "text") == null);
     try std.testing.expect(jsonString("{\"text\":\"bad\\x\"}", "text") == null);
     try std.testing.expect(jsonString("{\"text\":\"bad\nline\"}", "text") == null);
+}
+
+test "Windows AFD readable mask includes normal data and terminal events" {
+    try std.testing.expectEqual(
+        @as(std.os.windows.ULONG, (1 << 0) | (1 << 3) | (1 << 4) | (1 << 5)),
+        afd_readable_events,
+    );
+}
+
+test "Windows AFD relative timeout rounds up to 100ns units" {
+    try std.testing.expectEqual(@as(std.os.windows.LARGE_INTEGER, 0), windowsRelativeTimeoutFromNanoseconds(-1));
+    try std.testing.expectEqual(@as(std.os.windows.LARGE_INTEGER, 0), windowsRelativeTimeoutFromNanoseconds(0));
+    try std.testing.expectEqual(@as(std.os.windows.LARGE_INTEGER, -1), windowsRelativeTimeoutFromNanoseconds(1));
+    try std.testing.expectEqual(@as(std.os.windows.LARGE_INTEGER, -1), windowsRelativeTimeoutFromNanoseconds(100));
+    try std.testing.expectEqual(@as(std.os.windows.LARGE_INTEGER, -2), windowsRelativeTimeoutFromNanoseconds(101));
+    try std.testing.expectEqual(@as(std.os.windows.LARGE_INTEGER, -10_000), windowsRelativeTimeoutFromNanoseconds(1_000_000));
+}
+
+test "Windows AFD poll structures keep the native ABI layout" {
+    if (@sizeOf(usize) == 8) {
+        try std.testing.expectEqual(@as(usize, 16), @offsetOf(AfdPollInfo, "handles"));
+        try std.testing.expectEqual(@as(usize, 32), @sizeOf(AfdPollInfo));
+        try std.testing.expectEqual(@as(usize, 0), @offsetOf(AfdPollHandle, "handle"));
+        try std.testing.expectEqual(@as(usize, 8), @offsetOf(AfdPollHandle, "events"));
+        try std.testing.expectEqual(@as(usize, 12), @offsetOf(AfdPollHandle, "status"));
+        try std.testing.expectEqual(@as(usize, 16), @sizeOf(AfdPollHandle));
+    }
 }
 
 test "json number scanner validates complete JSON numbers" {

--- a/packages/petdex-desktop-native/src/plat.zig
+++ b/packages/petdex-desktop-native/src/plat.zig
@@ -228,48 +228,207 @@ pub fn forEachEntry(
 }
 
 pub fn readStdin(buf: []u8) []const u8 {
+    if (comptime builtin.os.tag == .windows) return readStdinWindows(buf);
+    return readStdinPortable(buf);
+}
+
+fn readStdinPortable(buf: []u8) []const u8 {
     var scope = Scope.init();
     defer scope.deinit();
     const io = scope.io();
-    var read_buf: [4096]u8 = undefined;
-    var reader = std.Io.File.stdin().reader(io, &read_buf);
-    return readCappedAndDrain(&reader.interface, buf);
-}
+    const stdin = std.Io.File.stdin();
+    var storage: [1]std.Io.Operation.Storage = undefined;
+    var batch = std.Io.Batch.init(&storage);
+    defer batch.cancel(io);
 
-/// Keep the first `buf.len` bytes but drain the rest of the pipe. Hook
-/// hosts can still be writing a large payload after the useful prefix; an
-/// early close makes their writer see EPIPE/Broken pipe.
-fn readCappedAndDrain(reader: anytype, buf: []u8) []const u8 {
-    var total: usize = 0;
     var discard: [4096]u8 = undefined;
+    var target: [1][]u8 = undefined;
+    var total: usize = 0;
+    var complete = false;
+    var deadline = stdinDeadline(io, stdin_read_timeout_ms);
+
+    // One outstanding read at a time keeps the capture buffer bounded while
+    // Io.Batch supplies poll/overlapped implementations for POSIX and Windows.
     while (true) {
-        const target = if (total < buf.len) buf[total..] else &discard;
-        const n = reader.readSliceShort(target) catch break;
-        if (n == 0) break;
+        target[0] = if (total < buf.len) buf[total..] else discard[0..];
+        batch.addAt(0, .{ .file_read_streaming = .{ .file = stdin, .data = &target } });
+
+        batch.awaitConcurrent(io, .{ .deadline = deadline }) catch break;
+        const completion = batch.next() orelse break;
+        const n = completion.result.file_read_streaming catch return buf[0..total];
+        if (n == 0) return buf[0..total];
+
         if (total < buf.len) total += n;
+        if (!complete and hasCompleteJsonPayload(buf[0..total])) {
+            complete = true;
+            // Once the JSON value is complete, give the host a short bounded
+            // drain window for trailing/oversized bytes, then let the process
+            // close its read side instead of waiting for EOF forever.
+            deadline = stdinDeadline(io, stdin_drain_grace_ms);
+        }
     }
     return buf[0..total];
 }
 
-test "readCappedAndDrain keeps the cap and consumes the source" {
-    const Source = struct {
-        bytes: []const u8,
-        offset: usize = 0,
+/// Windows' inherited stdin is a synchronous pipe. Zig 0.16's `std.Io`
+/// implementation sends that handle through `NtReadFile`; when the pipe is
+/// still open after a short payload, Windows returns `PENDING` and the
+/// synchronous path aborts at `unreachable`. Use the Win32 synchronous
+/// `ReadFile` API on a short-lived worker instead. The caller can then keep
+/// the same bounded JSON/drain deadlines without ever handing a caller-owned
+/// stack buffer to a potentially detached reader.
+const WindowsStdinTask = if (builtin.os.tag == .windows) struct {
+    handle: std.os.windows.HANDLE,
+    buffer: []u8,
+    written: std.atomic.Value(usize) = .init(0),
+    finished: std.atomic.Value(bool) = .init(false),
+} else void;
 
-        fn readSliceShort(self: *@This(), out: []u8) !usize {
-            if (self.offset >= self.bytes.len) return 0;
-            const n = @min(out.len, self.bytes.len - self.offset);
-            @memcpy(out[0..n], self.bytes[self.offset .. self.offset + n]);
-            self.offset += n;
-            return n;
-        }
+const windows_stdin_api = if (builtin.os.tag == .windows) struct {
+    extern "kernel32" fn ReadFile(
+        handle: std.os.windows.HANDLE,
+        buffer: std.os.windows.LPVOID,
+        bytes_to_read: std.os.windows.DWORD,
+        bytes_read: *std.os.windows.DWORD,
+        overlapped: ?*anyopaque,
+    ) callconv(.winapi) std.os.windows.BOOL;
+} else struct {};
+
+fn windowsStdinWorker(task: *WindowsStdinTask) void {
+    if (comptime builtin.os.tag != .windows) return;
+
+    var offset: usize = 0;
+    while (offset < task.buffer.len) {
+        var bytes_read: std.os.windows.DWORD = 0;
+        const ok = windows_stdin_api.ReadFile(
+            task.handle,
+            @ptrCast(task.buffer.ptr + offset),
+            1,
+            &bytes_read,
+            null,
+        );
+        if (ok == .FALSE or bytes_read == 0) break;
+        offset += @min(@as(usize, @intCast(bytes_read)), task.buffer.len - offset);
+        task.written.store(offset, .release);
+    }
+    task.finished.store(true, .release);
+}
+
+fn readStdinWindows(buf: []u8) []const u8 {
+    if (buf.len == 0) return buf[0..0];
+
+    const allocator = std.heap.page_allocator;
+    const task = allocator.create(WindowsStdinTask) catch return buf[0..0];
+    task.* = .{
+        .handle = std.Io.File.stdin().handle,
+        .buffer = allocator.alloc(u8, buf.len) catch {
+            allocator.destroy(task);
+            return buf[0..0];
+        },
     };
 
-    var source = Source{ .bytes = "0123456789" };
-    var kept: [4]u8 = undefined;
-    const captured = readCappedAndDrain(&source, &kept);
-    try std.testing.expectEqualStrings("0123", captured);
-    try std.testing.expectEqual(source.bytes.len, source.offset);
+    const thread = std.Thread.spawn(.{}, windowsStdinWorker, .{task}) catch {
+        allocator.free(task.buffer);
+        allocator.destroy(task);
+        return buf[0..0];
+    };
+
+    var scope = Scope.init();
+    defer scope.deinit();
+    const io = scope.io();
+    const read_deadline = stdinDeadline(io, stdin_read_timeout_ms);
+    var deadline = read_deadline;
+    var complete = false;
+
+    while (true) {
+        const count = task.written.load(.acquire);
+        if (!complete and count > 0 and hasCompleteJsonPayload(task.buffer[0..count])) {
+            complete = true;
+            deadline = stdinDeadline(io, stdin_drain_grace_ms);
+        }
+
+        if (task.finished.load(.acquire)) {
+            thread.join();
+            const final_count = @min(task.written.load(.acquire), buf.len);
+            @memcpy(buf[0..final_count], task.buffer[0..final_count]);
+            allocator.free(task.buffer);
+            allocator.destroy(task);
+            return buf[0..final_count];
+        }
+
+        if (deadline.durationFromNow(io).raw.toNanoseconds() <= 0) {
+            const final_count = @min(task.written.load(.acquire), buf.len);
+            @memcpy(buf[0..final_count], task.buffer[0..final_count]);
+            // The worker owns only heap storage and the hook process exits
+            // immediately after this function, so detaching is safe when a
+            // host deliberately leaves stdin open forever.
+            thread.detach();
+            return buf[0..final_count];
+        }
+
+        io.sleep(.fromMilliseconds(1), .awake) catch {};
+    }
+}
+
+const stdin_read_timeout_ms: u64 = 500;
+const stdin_drain_grace_ms: u64 = 300;
+
+fn stdinDeadline(io: std.Io, milliseconds: u64) std.Io.Clock.Timestamp {
+    return std.Io.Clock.Timestamp.fromNow(io, .{
+        .clock = .awake,
+        .raw = std.Io.Duration.fromMilliseconds(@intCast(milliseconds)),
+    });
+}
+
+/// Return whether a retained prefix contains one balanced JSON value. The
+/// hook payload is parsed again by hook_runner; this scanner only decides when
+/// it is safe to stop waiting for EOF. Strings and escaped quotes are skipped
+/// so braces inside tool commands do not trigger an early return.
+fn hasCompleteJsonPayload(bytes: []const u8) bool {
+    var start: usize = 0;
+    while (start < bytes.len and (bytes[start] == ' ' or bytes[start] == '\t' or bytes[start] == '\r' or bytes[start] == '\n')) start += 1;
+    if (start == bytes.len) return false;
+    const root = bytes[start];
+    if (root != '{' and root != '[') return false;
+
+    var expected: [128]u8 = undefined;
+    var depth: usize = 1;
+    expected[0] = if (root == '{') '}' else ']';
+    var quoted = false;
+    var escaped = false;
+
+    var i = start + 1;
+    while (i < bytes.len) : (i += 1) {
+        const byte = bytes[i];
+        if (quoted) {
+            if (escaped) escaped = false else if (byte == '\\') escaped = true else if (byte == '"') quoted = false;
+            continue;
+        }
+        if (byte == '"') {
+            quoted = true;
+            continue;
+        }
+        if (byte == '{' or byte == '[') {
+            if (depth == expected.len) return false;
+            expected[depth] = if (byte == '{') '}' else ']';
+            depth += 1;
+            continue;
+        }
+        if (byte != '}' and byte != ']') continue;
+        if (depth == 0 or expected[depth - 1] != byte) return false;
+        depth -= 1;
+        if (depth != 0) continue;
+        // The hook host may append whitespace; the first complete value is
+        // sufficient because later bytes are drained, not parsed.
+        return true;
+    }
+    return false;
+}
+
+test "complete JSON detection ignores braces inside strings" {
+    try std.testing.expect(hasCompleteJsonPayload("{\"command\":\"echo {still-open}\\\"\"}"));
+    try std.testing.expect(!hasCompleteJsonPayload("{\"command\":\"echo"));
+    try std.testing.expect(!hasCompleteJsonPayload("{\"command\":["));
 }
 
 // ------------------------------------------------------------------ clock

--- a/packages/petdex-desktop-native/tests/hook_stdin_test.py
+++ b/packages/petdex-desktop-native/tests/hook_stdin_test.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Exercise the native hook runner's bounded stdin lifetime.
+
+The runner exits before starting the desktop UI.  Keeping the parent pipe open
+therefore tests the exact failure mode that used to leave agent hook processes
+waiting forever, without requiring a display, a token, or a running server.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+MAX_EXIT_SECONDS = 3.0
+
+
+def run_case(binary: Path, label: str, payload: bytes | None) -> None:
+    with tempfile.TemporaryDirectory(prefix="petdex-hook-test-") as home:
+        env = os.environ.copy()
+        env["HOME"] = home
+        env["USERPROFILE"] = home
+        env["APPDATA"] = home
+
+        child = subprocess.Popen(
+            [str(binary), "bubble", "post", "codex"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=env,
+        )
+        try:
+            if payload is not None:
+                assert child.stdin is not None
+                child.stdin.write(payload)
+                child.stdin.flush()
+                # Deliberately do not close stdin.  The parent keeps the pipe
+                # open to reproduce hosts that write JSON but never send EOF.
+
+            started = time.monotonic()
+            try:
+                exit_code = child.wait(timeout=MAX_EXIT_SECONDS)
+            except subprocess.TimeoutExpired as error:
+                child.kill()
+                child.wait()
+                raise AssertionError(f"native hook did not exit for {label}") from error
+
+            elapsed = time.monotonic() - started
+            if exit_code != 0:
+                raise AssertionError(f"native hook exited {exit_code} for {label}")
+            if elapsed > MAX_EXIT_SECONDS:
+                raise AssertionError(f"native hook exceeded timeout for {label}")
+        finally:
+            if child.stdin is not None:
+                child.stdin.close()
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: hook_stdin_test.py <native-binary>", file=sys.stderr)
+        return 2
+
+    binary = Path(sys.argv[1])
+    if not binary.is_file() and Path(f"{binary}.exe").is_file():
+        binary = Path(f"{binary}.exe")
+    if not binary.is_file():
+        print("native hook binary is missing", file=sys.stderr)
+        return 2
+
+    run_case(binary, "complete payload without EOF", b'{"tool_name":"Read"}')
+    run_case(binary, "silent stdin", None)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/petdex-desktop-native/tests/remote_hook_test.sh
+++ b/packages/petdex-desktop-native/tests/remote_hook_test.sh
@@ -6,6 +6,12 @@ fixture=$(mktemp -d)
 trap 'rm -rf "$fixture"' 0 1 2 15
 mkdir -p "$fixture/home/.petdex/runtime" "$fixture/bin"
 printf 'test-token\n' > "$fixture/home/.petdex/runtime/update-token"
+python3_path=$(command -v python3 || true)
+if [ -n "$python3_path" ]; then
+    test_path="$(dirname "$python3_path"):/usr/bin:/bin"
+else
+    test_path="/usr/bin:/bin"
+fi
 
 cat > "$fixture/bin/curl" <<'MOCK'
 #!/bin/sh
@@ -20,13 +26,70 @@ exit 0
 MOCK
 chmod +x "$fixture/bin/curl"
 
+wait_for_marker() {
+    marker=$1
+    attempts=0
+    while [ "$attempts" -lt 30 ]; do
+        [ -f "$marker" ] && return 0
+        attempts=$((attempts + 1))
+        sleep 0.1
+    done
+    return 1
+}
+
 payload='{"session_id":"raw-turn","session_key":"gateway/session key","petdex_session_title":"Canonical title","last_assistant_message":"Remote answer"}'
-printf '%s' "$payload" | HOME="$fixture/home" PATH="$fixture/bin:/usr/bin:/bin" \
+printf '%s' "$payload" | HOME="$fixture/home" PATH="$fixture/bin:$test_path" \
     PETDEX_CAPTURE="$fixture/capture" sh "$root/src/assets/petdex-remote-hook.sh" bubble assistant hermes
 
 grep -Eq '"session_id":"[0-9a-f]{64}"' "$fixture/capture"
 grep -q '"source_session_id":"raw-turn"' "$fixture/capture"
 grep -q '"session_kind":"primary"' "$fixture/capture"
+
+# A host may keep the stdin write end open after the JSON is complete. The
+# remote hook must return within its bounded drain window instead of waiting
+# for EOF indefinitely.
+bounded_fifo="$fixture/bounded-input"
+bounded_done="$fixture/bounded-done"
+mkfifo "$bounded_fifo"
+(
+    HOME="$fixture/home" PATH="$fixture/bin:$test_path" \
+        PETDEX_CAPTURE="$fixture/capture" sh "$root/src/assets/petdex-remote-hook.sh" bubble assistant hermes
+    : > "$bounded_done"
+) < "$bounded_fifo" &
+bounded_pid=$!
+exec 3>"$bounded_fifo"
+printf '%s' "$payload" >&3
+if ! wait_for_marker "$bounded_done"; then
+    echo "remote hook waited for EOF after a complete payload" >&2
+    kill "$bounded_pid" 2>/dev/null || true
+    exec 3>&-
+    wait "$bounded_pid" 2>/dev/null || true
+    exit 1
+fi
+exec 3>&-
+wait "$bounded_pid"
+
+# Silent stdin is bounded too; a disconnected or miswired host must not leave
+# a remote shell process behind forever.
+silent_fifo="$fixture/silent-input"
+silent_done="$fixture/silent-done"
+mkfifo "$silent_fifo"
+(
+    HOME="$fixture/home" PATH="$fixture/bin:$test_path" \
+        PETDEX_CAPTURE="$fixture/capture" sh "$root/src/assets/petdex-remote-hook.sh" bubble assistant hermes
+    : > "$silent_done"
+) < "$silent_fifo" &
+silent_pid=$!
+exec 4>"$silent_fifo"
+if ! wait_for_marker "$silent_done"; then
+    echo "remote hook waited for silent stdin" >&2
+    kill "$silent_pid" 2>/dev/null || true
+    exec 4>&-
+    wait "$silent_pid" 2>/dev/null || true
+    exit 1
+fi
+exec 4>&-
+wait "$silent_pid"
 
 # The transport-published Hermes home must drive hook-side canonical lookup
 # even when the hook process itself does not inherit HERMES_HOME.
@@ -47,7 +110,7 @@ with sqlite3.connect(sys.argv[1]) as database:
     )
 PY
 payload='{"session_id":"custom-raw","last_assistant_message":"Custom answer"}'
-printf '%s' "$payload" | HOME="$fixture/home" PATH="$fixture/bin:/usr/bin:/bin" \
+printf '%s' "$payload" | HOME="$fixture/home" PATH="$fixture/bin:$test_path" \
     PETDEX_CAPTURE="$fixture/capture" sh "$root/src/assets/petdex-remote-hook.sh" bubble assistant hermes
 tail -n 1 "$fixture/capture" | grep -q '"session_id":"custom-key"'
 tail -n 1 "$fixture/capture" | grep -q '"title":"Custom server title"'
@@ -55,7 +118,7 @@ tail -n 1 "$fixture/capture" | grep -q '"title":"Custom server title"'
 # Remote metadata is untrusted text even though the transport is authenticated.
 # Controls, quotes, and backslashes must not escape the compact JSON body or
 # create a second synthetic field when the shell interpolates it.
-python3 - <<'PY' | HOME="$fixture/home" PATH="$fixture/bin:/usr/bin:/bin" \
+python3 - <<'PY' | HOME="$fixture/home" PATH="$fixture/bin:$test_path" \
     PETDEX_CAPTURE="$fixture/capture" sh "$root/src/assets/petdex-remote-hook.sh" bubble assistant hermes
 import json
 import sys
@@ -84,7 +147,7 @@ PY
 # Hermes sessions.
 before=$(wc -l < "$fixture/capture")
 payload='{"session_id":"child","petdex_conversation_key":"parent","petdex_session_kind":"subagent","last_assistant_message":"noise"}'
-printf '%s' "$payload" | HOME="$fixture/home" PATH="$fixture/bin:/usr/bin:/bin" \
+printf '%s' "$payload" | HOME="$fixture/home" PATH="$fixture/bin:$test_path" \
     PETDEX_CAPTURE="$fixture/capture" sh "$root/src/assets/petdex-remote-hook.sh" bubble assistant hermes
 after=$(wc -l < "$fixture/capture")
 test "$before" -eq "$after"
@@ -125,7 +188,7 @@ rollout.write_text(
 PY
 before=$(wc -l < "$fixture/capture")
 payload='{"session_id":"00000000-0000-0000-0000-000000000002","last_assistant_message":"child done"}'
-printf '%s' "$payload" | HOME="$fixture/home" PATH="$fixture/bin:/usr/bin:/bin" \
+printf '%s' "$payload" | HOME="$fixture/home" PATH="$fixture/bin:$test_path" \
     PETDEX_CAPTURE="$fixture/capture" sh "$root/src/assets/petdex-remote-hook.sh" bubble stop codex
 after=$(wc -l < "$fixture/capture")
 test "$before" -eq "$after"


### PR DESCRIPTION
## Summary

Signed replacement for #738. Preserves Mison as the commit author and the exact validated tree while satisfying the default-branch signed-history rule.

- Bound CLI, native, and remote hook stdin handling when a host never sends EOF.
- Preserve explicit agent identity and single-server token ownership.
- Add Windows pipe/socket deadlines and cross-platform regressions.

Fixes #689.

## Validation

- Focused bubble runner: 46 passed
- DSH integration: 17 passed
- Remote hook regression: passed
- Root suite: 484 passed
- Biome and i18n: passed
- Production build: passed
- Tree matches the validated #738 merge result byte-for-byte