### PR TITLE
fix: enforce sprite atlas review contracts

### DIFF
--- a/src/components/submit/pet-submit-form.tsx
+++ b/src/components/submit/pet-submit-form.tsx
@@ -18,6 +18,10 @@ import { useTranslations } from "next-intl";
 
 import { petStates } from "@/lib/pet-states";
 import { deriveSlug } from "@/lib/slug";
+import {
+  canonicalSpriteDimensions,
+  detectSpriteAtlas,
+} from "@/lib/sprite-atlas";
 import { parseSpriteVersionNumber } from "@/lib/sprite-version";
 import { PET_ASSET_MAX_BYTES } from "@/lib/upload-limits";
 
@@ -76,7 +80,8 @@ type SubmitResponse = {
   review: SubmissionReviewOutcome;
 };
 
-const REQUIRED = { width: 1536, height: 1872 } as const;
+const CLASSIC_ATLAS = canonicalSpriteDimensions(1);
+const V2_ATLAS = canonicalSpriteDimensions(2);
 const PETS_DIR = "~/.codex/pets";
 
 export function PetSubmitForm() {
@@ -312,8 +317,7 @@ export function PetSubmitForm() {
       let height = 0;
       if (spritesheetUrl) {
         ({ width, height } = await measureImage(spritesheetUrl));
-        const isClassicGrid = width * 1872 === height * 1536;
-        const isV2Grid = width * 2288 === height * 1536;
+        const atlas = detectSpriteAtlas(width, height);
         if (width === 0 || height === 0) {
           issues.push(t("issues.unreadableSpritesheet"));
         } else if (width < 256 || height < 256) {
@@ -321,14 +325,26 @@ export function PetSubmitForm() {
             t("issues.tooSmall", {
               width,
               height,
-              recommendedWidth: REQUIRED.width,
-              recommendedHeight: REQUIRED.height,
+              classicWidth: CLASSIC_ATLAS.width,
+              classicHeight: CLASSIC_ATLAS.height,
+              v2Width: V2_ATLAS.width,
+              v2Height: V2_ATLAS.height,
             }),
           );
-        } else if (!isClassicGrid && !isV2Grid) {
+        } else if (!atlas) {
           // Mirror the server-side grid check so the preview never says
           // "ready" for a sheet /api/submit will reject.
           issues.push(t("issues.badGrid", { width, height }));
+        } else if (
+          spriteVersion.ok &&
+          atlas.version !== spriteVersion.version
+        ) {
+          issues.push(
+            t("issues.spriteVersionMismatch", {
+              detected: atlas.version,
+              declared: spriteVersion.version,
+            }),
+          );
         }
       }
 
@@ -630,8 +646,10 @@ export function PetSubmitForm() {
                 {chunks}
               </code>
             ),
-            width: REQUIRED.width,
-            height: REQUIRED.height,
+            classicWidth: CLASSIC_ATLAS.width,
+            classicHeight: CLASSIC_ATLAS.height,
+            v2Width: V2_ATLAS.width,
+            v2Height: V2_ATLAS.height,
           })}
         </span>
 

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -280,7 +280,7 @@
     "form": {
       "drop": {
         "title": "Upload a pet package",
-        "instructions": "Drop a folder or a ZIP with <petJson>pet.json</petJson> and <spritesheet>spritesheet.webp</spritesheet> (or .png). Recommended {width}×{height}, 8×9 frame grid.",
+        "instructions": "Drop a folder or a ZIP with <petJson>pet.json</petJson> and <spritesheet>spritesheet.webp</spritesheet> (or .png). Supported grids: {classicWidth}×{classicHeight} (8×9) or {v2Width}×{v2Height} (v2 8×11).",
         "short": "Drop a folder or a ZIP with pet.json + spritesheet.",
         "ariaLabel": "Pet package drop zone",
         "pickFolder": "Pick folder",
@@ -372,8 +372,9 @@
         "invalidJson": "pet.json is not valid JSON.",
         "invalidSpriteVersion": "pet.json has unsupported spriteVersionNumber: {value}. Use 1, 2, or omit it.",
         "unreadableSpritesheet": "Spritesheet image is unreadable.",
-        "tooSmall": "Spritesheet seems too small ({width}×{height}). Use an 8×9 frame grid (recommended {recommendedWidth}×{recommendedHeight}).",
+        "tooSmall": "Spritesheet seems too small ({width}×{height}). Use {classicWidth}×{classicHeight} (8×9) or {v2Width}×{v2Height} (v2 8×11).",
         "badGrid": "Spritesheet grid is {width}×{height}, which doesn't match the 8×9 (1536×1872) or v2 8×11 (1536×2288) frame grid, so frames would render misaligned.",
+        "spriteVersionMismatch": "Spritesheet dimensions use v{detected}, but pet.json declares v{declared}. Update spriteVersionNumber before submitting.",
         "spritesheetMissingPetInfo": "No pet.json found next to this spritesheet, so a placeholder name/description was generated. Fill in the pet name and description below before submitting."
       }
     }

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -280,7 +280,7 @@
     "form": {
       "drop": {
         "title": "Sube un paquete de mascota",
-        "instructions": "Arrastra una carpeta o un ZIP con <petJson>pet.json</petJson> y <spritesheet>spritesheet.webp</spritesheet> (o .png). Recomendado {width}×{height}, grilla de 8×9 frames.",
+        "instructions": "Arrastra una carpeta o un ZIP con <petJson>pet.json</petJson> y <spritesheet>spritesheet.webp</spritesheet> (o .png). Grillas compatibles: {classicWidth}×{classicHeight} (8×9) o {v2Width}×{v2Height} (v2 8×11).",
         "short": "Arrastra una carpeta o un ZIP con pet.json + spritesheet.",
         "ariaLabel": "Zona para soltar el paquete de mascota",
         "pickFolder": "Elegir carpeta",
@@ -372,8 +372,9 @@
         "invalidJson": "pet.json no es JSON válido.",
         "invalidSpriteVersion": "pet.json tiene un spriteVersionNumber no compatible: {value}. Usa 1, 2 u omítelo.",
         "unreadableSpritesheet": "No se puede leer la imagen del spritesheet.",
-        "tooSmall": "El spritesheet parece muy pequeño ({width}×{height}). Usa una grilla de 8×9 frames (recomendado {recommendedWidth}×{recommendedHeight}).",
+        "tooSmall": "El spritesheet parece muy pequeño ({width}×{height}). Usa {classicWidth}×{classicHeight} (8×9) o {v2Width}×{v2Height} (v2 8×11).",
         "badGrid": "La grilla del spritesheet es {width}×{height}, que no coincide con la grilla 8×9 (1536×1872) ni la v2 8×11 (1536×2288), así que los frames se verían desalineados.",
+        "spriteVersionMismatch": "Las dimensiones del spritesheet usan v{detected}, pero pet.json declara v{declared}. Actualiza spriteVersionNumber antes de enviarlo.",
         "spritesheetMissingPetInfo": "No se encontró pet.json junto a este spritesheet, así que se generó un nombre/descripción de relleno. Completa el nombre y la descripción abajo antes de enviar."
       }
     }

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -306,7 +306,7 @@
     "form": {
       "drop": {
         "title": "上传宠物包",
-        "instructions": "拖入包含 <petJson>pet.json</petJson> 和 <spritesheet>精灵图集文件 spritesheet.webp</spritesheet>（或 .png）的文件夹或 ZIP。推荐 {width}×{height}，8×9 帧网格。",
+        "instructions": "拖入包含 <petJson>pet.json</petJson> 和 <spritesheet>精灵图集文件 spritesheet.webp</spritesheet>（或 .png）的文件夹或 ZIP。支持 {classicWidth}×{classicHeight}（8×9）或 {v2Width}×{v2Height}（v2 8×11）帧网格。",
         "short": "拖入包含 pet.json 和精灵图集 Spritesheet 的文件夹或 ZIP。",
         "ariaLabel": "宠物包拖放区域",
         "pickFolder": "选择文件夹",
@@ -399,8 +399,9 @@
         "invalidJson": "pet.json 不是有效的 JSON。",
         "invalidSpriteVersion": "pet.json 中的 spriteVersionNumber 不受支持：{value}。请使用 1、2，或省略该字段。",
         "unreadableSpritesheet": "无法读取精灵图集 Spritesheet 图片。",
-        "tooSmall": "精灵图集 Spritesheet 看起来太小（{width}×{height}）。请使用 8×9 帧网格（推荐 {recommendedWidth}×{recommendedHeight}）。",
+        "tooSmall": "精灵图集 Spritesheet 看起来太小（{width}×{height}）。请使用 {classicWidth}×{classicHeight}（8×9）或 {v2Width}×{v2Height}（v2 8×11）。",
         "badGrid": "精灵图集 Spritesheet 网格为 {width}×{height}，不符合 8×9（1536×1872）或 v2 8×11（1536×2288）帧网格，帧会错位显示。",
+        "spriteVersionMismatch": "精灵图集尺寸使用 v{detected}，但 pet.json 声明为 v{declared}。请先更新 spriteVersionNumber 再提交。",
         "spritesheetMissingPetInfo": "此精灵图集旁未找到 pet.json，已生成占位名称/描述。请在下方填写宠物名称和描述后再提交。"
       }
     }

