### PR TITLE
fix(desktop): stabilize multi-display input and drag placement

### DIFF
--- a/.github/workflows/desktop-native-ci.yml
+++ b/.github/workflows/desktop-native-ci.yml
@@ -941,11 +941,12 @@ jobs:
       # and ignores every mouse event, because the platform registers no
       # move_window_fn and all pet input is routed through it.
       #
-      # cuse drives real OS input (XTEST on X11, SendInput on Win32) and
-      # diffs the frames, so a pet that stops reacting fails here rather
-      # than reaching a user. The assertion is deliberately the CHANGED
-      # frame: a tap flips the pet between jumping and waving, and only
-      # a click that actually reached the window can produce that.
+      # cuse drives real OS input (XTEST on X11, SendInput on Win32). The
+      # click assertion uses a frame change because a tap flips the pet
+      # between jumping and waving. Dragging is asserted separately from
+      # the window's reported geometry: animation can change pixels even
+      # when the window never moved, so a screenshot diff is not evidence
+      # of a successful drag.
       # Not blocking on Linux yet: cuse cannot enumerate windows on a
       # bare X11 display (crafter-agents/cuse#65), so that leg cannot aim
       # a click even though xwininfo sees the window in the same job.
@@ -959,7 +960,7 @@ jobs:
         shell: bash
         working-directory: packages/petdex-desktop-native
         env:
-          CUSE_REF: fa387098481758959561d89b57b6428a27497ce3
+          CUSE_REF: 0ade4f9795f0ee8a49f0c2c0401c3ef0bdace0a4
         run: |
           set -euo pipefail
 
@@ -1039,7 +1040,57 @@ jobs:
               target=(--window="$title")
               ;;
             windows)
-              target=(112 210)
+              geometry() {
+                # Petdex is a transparent, chromeless window. Windows UI
+                # Automation (which backs cuse windows) does not expose that
+                # surface reliably, so query the process-owned Win32 window
+                # directly. GetWindowRect reports the same physical screen
+                # coordinates that SendInput and the GDI screenshot use.
+                powershell.exe -NoProfile -NonInteractive -Command '
+                  $source = "using System;using System.Runtime.InteropServices;public static class PetdexGeometry { [StructLayout(LayoutKind.Sequential)] public struct Rect { public int Left; public int Top; public int Right; public int Bottom; } [DllImport(`"user32.dll`", SetLastError = true)] public static extern bool GetWindowRect(IntPtr hWnd, out Rect rect); [DllImport(`"user32.dll`")] public static extern uint GetDpiForWindow(IntPtr hWnd); }"
+                  Add-Type $source
+                  $process = Get-Process -Name "petdex-desktop-native" -ErrorAction SilentlyContinue |
+                    Where-Object { -not $_.HasExited -and $_.MainWindowHandle -ne [IntPtr]::Zero } |
+                    Select-Object -First 1
+                  if ($null -eq $process) {
+                    Write-Error "FAIL: could not find the Petdex process window"
+                    exit 1
+                  }
+                  $process.Refresh()
+                  $rect = New-Object PetdexGeometry+Rect
+                  if (-not [PetdexGeometry]::GetWindowRect($process.MainWindowHandle, [ref]$rect)) {
+                    Write-Error "FAIL: GetWindowRect failed for the Petdex window"
+                    exit 1
+                  }
+                  [PSCustomObject]@{
+                    x = $rect.Left
+                    y = $rect.Top
+                    width = $rect.Right - $rect.Left
+                    height = $rect.Bottom - $rect.Top
+                    dpi = [PetdexGeometry]::GetDpiForWindow($process.MainWindowHandle)
+                  } | ConvertTo-Json -Compress
+                '
+              }
+              fit_geometry=$(geometry)
+              echo "fitted geometry: $fit_geometry"
+              FIT="$fit_geometry" bun -e '
+                const geometry = JSON.parse(process.env.FIT);
+                const dpi = Number(geometry.dpi) || 96;
+                const expectedWidth = Math.round(192 * 0.7 * dpi / 96);
+                const expectedHeight = Math.round(208 * 0.7 * dpi / 96);
+                const widthOk = Math.abs(geometry.width - expectedWidth) <= 3;
+                // The Win32 menu may contribute a caption-height strip to
+                // the outer rectangle; it must not hide a stale max canvas.
+                const heightOk = geometry.height >= expectedHeight - 3 && geometry.height <= expectedHeight + 48;
+                if (!widthOk || !heightOk) {
+                  console.error(`FAIL: Windows fit geometry is ${geometry.width}x${geometry.height}, expected content near ${expectedWidth}x${expectedHeight} at ${dpi} DPI`);
+                  process.exit(1);
+                }
+              '
+              target=($(FIT="$fit_geometry" bun -e '
+                const geometry = JSON.parse(process.env.FIT);
+                console.log(Math.round(geometry.x + geometry.width / 2), Math.round(geometry.y + geometry.height * 0.75));
+              '))
               ;;
           esac
 
@@ -1063,7 +1114,7 @@ jobs:
           esac
           if [ "${{ matrix.platform }}" = windows ]; then
             "${bin}" capture menu-before.png --json
-            "${bin}" click 112 210 --button=right --json
+            "${bin}" click "${target[@]}" --button=right --json
             sleep 1
             "${bin}" capture menu-open.png --json
             opened=$(verdict menu-before.png menu-open.png)
@@ -1082,20 +1133,38 @@ jobs:
               *) echo "FAIL: the context menu did not close"; exit 1 ;;
             esac
 
-            moved="SAME 0%"
+            moved=""
             for attempt in 1 2 3; do
               "${bin}" capture drag-before.png --json
-              "${bin}" drag 112 210 192 250 --json
+              before_geometry=$(geometry)
+              echo "drag attempt $attempt before: $before_geometry"
+              drag=($(BEFORE="$before_geometry" bun -e '
+                const geometry = JSON.parse(process.env.BEFORE);
+                const fromX = Math.round(geometry.x + geometry.width / 2);
+                const fromY = Math.round(geometry.y + geometry.height * 0.75);
+                console.log(fromX, fromY, fromX + 80, fromY + 40);
+              '))
+              "${bin}" drag "${drag[@]}" --json
               sleep 1
               "${bin}" capture drag-after.png --json
-              moved=$(verdict drag-before.png drag-after.png)
+              after_geometry=$(geometry)
+              echo "drag attempt $attempt after: $after_geometry"
+              moved=$(BEFORE="$before_geometry" AFTER="$after_geometry" bun -e '
+                const before = JSON.parse(process.env.BEFORE);
+                const after = JSON.parse(process.env.AFTER);
+                const dx = after.x - before.x;
+                const dy = after.y - before.y;
+                const moved = Math.max(Math.abs(dx), Math.abs(dy)) >= 20;
+                console.log(`${moved ? "MOVED" : "STATIONARY"} dx=${dx} dy=${dy}`);
+                if (!moved) process.exit(1);
+              ' 2>/dev/null || true)
               echo "drag attempt $attempt: $moved"
               case "$moved" in
-                CHANGED*) break ;;
+                MOVED*) break ;;
               esac
             done
             case "$moved" in
-              CHANGED*) ;;
+              MOVED*) ;;
               *) echo "FAIL: the pet did not move after a real drag"; exit 1 ;;
             esac
           fi

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -39,9 +39,12 @@ const canvas_label = "pet-canvas";
 const frame_w: f32 = 192;
 const frame_h: f32 = 208;
 const max_scale: f32 = 1.2;
-const win_w: f32 = frame_w * max_scale;
-const win_h: f32 = frame_h * max_scale;
 const pet_edge_pad: f32 = 8;
+const win_w: f32 = frame_w * max_scale;
+// Linux keeps the startup canvas fixed instead of resizing it to the sprite.
+// Reserve the bottom edge pad in that canvas so the largest supported sprite
+// still starts at y=0 rather than clipping its top rows.
+const win_h: f32 = frame_h * max_scale + (if (builtin.target.os.tag == .linux) pet_edge_pad else 0);
 const cols: u64 = 8;
 const sheet_image_id: u64 = 1;
 /// What a first run offers to download. Small, friendly, and already in
