### PR TITLE
feat(desktop): support the compact manifest installer contract

### DIFF
--- a/packages/petdex-desktop-native/src/installer.zig
+++ b/packages/petdex-desktop-native/src/installer.zig
@@ -25,7 +25,10 @@ const plat = @import("plat.zig");
 /// from the CLI list, one of the two starts refusing legitimate pets.
 const trusted_asset_host = "assets.petdex.dev";
 
-pub const manifest_url = "https://petdex.dev/api/manifest";
+/// The compact manifest is the production catalog contract. Keep the
+/// legacy URL as a bounded fallback for older deployments and mirrors.
+pub const manifest_url = "https://petdex.dev/api/manifest/v2";
+pub const legacy_manifest_url = "https://petdex.dev/api/manifest";
 
 /// Sent on asset requests exactly like the CLI's PETDEX_REFERER: the
 /// asset host answers on it, and dropping it here would make the app's
@@ -71,6 +74,9 @@ pub const install_roots = [_][]const u8{ ".petdex/pets", ".codex/pets" };
 pub const Urls = struct {
     pet_json: []const u8,
     spritesheet: []const u8,
+    /// Empty for the legacy object manifest. Compact v2 rows store asset
+    /// keys relative to this trusted base instead of repeating full URLs.
+    asset_base: []const u8 = "",
 
     /// `spritesheet.png` only when the URL says png, else webp — the
     /// CLI's rule. The extension has to match the bytes, since the
@@ -78,6 +84,30 @@ pub const Urls = struct {
     /// content, not suffix.
     pub fn spritesheetExt(self: Urls) []const u8 {
         return if (std.mem.endsWith(u8, self.spritesheet, ".png")) "png" else "webp";
+    }
+
+    fn resolve(self: Urls, raw: []const u8, buf: []u8) ?[]const u8 {
+        if (std.mem.startsWith(u8, raw, "https://")) {
+            return if (isTrustedAssetUrl(raw)) raw else null;
+        }
+        // Never reinterpret another absolute URL (including http:// and
+        // protocol-relative //host paths) as a relative asset key under the
+        // trusted base. The manifest is untrusted input at this boundary.
+        if (std.mem.startsWith(u8, raw, "//") or std.mem.indexOf(u8, raw, "://") != null) return null;
+        if (self.asset_base.len == 0 or !isTrustedAssetUrl(self.asset_base)) return null;
+        if (raw.len == 0 or raw[0] == '/' or std.mem.indexOf(u8, raw, "..") != null) return null;
+        var base_len = self.asset_base.len;
+        while (base_len > 0 and self.asset_base[base_len - 1] == '/') : (base_len -= 1) {}
+        const base = self.asset_base[0..base_len];
+        return std.fmt.bufPrint(buf, "{s}/{s}", .{ base, raw }) catch null;
+    }
+
+    pub fn resolvePetJson(self: Urls, buf: []u8) ?[]const u8 {
+        return self.resolve(self.pet_json, buf);
+    }
+
+    pub fn resolveSpritesheet(self: Urls, buf: []u8) ?[]const u8 {
+        return self.resolve(self.spritesheet, buf);
     }
 };
 
@@ -89,6 +119,24 @@ pub const Urls = struct {
 /// `homelander-2` both exist, and a prefix match would install the
 /// wrong pet — then reads only forward to that object's closing brace.
 pub fn findPetUrls(manifest: []const u8, slug: []const u8) ?Urls {
+    if (isCompactManifest(manifest)) return findCompactPetUrls(manifest, slug);
+    return findLegacyPetUrls(manifest, slug);
+}
+
+fn isCompactManifest(manifest: []const u8) bool {
+    // Do not classify a legacy object manifest because a pet's display name
+    // happens to contain the words `assetBase` and `fields`. The compact
+    // contract has an explicit version marker and a fixed field declaration;
+    // both are checked before any tuple positions are interpreted.
+    const head = manifest[0..@min(manifest.len, 4096)];
+    const compact_fields =
+        "\"fields\":[\"slug\",\"displayName\",\"kind\",\"submittedBy\",\"spritesheet\",\"petJson\",\"zip\",\"spriteVersionNumber\"]";
+    return std.mem.indexOf(u8, head, "\"v\":2") != null and
+        std.mem.indexOf(u8, head, "\"assetBase\"") != null and
+        std.mem.indexOf(u8, head, compact_fields) != null;
+}
+
+fn findLegacyPetUrls(manifest: []const u8, slug: []const u8) ?Urls {
     var needle_buf: [96]u8 = undefined;
     const needle = std.fmt.bufPrint(&needle_buf, "\"slug\":\"{s}\"", .{slug}) catch return null;
     const at = std.mem.indexOf(u8, manifest, needle) orelse return null;
@@ -101,6 +149,118 @@ pub fn findPetUrls(manifest: []const u8, slug: []const u8) ?Urls {
         .pet_json = jsonStringField(obj, "petJsonUrl") orelse return null,
         .spritesheet = jsonStringField(obj, "spritesheetUrl") orelse return null,
     };
+}
+
+fn findCompactPetUrls(manifest: []const u8, slug: []const u8) ?Urls {
+    var needle_buf: [96]u8 = undefined;
+    const needle = std.fmt.bufPrint(&needle_buf, "[\"{s}\",", .{slug}) catch return null;
+    const at = std.mem.indexOf(u8, manifest, needle) orelse return null;
+    const row = manifest[at..@min(manifest.len, at + 2048)];
+    return .{
+        .pet_json = jsonArrayStringAt(row, 5) orelse return null,
+        .spritesheet = jsonArrayStringAt(row, 4) orelse return null,
+        .asset_base = jsonStringField(manifest, "assetBase") orelse return null,
+    };
+}
+
+/// Return one string element from a compact manifest row. This small JSON
+/// scanner understands escaped quotes and skips non-string values so nullable
+/// credits or zip fields cannot shift the asset columns.
+fn jsonArrayStringAt(array: []const u8, wanted: usize) ?[]const u8 {
+    var pos: usize = 0;
+    while (pos < array.len and std.ascii.isWhitespace(array[pos])) : (pos += 1) {}
+    if (pos >= array.len or array[pos] != '[') return null;
+    pos += 1;
+    var index: usize = 0;
+    while (index <= wanted) {
+        while (pos < array.len and std.ascii.isWhitespace(array[pos])) : (pos += 1) {}
+        if (pos >= array.len) return null;
+        if (array[pos] == '"') {
+            const start = pos + 1;
+            const end = skipJsonString(array, pos) orelse return null;
+            if (index == wanted) return array[start .. end - 1];
+            pos = end;
+        } else {
+            if (index == wanted) return null;
+            pos = skipJsonValue(array, pos) orelse return null;
+        }
+        while (pos < array.len and std.ascii.isWhitespace(array[pos])) : (pos += 1) {}
+        if (pos >= array.len or array[pos] != ',') return null;
+        pos += 1;
+        index += 1;
+    }
+    return null;
+}
+
+fn skipJsonString(source: []const u8, start: usize) ?usize {
+    if (start >= source.len or source[start] != '"') return null;
+    var pos = start + 1;
+    while (pos < source.len) : (pos += 1) {
+        switch (source[pos]) {
+            '"' => return pos + 1,
+            '\\' => {
+                if (pos + 1 >= source.len) return null;
+                pos += 1;
+            },
+            0...0x1f => return null,
+            else => {},
+        }
+    }
+    return null;
+}
+
+/// Skip one JSON value without allocating. Compact manifest columns that are
+/// not needed for installation may be null, numeric, boolean, or nested data;
+/// only the requested asset columns are required to be strings.
+fn skipJsonValue(source: []const u8, start: usize) ?usize {
+    if (start >= source.len) return null;
+    switch (source[start]) {
+        '"' => return skipJsonString(source, start),
+        'n' => return if (std.mem.startsWith(u8, source[start..], "null")) start + 4 else null,
+        't' => return if (std.mem.startsWith(u8, source[start..], "true")) start + 4 else null,
+        'f' => return if (std.mem.startsWith(u8, source[start..], "false")) start + 5 else null,
+        '[', '{' => {
+            var depth: usize = 0;
+            var pos = start;
+            var in_string = false;
+            var escaped = false;
+            while (pos < source.len) : (pos += 1) {
+                const byte = source[pos];
+                if (in_string) {
+                    if (escaped) {
+                        escaped = false;
+                    } else if (byte == '\\') {
+                        escaped = true;
+                    } else if (byte == '"') {
+                        in_string = false;
+                    }
+                    continue;
+                }
+                switch (byte) {
+                    '"' => in_string = true,
+                    '[', '{' => depth += 1,
+                    ']', '}' => {
+                        if (depth == 0) return null;
+                        depth -= 1;
+                        if (depth == 0) return pos + 1;
+                    },
+                    else => {},
+                }
+            }
+            return null;
+        },
+        '-', '0'...'9' => {
+            var pos = start;
+            while (pos < source.len) : (pos += 1) {
+                switch (source[pos]) {
+                    ' ', '\t', '\r', '\n', ',', ']' => return pos,
+                    else => {},
+                }
+            }
+            return pos;
+        },
+        else => return null,
+    }
 }
 
 /// `"key":"value"` inside one already-narrowed object. The manifest
@@ -167,9 +327,9 @@ pub const missing_downloader_note = "petdex: cannot download pets, neither curl 
 /// comes from a remote manifest and the slug from any website, so a
 /// shell here would be a command injection with extra steps.
 ///
-/// `-L` is mandatory, not defensive: /api/manifest answers 307 to
-/// assets.petdex.dev, so without it curl writes an empty file and the
-/// install fails with a valid-looking 0-byte pet. `--fail` turns an
+/// `-L` is mandatory, not defensive: both public manifest routes answer
+/// 307 to assets.petdex.dev, so without it curl writes an empty file and
+/// the install fails with a valid-looking 0-byte pet. `--fail` turns an
 /// HTTP error into a nonzero exit instead of writing the error page
 /// into pet.json.
 pub const max_argv = 12;
@@ -251,6 +411,64 @@ test "manifest lookup picks the exact slug, not a prefix" {
     try std.testing.expectEqualStrings("png", second.spritesheetExt());
 
     try std.testing.expect(findPetUrls(manifest, "nonexistent") == null);
+}
+
+test "legacy manifest asset URLs stay host-bound during resolution" {
+    const manifest =
+        \\{"generatedAt":"x","total":1,"pets":[{"slug":"evil","displayName":"Evil","kind":"character","submittedBy":null,"spritesheetUrl":"https://evil.example/sprite.webp","petJsonUrl":"https://assets.petdex.dev/pets/evil/pet.json","zipUrl":null}]}
+    ;
+    const urls = findPetUrls(manifest, "evil").?;
+    var buf: [512]u8 = undefined;
+    try std.testing.expect(urls.resolveSpritesheet(buf[0..]) == null);
+    try std.testing.expectEqualStrings(
+        "https://assets.petdex.dev/pets/evil/pet.json",
+        urls.resolvePetJson(buf[0..]).?,
+    );
+}
+
+test "relative resolution rejects absolute non-https keys" {
+    const urls = Urls{
+        .pet_json = "http://evil.example/pet.json",
+        .spritesheet = "//evil.example/sprite.webp",
+        .asset_base = "https://assets.petdex.dev",
+    };
+    var buf: [512]u8 = undefined;
+    try std.testing.expect(urls.resolvePetJson(buf[0..]) == null);
+    try std.testing.expect(urls.resolveSpritesheet(buf[0..]) == null);
+}
+
+test "compact manifest resolves relative asset keys" {
+    const manifest =
+        \\{"v":2,"generatedAt":"x","total":1,"assetBase":"https://assets.petdex.dev","fields":["slug","displayName","kind","submittedBy","spritesheet","petJson","zip","spriteVersionNumber"],"pets":[["homelander","H, comma","character",null,"pets/homelander/sprite.webp","pets/homelander/pet.json",null,2]]}
+    ;
+    const urls = findPetUrls(manifest, "homelander").?;
+    var sheet_buf: [512]u8 = undefined;
+    var json_buf: [512]u8 = undefined;
+    const sheet = urls.resolveSpritesheet(sheet_buf[0..]).?;
+    const json = urls.resolvePetJson(json_buf[0..]).?;
+    try std.testing.expectEqualStrings("https://assets.petdex.dev/pets/homelander/sprite.webp", sheet);
+    try std.testing.expectEqualStrings("https://assets.petdex.dev/pets/homelander/pet.json", json);
+    try std.testing.expectEqualStrings("webp", urls.spritesheetExt());
+    try std.testing.expect(findPetUrls(manifest, "missing") == null);
+}
+
+test "legacy marker words do not switch the parser to compact mode" {
+    const manifest =
+        \\{"generatedAt":"x","total":1,"pets":[{"slug":"legacy","displayName":"assetBase fields v:2","kind":"character","submittedBy":null,"spritesheetUrl":"https://assets.petdex.dev/pets/legacy/sprite.webp","petJsonUrl":"https://assets.petdex.dev/pets/legacy/pet.json","zipUrl":null}]}
+    ;
+    const urls = findPetUrls(manifest, "legacy").?;
+    try std.testing.expectEqualStrings("", urls.asset_base);
+    try std.testing.expectEqualStrings(
+        "https://assets.petdex.dev/pets/legacy/sprite.webp",
+        urls.spritesheet,
+    );
+}
+
+test "compact parser requires the declared v2 field contract" {
+    const manifest =
+        \\{"assetBase":"https://assets.petdex.dev","fields":["slug","displayName"],"pets":[["demo","Demo"]]}
+    ;
+    try std.testing.expect(findPetUrls(manifest, "demo") == null);
 }
 
 test "download argv passes the url as its own argument" {

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -432,6 +432,12 @@ pub const InstallState = struct {
     /// install either succeeded or never ran.
     error_text: [96]u8 = @splat(0),
     error_len: usize = 0,
+    /// The compact endpoint is preferred. A failed request gets one
+    /// retry against the legacy endpoint for older mirrors.
+    manifest_fallback_attempted: bool = false,
+    /// Resolved v2 asset URLs must outlive the helper that schedules the
+    /// downloader effect, so keep their scratch storage in the model.
+    asset_url_buffers: [2][1024]u8 = @splat(@splat(0)),
     installed_ok: usize = 0,
 
     pub fn currentSlug(self: *const InstallState) []const u8 {
@@ -547,6 +553,7 @@ fn startInstallQueue(model: *Model, fx: *Effects) void {
     model.install.current = 0;
     model.install.installed_ok = 0;
     model.install.error_len = 0;
+    model.install.manifest_fallback_attempted = false;
     fx.spawn(.{
         .key = manifest_key,
         .argv = installer.downloadArgv(which, &argv_buf, installer.manifest_url, dest),
@@ -575,10 +582,18 @@ fn beginCurrentPet(model: *Model, fx: *Effects) bool {
         model.install.setError("{s} is not in the catalog", .{slug});
         return false;
     };
+    const pet_json = urls.resolvePetJson(model.install.asset_url_buffers[0][0..]) orelse {
+        model.install.setError("{s} has an invalid pet.json URL", .{slug});
+        return false;
+    };
+    const spritesheet = urls.resolveSpritesheet(model.install.asset_url_buffers[1][0..]) orelse {
+        model.install.setError("{s} has an invalid spritesheet URL", .{slug});
+        return false;
+    };
     // The host check happens before a single byte is requested: an
     // approved-but-stale row could carry a URL off the asset origin,
     // and the app must not write those bytes to a pet directory.
-    if (!installer.isTrustedAssetUrl(urls.pet_json) or !installer.isTrustedAssetUrl(urls.spritesheet)) {
+    if (!installer.isTrustedAssetUrl(pet_json) or !installer.isTrustedAssetUrl(spritesheet)) {
         model.install.setError("{s} has an untrusted asset host", .{slug});
         return false;
     }
@@ -592,7 +607,7 @@ fn beginCurrentPet(model: *Model, fx: *Effects) bool {
     model.install.phase = .pet_json;
     fx.spawn(.{
         .key = pet_json_key,
-        .argv = installer.downloadArgv(which, &argv_buf, urls.pet_json, dest),
+        .argv = installer.downloadArgv(which, &argv_buf, pet_json, dest),
         .output = .collect,
         .on_exit = Effects.exitMsg(.pet_json_done),
     });
@@ -610,7 +625,8 @@ fn beginSpritesheet(model: *Model, fx: *Effects) bool {
     const manifest = plat.readFileAlloc(boot_allocator, manifest_path, max_manifest_bytes) orelse return false;
     defer boot_allocator.free(manifest);
     const urls = installer.findPetUrls(manifest, slug) orelse return false;
-    if (!installer.isTrustedAssetUrl(urls.spritesheet)) return false;
+    const spritesheet = urls.resolveSpritesheet(model.install.asset_url_buffers[1][0..]) orelse return false;
+    if (!installer.isTrustedAssetUrl(spritesheet)) return false;
 
     var name_buf: [32]u8 = undefined;
     const name = std.fmt.bufPrint(&name_buf, "spritesheet.{s}", .{urls.spritesheetExt()}) catch return false;
@@ -621,7 +637,7 @@ fn beginSpritesheet(model: *Model, fx: *Effects) bool {
     model.install.phase = .spritesheet;
     fx.spawn(.{
         .key = spritesheet_key,
-        .argv = installer.downloadArgv(which, &argv_buf, urls.spritesheet, dest),
+        .argv = installer.downloadArgv(which, &argv_buf, spritesheet, dest),
         .output = .collect,
         .on_exit = Effects.exitMsg(.spritesheet_done),
     });
@@ -631,19 +647,28 @@ fn beginSpritesheet(model: *Model, fx: *Effects) bool {
 /// Copy the finished pet into the second root. The CLI downloads each
 /// asset twice; copying the bytes already on disk costs one read
 /// instead of a second round trip over the network.
-fn mirrorToCodexRoot(slug: []const u8, ext_png: bool) void {
-    const home = env_home orelse return;
+fn mirrorToCodexRoot(slug: []const u8, ext_png: bool) bool {
+    const home = env_home orelse return false;
     var name_buf: [32]u8 = undefined;
-    const sheet_name = std.fmt.bufPrint(&name_buf, "spritesheet.{s}", .{if (ext_png) "png" else "webp"}) catch return;
+    const sheet_name = std.fmt.bufPrint(&name_buf, "spritesheet.{s}", .{if (ext_png) "png" else "webp"}) catch return false;
+    // Do not rely on the download side having created the second root. A
+    // first install can race a stale/partial directory tree, and a failed
+    // mkdir must not be converted into a successful half-install.
+    var dir_buf: [512]u8 = undefined;
+    const dir = installer.petDir(&dir_buf, home, installer.install_roots[1], slug) orelse return false;
+    plat.makeDir(dir);
+    var copied: usize = 0;
     for ([_][]const u8{ "pet.json", sheet_name }) |name| {
         var src_buf: [512]u8 = undefined;
         var dst_buf: [512]u8 = undefined;
-        const src = installer.petFile(&src_buf, home, installer.install_roots[0], slug, name) orelse continue;
-        const dst = installer.petFile(&dst_buf, home, installer.install_roots[1], slug, name) orelse continue;
-        const bytes = plat.readFileAlloc(boot_allocator, src, max_sheet_file_bytes) orelse continue;
+        const src = installer.petFile(&src_buf, home, installer.install_roots[0], slug, name) orelse return false;
+        const dst = installer.petFile(&dst_buf, home, installer.install_roots[1], slug, name) orelse return false;
+        const bytes = plat.readFileAlloc(boot_allocator, src, max_sheet_file_bytes) orelse return false;
         defer boot_allocator.free(bytes);
-        _ = plat.writeFile(dst, bytes);
+        if (!plat.writeFile(dst, bytes)) return false;
+        copied += 1;
     }
+    return copied == 2;
 }
 
 /// Add a freshly installed pet to the in-memory catalog. A rescan would
@@ -2038,6 +2063,25 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             // there is nothing to resolve any slug against: the whole
             // queue ends here rather than failing pet by pet.
             if (exit.reason != .exited or exit.code != 0) {
+                if (!model.install.manifest_fallback_attempted) {
+                    model.install.manifest_fallback_attempted = true;
+                    var path_buf: [512]u8 = undefined;
+                    const path = manifestTmpPath(&path_buf) orelse {
+                        model.install.setError("Could not reach petdex.dev", .{});
+                        model.install.phase = .idle;
+                        model.install.queued = 0;
+                        return;
+                    };
+                    const which = installer.detect() orelse return;
+                    var argv_buf: [installer.max_argv][]const u8 = undefined;
+                    fx.spawn(.{
+                        .key = manifest_key,
+                        .argv = installer.downloadArgv(which, &argv_buf, installer.legacy_manifest_url, path),
+                        .output = .collect,
+                        .on_exit = Effects.exitMsg(.manifest_done),
+                    });
+                    return;
+                }
                 model.install.setError("Could not reach petdex.dev", .{});
                 model.install.phase = .idle;
                 model.install.queued = 0;
@@ -2066,7 +2110,11 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
                 advanceInstallQueue(model, fx);
                 return;
             }
-            mirrorToCodexRoot(slug, model.install.ext_png);
+            if (!mirrorToCodexRoot(slug, model.install.ext_png)) {
+                model.install.setError("{s}: failed to mirror into Codex pets", .{slug});
+                advanceInstallQueue(model, fx);
+                return;
+            }
             model.install.installed_ok += 1;
             // The pet is only usable once the catalog knows it; a fresh
             // thumbnail pass picks it up the next time settings is open.

--- a/packages/petdex-desktop-native/src/plat.zig
+++ b/packages/petdex-desktop-native/src/plat.zig
@@ -137,6 +137,11 @@ fn writeFileIo(io: std.Io, path: []const u8, bytes: []const u8, mode: ?u16) bool
 
     var atomic_file = std.Io.Dir.cwd().createFileAtomic(io, target_path, .{
         .permissions = permissionsFromMode(mode),
+        // Callers pass user-scoped paths whose parent may not exist yet
+        // (notably the Codex mirror on a first install). Keep the atomic
+        // replacement semantics, but do not turn a missing parent into a
+        // silently ignored write failure.
+        .make_path = true,
         .replace = true,
     }) catch return false;
     defer atomic_file.deinit(io);
@@ -911,4 +916,17 @@ pub fn activateRunningDefaultBrowser() BrowserActivation {
         if (@as(MsgSendBoolOptions, @ptrCast(&AppleApp.objc_msgSend))(app, activate_sel, 0)) return .activated;
     }
     return .activation_failed;
+}
+
+test "writeFile creates missing parent directories atomically" {
+    const root = ".zig-cache/petdex-plat-write-file";
+    _ = deleteTree(root);
+    defer _ = deleteTree(root);
+
+    const path = root ++ "/nested/pet.json";
+    try std.testing.expect(writeFile(path, "petdex"));
+
+    var buf: [32]u8 = undefined;
+    const got = readFile(path, &buf) orelse return error.ReadFailed;
+    try std.testing.expectEqualStrings("petdex", got);
 }


### PR DESCRIPTION
Second signed replacement slice for #740.

Preserves Mison as the original author while keeping the desktop installer contract separate from the CLI and documentation work.

Changes:
- prefers the compact v2 manifest with one bounded legacy fallback
- resolves relative asset keys only under the trusted asset host
- rejects absolute non-HTTPS and path-traversal values
- keeps resolved URLs alive across async download effects
- makes the Codex mirror write atomic and fail visibly instead of reporting a partial install

Validation:
- pinned Native SDK patch application
- ReleaseFast native build
- native test: 227 passed, 0 failed
- git diff --check

The PR must pass the native matrix on macOS, Linux, and Windows. No desktop release is included.