--- a/src/lib/response-body.test.ts
+++ b/src/lib/response-body.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+
+import { readResponseBodyBounded } from "@/lib/response-body";
+
+function responseFromChunks(chunks: Uint8Array[]): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(chunk);
+        controller.close();
+      },
+    }),
+  );
+}
+
+describe("readResponseBodyBounded", () => {
+  it("counts chunked bodies when content length is unavailable", async () => {
+    const body = await readResponseBodyBounded(
+      responseFromChunks([new Uint8Array([1, 2]), new Uint8Array([3, 4])]),
+      4,
+    );
+    expect(body).toEqual(Buffer.from([1, 2, 3, 4]));
+  });
+
+  it("rejects a chunked body before retaining bytes over the limit", async () => {
+    await expect(
+      readResponseBodyBounded(
+        responseFromChunks([new Uint8Array([1, 2]), new Uint8Array([3])]),
+        2,
+      ),
+    ).rejects.toThrow("response body exceeds limit");
+  });
+
+  it("times out a body that stops producing chunks", async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1]));
+      },
+    });
+    await expect(
+      readResponseBodyBounded(new Response(body), 4, 20),
+    ).rejects.toThrow("response body read timed out");
+  });
+
+  it("does not wait for a stalled cancel after crossing the byte limit", async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+      },
+      cancel() {
+        return new Promise<void>(() => {});
+      },
+    });
+
+    const result = await Promise.race([
+      readResponseBodyBounded(new Response(body), 2).then(
+        () => "resolved",
+        (error: unknown) =>
+          error instanceof Error ? error.message : String(error),
+      ),
+      new Promise<string>((resolve) =>
+        setTimeout(() => resolve("timed out"), 100),
+      ),
+    ]);
+    expect(result).toBe("response body exceeds limit");
+  });
+});