@@ -185,6 +188,15 @@ pub const Model = struct {
     /// the top of the screen for the expanded height to fit. Flipped,
     /// the front card is the TOP one and the stack grows downward.
     bubble_flipped: bool = false,
+    /// A constrained placement probe can prove that the above candidate is
+    /// outside the current display's visible frame. Keep that result until
+    /// the pet moves to another display/position or the bubble is resized;
+    /// otherwise every frame would try the rejected side again and cause
+    /// visible jitter at a monitor edge.
+    bubble_above_blocked: bool = false,
+    bubble_above_blocked_x: f64 = 0,
+    bubble_above_blocked_y: f64 = 0,
+    bubble_above_blocked_h: f32 = 0,
     // Drag + momentum, the old desktop's "Codex parity" physics: the
     // frame clock samples the window origin and the primary button
     // through fx.moveWindow(0,0); a down->up edge computes the release
@@ -409,13 +421,10 @@ pub const InstallState = struct {
     phase: InstallPhase = .idle,
     queue: [max_install_queue][64]u8 = @splat(@splat(0)),
     queue_len: [max_install_queue]usize = @splat(0),
+    activate: [max_install_queue]bool = @splat(false),
     queued: usize = 0,
     /// Index into `queue` of the pet being downloaded right now.
     current: usize = 0,
-    /// Set when the deep link was `petdex://<slug>` rather than
-    /// `petdex://install?…`: that form means "use this pet", so the
-    /// install activates it on completion.
-    activate_when_done: bool = false,
     /// Chosen once per install so pet.json and the spritesheet land
     /// under matching names (`spritesheet.png` vs `.webp`).
     ext_png: bool = false,
@@ -438,18 +447,47 @@ pub const InstallState = struct {
         return self.phase != .idle;
     }
 
+    pub fn currentActivates(self: *const InstallState) bool {
+        if (self.current >= self.queued) return false;
+        return self.activate[self.current];
+    }
+
     /// Copy a slug off a borrowed URL slice. Rejected slugs never enter
     /// the queue, so nothing downstream has to re-validate a path.
-    pub fn enqueue(self: *InstallState, slug: []const u8) bool {
-        if (self.queued >= max_install_queue) return false;
+    ///
+    /// A repeated request is merged rather than dropped. This matters
+    /// when a bare `petdex://slug` arrives while the same slug is already
+    /// downloading: the second request upgrades the existing work to an
+    /// activating request without starting a duplicate download.
+    pub fn enqueueRequest(self: *InstallState, slug: []const u8, activate: bool) bool {
         if (!installer.slugOk(slug)) return false;
         for (0..self.queued) |i| {
-            if (std.mem.eql(u8, self.queue[i][0..self.queue_len[i]], slug)) return false;
+            if (std.mem.eql(u8, self.queue[i][0..self.queue_len[i]], slug)) {
+                self.activate[i] = self.activate[i] or activate;
+                return true;
+            }
         }
+        if (self.queued >= max_install_queue) return false;
         @memcpy(self.queue[self.queued][0..slug.len], slug);
         self.queue_len[self.queued] = slug.len;
+        self.activate[self.queued] = activate;
         self.queued += 1;
         return true;
+    }
+
+    pub fn enqueue(self: *InstallState, slug: []const u8) bool {
+        return self.enqueueRequest(slug, false);
+    }
+
+    pub fn removeAt(self: *InstallState, index: usize) void {
+        if (index >= self.queued) return;
+        var i = index;
+        while (i + 1 < self.queued) : (i += 1) {
+            self.queue[i] = self.queue[i + 1];
+            self.queue_len[i] = self.queue_len[i + 1];
+            self.activate[i] = self.activate[i + 1];
+        }
+        self.queued -= 1;
     }
 
     pub fn setError(self: *InstallState, comptime fmt: []const u8, args: anytype) void {
@@ -673,6 +711,48 @@ const url_scheme_prefix = "petdex://";
 var pending_install: InstallState = .{};
 var pending_ready: bool = false;
 
+fn stagePendingInstall(slug: []const u8, activate: bool) bool {
+    if (!pending_install.enqueueRequest(slug, activate)) return false;
+    pending_ready = true;
+    return true;
+}
+
+/// Merge staged requests into the active queue without starting a second
+/// run. This is called from the app's update loop, so it is safe to append
+/// while a manifest or asset effect is in flight; `advanceInstallQueue`
+/// will visit the appended entries after the current one. If the active
+/// fixed-size queue is full, the unmerged tail stays staged for the next
+/// poll instead of being discarded.
+fn mergePendingInstall(model: *Model) ?u32 {
+    if (!pending_ready) return null;
+    var immediate_selection: ?u32 = null;
+    var i: usize = 0;
+    while (i < pending_install.queued) {
+        const slug = pending_install.queue[i][0..pending_install.queue_len[i]];
+        // A bare deep link means "use this pet". If the pet finished
+        // downloading between the URL callback and this merge, select the
+        // catalog entry instead of downloading it a second time. Explicit
+        // `petdex://install` requests keep their existing install semantics.
+        if (pending_install.activate[i]) {
+            if (catalogIndexOf(slug)) |index| {
+                immediate_selection = @intCast(index);
+                pending_install.removeAt(i);
+                continue;
+            }
+        }
+        if (!model.install.enqueueRequest(slug, pending_install.activate[i])) {
+            i += 1;
+            continue;
+        }
+        pending_install.removeAt(i);
+    }
+    if (pending_install.queued == 0) {
+        pending_install = .{};
+        pending_ready = false;
+    }
+    return immediate_selection;
+}
+
 /// `petdex://<slug>` selects a pet, installing it first when it is not
 /// on disk; `petdex://install?slug=a&slug=b` installs without
 /// selecting (petdex-desktop-link.ts builds both forms).
@@ -681,6 +761,8 @@ var pending_ready: bool = false;
 /// callback, so the common case keeps its immediate swap and never
 /// touches the network.
 fn onUrlsOpened(urls: []const []const u8) ?Msg {
+    var staged = false;
+    var immediate_selection: ?u32 = null;
     for (urls) |url| {
         if (!std.mem.startsWith(u8, url, url_scheme_prefix)) continue;
         const rest = url[url_scheme_prefix.len..];
@@ -688,29 +770,30 @@ fn onUrlsOpened(urls: []const []const u8) ?Msg {
 
         if (std.mem.eql(u8, host, "install")) {
             const query = std.mem.indexOfScalar(u8, rest, '?') orelse continue;
-            pending_install = .{};
             var it = std.mem.splitScalar(u8, rest[query + 1 ..], '&');
             while (it.next()) |pair| {
                 if (!std.mem.startsWith(u8, pair, "slug=")) continue;
                 var value = pair["slug=".len..];
                 if (std.mem.indexOfScalar(u8, value, '#')) |cut| value = value[0..cut];
-                _ = pending_install.enqueue(value);
+                staged = stagePendingInstall(value, false) or staged;
             }
-            if (pending_install.queued == 0) continue;
-            pending_install.activate_when_done = false;
-            pending_ready = true;
-            return .noop;
+            continue;
         }
 
         // NSURL hands back the absoluteString, and a bare host round
         // trips as `petdex://slug/`.
-        if (catalogIndexOf(host)) |index| return .{ .select_pet = @intCast(index) };
-        pending_install = .{};
-        if (!pending_install.enqueue(host)) continue;
-        pending_install.activate_when_done = true;
-        pending_ready = true;
-        return .noop;
+        if (catalogIndexOf(host)) |index| {
+            // Process every URL in the callback. If a batch contains
+            // both an already-installed pet and a new one, the immediate
+            // selection is returned while the new install remains staged.
+            immediate_selection = @intCast(index);
+            continue;
+        }
+        staged = stagePendingInstall(host, true) or staged;
     }
+
+    if (immediate_selection) |index| return .{ .select_pet = index };
+    if (staged) return .noop;
     return null;
 }
 
@@ -718,14 +801,15 @@ fn onUrlsOpened(urls: []const []const u8) ?Msg {
 /// `update`, the first place with an `fx` to spawn on.
 fn drainPendingInstall(model: *Model, fx: *Effects) void {
     if (!pending_ready) return;
-    pending_ready = false;
-    if (model.install.busy()) return;
-    const activate = pending_install.activate_when_done;
-    model.install.queued = 0;
-    for (0..pending_install.queued) |i| {
-        _ = model.install.enqueue(pending_install.queue[i][0..pending_install.queue_len[i]]);
+    const immediate_selection = mergePendingInstall(model);
+    if (immediate_selection) |index| {
+        update(model, .{ .select_pet = index }, fx);
     }
-    model.install.activate_when_done = activate;
+    // The staged entries are now part of the active queue. Do not reset or
+    // restart it while an effect is still running; the next poll will retry
+    // only any tail that did not fit.
+    if (model.install.busy()) return;
+    if (model.install.queued == 0) return;
     startInstallQueue(model, fx);
     // A deep-link install arrives from the browser with no Petdex window
     // in front of the user, so the progress banner would render into a
@@ -1945,8 +2029,7 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             // takes the identical path.
             if (model.install.busy()) return;
             model.install.error_len = 0;
-            _ = model.install.enqueue(default_pet_slug);
-            model.install.activate_when_done = true;
+            _ = model.install.enqueueRequest(default_pet_slug, true);
             startInstallQueue(model, fx);
         },
         .manifest_done => |exit| {
@@ -1989,7 +2072,7 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             // thumbnail pass picks it up the next time settings is open.
             const index = catalogAppend(slug, model.active_pet);
             thumbs_built = @min(thumbs_built, catalog_mod.catalog_len);
-            if (model.install.activate_when_done) {
+            if (model.install.currentActivates()) {
                 if (index) |i| {
                     // Deliberately routed through the same Msg the
                     // settings list uses, so activation after an install
@@ -2601,7 +2684,7 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             else
                 read.x;
             const pet_y = if (builtin.target.os.tag == .linux)
-                read.y + @as(f64, win_h - pet_edge_pad) - pet_h
+                read.y + @as(f64, linuxPetTopLocal(model.scale))
             else
                 read.y;
             const inside = read.cursor_x >= pet_x and read.cursor_x <= pet_x + pet_w and
@@ -2673,6 +2756,12 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
                 }
             }
             _ = expireBubbles(model, now);
+            // A newly drained bubble is declared as a popup in the same
+            // update pass. Compute Linux's side after expiry and before
+            // that declaration so the first rendered frame uses the same
+            // orientation as the compositor anchor, rather than showing a
+            // flipped tail for one frame until the next frame-clock tick.
+            if (builtin.target.os.tag == .linux and bubbleActive(model)) syncBubbleWindow(model, fx);
             if (model.waiting_sound and shouldEscalate(model.state, model.waiting_since_ms, model.waiting_escalated, now)) {
                 model.waiting_escalated = true;
                 playWaitingChime(fx);
@@ -3406,6 +3495,7 @@ fn clearBubble(model: *Model) void {
     model.bubbles = @splat(.{});
     model.bubbles_len = 0;
     model.bubble_expires_at_ms = @splat(-1);
+    model.bubble_above_blocked = false;
     hook_server.mailbox.clearBubbles();
 }
 
@@ -3560,6 +3650,16 @@ const BubbleMovePlan = struct {
     dy: f64,
 };
 
+const bubble_probe_position_epsilon: f64 = 4;
+
+fn bubbleAboveProbeStale(model: *const Model, bubble_h: f32) bool {
+    if (!model.bubble_above_blocked) return false;
+    if (@abs(model.pet_x - model.bubble_above_blocked_x) > bubble_probe_position_epsilon) return true;
+    if (@abs(model.pet_y - model.bubble_above_blocked_y) > bubble_probe_position_epsilon) return true;
+    if (@abs(bubble_h - model.bubble_above_blocked_h) > 0.5) return true;
+    return false;
+}
+
 /// Calculate a global-coordinate move without applying a display clamp.
 /// The caller applies the destination display's visible-frame constraint
 /// only after this move has crossed any monitor boundary.
@@ -3578,15 +3678,100 @@ fn bubbleClampCorrection(actual_x: f64, actual_y: f64, settled_x: f64, settled_y
     return bubbleMovePlan(actual_x, actual_y, settled_x, settled_y);
 }
 
+/// Apply the destination display's visible-frame clamp and reconcile hosts
+/// that report the clamped origin without moving the actual window. The
+/// probe is also used when the bubble is already at its target: taskbar,
+/// display-layout, and display-scale changes can invalidate a previously
+/// valid origin without changing the requested coordinates.
+fn settleBubbleWindow(model: *Model, fx: *Effects, bubble_h: f32, want_x: f64) bool {
+    var settled = fx.moveWindow("bubble", 0, 0, true) orelse return false;
+    var actual = fx.moveWindow("bubble", 0, 0, false) orelse return false;
+    // A negative global y is valid on a monitor above the primary screen,
+    // so the initial direction deliberately stays above. If the above
+    // candidate is clipped by the destination display, flip below and make
+    // a second bounded pass.
+    if (!model.bubble_flipped and settled.hit_y) {
+        model.bubble_flipped = true;
+        model.bubble_above_blocked = true;
+        model.bubble_above_blocked_x = model.pet_x;
+        model.bubble_above_blocked_y = model.pet_y;
+        model.bubble_above_blocked_h = bubble_h;
+        const flipped_y = bubbleWantY(model, bubble_h);
+        if (bubbleMovePlan(actual.x, actual.y, want_x, flipped_y)) |flip_plan| {
+            _ = fx.moveWindow("bubble", flip_plan.dx, flip_plan.dy, false) orelse return false;
+        }
+        // Re-probe even when the flipped target is already at the current
+        // origin; the display may still clamp the candidate after the side
+        // changes, and the readback must describe that final placement.
+        settled = fx.moveWindow("bubble", 0, 0, true) orelse return false;
+        actual = fx.moveWindow("bubble", 0, 0, false) orelse return false;
+    }
+    if (!model.bubble_flipped and !settled.hit_y) model.bubble_above_blocked = false;
+    if (bubbleClampCorrection(actual.x, actual.y, settled.x, settled.y)) |correction| {
+        const corrected = fx.moveWindow("bubble", correction.dx, correction.dy, false) orelse return false;
+        recordPetCenterLocal(model, corrected.x);
+    } else {
+        recordPetCenterLocal(model, actual.x);
+    }
+    return true;
+}
+
+/// The Linux pet is drawn inside the fixed startup canvas rather than
+/// resizing the toplevel to the sprite. Keep the canvas-local pet origin in
+/// one helper so bubble anchoring and pointer hit testing use the same
+/// geometry at every scale.
+fn linuxPetTopLocal(scale: f32) f32 {
+    return win_h - pet_edge_pad - frame_h * scale;
+}
+
+/// GtkPopover's GTK_POS_TOP placement puts the popup above the pointing
+/// rectangle. The descriptor therefore supplies the rectangle edge, not the
+/// popup top: above the pet the rectangle is the pet top minus the clearance;
+/// below it is the pet bottom plus clearance plus the popup height. The
+/// previous code supplied the pet edge for both cases, which made GTK choose
+/// the wrong side and cover the sprite on the X11/GTK path.
+fn linuxBubbleAnchorY(scale: f32, flipped: bool, bubble_h: f32) f32 {
+    const pet_top = linuxPetTopLocal(scale);
+    const pet_bottom = win_h - pet_edge_pad;
+    const clearance: f32 = @floatCast(bubble_pet_clearance);
+    return if (flipped)
+        pet_bottom + clearance + bubble_h
+    else
+        // A scale at the edge of the fixed canvas can leave less than the
+        // clearance above the sprite. Keep the GTK pointing rectangle inside
+        // the parent surface; the side selector flips below when the global
+        // display has no room above, while a monitor above the primary screen
+        // may still legitimately use the zero-edge anchor.
+        @max(@as(f32, 0), pet_top - clearance);
+}
+
+/// Return the pet's actual global top edge for side selection. On Linux the
+/// model position is the fixed canvas origin, not the sprite origin.
+fn bubblePetTopY(model: *const Model) f64 {
+    if (builtin.target.os.tag == .linux)
+        return model.pet_y + @as(f64, @floatCast(linuxPetTopLocal(model.scale)));
+    return model.pet_y;
+}
+
 /// Keep the bubble window glued above the pet and sized to its content:
 /// read both origins and close the gap. Self-correcting, so drags,
 /// throws, scale changes, and text-size changes all need no
 /// special-casing.
 fn syncBubbleWindow(model: *Model, fx: *Effects) void {
+    if (!bubbleActive(model)) {
+        model.bubble_above_blocked = false;
+        return;
+    }
+    const bubble_h = bubbleWindowHeight(model);
     // Linux uses a parent-local compositor popup. Its descriptor drives
     // size and anchoring, so application-side global moves are both
-    // unnecessary and invalid on Wayland.
-    if (builtin.target.os.tag == .linux or !bubbleActive(model)) return;
+    // unnecessary and invalid on Wayland. The side decision still belongs
+    // here so petdexWindows can publish the correct local anchor on the
+    // next reconciliation pass.
+    if (builtin.target.os.tag == .linux) {
+        model.bubble_flipped = bubbleShouldFlip(model, bubblePetTopY(model), @floatCast(bubble_h));
+        return;
+    }
     // The flip is decided HERE, in the function that consumes it, rather
     // than by each caller beforehand. bubbleWantY below reads the flag,
     // so a caller that moved the pet and forgot to refresh it first would
@@ -3594,9 +3779,12 @@ fn syncBubbleWindow(model: *Model, fx: *Effects) void {
     // what the throw branch did: it drives its own moveWindow and returns
     // before the cursor poll, so it never reached the frame clock's
     // update and flew the whole arc with a stale flag.
-    model.bubble_flipped = bubbleShouldFlip(model, model.pet_y, @floatCast(bubbleWindowHeight(model)));
     const bubble_w = bubbleWindowWidth(model);
-    const bubble_h = bubbleWindowHeight(model);
+    if (bubbleAboveProbeStale(model, bubble_h)) model.bubble_above_blocked = false;
+    model.bubble_flipped = if (model.bubble_above_blocked)
+        true
+    else
+        bubbleShouldFlip(model, bubblePetTopY(model), @floatCast(bubble_h));
     // Resize before moving: the move centers on the new width, so doing
     // it the other way round centers on the old one and leaves the
     // bubble offset by half the delta.
@@ -3614,24 +3802,11 @@ fn syncBubbleWindow(model: *Model, fx: *Effects) void {
         // window. It cannot be used for the first leg of a cross-display
         // move: the bubble would remain trapped on the old display.
         _ = fx.moveWindow("bubble", plan.dx, plan.dy, false) orelse return;
-        // The global move has reached the target display. A zero-distance
-        // constrained move now lets that display apply its visible-frame
-        // correction, including negative coordinates and taskbar insets.
-        const settled = fx.moveWindow("bubble", 0, 0, true) orelse return;
-        // The pre-fix macOS host returned the clamped origin here but did
-        // not call setFrameOrigin when dx/dy were zero. Read the actual
-        // origin back and reconcile that legacy behavior explicitly; this
-        // also makes the app robust while an SDK fix is rolling out.
-        const actual = fx.moveWindow("bubble", 0, 0, false) orelse return;
-        if (bubbleClampCorrection(actual.x, actual.y, settled.x, settled.y)) |correction| {
-            const corrected = fx.moveWindow("bubble", correction.dx, correction.dy, false) orelse return;
-            recordPetCenterLocal(model, corrected.x);
-        } else {
-            recordPetCenterLocal(model, actual.x);
-        }
-        return;
     }
-    recordPetCenterLocal(model, cur.x);
+    // Always run the constrained probe, including a zero-distance target:
+    // taskbar/display-layout changes can invalidate an otherwise unchanged
+    // origin and must be reconciled before recording the local anchor.
+    if (!settleBubbleWindow(model, fx, bubble_h, want_x)) return;
 }
 
 /// Project the pet's center into the stack container's coordinates.
@@ -3668,6 +3843,11 @@ fn bubbleWantY(model: *const Model, bubble_h: f32) f64 {
 /// that threshold plus a margin to come back up.
 fn bubbleShouldFlip(model: *const Model, space_above: f64, needed: f64) bool {
     const required = needed + bubble_pet_clearance;
+    // Screen coordinates are global across the desktop. A monitor above
+    // the primary screen legitimately reports negative y, which is not
+    // evidence that there is no room above the pet. The destination
+    // monitor's constrained move supplies that fact through hit_y.
+    if (space_above < 0) return false;
     if (model.bubble_flipped) return space_above < required + bubble_flip_hysteresis;
     return space_above < required;
 }
@@ -4002,7 +4182,12 @@ fn petdexWindows(model: *const Model, scratch: *PetdexApp.WindowsScratch) []cons
         const bubble_w = bubbleWindowWidth(model);
         const bubble_h = bubbleWindowHeight(model);
         if (comptime builtin.target.os.tag == .linux) {
-            const pet_h = frame_h * model.scale;
+            // A popup is created before the next frame-clock sync can
+            // update `model.bubble_flipped`. Decide the initial side from
+            // the current geometry here as well; otherwise a pet near the
+            // top creates a GTK popover with a negative anchor, which the
+            // compositor maps off-screen and leaves at its 1px minimum.
+            const linux_flipped = bubbleShouldFlip(model, bubblePetTopY(model), @floatCast(bubble_h));
             scratch.windows[count] = .{
                 .label = "bubble",
                 .canvas_label = "bubble-canvas",
@@ -4010,7 +4195,10 @@ fn petdexWindows(model: *const Model, scratch: *PetdexApp.WindowsScratch) []cons
                 .width = bubble_w,
                 .height = bubble_h,
                 .x = win_w / 2,
-                .y = win_h - pet_edge_pad - pet_h,
+                // GTK_POS_TOP places the popup above its pointing
+                // rectangle. Supply a side-aware rectangle edge so the
+                // compositor never places the bubble over the sprite.
+                .y = linuxBubbleAnchorY(model.scale, linux_flipped, bubble_h),
                 .resizable = false,
                 .titlebar = .chromeless,
                 .floating = true,
@@ -4381,6 +4569,100 @@ test "activating index 0 works before any sheet is loaded" {
     const would_skip_now = 0 == fresh.active_pet and fresh.sheet_loaded;
     try std.testing.expect(would_skip_before);
     try std.testing.expect(!would_skip_now);
+}
+
+test "deep-link install requests merge into a busy queue" {
+    // URL callbacks can arrive while a manifest or asset download is in
+    // flight. New requests must join the active run without resetting its
+    // current item or dropping the activation bit for any queued pet.
+    pending_install = .{};
+    pending_ready = false;
+    defer {
+        pending_install = .{};
+        pending_ready = false;
+    }
+
+    _ = onUrlsOpened(&.{"petdex://install?slug=queue-a"});
+    _ = onUrlsOpened(&.{"petdex://queue-b"});
+    try std.testing.expect(pending_ready);
+    try std.testing.expectEqual(@as(usize, 2), pending_install.queued);
+    try std.testing.expect(!pending_install.activate[0]);
+    try std.testing.expect(pending_install.activate[1]);
+
+    var model: Model = .{};
+    try std.testing.expect(model.install.enqueueRequest("active", false));
+    model.install.phase = .manifest;
+    try std.testing.expect(mergePendingInstall(&model) == null);
+    try std.testing.expect(!pending_ready);
+    try std.testing.expectEqual(@as(usize, 3), model.install.queued);
+    try std.testing.expectEqualStrings("active", model.install.queue[0][0..model.install.queue_len[0]]);
+    try std.testing.expectEqualStrings("queue-a", model.install.queue[1][0..model.install.queue_len[1]]);
+    try std.testing.expectEqualStrings("queue-b", model.install.queue[2][0..model.install.queue_len[2]]);
+    try std.testing.expect(!model.install.activate[0]);
+    try std.testing.expect(!model.install.activate[1]);
+    try std.testing.expect(model.install.activate[2]);
+
+    // A full active queue may only consume the prefix that fits. The
+    // remaining staged tail keeps the ready signal until the next poll.
+    pending_install = .{};
+    pending_ready = false;
+    _ = onUrlsOpened(&.{"petdex://install?slug=queue-c&slug=queue-d"});
+    var full_model: Model = .{};
+    for (0..max_install_queue - 1) |i| {
+        var slug_buf: [16]u8 = undefined;
+        const slug = std.fmt.bufPrint(&slug_buf, "active-{d}", .{i}) catch unreachable;
+        try std.testing.expect(full_model.install.enqueue(slug));
+    }
+    full_model.install.phase = .spritesheet;
+    try std.testing.expect(mergePendingInstall(&full_model) == null);
+    try std.testing.expectEqual(@as(usize, 1), pending_install.queued);
+    try std.testing.expect(pending_ready);
+    try std.testing.expectEqualStrings("queue-d", pending_install.queue[0][0..pending_install.queue_len[0]]);
+    try std.testing.expectEqual(@as(usize, max_install_queue), full_model.install.queued);
+
+    full_model.install.removeAt(0);
+    try std.testing.expect(mergePendingInstall(&full_model) == null);
+    try std.testing.expect(!pending_ready);
+    try std.testing.expectEqual(@as(usize, max_install_queue), full_model.install.queued);
+    try std.testing.expectEqualStrings("queue-d", full_model.install.queue[max_install_queue - 1][0..full_model.install.queue_len[max_install_queue - 1]]);
+}
+
+test "deep-link install requests merge duplicates and process URL batches" {
+    pending_install = .{};
+    pending_ready = false;
+    defer {
+        pending_install = .{};
+        pending_ready = false;
+    }
+
+    const urls = [_][]const u8{
+        "petdex://install?slug=queue-a&slug=queue-c",
+        "petdex://queue-a",
+    };
+    _ = onUrlsOpened(&urls);
+
+    // The duplicate `queue-a` is one install, upgraded to activation by
+    // the bare link. The second slug in the same callback is retained.
+    try std.testing.expectEqual(@as(usize, 2), pending_install.queued);
+    try std.testing.expectEqualStrings("queue-a", pending_install.queue[0][0..pending_install.queue_len[0]]);
+    try std.testing.expect(pending_install.activate[0]);
+    try std.testing.expectEqualStrings("queue-c", pending_install.queue[1][0..pending_install.queue_len[1]]);
+    try std.testing.expect(!pending_install.activate[1]);
+}
+
+test "install queue keeps activation per pet" {
+    var queue: InstallState = .{};
+    try std.testing.expect(queue.enqueueRequest("queue-a", false));
+    try std.testing.expect(queue.enqueueRequest("queue-b", true));
+    try std.testing.expect(queue.enqueueRequest("queue-c", false));
+    try std.testing.expect(queue.enqueueRequest("queue-a", true));
+    try std.testing.expectEqual(@as(usize, 3), queue.queued);
+    try std.testing.expect(queue.currentActivates());
+    queue.current = 1;
+    try std.testing.expect(queue.currentActivates());
+    queue.current = 2;
+    try std.testing.expect(!queue.currentActivates());
+    try std.testing.expect(queue.activate[0]);
 }
 
 test "empty-state copy fits the pet window" {
@@ -4925,6 +5207,31 @@ test "flipping sends the stack below the pet, clear of the sprite" {
     try std.testing.expect(bubbleWantY(&high, bubble_h) + @as(f64, @floatCast(bubble_h)) <= high.pet_y - bubble_pet_clearance + 0.01);
 }
 
+test "linux popup anchors clear the fixed canvas pet on both sides" {
+    const scale: f32 = 1;
+    const bubble_h: f32 = 115;
+    const pet_top = linuxPetTopLocal(scale);
+    const pet_bottom = win_h - pet_edge_pad;
+
+    const above = linuxBubbleAnchorY(scale, false, bubble_h);
+    try std.testing.expectApproxEqAbs(pet_top - @as(f32, @floatCast(bubble_pet_clearance)), above, 0.001);
+    try std.testing.expect(above <= pet_top - @as(f32, @floatCast(bubble_pet_clearance)) + 0.001);
+
+    const below = linuxBubbleAnchorY(scale, true, bubble_h);
+    try std.testing.expectApproxEqAbs(pet_bottom + @as(f32, @floatCast(bubble_pet_clearance)) + bubble_h, below, 0.001);
+    try std.testing.expect(below - bubble_h >= pet_bottom + @as(f32, @floatCast(bubble_pet_clearance)) - 0.001);
+
+    // The fixed Linux canvas keeps its bottom edge stable when the sprite is
+    // scaled; the above-side anchor follows the sprite's top edge.
+    const larger_above = linuxBubbleAnchorY(max_scale, false, bubble_h);
+    try std.testing.expect(larger_above < above);
+    try std.testing.expectEqual(below, linuxBubbleAnchorY(max_scale, true, bubble_h));
+    if (builtin.target.os.tag == .linux) {
+        try std.testing.expect(linuxPetTopLocal(max_scale) >= 0);
+        try std.testing.expect(linuxBubbleAnchorY(max_scale, false, bubble_h) >= 0);
+    }
+}
+
 test "the flip has hysteresis so a pet on the threshold does not flap" {
     var model: Model = .{};
     testPushBubble(&model, "alpha", "older", false, -1);
@@ -4943,6 +5250,38 @@ test "the flip has hysteresis so a pet on the threshold does not flap" {
     model.bubble_flipped = true;
     try std.testing.expect(bubbleShouldFlip(&model, needed + bubble_pet_clearance + bubble_flip_hysteresis - 1, needed));
     try std.testing.expect(!bubbleShouldFlip(&model, needed + bubble_pet_clearance + bubble_flip_hysteresis + 1, needed));
+}
+
+test "a pet above the primary screen keeps the first bubble candidate above" {
+    var model: Model = .{};
+    model.pet_y = -640;
+    model.bubble_flipped = false;
+    const needed: f64 = @floatCast(bubbleWindowHeight(&model));
+
+    // The host reports negative top-left y coordinates for monitors above
+    // the primary screen. The first candidate must therefore be above; the
+    // later clamp probe will flip it below only when that monitor has no
+    // room for the expanded bubble.
+    try std.testing.expect(!bubbleShouldFlip(&model, model.pet_y, needed));
+    model.bubble_flipped = true;
+    try std.testing.expect(!bubbleShouldFlip(&model, model.pet_y, needed));
+}
+
+test "a blocked above probe stays sticky until position or size changes" {
+    var model: Model = .{};
+    model.bubble_above_blocked = true;
+    model.bubble_above_blocked_x = 100;
+    model.bubble_above_blocked_y = -640;
+    model.bubble_above_blocked_h = 300;
+    model.pet_x = 100;
+    model.pet_y = -640;
+    try std.testing.expect(!bubbleAboveProbeStale(&model, 300));
+    model.pet_x += bubble_probe_position_epsilon + 1;
+    try std.testing.expect(bubbleAboveProbeStale(&model, 300));
+    model.pet_x = 100;
+    model.pet_y = -640;
+    try std.testing.expect(!bubbleAboveProbeStale(&model, 300));
+    try std.testing.expect(bubbleAboveProbeStale(&model, 301));
 }
 
 test "a flipped stack grows downward and is hit tested from the top" {
@@ -5066,15 +5405,26 @@ test "bubble movement crosses displays before applying target bounds" {
     const src = @embedFile("main.zig");
     const sync_start = std.mem.indexOf(u8, src, "fn syncBubbleWindow").?;
     const sync = src[sync_start..];
+    const settle_start = std.mem.indexOf(u8, src, "fn settleBubbleWindow").?;
+    const settle = src[settle_start..sync_start];
     const unbounded = std.mem.indexOf(u8, sync, "fx.moveWindow(\"bubble\", plan.dx, plan.dy, false)");
-    const bounded = std.mem.indexOf(u8, sync, "fx.moveWindow(\"bubble\", 0, 0, true)");
-    const readback = std.mem.indexOf(u8, sync, "const actual = fx.moveWindow(\"bubble\", 0, 0, false)");
-    const correction = std.mem.indexOf(u8, sync, "fx.moveWindow(\"bubble\", correction.dx, correction.dy, false)");
+    const sync_settle = std.mem.indexOf(u8, sync, "settleBubbleWindow(model, fx, bubble_h, want_x)");
+    // Search for comments rather than line-oriented snippets. Git for
+    // Windows may check this source out with CRLF, while macOS/Linux use
+    // LF; the ordering assertions must be independent of that EOL policy.
+    const no_move_boundary = std.mem.indexOf(u8, sync, "// Always run the constrained probe");
+    const flip_reprobe = std.mem.indexOf(u8, settle, "// Re-probe even when the flipped target");
+    const bounded = std.mem.indexOf(u8, settle, "fx.moveWindow(\"bubble\", 0, 0, true)");
+    const readback = std.mem.indexOf(u8, settle, "var actual = fx.moveWindow(\"bubble\", 0, 0, false)");
+    const correction = std.mem.indexOf(u8, settle, "fx.moveWindow(\"bubble\", correction.dx, correction.dy, false)");
     try std.testing.expect(unbounded != null);
+    try std.testing.expect(sync_settle != null);
+    try std.testing.expect(no_move_boundary != null);
+    try std.testing.expect(sync_settle.? > no_move_boundary.?);
+    try std.testing.expect(flip_reprobe != null);
     try std.testing.expect(bounded != null);
     try std.testing.expect(readback != null);
     try std.testing.expect(correction != null);
-    try std.testing.expect(unbounded.? < bounded.?);
     try std.testing.expect(bounded.? < readback.?);
     try std.testing.expect(readback.? < correction.?);
 }

--- a/patches/native-sdk-windows-pet-input.patch
+++ b/patches/native-sdk-windows-pet-input.patch
@@ -1,15 +1,37 @@
 diff --git a/src/platform/windows/root.zig b/src/platform/windows/root.zig
-index 7debdf9..0843612 100644
+index 7debdf9..346cc4c 100644
 --- a/src/platform/windows/root.zig
 +++ b/src/platform/windows/root.zig
-@@ -36,0 +37 @@ const WindowsEventKind = enum(c_int) {
+@@ -34,6 +34,7 @@ const WindowsEventKind = enum(c_int) {
+     appearance = 17,
+     audio = 18,
+     urls_opened = 19,
 +    context_menu_action = 20,
-@@ -104,0 +106,2 @@ const WindowsEvent = extern struct {
+ };
+ 
+ const WindowsEvent = extern struct {
+@@ -102,6 +103,8 @@ const WindowsEvent = extern struct {
+     /// NUL-separated, reusing the drop-path wire shape.
+     open_urls: [*]const u8,
+     open_urls_len: usize,
 +    widget_id: u64,
 +    menu_item_id: u32,
-@@ -133,0 +137 @@ extern fn native_sdk_windows_create_window(host: *WindowsHost, window_id: u64, w
+ };
+ 
+ const WindowsCallback = *const fn (context: ?*anyopaque, event: *const WindowsEvent) callconv(.c) void;
+@@ -131,6 +134,8 @@ extern fn native_sdk_windows_set_security_policy(host: *WindowsHost, allowed_ori
+ extern fn native_sdk_windows_set_menus(host: *WindowsHost, menu_titles: [*]const [*]const u8, menu_title_lens: [*]const usize, menu_count: usize, item_menu_indices: [*]const u32, item_labels: [*]const [*]const u8, item_label_lens: [*]const usize, item_commands: [*]const [*]const u8, item_command_lens: [*]const usize, item_keys: [*]const [*]const u8, item_key_lens: [*]const usize, item_modifiers: [*]const u32, item_separators: [*]const c_int, item_enabled: [*]const c_int, item_checked: [*]const c_int, item_count: usize) void;
+ extern fn native_sdk_windows_set_shortcuts(host: *WindowsHost, ids: [*]const [*]const u8, id_lens: [*]const usize, keys: [*]const [*]const u8, key_lens: [*]const usize, modifiers: [*]const u32, count: usize) void;
+ extern fn native_sdk_windows_create_window(host: *WindowsHost, window_id: u64, window_title: [*]const u8, window_title_len: usize, window_label: [*]const u8, window_label_len: usize, x: f64, y: f64, width: f64, height: f64, restore_frame: c_int, resizable: c_int, titlebar_style: c_int, window_flags: c_int, min_width: f64, min_height: f64) c_int;
 +extern fn native_sdk_windows_move_window(host: *WindowsHost, window_id: u64, dx: f64, dy: f64, clamp: c_int, out_x: *f64, out_y: *f64, out_hit_x: *c_int, out_hit_y: *c_int, out_primary_down: *c_int, out_cursor_x: *f64, out_cursor_y: *f64) c_int;
-@@ -182,0 +187,9 @@ extern fn native_sdk_windows_audio_spectrum_supported(host: *WindowsHost) c_int;
++extern fn native_sdk_windows_resize_window(host: *WindowsHost, window_id: u64, width: f64, height: f64, anchor_bottom_center: c_int) c_int;
+ extern fn native_sdk_windows_start_window_drag(host: *WindowsHost, window_id: u64) c_int;
+ extern fn native_sdk_windows_set_window_drag_regions(host: *WindowsHost, window_id: u64, label: [*]const u8, label_len: usize, rects: [*]const f64, exclusions: [*]const c_int, count: usize) c_int;
+ extern fn native_sdk_windows_window_chrome(host: *WindowsHost, window_id: u64, top: *f64, left: *f64, bottom: *f64, right: *f64, buttons_x: *f64, buttons_y: *f64, buttons_width: *f64, buttons_height: *f64) c_int;
+@@ -180,6 +185,15 @@ extern fn native_sdk_windows_audio_stop(host: *WindowsHost) c_int;
+ extern fn native_sdk_windows_audio_seek(host: *WindowsHost, position_ms: u64) c_int;
+ extern fn native_sdk_windows_audio_set_volume(host: *WindowsHost, volume: f64) c_int;
+ extern fn native_sdk_windows_audio_spectrum_supported(host: *WindowsHost) c_int;
 +extern fn native_sdk_windows_show_context_menu(host: *WindowsHost, window_id: u64, label: [*]const u8, label_len: usize, x: f64, y: f64, token: u64, items: [*]const WindowsContextMenuItem, count: usize) c_int;
 +
 +const WindowsContextMenuItem = extern struct {
@@ -19,22 +41,53 @@ index 7debdf9..0843612 100644
 +    enabled: c_int,
 +    separator: c_int,
 +};
-@@ -283,0 +297 @@ pub const WindowsPlatform = struct {
+ 
+ const WindowsOpenDialogOpts = extern struct {
+     title: [*]const u8,
+@@ -281,6 +295,8 @@ pub const WindowsPlatform = struct {
+                 .create_window_fn = createWindow,
+                 .focus_window_fn = focusWindow,
+                 .close_window_fn = closeWindow,
 +                .move_window_fn = moveWindow,
-@@ -296,0 +311 @@ pub const WindowsPlatform = struct {
++                .resize_window_fn = resizeWindow,
+                 .minimize_window_fn = minimizeWindow,
+                 .start_window_drag_fn = startWindowDrag,
+                 .set_window_drag_regions_fn = setWindowDragRegions,
+@@ -294,6 +310,7 @@ pub const WindowsPlatform = struct {
+                 .request_gpu_surface_frame_fn = requestGpuSurfaceFrame,
+                 .note_gpu_surface_input_fn = noteGpuSurfaceInput,
+                 .present_gpu_surface_pixels_fn = presentGpuSurfacePixels,
 +                .show_context_menu_fn = showContextMenu,
-@@ -371 +386,2 @@ pub const WindowsPlatform = struct {
+                 .create_webview_fn = createWebView,
+                 .set_webview_frame_fn = setWebViewFrame,
+                 .navigate_webview_fn = navigateWebView,
+@@ -368,7 +385,8 @@ pub const WindowsPlatform = struct {
+             // view-surface adoption are macOS-only today; Win32 keeps
+             // the engine's wheel physics (TrackPopupMenu is the natural
+             // future context-menu seam — the tray already uses it).
 -            .gpu_surface_scroll_drivers, .context_menus, .view_surface_adoption => false,
 +            .context_menus => self.web_engine == .system,
 +            .gpu_surface_scroll_drivers, .view_surface_adoption => false,
-@@ -532,0 +549,6 @@ fn windowsCallback(context: ?*anyopaque, event: *const WindowsEvent) callconv(.c
+         };
+     }
+ 
+@@ -530,6 +548,12 @@ fn windowsCallback(context: ?*anyopaque, event: *const WindowsEvent) callconv(.c
+             .buffering = event.audio_buffering != 0,
+             .bands = event.audio_bands,
+         } }),
 +        .context_menu_action => state.emit(.{ .context_menu_action = .{
 +            .window_id = event.window_id,
 +            .view_label = event.view_label[0..event.view_label_len],
 +            .token = event.widget_id,
 +            .item_id = event.menu_item_id,
 +        } }),
-@@ -746,0 +769,13 @@ fn focusWindow(context: ?*anyopaque, window_id: platform_mod.WindowId) anyerror!
+     }
+ }
+ 
+@@ -744,6 +768,24 @@ fn focusWindow(context: ?*anyopaque, window_id: platform_mod.WindowId) anyerror!
+     if (native_sdk_windows_focus_window(self.host, window_id) == 0) return error.FocusFailed;
+ }
+ 
 +fn moveWindow(context: ?*anyopaque, window_id: platform_mod.WindowId, dx: f64, dy: f64, clamp: bool) anyerror!platform_mod.MoveWindowResult {
 +    const self: *WindowsPlatform = @ptrCast(@alignCast(context.?));
 +    var out_x: f64 = 0;
@@ -48,7 +101,18 @@ index 7debdf9..0843612 100644
 +    return .{ .x = out_x, .y = out_y, .hit_x = out_hit_x != 0, .hit_y = out_hit_y != 0, .primary_down = out_primary != 0, .cursor_x = out_cursor_x, .cursor_y = out_cursor_y };
 +}
 +
-@@ -954,0 +990,17 @@ fn presentGpuSurfacePixels(context: ?*anyopaque, pixels: platform_mod.GpuSurface
++fn resizeWindow(context: ?*anyopaque, window_id: platform_mod.WindowId, width: f64, height: f64, anchor: platform_mod.WindowResizeAnchor) anyerror!void {
++    const self: *WindowsPlatform = @ptrCast(@alignCast(context.?));
++    if (native_sdk_windows_resize_window(self.host, window_id, width, height, if (anchor == .bottom_center) 1 else 0) == 0) return error.WindowNotFound;
++}
++
+ fn closeWindow(context: ?*anyopaque, window_id: platform_mod.WindowId) anyerror!void {
+     const self: *WindowsPlatform = @ptrCast(@alignCast(context.?));
+     if (native_sdk_windows_close_window(self.host, window_id) == 0) return error.CloseFailed;
+@@ -952,6 +994,23 @@ fn presentGpuSurfacePixels(context: ?*anyopaque, pixels: platform_mod.GpuSurface
+     ) == 0) return error.ViewNotFound;
+ }
+ 
 +fn showContextMenu(context: ?*anyopaque, request: platform_mod.ContextMenuRequest) anyerror!void {
 +    const self: *WindowsPlatform = @ptrCast(@alignCast(context.?));
 +    if (self.web_engine != .system) return error.UnsupportedService;
@@ -66,15 +130,33 @@ index 7debdf9..0843612 100644
 +    if (native_sdk_windows_show_context_menu(self.host, request.window_id, request.view_label.ptr, request.view_label.len, request.point.x, request.point.y, request.token, items[0..count].ptr, count) == 0) return error.WindowNotFound;
 +}
 +
+ fn createWebView(context: ?*anyopaque, options: platform_mod.WebViewOptions) anyerror!void {
+     const self: *WindowsPlatform = @ptrCast(@alignCast(context.?));
+     const frame = options.frame;
 diff --git a/src/platform/windows/webview2_host.cpp b/src/platform/windows/webview2_host.cpp
-index 4dd7ecd..24fd947 100644
+index 4dd7ecd..e50afae 100644
 --- a/src/platform/windows/webview2_host.cpp
 +++ b/src/platform/windows/webview2_host.cpp
-@@ -124,0 +125 @@ enum EventKind {
+@@ -122,6 +122,7 @@ enum EventKind {
+     kAppearance = 17,
+     kAudio = 18,
+     kUrlsOpened = 19,
 +    kContextMenuAction = 20,
-@@ -155,0 +157 @@ constexpr UINT kAudioSpectrumMessage = WM_APP + 46;
+ };
+ 
+ constexpr uint32_t kShortcutModifierPrimary = 1u << 0;
+@@ -153,6 +154,7 @@ constexpr UINT kAudioSessionMessage = WM_APP + 45;
+  * loop starves it far below the contract cadence, while posted messages
+  * keep their place in the queue. */
+ constexpr UINT kAudioSpectrumMessage = WM_APP + 46;
 +constexpr UINT kShowContextMenuMessage = WM_APP + 47;
-@@ -255,0 +258,10 @@ struct WindowsEvent {
+ constexpr const char *kAssetVirtualOrigin = "https://native-sdk-app.localhost";
+ 
+ /* COPYDATASTRUCT::dwData tag on the single-instance forward. dwData is
+@@ -253,6 +255,16 @@ struct WindowsEvent {
+      * NUL, so the separator stays unambiguous). */
+     const char *open_urls;
+     size_t open_urls_len;
 +    uint64_t widget_id;
 +    uint32_t menu_item_id;
 +};
@@ -85,12 +167,24 @@ index 4dd7ecd..24fd947 100644
 +    size_t label_len;
 +    int enabled;
 +    int separator;
-@@ -430,0 +443,4 @@ struct NativeView {
+ };
+ 
+ struct WindowsOpenDialogOpts {
+@@ -428,6 +440,10 @@ struct NativeView {
+     int gpu_nonblank = 0;
+     uint32_t gpu_sample_color = 0;
+     int gpu_pointer_down = 0;
 +    int gpu_primary_down = 0;
 +    int gpu_primary_latched = 0;
 +    double gpu_primary_x = 0;
 +    double gpu_primary_y = 0;
-@@ -563,0 +580,16 @@ struct AudioState {
+     double gpu_pointer_x = 0;
+     double gpu_pointer_y = 0;
+     WCHAR gpu_pending_high_surrogate = 0;
+@@ -561,6 +577,22 @@ struct AudioState {
+     std::shared_ptr<AudioDownloadCancel> download_cancel;
+ };
+ 
 +struct PendingContextMenu {
 +    bool active = false;
 +    uint64_t window_id = 0;
@@ -107,9 +201,21 @@ index 4dd7ecd..24fd947 100644
 +    std::vector<Item> items;
 +};
 +
-@@ -616,0 +649 @@ struct Host {
+ struct Host {
+     HINSTANCE instance = GetModuleHandleW(nullptr);
+     std::string app_name;
+@@ -614,6 +646,7 @@ struct Host {
+     std::string pending_forwarded_urls;
+     AudioState audio;
+     AudioSpectrumState spectrum;
 +    PendingContextMenu context_menu;
-@@ -2160,0 +2194,39 @@ static NativeView *gpuSurfaceViewForHwnd(Host *host, HWND hwnd) {
+     std::shared_ptr<HostLifetime> lifetime = std::make_shared<HostLifetime>();
+ };
+ 
+@@ -2158,6 +2191,45 @@ static NativeView *gpuSurfaceViewForHwnd(Host *host, HWND hwnd) {
+     return nullptr;
+ }
+ 
 +static void showAppContextMenu(Host *host, HWND hwnd) {
 +    if (!host || !host->context_menu.active) return;
 +    PendingContextMenu request = std::move(host->context_menu);
@@ -149,25 +255,120 @@ index 4dd7ecd..24fd947 100644
 +    PostMessageW(hwnd, WM_NULL, 0, 0);
 +}
 +
-@@ -2928,0 +3001,6 @@ static LRESULT CALLBACK gpuSurfaceProc(HWND hwnd, UINT message, WPARAM wparam, L
+ /* ------------------------------------------------------------------------
+  * Hidden-titlebar window chrome (the Win32 custom-frame pattern).
+  *
+@@ -2926,6 +2998,17 @@ static LRESULT CALLBACK gpuSurfaceProc(HWND hwnd, UINT message, WPARAM wparam, L
+             const double x = (double)(short)LOWORD(lparam) / scale;
+             const double y = (double)(short)HIWORD(lparam) / scale;
+             view->gpu_pointer_down = 1;
 +            if (message == WM_LBUTTONDOWN) {
 +                view->gpu_primary_down = 1;
-+                view->gpu_primary_latched = 2;
++                /* Keep three app polls alive: the first exposes the real
++                 * press point for hit testing, the second carries the
++                 * global endpoint while still pressed, and the third
++                 * reports release. Fast synthetic drags can deliver the
++                 * whole gesture before the runtime's first poll. */
++                view->gpu_primary_latched = 3;
 +                view->gpu_primary_x = x;
 +                view->gpu_primary_y = y;
 +            }
-@@ -2940,0 +3019,4 @@ static LRESULT CALLBACK gpuSurfaceProc(HWND hwnd, UINT message, WPARAM wparam, L
+             view->gpu_pointer_x = x;
+             view->gpu_pointer_y = y;
+             const int button = message == WM_LBUTTONDOWN ? 0 : message == WM_RBUTTONDOWN ? 1 : 2;
+@@ -2933,6 +3016,10 @@ static LRESULT CALLBACK gpuSurfaceProc(HWND hwnd, UINT message, WPARAM wparam, L
+             return 0;
+         }
+         case WM_LBUTTONUP:
 +            if (message == WM_LBUTTONUP) {
 +                view->gpu_primary_down = 0;
 +                if (view->gpu_primary_latched < 1) view->gpu_primary_latched = 1;
 +            }
-@@ -2957,0 +3040 @@ static LRESULT CALLBACK gpuSurfaceProc(HWND hwnd, UINT message, WPARAM wparam, L
-+            view->gpu_primary_down = 0;
-@@ -5033,0 +5117,3 @@ static LRESULT CALLBACK windowProc(HWND hwnd, UINT message, WPARAM wparam, LPARA
+         case WM_RBUTTONUP:
+         case WM_MBUTTONUP: {
+             const double x = (double)(short)LOWORD(lparam) / scale;
+@@ -2954,9 +3041,12 @@ static LRESULT CALLBACK gpuSurfaceProc(HWND hwnd, UINT message, WPARAM wparam, L
+             emitGpuSurfaceInput(host, *view, kind, x, y, 0, 0, 0, "", "", gpuModifierFlags());
+             return 0;
+         }
++        case WM_CANCELMODE:
+         case WM_CAPTURECHANGED:
+             if (view->gpu_pointer_down) {
+                 view->gpu_pointer_down = 0;
++                view->gpu_primary_down = 0;
++                view->gpu_primary_latched = 0;
+                 emitGpuSurfaceInput(host, *view, kGpuInputPointerCancel, view->gpu_pointer_x, view->gpu_pointer_y, 0, 0, 0, "", "", gpuModifierFlags());
+             }
+             break;
+@@ -5028,6 +5118,9 @@ static LRESULT CALLBACK windowProc(HWND hwnd, UINT message, WPARAM wparam, LPARA
+         case kAudioSessionMessage:
+             if (host) audioHandleSessionMessage(host, wparam, lparam);
+             return 0;
 +        case kShowContextMenuMessage:
 +            if (host) showAppContextMenu(host, hwnd);
 +            return 0;
-@@ -5942,0 +6029,59 @@ int native_sdk_windows_create_window(Host *host, uint64_t window_id, const char
+         case kAudioSpectrumMessage:
+             if (host) audioHandleSpectrumMessage(host, wparam);
+             return 0;
+@@ -5940,6 +6033,131 @@ int native_sdk_windows_create_window(Host *host, uint64_t window_id, const char
+     return 1;
+ }
+ 
++int native_sdk_windows_resize_window(Host *host, uint64_t window_id, double width, double height, int anchor_bottom_center) {
++    if (!host || width <= 0 || height <= 0) return 0;
++    auto found = host->windows.find(window_id);
++    if (found == host->windows.end() || !found->second.hwnd) return 0;
++    Window &window = found->second;
++    HWND hwnd = window.hwnd;
++
++    /* Window sizes cross the platform seam as logical content points. Keep
++     * the same style/DPI conversion as createNativeWindow so a resize lands
++     * on the requested client size for popup, standard, and hidden-titlebar
++     * windows alike. */
++    DWORD style = WS_OVERLAPPEDWINDOW;
++    if (!window.resizable) style &= ~(WS_THICKFRAME | WS_MAXIMIZEBOX);
++    if (windowIsChromeless(window)) {
++        style = WS_POPUP | WS_SYSMENU | WS_MINIMIZEBOX;
++        if (window.resizable) style |= WS_THICKFRAME | WS_MAXIMIZEBOX;
++    }
++    const bool has_menu = !host->menus.empty();
++    const UINT dpi = dpiForWindow(hwnd);
++    const double scale = dpi > 0 ? (double)dpi / 96.0 : 1.0;
++    const double content_width = width * scale;
++    const double content_height = height * scale;
++    LONG outer_width = 0;
++    LONG outer_height = 0;
++    if (windowUsesHiddenTitlebar(window)) {
++        const SIZE outer = hiddenOuterSizeForContent(style, 0, has_menu, content_width, content_height, dpi);
++        outer_width = outer.cx;
++        outer_height = outer.cy;
++    } else {
++        RECT desired = { 0, 0, physicalContentExtent(content_width), physicalContentExtent(content_height) };
++        adjustWindowRectForDpi(&desired, style, has_menu ? TRUE : FALSE, 0, dpi);
++        outer_width = desired.right - desired.left;
++        outer_height = desired.bottom - desired.top;
++    }
++    if (outer_width <= 0 || outer_height <= 0) return 0;
++
++    RECT current = {};
++    if (!GetWindowRect(hwnd, &current)) return 0;
++    const LONG current_width = current.right - current.left;
++    const LONG current_height = current.bottom - current.top;
++    LONG next_x = current.left;
++    LONG next_y = current.top;
++    if (anchor_bottom_center != 0) {
++        /* Keep the ground line and horizontal center fixed while the sprite
++         * scale changes. Physical coordinates are used here because the
++         * current window may already straddle a mixed-DPI monitor boundary. */
++        next_x = current.left + (current_width - outer_width) / 2;
++        next_y = current.top + current_height - outer_height;
++    }
++    if (!SetWindowPos(hwnd, nullptr, next_x, next_y, outer_width, outer_height, SWP_NOZORDER | SWP_NOACTIVATE)) return 0;
++    window.width = width;
++    window.height = height;
++    return 1;
++}
++
 +int native_sdk_windows_move_window(Host *host, uint64_t window_id, double dx, double dy, int clamp, double *out_x, double *out_y, int *out_hit_x, int *out_hit_y, int *out_primary_down, double *out_cursor_x, double *out_cursor_y) {
 +    if (!host) return 0;
 +    auto found = host->windows.find(window_id);
@@ -211,11 +412,22 @@ index 4dd7ecd..24fd947 100644
 +        NativeView &view = entry.second;
 +        if (view.window_id != window_id || view.kind != kViewGpuSurface) continue;
 +        if (view.gpu_primary_latched > 0) {
-+            primary_down = 1;
-+            if (view.hwnd) {
-+                const double x = view.gpu_primary_latched == 2 ? view.gpu_primary_x : view.gpu_pointer_x;
-+                const double y = view.gpu_primary_latched == 2 ? view.gpu_primary_y : view.gpu_pointer_y;
-+                POINT sampled = { (LONG)lround(x * scale), (LONG)lround(y * scale) };
++            /* 3 = press point/down, 2 = global endpoint/down,
++             * 1 = global endpoint/release only after WM_LBUTTONUP.
++             * If the button is still held, the final latched pulse stays
++             * down and subsequent polls use the live state. */
++            primary_down = (view.gpu_primary_latched > 1 || view.gpu_primary_down) ? 1 : 0;
++            if (view.gpu_primary_latched == 3 && view.hwnd) {
++                /* Preserve the press point for the first app poll. A fast
++                 * synthetic drag can move the cursor to its endpoint before
++                 * the runtime sees the down edge; using the live cursor on
++                 * that first pulse would miss the pet hit test. The second
++                 * pulse uses the GetCursorPos result above while still
++                 * reporting down; the third reports the same endpoint with
++                 * release. The child may not receive WM_MOUSEMOVE while a
++                 * transparent, borderless window is being dragged, but
++                 * Win32 still owns the authoritative global endpoint. */
++                POINT sampled = { (LONG)lround(view.gpu_primary_x * scale), (LONG)lround(view.gpu_primary_y * scale) };
 +                if (ClientToScreen(view.hwnd, &sampled)) cursor = sampled;
 +            }
 +            view.gpu_primary_latched--;
@@ -227,7 +439,13 @@ index 4dd7ecd..24fd947 100644
 +    return 1;
 +}
 +
-@@ -6272,0 +6418,25 @@ int native_sdk_windows_note_gpu_surface_input(Host *host, uint64_t window_id, co
+ void native_sdk_windows_start_timer(Host *host, uint64_t timer_id, uint64_t interval_ns, int repeats) {
+     if (!host) return;
+     native_sdk_windows_cancel_timer(host, timer_id);
+@@ -6270,6 +6488,31 @@ int native_sdk_windows_note_gpu_surface_input(Host *host, uint64_t window_id, co
+     return 1;
+ }
+ 
 +int native_sdk_windows_show_context_menu(Host *host, uint64_t window_id, const char *label, size_t label_len, double x, double y, uint64_t token, const WindowsContextMenuItem *items, size_t count) {
 +    if (!host || !items || count == 0) return 0;
 +    auto found = host->windows.find(window_id);
@@ -253,3 +471,6 @@ index 4dd7ecd..24fd947 100644
 +    return 1;
 +}
 +
+ int native_sdk_windows_present_gpu_surface_pixels(Host *host, uint64_t window_id, const char *label, size_t label_len, size_t width, size_t height, double scale, int has_dirty_rect, double dirty_x, double dirty_y, double dirty_width, double dirty_height, const uint8_t *rgba8, size_t rgba8_len) {
+     (void)scale;
+     (void)has_dirty_rect;

--- a/scripts/release-desktop.ts
+++ b/scripts/release-desktop.ts
@@ -343,6 +343,7 @@ function preflightTree(): void {
       "packages/petdex-desktop-native/src",
       "packages/petdex-desktop-native/app.zon",
       "patches/native-sdk-macos-headerpad.patch",
+      "patches/native-sdk-windows-pet-input.patch",
       "packages/petdex-desktop-native/assets",
       "scripts/patch-native-sdk.sh",
       "scripts/release-desktop.ts",


### PR DESCRIPTION
Signed replacement for #739.

Preserves Mison as the original author while keeping the default branch signature contract.

Changes:
- stabilizes multi-display placement and pointer input
- validates drag movement using real window geometry instead of animation-only pixel changes
- updates the vendored Windows native SDK input patch
- pins the cuse source gate to latest validated main at 0ade4f9795f0ee8a49f0c2c0401c3ef0bdace0a4

Validation:
- bun run check
- bun run i18n:check
- bun test: 484 passed, 0 failed
- git diff --check for source files
- the vendored patch retains required unified-diff context markers and is validated by applying it to the pinned Native SDK in CI

The cross-platform native workflow must pass on macOS, Linux, and Windows. Windows cuse screenshots will be downloaded and inspected before merge.