### PR TITLE
feat(cli): prefer the compact manifest contract

### DIFF
--- a/packages/petdex-cli/bin/petdex.test.ts
+++ b/packages/petdex-cli/bin/petdex.test.ts
@@ -33,4 +33,12 @@ describe("retired command aliases", () => {
       normalizeCommand(expected.stderr, canonical),
     );
   });
+
+  test("select points legacy users to the desktop app", () => {
+    const result = runCli("select");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain("Unknown command");
+    expect(result.stderr).toContain("desktop app");
+  });
 });

--- a/packages/petdex-cli/bin/petdex.ts
+++ b/packages/petdex-cli/bin/petdex.ts
@@ -17,6 +17,10 @@ import {
   readEditZipAsset,
 } from "../src/edit-assets.js";
 import {
+  fetchManifest as fetchCatalogManifest,
+  type ManifestPet,
+} from "../src/manifest.js";
+import {
   emit,
   getStatus,
   maybeShowFirstRunNotice,
@@ -47,6 +51,7 @@ const RETIRED_COMMANDS = new Map<string, string>([
   ["stop", DESKTOP_STOP_REDIRECT],
   ["toggle", "Toggle the mascot from the Petdex menu bar icon."],
   ["desktop", "The desktop app manages its own lifecycle."],
+  ["select", "Select pets from the Petdex desktop app."],
   ["update", "The desktop app updates itself automatically."],
   // Desktop Settings → Agents:
   // packages/petdex-desktop-native/src/settings_view.zig (`agentsSection`).
@@ -273,26 +278,11 @@ async function cmdWhoami() {
   }
 }
 
-type ManifestPet = {
-  slug: string;
-  displayName: string;
-  spritesheetUrl: string;
-  petJsonUrl: string;
-  spriteVersionNumber?: 1 | 2;
-};
-
 function parseSpriteVersionNumber(petJson: Record<string, unknown>): 1 | 2 {
   const value = petJson.spriteVersionNumber;
   if (value === undefined || value === 1) return 1;
   if (value === 2) return 2;
   throw new Error("spriteVersionNumber must be omitted, 1, or 2");
-}
-
-async function fetchManifest(): Promise<ManifestPet[]> {
-  const res = await fetch(`${PETDEX_URL}/api/manifest`);
-  if (!res.ok) throw new Error(`manifest fetch ${res.status}`);
-  const data = (await res.json()) as { pets: ManifestPet[] };
-  return data.pets;
 }
 
 async function installOne(pet: ManifestPet): Promise<void> {
@@ -379,7 +369,7 @@ async function cmdInstall(args: string[]) {
 
   let manifest: ManifestPet[];
   try {
-    manifest = await fetchManifest();
+    manifest = await fetchCatalogManifest(PETDEX_URL);
   } catch (err) {
     s.stop(pc.red("manifest failed"));
     throw err;
@@ -470,23 +460,16 @@ async function cmdInstall(args: string[]) {
 async function cmdList() {
   const s = p.spinner();
   s.start("Fetching gallery");
-  const res = await fetch(`${PETDEX_URL}/api/manifest`);
-  if (!res.ok) {
+  let data: ManifestPet[];
+  try {
+    data = await fetchCatalogManifest(PETDEX_URL);
+  } catch (error) {
     s.stop(pc.red("failed"));
-    throw new Error(`failed to fetch manifest: ${res.status}`);
+    throw error;
   }
-  const data = (await res.json()) as {
-    total: number;
-    pets: Array<{
-      slug: string;
-      displayName: string;
-      kind: string;
-      submittedBy: string | null;
-    }>;
-  };
-  s.stop(`${data.total} pets`);
+  s.stop(`${data.length} pets`);
 
-  const lines = data.pets.map((pet) => {
+  const lines = data.map((pet) => {
     const tag = pet.submittedBy ? pc.dim(` by ${pet.submittedBy}`) : "";
     return `  ${pc.cyan(pet.slug.padEnd(26))} ${pet.displayName}${tag}`;
   });

--- a/packages/petdex-cli/src/manifest.test.ts
+++ b/packages/petdex-cli/src/manifest.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  fetchManifest,
+  parseCompactManifest,
+  parseLegacyManifest,
+  parseManifestPayload,
+} from "./manifest";
+
+const compact = {
+  v: 2,
+  generatedAt: "2026-08-25T00:00:00.000Z",
+  total: 1,
+  assetBase: "https://assets.petdex.dev",
+  fields: [
+    "slug",
+    "displayName",
+    "kind",
+    "submittedBy",
+    "spritesheet",
+    "petJson",
+    "zip",
+    "spriteVersionNumber",
+  ],
+  pets: [
+    [
+      "demo",
+      "Demo",
+      "character",
+      null,
+      "pets/demo/sprite.webp",
+      "pets/demo/pet.json",
+      null,
+      2,
+    ],
+  ],
+};
+
+const legacy = {
+  total: 1,
+  pets: [
+    {
+      slug: "demo",
+      displayName: "Demo",
+      kind: "character",
+      submittedBy: null,
+      spritesheetUrl: "https://assets.petdex.dev/pets/demo/sprite.webp",
+      petJsonUrl: "https://assets.petdex.dev/pets/demo/pet.json",
+      zipUrl: null,
+    },
+  ],
+};
+
+describe("manifest parsing", () => {
+  it("parses compact v2 rows and resolves asset references", () => {
+    expect(parseCompactManifest(compact)).toEqual([
+      {
+        slug: "demo",
+        displayName: "Demo",
+        kind: "character",
+        submittedBy: null,
+        spritesheetUrl: "https://assets.petdex.dev/pets/demo/sprite.webp",
+        petJsonUrl: "https://assets.petdex.dev/pets/demo/pet.json",
+        zipUrl: null,
+        spriteVersionNumber: 2,
+      },
+    ]);
+  });
+
+  it("parses legacy rows and defaults an omitted version to v1", () => {
+    expect(parseLegacyManifest(legacy)[0]?.spriteVersionNumber).toBe(1);
+    expect(parseManifestPayload(legacy)).toHaveLength(1);
+  });
+
+  it("rejects malformed or untrusted rows", () => {
+    expect(() =>
+      parseCompactManifest({ ...compact, fields: ["wrong"] }),
+    ).toThrow("compact manifest fields");
+    expect(() =>
+      parseCompactManifest({
+        ...compact,
+        pets: [[...compact.pets[0].slice(0, 7), 3]],
+      }),
+    ).toThrow("compact manifest pet");
+    expect(() =>
+      parseLegacyManifest({
+        ...legacy,
+        pets: [
+          {
+            ...legacy.pets[0],
+            spritesheetUrl: "https://example.test/sprite.webp",
+          },
+        ],
+      }),
+    ).toThrow("untrusted asset host");
+  });
+});
+
+describe("manifest endpoint compatibility", () => {
+  it("prefers v2 and does not request the legacy endpoint", async () => {
+    const requested: string[] = [];
+    const pets = await fetchManifest("https://petdex.test", async (url) => {
+      requested.push(String(url));
+      return new Response(JSON.stringify(compact), {
+        headers: { "content-type": "application/json" },
+      });
+    });
+    expect(pets).toHaveLength(1);
+    expect(requested).toEqual(["https://petdex.test/api/manifest/v2"]);
+  });
+
+  it("falls back to the legacy endpoint when v2 is unavailable", async () => {
+    const requested: string[] = [];
+    const pets = await fetchManifest("https://petdex.test", async (url) => {
+      requested.push(String(url));
+      if (requested.length === 1) return new Response("", { status: 500 });
+      return new Response(JSON.stringify(legacy), {
+        headers: { "content-type": "application/json" },
+      });
+    });
+    expect(pets[0]?.slug).toBe("demo");
+    expect(requested).toEqual([
+      "https://petdex.test/api/manifest/v2",
+      "https://petdex.test/api/manifest",
+    ]);
+  });
+
+  it("reports both endpoint failures", async () => {
+    await expect(
+      fetchManifest(
+        "https://petdex.test",
+        async () => new Response("", { status: 503 }),
+      ),
+    ).rejects.toThrow("manifest unavailable");
+  });
+});

--- a/packages/petdex-cli/src/manifest.ts
+++ b/packages/petdex-cli/src/manifest.ts
@@ -1,0 +1,196 @@
+import { isTrustedAssetUrl } from "./asset-hosts.js";
+
+const MANIFEST_TIMEOUT_MS = 15_000;
+const COMPACT_FIELDS = [
+  "slug",
+  "displayName",
+  "kind",
+  "submittedBy",
+  "spritesheet",
+  "petJson",
+  "zip",
+  "spriteVersionNumber",
+] as const;
+
+export type ManifestPet = {
+  slug: string;
+  displayName: string;
+  kind: string;
+  submittedBy: string | null;
+  spritesheetUrl: string;
+  petJsonUrl: string;
+  zipUrl: string | null;
+  spriteVersionNumber: 1 | 2;
+};
+
+type FetchJson = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function isSpriteVersion(value: unknown): value is 1 | 2 {
+  return value === 1 || value === 2;
+}
+
+function requireTrustedAssetUrl(raw: string, assetBase?: string): string {
+  let url: URL;
+  try {
+    url = assetBase
+      ? new URL(raw, `${assetBase.replace(/\/+$/, "")}/`)
+      : new URL(raw);
+  } catch {
+    throw new Error("manifest contains an invalid asset URL");
+  }
+  const resolved = url.toString();
+  if (!isTrustedAssetUrl(resolved)) {
+    throw new Error("manifest contains an untrusted asset host");
+  }
+  return resolved;
+}
+
+function requireAssetBase(raw: unknown): string {
+  if (typeof raw !== "string") {
+    throw new Error("compact manifest is missing assetBase");
+  }
+  return requireTrustedAssetUrl(raw);
+}
+
+function validateManifestTotal(
+  input: Record<string, unknown>,
+  count: number,
+): void {
+  if (input.total !== undefined && input.total !== count) {
+    throw new Error("manifest total does not match its entries");
+  }
+}
+
+export function parseCompactManifest(input: unknown): ManifestPet[] {
+  if (!isRecord(input) || input.v !== 2 || !Array.isArray(input.pets)) {
+    throw new Error("invalid compact manifest");
+  }
+  const assetBase = requireAssetBase(input.assetBase);
+  if (
+    !Array.isArray(input.fields) ||
+    input.fields.length !== COMPACT_FIELDS.length ||
+    input.fields.some((field, index) => field !== COMPACT_FIELDS[index])
+  ) {
+    throw new Error("invalid compact manifest fields");
+  }
+  validateManifestTotal(input, input.pets.length);
+
+  return input.pets.map((rawPet, index) => {
+    if (
+      !Array.isArray(rawPet) ||
+      rawPet.length !== COMPACT_FIELDS.length ||
+      typeof rawPet[0] !== "string" ||
+      typeof rawPet[1] !== "string" ||
+      typeof rawPet[2] !== "string" ||
+      !isNullableString(rawPet[3]) ||
+      typeof rawPet[4] !== "string" ||
+      typeof rawPet[5] !== "string" ||
+      !isNullableString(rawPet[6]) ||
+      !isSpriteVersion(rawPet[7])
+    ) {
+      throw new Error(`invalid compact manifest pet at index ${index}`);
+    }
+    return {
+      slug: rawPet[0],
+      displayName: rawPet[1],
+      kind: rawPet[2],
+      submittedBy: rawPet[3],
+      spritesheetUrl: requireTrustedAssetUrl(rawPet[4], assetBase),
+      petJsonUrl: requireTrustedAssetUrl(rawPet[5], assetBase),
+      zipUrl: rawPet[6] ? requireTrustedAssetUrl(rawPet[6], assetBase) : null,
+      spriteVersionNumber: rawPet[7],
+    };
+  });
+}
+
+export function parseLegacyManifest(input: unknown): ManifestPet[] {
+  if (!isRecord(input) || !Array.isArray(input.pets)) {
+    throw new Error("invalid legacy manifest");
+  }
+  validateManifestTotal(input, input.pets.length);
+
+  return input.pets.map((rawPet, index) => {
+    if (
+      !isRecord(rawPet) ||
+      typeof rawPet.slug !== "string" ||
+      typeof rawPet.displayName !== "string" ||
+      typeof rawPet.kind !== "string" ||
+      !isNullableString(rawPet.submittedBy) ||
+      typeof rawPet.spritesheetUrl !== "string" ||
+      typeof rawPet.petJsonUrl !== "string" ||
+      !isNullableString(rawPet.zipUrl) ||
+      (rawPet.spriteVersionNumber !== undefined &&
+        !isSpriteVersion(rawPet.spriteVersionNumber))
+    ) {
+      throw new Error(`invalid legacy manifest pet at index ${index}`);
+    }
+    return {
+      slug: rawPet.slug,
+      displayName: rawPet.displayName,
+      kind: rawPet.kind,
+      submittedBy: rawPet.submittedBy,
+      spritesheetUrl: requireTrustedAssetUrl(rawPet.spritesheetUrl),
+      petJsonUrl: requireTrustedAssetUrl(rawPet.petJsonUrl),
+      zipUrl: rawPet.zipUrl ? requireTrustedAssetUrl(rawPet.zipUrl) : null,
+      spriteVersionNumber: rawPet.spriteVersionNumber ?? 1,
+    };
+  });
+}
+
+export function parseManifestPayload(input: unknown): ManifestPet[] {
+  if (isRecord(input) && input.v === 2) return parseCompactManifest(input);
+  return parseLegacyManifest(input);
+}
+
+async function requestJson(
+  fetchImpl: FetchJson,
+  url: string,
+): Promise<unknown> {
+  const response = await fetchImpl(url, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(MANIFEST_TIMEOUT_MS),
+  });
+  if (!response.ok) throw new Error(`manifest fetch ${response.status}`);
+  try {
+    return await response.json();
+  } catch {
+    throw new Error("manifest response was not valid JSON");
+  }
+}
+
+export async function fetchManifest(
+  petdexUrl: string,
+  fetchImpl: FetchJson = fetch,
+): Promise<ManifestPet[]> {
+  const base = petdexUrl.replace(/\/+$/, "");
+  let compactError: unknown;
+  try {
+    return parseCompactManifest(
+      await requestJson(fetchImpl, `${base}/api/manifest/v2`),
+    );
+  } catch (error) {
+    compactError = error;
+  }
+
+  try {
+    return parseLegacyManifest(
+      await requestJson(fetchImpl, `${base}/api/manifest`),
+    );
+  } catch (legacyError) {
+    const compactMessage =
+      compactError instanceof Error ? compactError.message : "unknown error";
+    const legacyMessage =
+      legacyError instanceof Error ? legacyError.message : "unknown error";
+    throw new Error(
+      `manifest unavailable (v2: ${compactMessage}; legacy: ${legacyMessage})`,
+    );
+  }
+}


### PR DESCRIPTION
First signed replacement slice for #740.

Preserves Mison as the original author while separating the CLI manifest contract from desktop installer and documentation changes.

Changes:
- strictly parses the compact v2 manifest schema
- resolves only trusted asset URLs
- falls back to the legacy manifest endpoint when v2 is unavailable
- uses the same parser for list and install
- keeps the retired select command pointing users to the desktop app

Validation:
- bun test: 491 passed, 0 failed
- focused CLI tests: 10 passed, 0 failed
- bun run check
- bun x tsc --noEmit
- CLI package build
- git diff --check

No CLI package release is included.