--- a/src/lib/response-body.ts
+++ b/src/lib/response-body.ts
@@ -1,0 +1,68 @@
+/**
+ * Read a response body incrementally without allowing an untrusted stream to
+ * exceed the caller's byte limit or remain pending indefinitely.
+ */
+export async function readResponseBodyBounded(
+  response: Response,
+  maxBytes: number,
+  timeoutMs = 15_000,
+): Promise<Buffer> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
+    throw new Error("invalid response body limit");
+  }
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new Error("invalid response body timeout");
+  }
+  if (!response.body) throw new Error("response body is empty");
+
+  const reader = response.body.getReader();
+  const chunks: Buffer[] = [];
+  let total = 0;
+  const deadline = Date.now() + timeoutMs;
+  let timedOut = false;
+
+  try {
+    while (true) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        timedOut = true;
+        throw new Error("response body read timed out");
+      }
+
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const { done, value } = await Promise.race([
+          reader.read(),
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(() => {
+              timedOut = true;
+              reject(new Error("response body read timed out"));
+            }, remaining);
+          }),
+        ]);
+        if (done) break;
+        if (!value) continue;
+        total += value.byteLength;
+        if (total > maxBytes) {
+          void reader.cancel("response body exceeds limit").catch(() => {});
+          throw new Error("response body exceeds limit");
+        }
+        chunks.push(Buffer.from(value));
+      } finally {
+        if (timer !== undefined) clearTimeout(timer);
+      }
+    }
+  } catch (error) {
+    if (timedOut)
+      void reader.cancel("response body read timed out").catch(() => {});
+    throw error;
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // A timed-out pending read can still hold the stream lock briefly.
+    }
+  }
+
+  return Buffer.concat(chunks, total);
+}

--- a/src/lib/security.test.ts
+++ b/src/lib/security.test.ts
@@ -178,6 +178,20 @@ describe("validateSubmission", () => {
     ).toBeNull();
   });
 
+  it("rejects dimensions whose atlas version disagrees with metadata", () => {
+    const r = validateSubmission({
+      ...BASE_INPUT,
+      spriteVersionNumber: 1,
+      spritesheetWidth: 1536,
+      spritesheetHeight: 2288,
+    });
+    expect(r?.ok).toBe(false);
+    if (r && r.ok === false) {
+      expect(r.error).toBe("invalid_sprite_version");
+      expect(r.field).toBe("spriteVersionNumber");
+    }
+  });
+
   it("rejects an unsupported spriteVersionNumber from pet.json", () => {
     const r = validateSubmission({
       ...BASE_INPUT,

--- a/src/lib/sprite-atlas.test.ts
+++ b/src/lib/sprite-atlas.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  canonicalSpriteDimensions,
+  detectSpriteAtlas,
+} from "@/lib/sprite-atlas";
+
+describe("sprite atlas geometry", () => {
+  it("recognizes classic and v2 canonical dimensions", () => {
+    expect(detectSpriteAtlas(1536, 1872)).toMatchObject({
+      version: 1,
+      rows: 9,
+      scale: 1,
+    });
+    expect(detectSpriteAtlas(1536, 2288)).toMatchObject({
+      version: 2,
+      rows: 11,
+      scale: 1,
+    });
+  });
+
+  it("recognizes preserved-ratio scaled sheets", () => {
+    expect(detectSpriteAtlas(768, 936)).toMatchObject({
+      version: 1,
+      scale: 0.5,
+    });
+    expect(detectSpriteAtlas(3072, 4576)).toMatchObject({
+      version: 2,
+      scale: 2,
+    });
+  });
+
+  it("keeps exact ratios for safe dimensions whose products exceed Number precision", () => {
+    const scale = 4_000_000_000_000;
+    const width = 1536 * scale;
+    const height = 1872 * scale;
+    expect(Number.isSafeInteger(width)).toBeTrue();
+    expect(Number.isSafeInteger(height)).toBeTrue();
+    expect(width * 1872).toBeGreaterThan(Number.MAX_SAFE_INTEGER);
+    expect(height * 1536).toBeGreaterThan(Number.MAX_SAFE_INTEGER);
+    expect(detectSpriteAtlas(width, height)).toMatchObject({
+      version: 1,
+      rows: 9,
+      scale,
+    });
+  });
+
+  it("rejects malformed, unsafe, and ambiguous dimensions", () => {
+    expect(detectSpriteAtlas(1536, 2000)).toBeNull();
+    expect(detectSpriteAtlas(256, 312)).toBeNull();
+    expect(detectSpriteAtlas("1536", 1872)).toBeNull();
+    expect(detectSpriteAtlas(Number.NaN, 1872)).toBeNull();
+    expect(detectSpriteAtlas(Number.MAX_SAFE_INTEGER, 1872)).toBeNull();
+  });
+
+  it("keeps canonical dimensions tied to the declared version", () => {
+    expect(canonicalSpriteDimensions(1)).toEqual({ width: 1536, height: 1872 });
+    expect(canonicalSpriteDimensions(2)).toEqual({ width: 1536, height: 2288 });
+  });
+});

--- a/src/lib/sprite-atlas.ts
+++ b/src/lib/sprite-atlas.ts
@@ -1,0 +1,72 @@
+export const SPRITE_COLUMNS = 8;
+export const SPRITE_FRAME_WIDTH = 192;
+export const SPRITE_FRAME_HEIGHT = 208;
+
+export type SpriteAtlasVersion = 1 | 2;
+
+export type SpriteAtlasLayout = {
+  version: SpriteAtlasVersion;
+  rows: 9 | 11;
+  width: number;
+  height: number;
+  scale: number;
+};
+
+const layouts = [
+  { version: 1 as const, rows: 9 as const },
+  { version: 2 as const, rows: 11 as const },
+];
+
+/**
+ * Identify a supported atlas from its dimensions without decoding pixels.
+ * Scaled sheets are accepted only when each row and column still lands on an
+ * integer cell boundary. Callers that render fixed 192x208 cells can then
+ * normalize them without introducing fractional crop boundaries.
+ */
+export function detectSpriteAtlas(
+  width: unknown,
+  height: unknown,
+): SpriteAtlasLayout | null {
+  if (
+    typeof width !== "number" ||
+    typeof height !== "number" ||
+    !Number.isSafeInteger(width) ||
+    !Number.isSafeInteger(height) ||
+    width <= 0 ||
+    height <= 0
+  ) {
+    return null;
+  }
+
+  for (const layout of layouts) {
+    const canonicalWidth = SPRITE_COLUMNS * SPRITE_FRAME_WIDTH;
+    const canonicalHeight = layout.rows * SPRITE_FRAME_HEIGHT;
+    const widthBigInt = BigInt(width);
+    const heightBigInt = BigInt(height);
+    const canonicalWidthBigInt = BigInt(canonicalWidth);
+    const canonicalHeightBigInt = BigInt(canonicalHeight);
+    if (
+      width % SPRITE_COLUMNS !== 0 ||
+      height % layout.rows !== 0 ||
+      widthBigInt * canonicalHeightBigInt !==
+        heightBigInt * canonicalWidthBigInt
+    )
+      continue;
+
+    return {
+      ...layout,
+      width,
+      height,
+      scale: width / canonicalWidth,
+    };
+  }
+
+  return null;
+}
+
+export function canonicalSpriteDimensions(version: SpriteAtlasVersion) {
+  return {
+    width: SPRITE_COLUMNS * SPRITE_FRAME_WIDTH,
+    height: (version === 2 ? 11 : 9) * SPRITE_FRAME_HEIGHT,
+  };
+}

--- a/src/lib/submission-review-image.ts
+++ b/src/lib/submission-review-image.ts
@@ -1,15 +1,19 @@
 import sharp from "sharp";
 
 import { petStates } from "@/lib/pet-states";
+import {
+  canonicalSpriteDimensions,
+  detectSpriteAtlas,
+  SPRITE_COLUMNS,
+  SPRITE_FRAME_HEIGHT,
+  SPRITE_FRAME_WIDTH,
+} from "@/lib/sprite-atlas";
 
-const SPRITESHEET_COLUMNS = 8;
-const SPRITESHEET_ROWS = 9;
-const POLICY_CELL_W = 192;
-const POLICY_CELL_H = 208;
-const EXPECTED_SPRITESHEET_W = SPRITESHEET_COLUMNS * POLICY_CELL_W;
-const EXPECTED_SPRITESHEET_H = SPRITESHEET_ROWS * POLICY_CELL_H;
 const POLICY_BACKGROUND = { r: 120, g: 120, b: 120 };
-const MAX_POLICY_SOURCE_DIMENSION = 4096;
+// Preserve the largest integer-cell atlas accepted by sprite-atlas.ts. The
+// v2 contract allows a 2x 8x11 sheet (3072x4576), whose height is above the
+// old 4096px guard and must still reach the visual review stage.
+const MAX_POLICY_SOURCE_DIMENSION = 4576;
 const MAX_POLICY_SOURCE_PIXELS = 16_777_216;
 const MAX_POLICY_OUTPUT_CHARS = 2 * 1024 * 1024;
 
@@ -46,22 +50,31 @@ export async function preparePolicyReviewImage(
       };
     }
 
-    if (
-      metadata.width !== EXPECTED_SPRITESHEET_W ||
-      metadata.height !== EXPECTED_SPRITESHEET_H
-    ) {
+    const layout = detectSpriteAtlas(metadata.width, metadata.height);
+    if (!layout) {
       return {
         ok: false,
-        reason: `Spritesheet must be ${EXPECTED_SPRITESHEET_W}x${EXPECTED_SPRITESHEET_H} for policy OCR review.`,
+        reason:
+          "Spritesheet must preserve the 8x9 (1536x1872) or v2 8x11 (1536x2288) atlas ratio for policy OCR review.",
       };
     }
 
-    const source = await sharp(spriteBuffer).ensureAlpha().raw().toBuffer();
-    const contactSheet = renderPolicyContactSheet(source);
+    const canonical = canonicalSpriteDimensions(layout.version);
+    const source = await sharp(spriteBuffer)
+      .ensureAlpha()
+      .resize({
+        width: canonical.width,
+        height: canonical.height,
+        fit: "fill",
+        kernel: sharp.kernel.nearest,
+      })
+      .raw()
+      .toBuffer();
+    const contactSheet = renderPolicyContactSheet(source, layout.rows);
     const sheet = await sharp(contactSheet, {
       raw: {
-        width: EXPECTED_SPRITESHEET_W,
-        height: EXPECTED_SPRITESHEET_H,
+        width: canonical.width,
+        height: canonical.height,
         channels: 4,
       },
     })
@@ -83,10 +96,9 @@ export async function preparePolicyReviewImage(
   }
 }
 
-function renderPolicyContactSheet(source: Buffer): Buffer {
-  const output = Buffer.alloc(
-    EXPECTED_SPRITESHEET_W * EXPECTED_SPRITESHEET_H * 4,
-  );
+function renderPolicyContactSheet(source: Buffer, rows: 9 | 11): Buffer {
+  const { width, height } = canonicalSpriteDimensions(rows === 11 ? 2 : 1);
+  const output = Buffer.alloc(width * height * 4);
   for (let index = 0; index < output.length; index += 4) {
     output[index] = POLICY_BACKGROUND.r;
     output[index + 1] = POLICY_BACKGROUND.g;
@@ -95,10 +107,27 @@ function renderPolicyContactSheet(source: Buffer): Buffer {
   }
 
   for (const state of petStates) {
-    const top = state.row * POLICY_CELL_H;
+    const top = state.row * SPRITE_FRAME_HEIGHT;
     for (let column = 0; column < state.frames; column++) {
-      const left = column * POLICY_CELL_W;
-      copyCellOverBackground(source, output, left, top);
+      const left = column * SPRITE_FRAME_WIDTH;
+      copyCellOverBackground(source, output, width, left, top);
+    }
+  }
+
+  // v2 adds two rows of look-direction frames. They are not animation
+  // states in the classic viewer, but policy review still needs to inspect
+  // every visible cell instead of silently dropping those rows.
+  if (rows === 11) {
+    for (let row = 9; row < 11; row++) {
+      for (let column = 0; column < SPRITE_COLUMNS; column++) {
+        copyCellOverBackground(
+          source,
+          output,
+          width,
+          column * SPRITE_FRAME_WIDTH,
+          row * SPRITE_FRAME_HEIGHT,
+        );
+      }
     }
   }
 
@@ -108,12 +137,13 @@ function renderPolicyContactSheet(source: Buffer): Buffer {
 function copyCellOverBackground(
   source: Buffer,
   output: Buffer,
+  width: number,
   left: number,
   top: number,
 ): void {
-  for (let y = 0; y < POLICY_CELL_H; y++) {
-    for (let x = 0; x < POLICY_CELL_W; x++) {
-      const offset = ((top + y) * EXPECTED_SPRITESHEET_W + left + x) * 4;
+  for (let y = 0; y < SPRITE_FRAME_HEIGHT; y++) {
+    for (let x = 0; x < SPRITE_FRAME_WIDTH; x++) {
+      const offset = ((top + y) * width + left + x) * 4;
       const alpha = source[offset + 3];
       if (alpha === 0) continue;
       if (alpha === 255) {

--- a/src/lib/submission-review.test.ts
+++ b/src/lib/submission-review.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, setDefaultTimeout } from "bun:test";
 import { randomBytes } from "node:crypto";
+
+// Sharp's native pipeline can take several seconds to initialize on a cold
+// CI worker. Keep a bounded file-level budget for this image-heavy suite
+// without weakening the production request timeouts.
+setDefaultTimeout(30_000);
 
 import sharp from "sharp";
 
@@ -595,7 +600,105 @@ describe("submission policy contact sheet", () => {
 
     await expect(preparePolicyReviewImage(sprite)).resolves.toEqual({
       ok: false,
-      reason: "Spritesheet must be 1536x1872 for policy OCR review.",
+      reason:
+        "Spritesheet must preserve the 8x9 (1536x1872) or v2 8x11 (1536x2288) atlas ratio for policy OCR review.",
+    });
+  });
+
+  it("normalizes a scaled classic atlas before policy review", async () => {
+    const sprite = await sharp({
+      create: {
+        width: 768,
+        height: 936,
+        channels: 4,
+        background: { r: 0, g: 0, b: 0, alpha: 0 },
+      },
+    })
+      .composite([
+        {
+          input: await sharp({
+            create: {
+              width: 96,
+              height: 104,
+              channels: 4,
+              background: { r: 25, g: 210, b: 80, alpha: 1 },
+            },
+          })
+            .png()
+            .toBuffer(),
+          left: 7 * 96,
+          top: 0,
+        },
+      ])
+      .png()
+      .toBuffer();
+
+    const dataUrl = await policyReviewImageDataUrl(sprite);
+    const image = Buffer.from(dataUrl?.split(",")[1] ?? "", "base64");
+    const metadata = await sharp(image).metadata();
+    expect(metadata.width).toBe(1536);
+    expect(metadata.height).toBe(1872);
+  });
+
+  it("reviews all rows of a v2 8x11 atlas", async () => {
+    const width = 8 * 192;
+    const height = 11 * 208;
+    const sprite = await sharp({
+      create: {
+        width,
+        height,
+        channels: 4,
+        background: { r: 0, g: 0, b: 0, alpha: 0 },
+      },
+    })
+      .composite([
+        {
+          input: await sharp({
+            create: {
+              width: 192,
+              height: 208,
+              channels: 4,
+              background: { r: 240, g: 210, b: 10, alpha: 1 },
+            },
+          })
+            .png()
+            .toBuffer(),
+          left: 7 * 192,
+          top: 10 * 208,
+        },
+      ])
+      .png()
+      .toBuffer();
+
+    const dataUrl = await policyReviewImageDataUrl(sprite);
+    const image = Buffer.from(dataUrl?.split(",")[1] ?? "", "base64");
+    const metadata = await sharp(image).metadata();
+    expect(metadata.width).toBe(width);
+    expect(metadata.height).toBe(height);
+    const { data } = await sharp(image)
+      .ensureAlpha()
+      .raw()
+      .toBuffer({ resolveWithObject: true });
+    const offset = (10 * 208 * width + 7 * 192 + 96) * 4;
+    expect(Array.from(data.slice(offset, offset + 4))).toEqual([
+      240, 210, 10, 255,
+    ]);
+  });
+
+  it("accepts a 2x v2 atlas within the supported review dimensions", async () => {
+    const sprite = await sharp({
+      create: {
+        width: 3072,
+        height: 4576,
+        channels: 4,
+        background: { r: 0, g: 0, b: 0, alpha: 0 },
+      },
+    })
+      .png()
+      .toBuffer();
+
+    await expect(preparePolicyReviewImage(sprite)).resolves.toMatchObject({
+      ok: true,
     });
   });
 

--- a/src/lib/submission-review.ts
+++ b/src/lib/submission-review.ts
@@ -18,6 +18,8 @@ import {
   scanPetManifestsSecurity,
   scanPetSecurity,
 } from "@/lib/pet-security";
+import { readResponseBodyBounded } from "@/lib/response-body";
+import { detectSpriteAtlas } from "@/lib/sprite-atlas";
 import { decideAutomatedReview } from "@/lib/submission-review-decision";
 import { preparePolicyReviewImage } from "@/lib/submission-review-image";
 import {
@@ -447,6 +449,16 @@ async function analyzeAssets(row: SubmittedPet): Promise<AssetAnalysis> {
         metadata.height < MIN_SPRITE_DIM
       ) {
         reasons.push("spritesheet dimensions are below the minimum size.");
+      }
+      const atlas = detectSpriteAtlas(metadata.width, metadata.height);
+      if (!atlas) {
+        reasons.push(
+          "spritesheet dimensions do not match a supported 8x9 or v2 8x11 atlas.",
+        );
+      } else if (atlas.version !== row.spriteVersionNumber) {
+        reasons.push(
+          `spritesheet uses v${atlas.version} dimensions but pet metadata declares v${row.spriteVersionNumber}.`,
+        );
       }
       dhash = await dhashFromSpriteBuffer(sprite.buffer);
       if (!dhash)
@@ -972,12 +984,24 @@ async function fetchAllowedBuffer(
         reason: `${label} exceeds the maximum allowed size.`,
       };
     }
-    const buffer = Buffer.from(await res.arrayBuffer());
-    if (buffer.byteLength > maxBytes) {
-      return {
-        ok: false,
-        reason: `${label} exceeds the maximum allowed size.`,
-      };
+    let buffer: Buffer;
+    try {
+      buffer = await readResponseBodyBounded(
+        res,
+        maxBytes,
+        REVIEW_FETCH_TIMEOUT_MS,
+      );
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message === "response body exceeds limit"
+      ) {
+        return {
+          ok: false,
+          reason: `${label} exceeds the maximum allowed size.`,
+        };
+      }
+      throw error;
     }
     return { ok: true, buffer };
   } catch {

--- a/src/lib/submissions-validation.ts
+++ b/src/lib/submissions-validation.ts
@@ -2,6 +2,7 @@ import {
   BLOCKED_KEYWORD_REASON,
   findBlockedKeyword,
 } from "@/lib/keyword-blocklist";
+import { detectSpriteAtlas } from "@/lib/sprite-atlas";
 import { normalizeSpriteVersionNumber } from "@/lib/sprite-version";
 import { isAllowedAssetUrl } from "@/lib/url-allowlist";
 import { containsUrl, URL_BLOCKED_REASON } from "@/lib/url-blocklist";
@@ -59,37 +60,32 @@ export function validateSubmission(
       };
     }
   }
+  const width = body.spritesheetWidth;
+  const height = body.spritesheetHeight;
   if (
-    !body.spritesheetWidth ||
-    !body.spritesheetHeight ||
-    body.spritesheetWidth < MIN_SPRITE_DIM ||
-    body.spritesheetHeight < MIN_SPRITE_DIM
+    typeof width !== "number" ||
+    typeof height !== "number" ||
+    !Number.isSafeInteger(width) ||
+    !Number.isSafeInteger(height) ||
+    width < MIN_SPRITE_DIM ||
+    height < MIN_SPRITE_DIM
   ) {
     return {
       ok: false,
       status: 400,
       error: "invalid_spritesheet",
-      message: `Spritesheet seems too small. Got ${body.spritesheetWidth}x${body.spritesheetHeight}, expected at least ${MIN_SPRITE_DIM}x${MIN_SPRITE_DIM} (ideal 1536x1872).`,
-      got: { width: body.spritesheetWidth, height: body.spritesheetHeight },
+      message: `Spritesheet dimensions are invalid. Got ${String(width)}x${String(height)}, expected integer dimensions at least ${MIN_SPRITE_DIM}x${MIN_SPRITE_DIM}.`,
+      got: { width, height },
     };
   }
-  // The viewer walks 192x208 cells on an 8-column grid, so only two
-  // atlas shapes render correctly: the classic 8x9 (1536x1872) and the
-  // hatch-pet v2 8x11 (1536x2288, rows 9-10 hold the 16 look
-  // directions). Clean scales of either are fine (768x936, 3072x4576).
-  // Anything else gets squashed with every frame crop landing
-  // mid-sprite, which is how an early v2 sheet shipped visibly broken.
-  const isClassicGrid =
-    body.spritesheetWidth * 1872 === body.spritesheetHeight * 1536;
-  const isV2Grid =
-    body.spritesheetWidth * 2288 === body.spritesheetHeight * 1536;
-  if (!isClassicGrid && !isV2Grid) {
+  const atlas = detectSpriteAtlas(width, height);
+  if (!atlas) {
     return {
       ok: false,
       status: 400,
       error: "invalid_spritesheet",
-      message: `Spritesheet must be an 8x9 grid (1536x1872) or a v2 8x11 grid (1536x2288). Got ${body.spritesheetWidth}x${body.spritesheetHeight}, which the pet viewer would squash and misalign.`,
-      got: { width: body.spritesheetWidth, height: body.spritesheetHeight },
+      message: `Spritesheet must preserve the 8x9 (1536x1872) or v2 8x11 (1536x2288) atlas ratio. Got ${width}x${height}, which the pet viewer would squash and misalign.`,
+      got: { width, height },
     };
   }
   const spriteVersion = normalizeSpriteVersionNumber(body.spriteVersionNumber);
@@ -101,6 +97,16 @@ export function validateSubmission(
       field: "spriteVersionNumber",
       message: "spriteVersionNumber must be omitted, 1, or 2.",
       got: spriteVersion.value,
+    };
+  }
+  if (atlas.version !== spriteVersion.version) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_sprite_version",
+      field: "spriteVersionNumber",
+      message: `spriteVersionNumber ${spriteVersion.version} does not match the ${atlas.rows}-row atlas dimensions.`,
+      got: spriteVersion.version,
     };
   }
   // Reject any URL outside the allowlist. Without this, a malicious


### PR DESCRIPTION
Code-only replacement for #737.

- validate classic and v2 atlas geometry consistently across submit, review, and UI
- inspect all v2 rows during policy review
- bound streamed asset reads by size and time
- exclude the stale 178k-line generated audit snapshot from git

Validated locally with 504 passing tests, Biome, and diff checks.