### PR TITLE
feat(desktop): add Flock and Petdex account sync

### DIFF
--- a/packages/petdex-desktop-native/app.zon
+++ b/packages/petdex-desktop-native/app.zon
@@ -3,7 +3,7 @@
     .name = "petdex-desktop-native",
     .display_name = "Petdex",
     .description = "Petdex desktop pet on Native SDK: no WebView, no Node.",
-    .version = "0.8.0",
+    .version = "0.9.0",
     .icons = .{"assets/icon.png"},
     .platforms = .{ "macos", "windows", "linux" },
     .permissions = .{ "view", "command" },

--- a/packages/petdex-desktop-native/integrations/herdr/bridge.test.ts
+++ b/packages/petdex-desktop-native/integrations/herdr/bridge.test.ts
@@ -62,6 +62,7 @@ describe("Herdr Petdex bridge", () => {
     expect(update).toEqual({
       bubble: {
         agent_source: "claude",
+        agent_state: "blocked",
         busy: false,
         herdr_pane_id: "w1:p5",
         session_id: "session-1",
@@ -220,5 +221,25 @@ describe("Herdr Petdex bridge", () => {
     } finally {
       await rm(stateRoot, { recursive: true, force: true });
     }
+  });
+
+  test("reports this pane's own status, not the aggregate", () => {
+    // Petdex renders one body per session. Sending only the aggregate
+    // would move every body when any single agent changed, which is the
+    // exact behaviour the flock window exists to replace.
+    const working = updateFromEvent(
+      {
+        data: {
+          agent: "claude",
+          agent_status: "working",
+          pane_id: "w1:p5",
+        },
+      },
+      { ...agent, agent_status: "working" },
+      "waiting",
+      { includeAgents: ["claude"] },
+    );
+    expect(working?.bubble.agent_state).toBe("working");
+    expect(working?.state).toBe("waiting");
   });
 });

--- a/packages/petdex-desktop-native/integrations/herdr/bridge.ts
+++ b/packages/petdex-desktop-native/integrations/herdr/bridge.ts
@@ -37,6 +37,9 @@ export type BridgeConfig = {
 export type PetdexUpdate = {
   bubble: {
     agent_source: string;
+    /// This pane's own status, not the aggregate. Petdex renders one body
+    /// per session, so collapsing here would lose which agent is blocked.
+    agent_state: AgentStatus;
     busy: boolean;
     herdr_pane_id: string;
     session_id: string;
@@ -167,6 +170,7 @@ export function updateFromEvent(
   return {
     bubble: {
       agent_source: agent,
+      agent_state: status,
       busy: status === "working",
       herdr_pane_id: paneId,
       session_id: nativeSession || `herdr:${paneId}`,

--- a/packages/petdex-desktop-native/src/desktop_auth.zig
+++ b/packages/petdex-desktop-native/src/desktop_auth.zig
@@ -10,7 +10,7 @@ pub const scopes = "profile email openid offline_access";
 pub const library_url = "https://petdex.dev/api/desktop/library";
 pub const service = "dev.petdex.desktop-native";
 pub const account = "oauth";
-pub const keychain_accounts = [_][]const u8{ "oauth-0", "oauth-1", "oauth-2" };
+pub const keychain_accounts = [_][]const u8{ "oauth-0", "oauth-1", "oauth-2", "oauth-3", "oauth-4" };
 pub const max_pets = 64;
 
 pub const Phase = enum { signed_out, loading, authorizing, exchanging, syncing, signed_in, failed, unavailable };
@@ -113,7 +113,7 @@ const TokenResponse = struct {
 
 const StoredTokens = struct {
     access_token: ?[]const u8 = null,
-    refresh_token: []const u8,
+    refresh_token: ?[]const u8 = null,
 };
 
 const LibraryPet = struct {
@@ -187,11 +187,20 @@ pub fn applyStoredTokens(state: *State, allocator: std.mem.Allocator, body: []co
     if (trimmed[0] != '{') return copyField(&state.refresh_token, &state.refresh_token_len, trimmed);
     var parsed = std.json.parseFromSlice(StoredTokens, allocator, trimmed, .{ .ignore_unknown_fields = true }) catch return false;
     defer parsed.deinit();
+    var restored = false;
     if (parsed.value.access_token) |access| {
-        if (!copyField(&state.access_token, &state.access_token_len, access)) return false;
+        if (access.len > 0) {
+            if (!copyField(&state.access_token, &state.access_token_len, access)) return false;
+            restored = true;
+        }
     }
-    if (!copyField(&state.refresh_token, &state.refresh_token_len, parsed.value.refresh_token)) return false;
-    return true;
+    if (parsed.value.refresh_token) |refresh| {
+        if (refresh.len > 0) {
+            if (!copyField(&state.refresh_token, &state.refresh_token_len, refresh)) return false;
+            restored = true;
+        }
+    }
+    return restored;
 }
 
 pub fn keychainChunk(token: []const u8, index: usize) ?[]const u8 {
@@ -202,8 +211,8 @@ pub fn keychainChunk(token: []const u8, index: usize) ?[]const u8 {
 }
 
 pub fn storedTokens(state: *const State, out: []u8) ?[]const u8 {
-    if (state.refresh_token_len == 0) return null;
-    return std.fmt.bufPrint(out, "{{\"refresh_token\":\"{s}\"}}", .{state.refreshToken()}) catch null;
+    if (state.access_token_len == 0 and state.refresh_token_len == 0) return null;
+    return std.fmt.bufPrint(out, "{{\"access_token\":\"{s}\",\"refresh_token\":\"{s}\"}}", .{ state.accessToken(), state.refreshToken() }) catch null;
 }
 
 fn petStatus(value: []const u8) ?PetStatus {
@@ -279,18 +288,34 @@ test "library payload copies bounded user and pet data" {
     try std.testing.expectEqual(PetStatus.caught, state.caught[0].status);
 }
 
-test "Keychain payload persists only the refresh token" {
+test "Keychain payload persists available OAuth tokens" {
     var state: State = .{};
+    const access = "access-token";
     const refresh = "refresh-token";
+    @memcpy(state.access_token[0..access.len], access);
+    state.access_token_len = access.len;
     @memcpy(state.refresh_token[0..refresh.len], refresh);
     state.refresh_token_len = refresh.len;
-    var out: [128]u8 = undefined;
-    try std.testing.expectEqualStrings("{\"refresh_token\":\"refresh-token\"}", storedTokens(&state, &out).?);
+    var out: [256]u8 = undefined;
+    try std.testing.expectEqualStrings("{\"access_token\":\"access-token\",\"refresh_token\":\"refresh-token\"}", storedTokens(&state, &out).?);
 
     var restored: State = .{};
     try std.testing.expect(applyStoredTokens(&restored, std.testing.allocator, storedTokens(&state, &out).?));
-    try std.testing.expectEqual(@as(usize, 0), restored.access_token_len);
+    try std.testing.expectEqualStrings(access, restored.accessToken());
     try std.testing.expectEqualStrings(refresh, restored.refreshToken());
+}
+
+test "Keychain payload persists access-only OAuth sessions" {
+    var state: State = .{};
+    const access = "access-token";
+    @memcpy(state.access_token[0..access.len], access);
+    state.access_token_len = access.len;
+    var out: [128]u8 = undefined;
+    const stored = storedTokens(&state, &out).?;
+    var restored: State = .{};
+    try std.testing.expect(applyStoredTokens(&restored, std.testing.allocator, stored));
+    try std.testing.expectEqualStrings(access, restored.accessToken());
+    try std.testing.expectEqual(@as(usize, 0), restored.refresh_token_len);
 }
 
 test "Keychain chunks reassemble the full refresh token" {

--- a/packages/petdex-desktop-native/src/desktop_auth.zig
+++ b/packages/petdex-desktop-native/src/desktop_auth.zig
@@ -10,8 +10,35 @@ pub const scopes = "profile email openid offline_access";
 pub const library_url = "https://petdex.dev/api/desktop/library";
 pub const service = "dev.petdex.desktop-native";
 pub const account = "oauth";
-pub const keychain_accounts = [_][]const u8{ "oauth-0", "oauth-1", "oauth-2", "oauth-3", "oauth-4" };
 pub const max_pets = 64;
+
+const err_sec_success: c_int = 0;
+const err_sec_item_not_found: c_int = -25300;
+
+extern "c" fn SecKeychainFindGenericPassword(
+    keychain_or_array: ?*const anyopaque,
+    service_name_length: u32,
+    service_name: [*]const u8,
+    account_name_length: u32,
+    account_name: [*]const u8,
+    password_length: ?*u32,
+    password_data: ?*?*anyopaque,
+    item_ref: ?*?*anyopaque,
+) c_int;
+extern "c" fn SecKeychainAddGenericPassword(
+    keychain: ?*const anyopaque,
+    service_name_length: u32,
+    service_name: [*]const u8,
+    account_name_length: u32,
+    account_name: [*]const u8,
+    password_length: u32,
+    password_data: *const anyopaque,
+    item_ref: ?*?*anyopaque,
+) c_int;
+extern "c" fn SecKeychainItemModifyAttributesAndData(item_ref: *anyopaque, attr_list: ?*const anyopaque, length: u32, data: *const anyopaque) c_int;
+extern "c" fn SecKeychainItemDelete(item_ref: *anyopaque) c_int;
+extern "c" fn SecKeychainItemFreeContent(attr_list: ?*anyopaque, data: ?*anyopaque) c_int;
+extern "c" fn CFRelease(value: *const anyopaque) void;
 
 pub const Phase = enum { signed_out, loading, authorizing, exchanging, syncing, signed_in, failed, unavailable };
 pub const PetStatus = enum { pending, approved, rejected, caught };
@@ -203,16 +230,47 @@ pub fn applyStoredTokens(state: *State, allocator: std.mem.Allocator, body: []co
     return restored;
 }
 
-pub fn keychainChunk(token: []const u8, index: usize) ?[]const u8 {
-    if (token.len < keychain_accounts.len or index >= keychain_accounts.len) return null;
-    const start = token.len * index / keychain_accounts.len;
-    const end = token.len * (index + 1) / keychain_accounts.len;
-    return token[start..end];
-}
-
 pub fn storedTokens(state: *const State, out: []u8) ?[]const u8 {
     if (state.access_token_len == 0 and state.refresh_token_len == 0) return null;
     return std.fmt.bufPrint(out, "{{\"access_token\":\"{s}\",\"refresh_token\":\"{s}\"}}", .{ state.accessToken(), state.refreshToken() }) catch null;
+}
+
+pub fn loadStoredSession(out: []u8) ?[]const u8 {
+    if (!available) return null;
+    var password_len: u32 = 0;
+    var password_data: ?*anyopaque = null;
+    var item_ref: ?*anyopaque = null;
+    const status = SecKeychainFindGenericPassword(null, service.len, service.ptr, account.len, account.ptr, &password_len, &password_data, &item_ref);
+    defer {
+        if (password_data != null) _ = SecKeychainItemFreeContent(null, password_data);
+        if (item_ref) |item| CFRelease(item);
+    }
+    if (status != err_sec_success or password_len == 0 or password_len > out.len) return null;
+    const source: [*]const u8 = @ptrCast(password_data.?);
+    @memcpy(out[0..password_len], source[0..password_len]);
+    return out[0..password_len];
+}
+
+pub fn saveStoredSession(session: []const u8) bool {
+    if (!available or session.len == 0 or session.len > std.math.maxInt(u32)) return false;
+    var item_ref: ?*anyopaque = null;
+    const status = SecKeychainFindGenericPassword(null, service.len, service.ptr, account.len, account.ptr, null, null, &item_ref);
+    if (status == err_sec_success) {
+        defer CFRelease(item_ref.?);
+        return SecKeychainItemModifyAttributesAndData(item_ref.?, null, @intCast(session.len), session.ptr) == err_sec_success;
+    }
+    if (status != err_sec_item_not_found) return false;
+    return SecKeychainAddGenericPassword(null, service.len, service.ptr, account.len, account.ptr, @intCast(session.len), session.ptr, null) == err_sec_success;
+}
+
+pub fn deleteStoredSession() bool {
+    if (!available) return false;
+    var item_ref: ?*anyopaque = null;
+    const status = SecKeychainFindGenericPassword(null, service.len, service.ptr, account.len, account.ptr, null, null, &item_ref);
+    if (status == err_sec_item_not_found) return true;
+    if (status != err_sec_success) return false;
+    defer CFRelease(item_ref.?);
+    return SecKeychainItemDelete(item_ref.?) == err_sec_success;
 }
 
 fn petStatus(value: []const u8) ?PetStatus {
@@ -316,20 +374,4 @@ test "Keychain payload persists access-only OAuth sessions" {
     try std.testing.expect(applyStoredTokens(&restored, std.testing.allocator, stored));
     try std.testing.expectEqualStrings(access, restored.accessToken());
     try std.testing.expectEqual(@as(usize, 0), restored.refresh_token_len);
-}
-
-test "Keychain chunks reassemble the full refresh token" {
-    const token = "abcdefghijklmnopqrstuvwxyz";
-    var restored: [token.len]u8 = undefined;
-    var offset: usize = 0;
-    for (0..keychain_accounts.len) |index| {
-        const chunk = keychainChunk(token, index).?;
-        @memcpy(restored[offset..][0..chunk.len], chunk);
-        offset += chunk.len;
-    }
-    try std.testing.expectEqualStrings(token, restored[0..offset]);
-
-    var state: State = .{};
-    try std.testing.expect(applyStoredTokens(&state, std.testing.allocator, &restored));
-    try std.testing.expectEqualStrings(token, state.refreshToken());
 }

--- a/packages/petdex-desktop-native/src/desktop_auth.zig
+++ b/packages/petdex-desktop-native/src/desktop_auth.zig
@@ -10,6 +10,7 @@ pub const scopes = "profile email openid offline_access";
 pub const library_url = "https://petdex.dev/api/desktop/library";
 pub const service = "dev.petdex.desktop-native";
 pub const account = "oauth";
+pub const keychain_accounts = [_][]const u8{ "oauth-0", "oauth-1", "oauth-2" };
 pub const max_pets = 64;
 
 pub const Phase = enum { signed_out, loading, authorizing, exchanging, syncing, signed_in, failed, unavailable };
@@ -181,13 +182,23 @@ pub fn applyTokenResponse(state: *State, allocator: std.mem.Allocator, body: []c
 }
 
 pub fn applyStoredTokens(state: *State, allocator: std.mem.Allocator, body: []const u8) bool {
-    var parsed = std.json.parseFromSlice(StoredTokens, allocator, std.mem.trim(u8, body, " \r\n"), .{ .ignore_unknown_fields = true }) catch return false;
+    const trimmed = std.mem.trim(u8, body, " \r\n");
+    if (trimmed.len == 0) return false;
+    if (trimmed[0] != '{') return copyField(&state.refresh_token, &state.refresh_token_len, trimmed);
+    var parsed = std.json.parseFromSlice(StoredTokens, allocator, trimmed, .{ .ignore_unknown_fields = true }) catch return false;
     defer parsed.deinit();
     if (parsed.value.access_token) |access| {
         if (!copyField(&state.access_token, &state.access_token_len, access)) return false;
     }
     if (!copyField(&state.refresh_token, &state.refresh_token_len, parsed.value.refresh_token)) return false;
     return true;
+}
+
+pub fn keychainChunk(token: []const u8, index: usize) ?[]const u8 {
+    if (token.len < keychain_accounts.len or index >= keychain_accounts.len) return null;
+    const start = token.len * index / keychain_accounts.len;
+    const end = token.len * (index + 1) / keychain_accounts.len;
+    return token[start..end];
 }
 
 pub fn storedTokens(state: *const State, out: []u8) ?[]const u8 {
@@ -280,4 +291,20 @@ test "Keychain payload persists only the refresh token" {
     try std.testing.expect(applyStoredTokens(&restored, std.testing.allocator, storedTokens(&state, &out).?));
     try std.testing.expectEqual(@as(usize, 0), restored.access_token_len);
     try std.testing.expectEqualStrings(refresh, restored.refreshToken());
+}
+
+test "Keychain chunks reassemble the full refresh token" {
+    const token = "abcdefghijklmnopqrstuvwxyz";
+    var restored: [token.len]u8 = undefined;
+    var offset: usize = 0;
+    for (0..keychain_accounts.len) |index| {
+        const chunk = keychainChunk(token, index).?;
+        @memcpy(restored[offset..][0..chunk.len], chunk);
+        offset += chunk.len;
+    }
+    try std.testing.expectEqualStrings(token, restored[0..offset]);
+
+    var state: State = .{};
+    try std.testing.expect(applyStoredTokens(&state, std.testing.allocator, &restored));
+    try std.testing.expectEqualStrings(token, state.refreshToken());
 }

--- a/packages/petdex-desktop-native/src/desktop_auth.zig
+++ b/packages/petdex-desktop-native/src/desktop_auth.zig
@@ -1,0 +1,283 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const plat = @import("plat.zig");
+
+pub const available = builtin.os.tag == .macos;
+pub const issuer = "https://clerk.petdex.dev";
+pub const client_id = "LcThwEayl6KAA1Qm";
+pub const redirect_uri = "http://127.0.0.1:7777/callback";
+pub const scopes = "profile email openid offline_access";
+pub const library_url = "https://petdex.dev/api/desktop/library";
+pub const service = "dev.petdex.desktop-native";
+pub const account = "oauth";
+pub const max_pets = 64;
+
+pub const Phase = enum { signed_out, loading, authorizing, exchanging, syncing, signed_in, failed, unavailable };
+pub const PetStatus = enum { pending, approved, rejected, caught };
+pub const LibraryView = enum { installed, yours, caught };
+
+pub const Pet = struct {
+    slug: [64]u8 = @splat(0),
+    slug_len: usize = 0,
+    display_name: [96]u8 = @splat(0),
+    display_name_len: usize = 0,
+    thumbnail_url: [512]u8 = @splat(0),
+    thumbnail_url_len: usize = 0,
+    status: PetStatus = .pending,
+
+    pub fn slugSlice(self: *const Pet) []const u8 {
+        return self.slug[0..self.slug_len];
+    }
+
+    pub fn displayName(self: *const Pet) []const u8 {
+        return self.display_name[0..self.display_name_len];
+    }
+
+    pub fn thumbnailUrl(self: *const Pet) []const u8 {
+        return self.thumbnail_url[0..self.thumbnail_url_len];
+    }
+};
+
+pub const State = struct {
+    phase: Phase = if (available) .signed_out else .unavailable,
+    access_token: [8192]u8 = @splat(0),
+    access_token_len: usize = 0,
+    refresh_token: [8192]u8 = @splat(0),
+    refresh_token_len: usize = 0,
+    verifier: [86]u8 = @splat(0),
+    verifier_len: usize = 0,
+    oauth_state: [43]u8 = @splat(0),
+    oauth_state_len: usize = 0,
+    email: [160]u8 = @splat(0),
+    email_len: usize = 0,
+    name: [128]u8 = @splat(0),
+    name_len: usize = 0,
+    avatar_url: [1024]u8 = @splat(0),
+    avatar_url_len: usize = 0,
+    owned: [max_pets]Pet = @splat(.{}),
+    owned_len: usize = 0,
+    caught: [max_pets]Pet = @splat(.{}),
+    caught_len: usize = 0,
+    refreshing: bool = false,
+    error_text: [192]u8 = @splat(0),
+    error_len: usize = 0,
+
+    pub fn accessToken(self: *const State) []const u8 {
+        return self.access_token[0..self.access_token_len];
+    }
+
+    pub fn refreshToken(self: *const State) []const u8 {
+        return self.refresh_token[0..self.refresh_token_len];
+    }
+
+    pub fn verifierSlice(self: *const State) []const u8 {
+        return self.verifier[0..self.verifier_len];
+    }
+
+    pub fn oauthState(self: *const State) []const u8 {
+        return self.oauth_state[0..self.oauth_state_len];
+    }
+
+    pub fn emailSlice(self: *const State) []const u8 {
+        return self.email[0..self.email_len];
+    }
+
+    pub fn nameSlice(self: *const State) []const u8 {
+        return self.name[0..self.name_len];
+    }
+
+    pub fn avatarUrl(self: *const State) []const u8 {
+        return self.avatar_url[0..self.avatar_url_len];
+    }
+
+    pub fn errorSlice(self: *const State) []const u8 {
+        return self.error_text[0..self.error_len];
+    }
+
+    pub fn setError(self: *State, text: []const u8) void {
+        self.phase = .failed;
+        self.error_len = @min(text.len, self.error_text.len);
+        @memcpy(self.error_text[0..self.error_len], text[0..self.error_len]);
+    }
+
+    pub fn clearSession(self: *State) void {
+        self.* = .{};
+    }
+};
+
+const TokenResponse = struct {
+    access_token: []const u8,
+    refresh_token: ?[]const u8 = null,
+};
+
+const StoredTokens = struct {
+    access_token: ?[]const u8 = null,
+    refresh_token: []const u8,
+};
+
+const LibraryPet = struct {
+    slug: []const u8,
+    displayName: []const u8,
+    status: []const u8,
+    thumbnailUrl: ?[]const u8 = null,
+};
+
+const LibraryUser = struct {
+    email: ?[]const u8 = null,
+    username: ?[]const u8 = null,
+    firstName: ?[]const u8 = null,
+    lastName: ?[]const u8 = null,
+    imageUrl: ?[]const u8 = null,
+};
+
+const LibraryResponse = struct {
+    user: LibraryUser,
+    owned: []const LibraryPet,
+    caught: []const LibraryPet,
+};
+
+fn copyField(dest: []u8, len: *usize, value: []const u8) bool {
+    if (value.len > dest.len) return false;
+    @memcpy(dest[0..value.len], value);
+    len.* = value.len;
+    return true;
+}
+
+pub fn begin(state: *State, url_buf: []u8) ?[]const u8 {
+    var verifier_raw: [64]u8 = undefined;
+    var state_raw: [32]u8 = undefined;
+    plat.fillRandom(&verifier_raw) catch return null;
+    plat.fillRandom(&state_raw) catch return null;
+    state.verifier_len = std.base64.url_safe_no_pad.Encoder.calcSize(verifier_raw.len);
+    _ = std.base64.url_safe_no_pad.Encoder.encode(state.verifier[0..state.verifier_len], &verifier_raw);
+    state.oauth_state_len = std.base64.url_safe_no_pad.Encoder.calcSize(state_raw.len);
+    _ = std.base64.url_safe_no_pad.Encoder.encode(state.oauth_state[0..state.oauth_state_len], &state_raw);
+    var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(state.verifierSlice(), &digest, .{});
+    var challenge: [43]u8 = undefined;
+    const encoded = std.base64.url_safe_no_pad.Encoder.encode(&challenge, &digest);
+    const url = std.fmt.bufPrint(url_buf, "{s}/oauth/authorize?client_id={s}&response_type=code&redirect_uri=http%3A%2F%2F127.0.0.1%3A7777%2Fcallback&scope=profile%20email%20openid%20offline_access&code_challenge={s}&code_challenge_method=S256&state={s}", .{ issuer, client_id, encoded, state.oauthState() }) catch return null;
+    state.phase = .authorizing;
+    state.error_len = 0;
+    return url;
+}
+
+pub fn tokenBody(state: *const State, code: []const u8, out: []u8) ?[]const u8 {
+    return std.fmt.bufPrint(out, "grant_type=authorization_code&client_id={s}&code={s}&code_verifier={s}&redirect_uri=http%3A%2F%2F127.0.0.1%3A7777%2Fcallback", .{ client_id, code, state.verifierSlice() }) catch null;
+}
+
+pub fn refreshBody(state: *const State, out: []u8) ?[]const u8 {
+    return std.fmt.bufPrint(out, "grant_type=refresh_token&client_id={s}&refresh_token={s}&scope=profile%20email%20openid%20offline_access", .{ client_id, state.refreshToken() }) catch null;
+}
+
+pub fn applyTokenResponse(state: *State, allocator: std.mem.Allocator, body: []const u8) bool {
+    var parsed = std.json.parseFromSlice(TokenResponse, allocator, body, .{ .ignore_unknown_fields = true }) catch return false;
+    defer parsed.deinit();
+    if (!copyField(&state.access_token, &state.access_token_len, parsed.value.access_token)) return false;
+    if (parsed.value.refresh_token) |refresh| {
+        if (!copyField(&state.refresh_token, &state.refresh_token_len, refresh)) return false;
+    }
+    return true;
+}
+
+pub fn applyStoredTokens(state: *State, allocator: std.mem.Allocator, body: []const u8) bool {
+    var parsed = std.json.parseFromSlice(StoredTokens, allocator, std.mem.trim(u8, body, " \r\n"), .{ .ignore_unknown_fields = true }) catch return false;
+    defer parsed.deinit();
+    if (parsed.value.access_token) |access| {
+        if (!copyField(&state.access_token, &state.access_token_len, access)) return false;
+    }
+    if (!copyField(&state.refresh_token, &state.refresh_token_len, parsed.value.refresh_token)) return false;
+    return true;
+}
+
+pub fn storedTokens(state: *const State, out: []u8) ?[]const u8 {
+    if (state.refresh_token_len == 0) return null;
+    return std.fmt.bufPrint(out, "{{\"refresh_token\":\"{s}\"}}", .{state.refreshToken()}) catch null;
+}
+
+fn petStatus(value: []const u8) ?PetStatus {
+    if (std.mem.eql(u8, value, "pending")) return .pending;
+    if (std.mem.eql(u8, value, "approved")) return .approved;
+    if (std.mem.eql(u8, value, "rejected")) return .rejected;
+    if (std.mem.eql(u8, value, "caught")) return .caught;
+    return null;
+}
+
+fn copyPets(dest: []Pet, source: []const LibraryPet) usize {
+    var count: usize = 0;
+    for (source[0..@min(source.len, dest.len)]) |item| {
+        const status = petStatus(item.status) orelse continue;
+        if (item.slug.len > dest[count].slug.len or item.displayName.len > dest[count].display_name.len) continue;
+        @memcpy(dest[count].slug[0..item.slug.len], item.slug);
+        dest[count].slug_len = item.slug.len;
+        @memcpy(dest[count].display_name[0..item.displayName.len], item.displayName);
+        dest[count].display_name_len = item.displayName.len;
+        dest[count].status = status;
+        if (item.thumbnailUrl) |url| {
+            _ = copyField(&dest[count].thumbnail_url, &dest[count].thumbnail_url_len, url);
+        }
+        count += 1;
+    }
+    return count;
+}
+
+pub fn applyLibrary(state: *State, allocator: std.mem.Allocator, body: []const u8) bool {
+    var parsed = std.json.parseFromSlice(LibraryResponse, allocator, body, .{ .ignore_unknown_fields = true }) catch return false;
+    defer parsed.deinit();
+    state.email_len = 0;
+    state.name_len = 0;
+    state.avatar_url_len = 0;
+    if (parsed.value.user.email) |email| _ = copyField(&state.email, &state.email_len, email);
+    if (parsed.value.user.imageUrl) |url| _ = copyField(&state.avatar_url, &state.avatar_url_len, url);
+    if (parsed.value.user.username) |username| {
+        _ = copyField(&state.name, &state.name_len, username);
+    } else if (parsed.value.user.firstName) |first| {
+        if (parsed.value.user.lastName) |last| {
+            const written = std.fmt.bufPrint(&state.name, "{s} {s}", .{ first, last }) catch return false;
+            state.name_len = written.len;
+        } else {
+            _ = copyField(&state.name, &state.name_len, first);
+        }
+    }
+    state.owned_len = copyPets(&state.owned, parsed.value.owned);
+    state.caught_len = copyPets(&state.caught, parsed.value.caught);
+    state.phase = .signed_in;
+    state.error_len = 0;
+    return true;
+}
+
+test "PKCE authorization uses a fresh verifier and state" {
+    var state: State = .{};
+    var url: [1024]u8 = undefined;
+    const value = begin(&state, &url).?;
+    try std.testing.expectEqual(Phase.authorizing, state.phase);
+    try std.testing.expectEqual(@as(usize, 86), state.verifier_len);
+    try std.testing.expectEqual(@as(usize, 43), state.oauth_state_len);
+    try std.testing.expect(std.mem.indexOf(u8, value, "code_challenge_method=S256") != null);
+    try std.testing.expect(std.mem.indexOf(u8, value, state.oauthState()) != null);
+}
+
+test "library payload copies bounded user and pet data" {
+    var state: State = .{};
+    const body = "{\"user\":{\"email\":\"hi@petdex.dev\",\"username\":\"hunter\",\"imageUrl\":\"https://img.clerk.com/hunter.png\"},\"owned\":[{\"slug\":\"boba\",\"displayName\":\"Boba\",\"status\":\"approved\",\"thumbnailUrl\":\"https://assets.petdex.dev/pets/boba/thumb.webp\"}],\"caught\":[{\"slug\":\"droid\",\"displayName\":\"Droid\",\"status\":\"caught\"}]}";
+    try std.testing.expect(applyLibrary(&state, std.testing.allocator, body));
+    try std.testing.expectEqualStrings("hunter", state.nameSlice());
+    try std.testing.expectEqualStrings("boba", state.owned[0].slugSlice());
+    try std.testing.expectEqualStrings("https://assets.petdex.dev/pets/boba/thumb.webp", state.owned[0].thumbnailUrl());
+    try std.testing.expectEqualStrings("https://img.clerk.com/hunter.png", state.avatarUrl());
+    try std.testing.expectEqual(PetStatus.caught, state.caught[0].status);
+}
+
+test "Keychain payload persists only the refresh token" {
+    var state: State = .{};
+    const refresh = "refresh-token";
+    @memcpy(state.refresh_token[0..refresh.len], refresh);
+    state.refresh_token_len = refresh.len;
+    var out: [128]u8 = undefined;
+    try std.testing.expectEqualStrings("{\"refresh_token\":\"refresh-token\"}", storedTokens(&state, &out).?);
+
+    var restored: State = .{};
+    try std.testing.expect(applyStoredTokens(&restored, std.testing.allocator, storedTokens(&state, &out).?));
+    try std.testing.expectEqual(@as(usize, 0), restored.access_token_len);
+    try std.testing.expectEqualStrings(refresh, restored.refreshToken());
+}

--- a/packages/petdex-desktop-native/src/flock.zig
+++ b/packages/petdex-desktop-native/src/flock.zig
@@ -57,10 +57,26 @@ fn copyInto(dest: []u8, dest_len: *usize, source: []const u8) void {
     dest_len.* = n;
 }
 
-/// A bubble's `busy` flag is the only per-agent signal the mailbox carries
-/// today, so V1 renders `running` against `idle`. V2 replaces this with a
-/// real per-agent state once the bridge stops collapsing them.
+/// This agent's body state. The mailbox carries a per-agent attention
+/// string when the sender knows one, so a blocked agent reads apart from
+/// a working one instead of both collapsing into "busy". Senders that do
+/// not report it fall back to the boolean, which is what every existing
+/// hook produces.
+///
+/// The names accepted here are the vocabulary the senders already speak:
+/// Herdr's four statuses and the richer set the direct hooks produce.
 pub fn stateForBubble(bubble: *const hook_server.Bubble) sprite.State {
+    const reported = bubble.agentStateSlice();
+    if (reported.len != 0) {
+        if (std.mem.eql(u8, reported, "blocked")) return .waiting;
+        if (std.mem.eql(u8, reported, "waiting")) return .waiting;
+        if (std.mem.eql(u8, reported, "working")) return .running;
+        if (std.mem.eql(u8, reported, "running")) return .running;
+        if (std.mem.eql(u8, reported, "idle")) return .idle;
+        if (std.mem.eql(u8, reported, "done")) return .idle;
+        // An unknown name is not a reason to lie about the agent: fall
+        // through to the boolean rather than inventing a state.
+    }
     return if (bubble.busy) .running else .idle;
 }
 
@@ -182,6 +198,12 @@ pub fn windowSize(count: usize, spec: LayoutSpec) struct { w: f32, h: f32 } {
         .w = @as(f32, @floatFromInt(shown_cols)) * spec.cell_w + @as(f32, @floatFromInt(shown_cols -| 1)) * spec.gap,
         .h = rows_f * (spec.cell_h + spec.label_h) + @as(f32, @floatFromInt(rows -| 1)) * spec.gap,
     };
+}
+
+fn testBubbleWithState(session: []const u8, agent: []const u8, busy: bool, state: []const u8) hook_server.Bubble {
+    var bubble = testBubble(session, agent, "", busy);
+    copyInto(&bubble.agent_state, &bubble.agent_state_len, state);
+    return bubble;
 }
 
 fn testBubble(session: []const u8, agent: []const u8, pane: []const u8, busy: bool) hook_server.Bubble {
@@ -311,4 +333,59 @@ test "columns never exceed the bodies on screen" {
     try std.testing.expectEqual(@as(usize, 1), columnsFor(0, 4));
     try std.testing.expectEqual(@as(usize, 2), rowsFor(6, 4));
     try std.testing.expectEqual(@as(usize, 1), rowsFor(0, 4));
+}
+
+test "a blocked agent reads apart from a working one" {
+    var model: Model = .{};
+    reconcile(&model, &[_]hook_server.Bubble{
+        testBubbleWithState("s1", "claude", true, "blocked"),
+        testBubbleWithState("s2", "codex", true, "working"),
+    });
+    try std.testing.expectEqual(sprite.State.waiting, model.members[0].state);
+    try std.testing.expectEqual(sprite.State.running, model.members[1].state);
+}
+
+test "one agent changing state leaves the others alone" {
+    // The aggregate the pet window shows would move every body at once.
+    // Here only the session that reported a change moves.
+    var model: Model = .{};
+    const before = [_]hook_server.Bubble{
+        testBubbleWithState("s1", "claude", true, "working"),
+        testBubbleWithState("s2", "codex", true, "working"),
+    };
+    reconcile(&model, &before);
+    try std.testing.expectEqual(sprite.State.running, model.members[1].state);
+
+    reconcile(&model, &[_]hook_server.Bubble{
+        testBubbleWithState("s1", "claude", true, "blocked"),
+        testBubbleWithState("s2", "codex", true, "working"),
+    });
+    try std.testing.expectEqual(sprite.State.waiting, model.members[0].state);
+    try std.testing.expectEqual(sprite.State.running, model.members[1].state);
+}
+
+test "a sender that reports no state keeps the busy behaviour" {
+    var model: Model = .{};
+    reconcile(&model, &[_]hook_server.Bubble{
+        testBubble("s1", "claude", "", true),
+        testBubble("s2", "codex", "", false),
+    });
+    try std.testing.expectEqual(sprite.State.running, model.members[0].state);
+    try std.testing.expectEqual(sprite.State.idle, model.members[1].state);
+}
+
+test "an unknown state name falls back instead of inventing one" {
+    var model: Model = .{};
+    reconcile(&model, &[_]hook_server.Bubble{
+        testBubbleWithState("s1", "claude", true, "quantum"),
+        testBubbleWithState("s2", "codex", false, "quantum"),
+    });
+    try std.testing.expectEqual(sprite.State.running, model.members[0].state);
+    try std.testing.expectEqual(sprite.State.idle, model.members[1].state);
+}
+
+test "Herdr done means idle, not verified completion" {
+    var model: Model = .{};
+    reconcile(&model, &[_]hook_server.Bubble{testBubbleWithState("s1", "claude", true, "done")});
+    try std.testing.expectEqual(sprite.State.idle, model.members[0].state);
 }

--- a/packages/petdex-desktop-native/src/flock.zig
+++ b/packages/petdex-desktop-native/src/flock.zig
@@ -68,12 +68,20 @@ fn copyInto(dest: []u8, dest_len: *usize, source: []const u8) void {
 pub fn stateForBubble(bubble: *const hook_server.Bubble) sprite.State {
     const reported = bubble.agentStateSlice();
     if (reported.len != 0) {
+        // Herdr's vocabulary: four statuses, all it can see.
         if (std.mem.eql(u8, reported, "blocked")) return .waiting;
-        if (std.mem.eql(u8, reported, "waiting")) return .waiting;
         if (std.mem.eql(u8, reported, "working")) return .running;
+        if (std.mem.eql(u8, reported, "done")) return .idle;
+        // What the direct hooks add on top, and the reason a body can say
+        // more than "busy": a failed tool call, a read-only pass, the end
+        // of a turn. None of these cross Herdr's plugin API.
+        if (std.mem.eql(u8, reported, "failed")) return .failed;
+        if (std.mem.eql(u8, reported, "review")) return .review;
+        if (std.mem.eql(u8, reported, "waving")) return .waving;
+        if (std.mem.eql(u8, reported, "jumping")) return .jumping;
+        if (std.mem.eql(u8, reported, "waiting")) return .waiting;
         if (std.mem.eql(u8, reported, "running")) return .running;
         if (std.mem.eql(u8, reported, "idle")) return .idle;
-        if (std.mem.eql(u8, reported, "done")) return .idle;
         // An unknown name is not a reason to lie about the agent: fall
         // through to the boolean rather than inventing a state.
     }
@@ -388,4 +396,63 @@ test "Herdr done means idle, not verified completion" {
     var model: Model = .{};
     reconcile(&model, &[_]hook_server.Bubble{testBubbleWithState("s1", "claude", true, "done")});
     try std.testing.expectEqual(sprite.State.idle, model.members[0].state);
+}
+
+test "a failed tool call shows as failure, not as idle" {
+    // The whole competitive claim: Herdr's plugin API carries four
+    // statuses and none of them is "that tool call errored". The direct
+    // hooks compute it, so a body can show it.
+    var model: Model = .{};
+    reconcile(&model, &[_]hook_server.Bubble{testBubbleWithState("s1", "claude", true, "failed")});
+    try std.testing.expectEqual(sprite.State.failed, model.members[0].state);
+}
+
+test "a read-only pass reads apart from an edit" {
+    var model: Model = .{};
+    reconcile(&model, &[_]hook_server.Bubble{
+        testBubbleWithState("s1", "claude", true, "review"),
+        testBubbleWithState("s2", "codex", true, "working"),
+    });
+    try std.testing.expectEqual(sprite.State.review, model.members[0].state);
+    try std.testing.expectEqual(sprite.State.running, model.members[1].state);
+}
+
+test "the states Herdr cannot express all survive the trip" {
+    // Each of these comes from a direct hook and has no equivalent in
+    // Herdr's working/blocked/idle/done.
+    const cases = [_]struct { reported: []const u8, want: sprite.State }{
+        .{ .reported = "failed", .want = .failed },
+        .{ .reported = "review", .want = .review },
+        .{ .reported = "waving", .want = .waving },
+        .{ .reported = "jumping", .want = .jumping },
+    };
+    for (cases) |case| {
+        var model: Model = .{};
+        reconcile(&model, &[_]hook_server.Bubble{testBubbleWithState("s1", "claude", true, case.reported)});
+        try std.testing.expectEqual(case.want, model.members[0].state);
+    }
+}
+
+test "a body without a pane offers no jump" {
+    // Direct hooks outside Herdr carry no pane. Such a body must stay
+    // inert rather than presenting a click that would reach nothing.
+    var model: Model = .{};
+    reconcile(&model, &[_]hook_server.Bubble{
+        testBubble("s1", "claude", "", true),
+        testBubble("s2", "codex", "w1:p9", true),
+    });
+    try std.testing.expectEqual(@as(usize, 0), model.members[0].herdrPaneSlice().len);
+    try std.testing.expectEqualStrings("w1:p9", model.members[1].herdrPaneSlice());
+}
+
+test "each body keeps its own pane, so a click cannot reach the wrong session" {
+    var model: Model = .{};
+    reconcile(&model, &[_]hook_server.Bubble{
+        testBubble("s1", "claude", "w1:pA", true),
+        testBubble("s2", "codex", "w1:pB", true),
+        testBubble("s3", "gemini", "w1:pC", true),
+    });
+    try std.testing.expectEqualStrings("w1:pA", model.members[0].herdrPaneSlice());
+    try std.testing.expectEqualStrings("w1:pB", model.members[1].herdrPaneSlice());
+    try std.testing.expectEqualStrings("w1:pC", model.members[2].herdrPaneSlice());
 }

--- a/packages/petdex-desktop-native/src/flock.zig
+++ b/packages/petdex-desktop-native/src/flock.zig
@@ -1,0 +1,314 @@
+//! Flock model: one body per live agent instead of one pet for all of them.
+//!
+//! The mailbox already keeps a bubble per conversation, keyed by session id
+//! and carrying the Herdr pane that produced it. Until now the app folded
+//! that set into a single `model.state`, so eight agents shared one mascot
+//! and one aggregate state. This module keeps the set intact and gives each
+//! member a body, a slot, and a state of its own.
+//!
+//! Pure data: no allocator, no effects, no platform. `reconcile` maps the
+//! drained bubbles onto members, `layout` places them in a grid, and both
+//! are directly testable without a window.
+
+const std = @import("std");
+const hook_server = @import("hook_server.zig");
+const sprite = @import("sprite.zig");
+
+pub const max_members = hook_server.max_bubbles;
+
+/// One agent's body. `session` is copied rather than referenced because the
+/// mailbox reuses its slots: a member has to survive the next drain that
+/// compacts the array underneath it.
+pub const Member = struct {
+    session: [64]u8 = @splat(0),
+    session_len: usize = 0,
+    label: [24]u8 = @splat(0),
+    label_len: usize = 0,
+    herdr_pane: [64]u8 = @splat(0),
+    herdr_pane_len: usize = 0,
+    state: sprite.State = .idle,
+    busy: bool = false,
+
+    pub fn sessionSlice(self: *const Member) []const u8 {
+        return self.session[0..self.session_len];
+    }
+    pub fn labelSlice(self: *const Member) []const u8 {
+        return self.label[0..self.label_len];
+    }
+    pub fn herdrPaneSlice(self: *const Member) []const u8 {
+        return self.herdr_pane[0..self.herdr_pane_len];
+    }
+};
+
+pub const Model = struct {
+    members: [max_members]Member = @splat(.{}),
+    len: usize = 0,
+    open: bool = false,
+
+    pub fn slice(self: *const Model) []const Member {
+        return self.members[0..self.len];
+    }
+};
+
+fn copyInto(dest: []u8, dest_len: *usize, source: []const u8) void {
+    const n = @min(dest.len, source.len);
+    @memcpy(dest[0..n], source[0..n]);
+    @memset(dest[n..], 0);
+    dest_len.* = n;
+}
+
+/// A bubble's `busy` flag is the only per-agent signal the mailbox carries
+/// today, so V1 renders `running` against `idle`. V2 replaces this with a
+/// real per-agent state once the bridge stops collapsing them.
+pub fn stateForBubble(bubble: *const hook_server.Bubble) sprite.State {
+    return if (bubble.busy) .running else .idle;
+}
+
+/// Rebuild the member set from the live bubbles, preserving each member's
+/// slot across drains so a body does not jump position when an unrelated
+/// agent above it goes away. Members whose session is gone are dropped.
+pub fn reconcile(model: *Model, bubbles: []const hook_server.Bubble) void {
+    var next: [max_members]Member = @splat(.{});
+    var taken: [max_members]bool = @splat(false);
+    var next_len: usize = 0;
+
+    // First pass: sessions we already had keep their existing slot.
+    for (bubbles) |*bubble| {
+        const session = bubble.sessionSlice();
+        for (model.members[0..model.len], 0..) |*existing, slot| {
+            if (existing.session_len == 0) continue;
+            if (!std.mem.eql(u8, existing.sessionSlice(), session)) continue;
+            if (slot >= max_members or taken[slot]) break;
+            next[slot] = existing.*;
+            next[slot].state = stateForBubble(bubble);
+            next[slot].busy = bubble.busy;
+            copyInto(&next[slot].label, &next[slot].label_len, bubble.agent[0..bubble.agent_len]);
+            copyInto(&next[slot].herdr_pane, &next[slot].herdr_pane_len, bubble.herdrPaneSlice());
+            taken[slot] = true;
+            if (slot + 1 > next_len) next_len = slot + 1;
+            break;
+        }
+    }
+
+    // Second pass: new sessions fill the lowest free slot.
+    for (bubbles) |*bubble| {
+        const session = bubble.sessionSlice();
+        var seen = false;
+        for (next[0..], 0..) |*member, slot| {
+            if (!taken[slot]) continue;
+            if (std.mem.eql(u8, member.sessionSlice(), session)) {
+                seen = true;
+                break;
+            }
+        }
+        if (seen) continue;
+        var slot: usize = 0;
+        while (slot < max_members and taken[slot]) slot += 1;
+        if (slot == max_members) break;
+        var member: Member = .{};
+        copyInto(&member.session, &member.session_len, session);
+        copyInto(&member.label, &member.label_len, bubble.agent[0..bubble.agent_len]);
+        copyInto(&member.herdr_pane, &member.herdr_pane_len, bubble.herdrPaneSlice());
+        member.state = stateForBubble(bubble);
+        member.busy = bubble.busy;
+        next[slot] = member;
+        taken[slot] = true;
+        if (slot + 1 > next_len) next_len = slot + 1;
+    }
+
+    // Compact so the renderer walks a dense prefix, keeping relative order.
+    var compact: [max_members]Member = @splat(.{});
+    var compact_len: usize = 0;
+    for (next[0..next_len], 0..) |member, slot| {
+        if (!taken[slot]) continue;
+        compact[compact_len] = member;
+        compact_len += 1;
+    }
+    model.members = compact;
+    model.len = compact_len;
+}
+
+pub const Cell = struct {
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+};
+
+pub const LayoutSpec = struct {
+    cell_w: f32,
+    cell_h: f32,
+    gap: f32,
+    columns: usize,
+    /// Height of the agent label under each body. Charged once per row,
+    /// not once per window: a second row needs its own strip or the last
+    /// bodies render clipped.
+    label_h: f32 = 0,
+};
+
+/// Grid geometry for `count` bodies. Columns are capped so a single agent
+/// does not render in a wide empty row, and the caller sizes its window
+/// from `windowSize` with the same spec.
+pub fn columnsFor(count: usize, max_columns: usize) usize {
+    if (count == 0) return 1;
+    if (max_columns == 0) return 1;
+    return @min(count, max_columns);
+}
+
+pub fn cellFor(index: usize, spec: LayoutSpec) Cell {
+    const cols = if (spec.columns == 0) 1 else spec.columns;
+    const col = index % cols;
+    const row = index / cols;
+    return .{
+        .x = @as(f32, @floatFromInt(col)) * (spec.cell_w + spec.gap),
+        .y = @as(f32, @floatFromInt(row)) * (spec.cell_h + spec.gap),
+        .w = spec.cell_w,
+        .h = spec.cell_h,
+    };
+}
+
+pub fn rowsFor(count: usize, columns: usize) usize {
+    const cols = if (columns == 0) 1 else columns;
+    if (count == 0) return 1;
+    return (count + cols - 1) / cols;
+}
+
+pub fn windowSize(count: usize, spec: LayoutSpec) struct { w: f32, h: f32 } {
+    const cols = if (spec.columns == 0) 1 else spec.columns;
+    const rows = rowsFor(count, cols);
+    const shown_cols = if (count == 0) 1 else @min(count, cols);
+    const rows_f: f32 = @floatFromInt(rows);
+    return .{
+        .w = @as(f32, @floatFromInt(shown_cols)) * spec.cell_w + @as(f32, @floatFromInt(shown_cols -| 1)) * spec.gap,
+        .h = rows_f * (spec.cell_h + spec.label_h) + @as(f32, @floatFromInt(rows -| 1)) * spec.gap,
+    };
+}
+
+fn testBubble(session: []const u8, agent: []const u8, pane: []const u8, busy: bool) hook_server.Bubble {
+    var bubble: hook_server.Bubble = .{};
+    copyInto(&bubble.session, &bubble.session_len, session);
+    copyInto(&bubble.agent, &bubble.agent_len, agent);
+    copyInto(&bubble.herdr_pane, &bubble.herdr_pane_len, pane);
+    bubble.busy = busy;
+    return bubble;
+}
+
+test "each live session gets its own body" {
+    var model: Model = .{};
+    const bubbles = [_]hook_server.Bubble{
+        testBubble("s1", "claude", "w1:p1", true),
+        testBubble("s2", "codex", "w1:p2", false),
+    };
+    reconcile(&model, &bubbles);
+    try std.testing.expectEqual(@as(usize, 2), model.len);
+    try std.testing.expectEqualStrings("s1", model.members[0].sessionSlice());
+    try std.testing.expectEqualStrings("s2", model.members[1].sessionSlice());
+}
+
+test "a busy agent runs while an idle one does not" {
+    var model: Model = .{};
+    const bubbles = [_]hook_server.Bubble{
+        testBubble("s1", "claude", "", true),
+        testBubble("s2", "codex", "", false),
+    };
+    reconcile(&model, &bubbles);
+    try std.testing.expectEqual(sprite.State.running, model.members[0].state);
+    try std.testing.expectEqual(sprite.State.idle, model.members[1].state);
+}
+
+test "a session keeps its body when its state changes" {
+    var model: Model = .{};
+    reconcile(&model, &[_]hook_server.Bubble{
+        testBubble("s1", "claude", "w1:p1", false),
+        testBubble("s2", "codex", "w1:p2", false),
+    });
+    reconcile(&model, &[_]hook_server.Bubble{
+        testBubble("s1", "claude", "w1:p1", true),
+        testBubble("s2", "codex", "w1:p2", false),
+    });
+    try std.testing.expectEqual(@as(usize, 2), model.len);
+    try std.testing.expectEqualStrings("s1", model.members[0].sessionSlice());
+    try std.testing.expectEqual(sprite.State.running, model.members[0].state);
+    try std.testing.expectEqual(sprite.State.idle, model.members[1].state);
+}
+
+test "a departed session leaves and the survivor keeps its identity" {
+    var model: Model = .{};
+    reconcile(&model, &[_]hook_server.Bubble{
+        testBubble("s1", "claude", "", false),
+        testBubble("s2", "codex", "", true),
+    });
+    reconcile(&model, &[_]hook_server.Bubble{testBubble("s2", "codex", "", true)});
+    try std.testing.expectEqual(@as(usize, 1), model.len);
+    try std.testing.expectEqualStrings("s2", model.members[0].sessionSlice());
+    try std.testing.expectEqual(sprite.State.running, model.members[0].state);
+}
+
+test "the pane id survives so a click can reach the session" {
+    var model: Model = .{};
+    reconcile(&model, &[_]hook_server.Bubble{testBubble("s1", "claude", "w3:pW", true)});
+    try std.testing.expectEqualStrings("w3:pW", model.members[0].herdrPaneSlice());
+}
+
+test "no live session leaves the flock empty" {
+    var model: Model = .{};
+    reconcile(&model, &[_]hook_server.Bubble{testBubble("s1", "claude", "", true)});
+    reconcile(&model, &[_]hook_server.Bubble{});
+    try std.testing.expectEqual(@as(usize, 0), model.len);
+}
+
+test "the flock never exceeds the mailbox it reads from" {
+    var model: Model = .{};
+    var bubbles: [max_members]hook_server.Bubble = undefined;
+    var buf: [8]u8 = undefined;
+    for (&bubbles, 0..) |*bubble, i| {
+        const session = std.fmt.bufPrint(&buf, "s{d}", .{i}) catch unreachable;
+        bubble.* = testBubble(session, "claude", "", i % 2 == 0);
+    }
+    reconcile(&model, &bubbles);
+    try std.testing.expectEqual(max_members, model.len);
+}
+
+test "bodies tile without overlapping" {
+    const spec: LayoutSpec = .{ .cell_w = 100, .cell_h = 80, .gap = 10, .columns = 3 };
+    const a = cellFor(0, spec);
+    const b = cellFor(1, spec);
+    const c = cellFor(3, spec);
+    try std.testing.expectEqual(@as(f32, 0), a.x);
+    try std.testing.expectEqual(@as(f32, 110), b.x);
+    try std.testing.expectEqual(@as(f32, 0), c.x);
+    try std.testing.expectEqual(@as(f32, 90), c.y);
+    try std.testing.expect(a.x + a.w <= b.x);
+}
+
+test "the window grows with the flock and never collapses" {
+    const spec: LayoutSpec = .{ .cell_w = 100, .cell_h = 80, .gap = 10, .columns = 3 };
+    const one = windowSize(1, spec);
+    const four = windowSize(4, spec);
+    const empty = windowSize(0, spec);
+    try std.testing.expectEqual(@as(f32, 100), one.w);
+    try std.testing.expectEqual(@as(f32, 80), one.h);
+    try std.testing.expectEqual(@as(f32, 320), four.w);
+    try std.testing.expectEqual(@as(f32, 170), four.h);
+    try std.testing.expect(empty.w > 0 and empty.h > 0);
+}
+
+test "a second row gets its own label strip" {
+    // The fifth body wraps. Charging the label once per window instead of
+    // once per row clipped it: the window was one row tall while the
+    // content was two.
+    const spec: LayoutSpec = .{ .cell_w = 100, .cell_h = 80, .gap = 10, .columns = 4, .label_h = 18 };
+    const four = windowSize(4, spec);
+    const five = windowSize(5, spec);
+    try std.testing.expectEqual(@as(f32, 98), four.h);
+    try std.testing.expectEqual(@as(f32, 206), five.h);
+    try std.testing.expect(five.h > four.h);
+}
+
+test "columns never exceed the bodies on screen" {
+    try std.testing.expectEqual(@as(usize, 1), columnsFor(1, 4));
+    try std.testing.expectEqual(@as(usize, 4), columnsFor(6, 4));
+    try std.testing.expectEqual(@as(usize, 1), columnsFor(0, 4));
+    try std.testing.expectEqual(@as(usize, 2), rowsFor(6, 4));
+    try std.testing.expectEqual(@as(usize, 1), rowsFor(0, 4));
+}

--- a/packages/petdex-desktop-native/src/hook_runner.zig
+++ b/packages/petdex-desktop-native/src/hook_runner.zig
@@ -109,7 +109,7 @@ pub fn run(phase: []const u8, arg_agent: ?[]const u8, origin_app: plat.OriginApp
     var post_count: usize = 0;
     var body_buf: [1536]u8 = undefined;
     if (text.len > 0) {
-        const body = bubbleBodyWithMetadata(&body_buf, text, title, busy, agent, session_id, source_app, source_tty, source_cwd, herdr_pane);
+        const body = bubbleBodyWithMetadata(&body_buf, text, title, busy, agent, session_id, source_app, source_tty, source_cwd, herdr_pane, state);
         if (body) |b| {
             if (startPost("/bubble", b, token)) |post| {
                 posts[post_count] = post;
@@ -164,10 +164,16 @@ fn isToolFailurePhase(phase: []const u8) bool {
 /// precisely how session_id got parsed, used for titles, and then left out of
 /// the POST that needed it.
 pub fn bubbleBody(out: []u8, text: []const u8, title: []const u8, busy: bool, agent: []const u8, session_id: ?[]const u8) ?[]const u8 {
-    return bubbleBodyWithMetadata(out, text, title, busy, agent, session_id, "", "", "", "");
+    return bubbleBodyWithMetadata(out, text, title, busy, agent, session_id, "", "", "", "", null);
 }
 
-fn bubbleBodyWithMetadata(out: []u8, text: []const u8, title: []const u8, busy: bool, agent: []const u8, session_id: ?[]const u8, source_app: []const u8, source_tty: []const u8, source_cwd: []const u8, herdr_pane: []const u8) ?[]const u8 {
+/// `agent_state` carries what this one session is doing to the bubble the
+/// desktop keys by session. The same value already goes to /state, but
+/// that endpoint aggregates: with several agents live it can only show
+/// one. The flock renders a body per session, so the rich states the
+/// hooks already compute (failed, review, waiting) have to travel here to
+/// survive. Senders that pass null keep the previous body byte for byte.
+pub fn bubbleBodyWithMetadata(out: []u8, text: []const u8, title: []const u8, busy: bool, agent: []const u8, session_id: ?[]const u8, source_app: []const u8, source_tty: []const u8, source_cwd: []const u8, herdr_pane: []const u8, agent_state: ?[]const u8) ?[]const u8 {
     var title_buf: [256]u8 = undefined;
     const title_part: []const u8 = if (title.len > 0)
         (std.fmt.bufPrint(&title_buf, ",\"title\":\"{s}\"", .{title}) catch return null)
@@ -183,7 +189,12 @@ fn bubbleBodyWithMetadata(out: []u8, text: []const u8, title: []const u8, busy: 
         (std.fmt.bufPrint(&metadata_buf, ",\"source_app\":\"{s}\",\"source_tty\":\"{s}\",\"source_cwd\":\"{s}\",\"herdr_pane_id\":\"{s}\"", .{ source_app, source_tty, source_cwd, herdr_pane }) catch return null)
     else
         "";
-    return std.fmt.bufPrint(out, "{{\"text\":\"{s}\"{s},\"busy\":{},\"agent_source\":\"{s}\"{s}{s}}}", .{ text, title_part, busy, agent, session_part, metadata }) catch null;
+    var state_buf: [48]u8 = undefined;
+    const state_part: []const u8 = if (agent_state) |st|
+        (std.fmt.bufPrint(&state_buf, ",\"agent_state\":\"{s}\"", .{st}) catch return null)
+    else
+        "";
+    return std.fmt.bufPrint(out, "{{\"text\":\"{s}\"{s},\"busy\":{},\"agent_source\":\"{s}\"{s}{s}{s}}}", .{ text, title_part, busy, agent, session_part, metadata, state_part }) catch null;
 }
 
 /// The /state request body. Extracted and pure for one reason: `run()` reaches
@@ -821,7 +832,7 @@ test "bubbleBody carries session_id, and omits it when there is none" {
 
 test "bubble metadata carries the exact Herdr pane id" {
     var buf: [1024]u8 = undefined;
-    const body = bubbleBodyWithMetadata(&buf, "Needs approval", "Fix auth", false, "cursor", "session-1", "ghostty", "", "/repo", "w1:p5").?;
+    const body = bubbleBodyWithMetadata(&buf, "Needs approval", "Fix auth", false, "cursor", "session-1", "ghostty", "", "/repo", "w1:p5", null).?;
     try t.expectEqualStrings("w1:p5", hook_server.jsonStringPub(body, "herdr_pane_id").?);
 }
 
@@ -899,4 +910,31 @@ test "clipEscaped cuts on a safe boundary" {
     const clipped = clipEscaped(&long, 110, &buf).?;
     try t.expect(clipped.len <= 110);
     try t.expect(clipped[clipped.len - 1] != '\\');
+}
+
+test "a bubble without a reported state is byte-identical to before" {
+    // The flock reads agent_state, but every sender that does not know one
+    // must keep producing exactly the body that shipped before the field
+    // existed: this is the compatibility promise, not a preference.
+    var with: [1536]u8 = undefined;
+    var without: [1536]u8 = undefined;
+    const a = bubbleBodyWithMetadata(&with, "text", "title", true, "claude", "s1", "", "", "", "", null).?;
+    const b = bubbleBody(&without, "text", "title", true, "claude", "s1").?;
+    try std.testing.expectEqualStrings(b, a);
+    try std.testing.expect(std.mem.indexOf(u8, a, "agent_state") == null);
+}
+
+test "a reported state rides the bubble that carries the session" {
+    var buf: [1536]u8 = undefined;
+    const body = bubbleBodyWithMetadata(&buf, "text", "title", true, "claude", "s1", "", "", "", "", "failed").?;
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"agent_state\":\"failed\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"session_id\":\"s1\"") != null);
+}
+
+test "the states only direct hooks can see reach the bubble" {
+    // stateForEvent already computes these; before this they only went to
+    // /state, which aggregates and cannot show two agents at once.
+    try std.testing.expectEqualStrings("failed", stateForEvent("tool-failure", "Bash").?);
+    try std.testing.expectEqualStrings("review", stateForEvent("pre", "Read").?);
+    try std.testing.expectEqualStrings("waiting", stateForEvent("approval-request", null).?);
 }

--- a/packages/petdex-desktop-native/src/hook_server.zig
+++ b/packages/petdex-desktop-native/src/hook_server.zig
@@ -303,6 +303,50 @@ pub const Mailbox = struct {
 
 pub var mailbox: Mailbox = .{};
 
+pub const AuthCallback = struct {
+    code: [2048]u8 = @splat(0),
+    code_len: usize = 0,
+    state: [128]u8 = @splat(0),
+    state_len: usize = 0,
+    error_text: [256]u8 = @splat(0),
+    error_len: usize = 0,
+
+    pub fn codeSlice(self: *const AuthCallback) []const u8 {
+        return self.code[0..self.code_len];
+    }
+
+    pub fn stateSlice(self: *const AuthCallback) []const u8 {
+        return self.state[0..self.state_len];
+    }
+
+    pub fn errorSlice(self: *const AuthCallback) []const u8 {
+        return self.error_text[0..self.error_len];
+    }
+};
+
+pub const AuthMailbox = struct {
+    mutex: SpinMutex = .{},
+    callback: AuthCallback = .{},
+    dirty: bool = false,
+
+    pub fn set(self: *AuthMailbox, callback: AuthCallback) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.callback = callback;
+        self.dirty = true;
+    }
+
+    pub fn take(self: *AuthMailbox) ?AuthCallback {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (!self.dirty) return null;
+        self.dirty = false;
+        return self.callback;
+    }
+};
+
+pub var auth_mailbox: AuthMailbox = .{};
+
 const valid_states = [_][]const u8{
     "idle",    "running", "running-left", "running-right", "waving",
     "jumping", "failed",  "review",       "waiting",
@@ -510,7 +554,7 @@ fn handleConnection(server: *Server, conn: *Conn) void {
     const target = part_it.next() orelse return;
     const path = if (std.mem.indexOfScalar(u8, target, '?')) |q| target[0..q] else target;
 
-    route(server, conn, method, path, head, body);
+    route(server, conn, method, target, path, head, body);
 }
 
 fn receiveWithTimeout(conn: *Conn, buffer: []u8, timeout: std.Io.Timeout) !usize {
@@ -585,10 +629,27 @@ fn windowsRelativeTimeoutFromNanoseconds(nanoseconds: i96) std.os.windows.LARGE_
     return -@as(std.os.windows.LARGE_INTEGER, @intCast(bounded));
 }
 
-fn route(server: *Server, conn: *Conn, method: []const u8, path: []const u8, head: []const u8, body: []const u8) void {
+fn route(server: *Server, conn: *Conn, method: []const u8, target: []const u8, path: []const u8, head: []const u8, body: []const u8) void {
     const get = std.mem.eql(u8, method, "GET");
     const post = std.mem.eql(u8, method, "POST");
     var scratch: [512]u8 = undefined;
+
+    if (get and std.mem.eql(u8, path, "/callback")) {
+        const query = if (std.mem.indexOfScalar(u8, target, '?')) |q| target[q + 1 ..] else "";
+        var callback: AuthCallback = .{};
+        if (queryValue(query, "code", &callback.code)) |value| callback.code_len = value.len;
+        if (queryValue(query, "state", &callback.state)) |value| callback.state_len = value.len;
+        if (queryValue(query, "error_description", &callback.error_text)) |value| {
+            callback.error_len = value.len;
+        } else if (queryValue(query, "error", &callback.error_text)) |value| {
+            callback.error_len = value.len;
+        }
+        auth_mailbox.set(callback);
+        if (callback.code_len > 0 and callback.state_len > 0) {
+            return respondHtml(conn, 200, "<!doctype html><meta charset=utf-8><title>Petdex</title><style>body{background:#0c0c0f;color:#f5f5f7;font:16px system-ui;display:grid;place-items:center;height:100vh;margin:0}main{text-align:center}h1{font-size:24px}</style><main><h1>Signed in to Petdex</h1><p>You can close this tab and return to the app.</p></main>");
+        }
+        return respondHtml(conn, 400, "<!doctype html><meta charset=utf-8><title>Petdex</title><style>body{background:#0c0c0f;color:#f5f5f7;font:16px system-ui;display:grid;place-items:center;height:100vh;margin:0}main{text-align:center}h1{font-size:24px}</style><main><h1>Petdex sign-in failed</h1><p>Return to the app and try again.</p></main>");
+    }
 
     if (get and std.mem.eql(u8, path, "/health")) {
         return respond(conn, 200, "{\"ok\":true,\"port\":7777}");
@@ -711,6 +772,14 @@ fn respondRuntimeFile(server: *Server, conn: *Conn, name: []const u8, fallback: 
 // ------------------------------------------------------------ http helpers
 
 fn respond(conn: *Conn, status: u16, body: []const u8) void {
+    respondTyped(conn, status, "application/json", body);
+}
+
+fn respondHtml(conn: *Conn, status: u16, body: []const u8) void {
+    respondTyped(conn, status, "text/html; charset=utf-8", body);
+}
+
+fn respondTyped(conn: *Conn, status: u16, content_type: []const u8, body: []const u8) void {
     var buf: [1024]u8 = undefined;
     const reason = switch (status) {
         200 => "OK",
@@ -722,12 +791,44 @@ fn respond(conn: *Conn, status: u16, body: []const u8) void {
         429 => "Too Many Requests",
         else => "OK",
     };
-    const head = std.fmt.bufPrint(&buf, "HTTP/1.1 {d} {s}\r\ncontent-type: application/json\r\ncontent-length: {d}\r\nconnection: close\r\n\r\n", .{ status, reason, body.len }) catch return;
+    const head = std.fmt.bufPrint(&buf, "HTTP/1.1 {d} {s}\r\ncontent-type: {s}\r\ncontent-length: {d}\r\nconnection: close\r\n\r\n", .{ status, reason, content_type, body.len }) catch return;
     var write_buf: [64]u8 = undefined;
     var writer = conn.stream.writer(conn.io, &write_buf);
     writer.interface.writeAll(head) catch return;
     writer.interface.writeAll(body) catch return;
     writer.interface.flush() catch return;
+}
+
+fn hexValue(c: u8) ?u8 {
+    if (c >= '0' and c <= '9') return c - '0';
+    if (c >= 'a' and c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' and c <= 'F') return c - 'A' + 10;
+    return null;
+}
+
+fn queryValue(query: []const u8, wanted: []const u8, out: []u8) ?[]const u8 {
+    var pairs = std.mem.splitScalar(u8, query, '&');
+    while (pairs.next()) |pair| {
+        const equal = std.mem.indexOfScalar(u8, pair, '=') orelse continue;
+        if (!std.mem.eql(u8, pair[0..equal], wanted)) continue;
+        var source = pair[equal + 1 ..];
+        var written: usize = 0;
+        while (source.len > 0) {
+            if (written >= out.len) return null;
+            if (source[0] == '%' and source.len >= 3) {
+                const hi = hexValue(source[1]) orelse return null;
+                const lo = hexValue(source[2]) orelse return null;
+                out[written] = (hi << 4) | lo;
+                source = source[3..];
+            } else {
+                out[written] = if (source[0] == '+') ' ' else source[0];
+                source = source[1..];
+            }
+            written += 1;
+        }
+        return out[0..written];
+    }
+    return null;
 }
 
 fn headerValue(head: []const u8, name: []const u8) ?[]const u8 {
@@ -928,6 +1029,13 @@ test "bubble session key prefers and normalizes canonical conversations" {
     const normalized = bubbleSessionKey(body, &hash);
     try std.testing.expectEqual(@as(usize, 64), normalized.len);
     try std.testing.expect(!std.mem.eql(u8, normalized, long[0..64]));
+}
+
+test "OAuth callback query values are decoded and bounded" {
+    var out: [32]u8 = undefined;
+    try std.testing.expectEqualStrings("hello world", queryValue("code=hello%20world&state=abc", "code", &out).?);
+    try std.testing.expectEqualStrings("abc", queryValue("code=hello&state=abc", "state", &out).?);
+    try std.testing.expect(queryValue("code=toolong", "code", out[0..3]) == null);
 }
 
 test "two sessions hold two bubbles and neither overwrites the other" {

--- a/packages/petdex-desktop-native/src/hook_server.zig
+++ b/packages/petdex-desktop-native/src/hook_server.zig
@@ -63,6 +63,12 @@ pub const Bubble = struct {
     herdr_pane: [64]u8 = @splat(0),
     herdr_pane_len: usize = 0,
     busy: bool = false,
+    /// Per-agent attention, when the sender knows it. `busy` alone cannot
+    /// tell a blocked agent from an idle one, and that distinction is the
+    /// whole point of showing a body per agent. Empty means the sender did
+    /// not say, and readers fall back to `busy`.
+    agent_state: [16]u8 = @splat(0),
+    agent_state_len: usize = 0,
     counter: u64 = 0,
 
     pub fn sessionSlice(self: *const Bubble) []const u8 {
@@ -76,6 +82,9 @@ pub const Bubble = struct {
     }
     pub fn herdrPaneSlice(self: *const Bubble) []const u8 {
         return self.herdr_pane[0..self.herdr_pane_len];
+    }
+    pub fn agentStateSlice(self: *const Bubble) []const u8 {
+        return self.agent_state[0..self.agent_state_len];
     }
 };
 
@@ -230,6 +239,25 @@ pub const Mailbox = struct {
         slot.counter = self.bubble_counter;
         self.bubbles_dirty = true;
         return slot.counter;
+    }
+
+    /// Record per-agent attention for a session that already has a slot.
+    /// Separate from setBubbleWithMetadata so the nine-parameter contract
+    /// every existing caller uses stays exactly as it is: a sender that
+    /// knows the state calls this right after, and one that does not
+    /// leaves the field empty for readers to fall back on `busy`.
+    pub fn setBubbleAgentState(self: *Mailbox, session: []const u8, state: []const u8) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        for (self.bubbles[0..self.bubbles_len]) |*b| {
+            if (!std.mem.eql(u8, b.sessionSlice(), session)) continue;
+            const n = @min(state.len, b.agent_state.len);
+            @memcpy(b.agent_state[0..n], state[0..n]);
+            @memset(b.agent_state[n..], 0);
+            b.agent_state_len = n;
+            self.bubbles_dirty = true;
+            return;
+        }
     }
 
     /// Drain the whole set into `out`, returning how many slots landed.
@@ -574,6 +602,11 @@ fn route(server: *Server, conn: *Conn, method: []const u8, path: []const u8, hea
             ) catch {};
         }
         const counter = mailbox.setBubbleWithMetadata(session, capped, agent[0..@min(agent.len, 24)], title[0..@min(title.len, 96)], origin_app, source_tty, source_cwd, herdr_pane, busy);
+        // Optional: a sender that can tell blocked from working says so
+        // here. Older senders omit it and keep the busy-only behaviour.
+        if (jsonString(body, "agent_state")) |state| {
+            mailbox.setBubbleAgentState(session, state[0..@min(state.len, 16)]);
+        }
         mirrorBubble(server, capped, counter, title[0..@min(title.len, 96)], agent[0..@min(agent.len, 24)], busy) catch {};
         const out = std.fmt.bufPrint(&scratch, "{{\"ok\":true,\"counter\":{d}}}", .{counter}) catch return;
         return respond(conn, 200, out);

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -117,6 +117,7 @@ pub const Msg = union(enum) {
     pet_filter: canvas.TextInputEvent,
     toggle_pets_expanded,
     toggle_flock_window,
+    focus_flock_member: u32,
     manifest_done: native_sdk.EffectExit,
     pet_json_done: native_sdk.EffectExit,
     spritesheet_done: native_sdk.EffectExit,
@@ -1603,11 +1604,15 @@ fn registerStateFrames(state: State, fx: *Effects) void {
 const flock_waiting_image_id: u64 = 10;
 const flock_running_image_id: u64 = 11;
 const flock_idle_image_id: u64 = 12;
+const flock_failed_image_id: u64 = 15;
+const flock_review_image_id: u64 = 16;
 
 pub fn flockImageId(state: State) u64 {
     return switch (state) {
         .waiting => flock_waiting_image_id,
         .running, .@"running-right", .@"running-left" => flock_running_image_id,
+        .failed => flock_failed_image_id,
+        .review => flock_review_image_id,
         else => flock_idle_image_id,
     };
 }
@@ -1620,10 +1625,15 @@ fn registerFlockFrames(fx: *Effects) void {
     const fh = sheet.height / sheet.rows;
     var scratch = boot_allocator.alloc(u8, fw * fh * 4) catch return;
     defer boot_allocator.free(scratch);
+    // Five stills fill the registry to its 16-slot cap alongside the pet
+    // window's eight frames, the agent strip, the avatar and the tail.
+    // Nothing else may claim a slot without freeing one here.
     const entries = [_]struct { state: State, id: u64 }{
         .{ .state = .waiting, .id = flock_waiting_image_id },
         .{ .state = .running, .id = flock_running_image_id },
         .{ .state = .idle, .id = flock_idle_image_id },
+        .{ .state = .failed, .id = flock_failed_image_id },
+        .{ .state = .review, .id = flock_review_image_id },
     };
     for (entries) |entry| {
         const def = stateDef(entry.state);
@@ -1992,6 +2002,16 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             applyState(model, model.state.next(), 0, fx);
         },
         .toggle_pets_expanded => model.pets_expanded = !model.pets_expanded,
+        .focus_flock_member => |index| {
+            // The pane id rode all the way from Herdr on the bubble this
+            // body was built from, so reaching the session is the same
+            // verb the pet window already uses for the front bubble.
+            if (index >= model.flock.len) return;
+            const member = &model.flock.members[index];
+            const pane = member.herdrPaneSlice();
+            if (pane.len == 0) return;
+            if (env_home) |home| _ = plat.activateHerdrPane(home, pane);
+        },
         .toggle_flock_window => {
             model.flock.open = !model.flock.open;
             // Badges read from the shared agent strip. It loads at boot,
@@ -4104,8 +4124,19 @@ fn flockSemanticLabel(state: State) []const u8 {
     return switch (state) {
         .waiting => "Agent blocked",
         .running, .@"running-right", .@"running-left" => "Agent working",
+        .failed => "Agent failed",
+        .review => "Agent reading",
+        .waving, .jumping => "Agent finished",
         else => "Agent idle",
     };
+}
+
+/// Which bodies earn the amber marker: the ones where a human either has
+/// to act or would want to look. A failed tool call qualifies for the
+/// same reason a blocked prompt does, and neither is legible from the
+/// pose alone at this size.
+fn flockNeedsAttention(state: State) bool {
+    return state == .waiting or state == .failed;
 }
 
 fn flockMember(ui: *AppUi, model: *const Model, index: usize, spec: flock_mod.LayoutSpec) AppUi.Node {
@@ -4118,7 +4149,16 @@ fn flockMember(ui: *AppUi, model: *const Model, index: usize, spec: flock_mod.La
     });
     body.widget.image_fit = .stretch;
     body.widget.image_sampling = .nearest;
-    return ui.column(.{ .cross = .center, .gap = 2 }, .{
+    // Whole cell, not just the sprite: a 115px target beats a 18px one,
+    // and the badge is part of the same body. A member with no pane (a
+    // direct hook outside Herdr) stays inert rather than offering a jump
+    // that would do nothing.
+    const pressable = member.herdrPaneSlice().len != 0;
+    return ui.column(.{
+        .cross = .center,
+        .gap = 2,
+        .on_press = if (pressable) .{ .focus_flock_member = @intCast(index) } else null,
+    }, .{
         body,
         flockBadge(ui, member),
     });
@@ -4147,7 +4187,7 @@ fn flockBadge(ui: *AppUi, member: *const flock_mod.Member) AppUi.Node {
     // across the room, and the resting poses of waiting and idle are too
     // close to carry that on their own. Same amber marker the bubble
     // already uses for the same meaning.
-    if (member.state != .waiting) return identity;
+    if (!flockNeedsAttention(member.state)) return identity;
     var marker = ui.text(.{ .size = .sm }, "!");
     marker.widget.style.foreground = canvas.Color.rgb8(250, 170, 48);
     return ui.row(.{ .cross = .center, .gap = 3 }, .{ identity, marker });
@@ -4515,19 +4555,44 @@ test "a flock body reserves more than its badge is tall" {
     try std.testing.expect(flock_label_h > flock_badge_px + 2);
 }
 
+test "every flock state names itself, none falls through to idle" {
+    // failed and review were mapped to their own artwork but not to their
+    // own label, so both announced themselves as idle: the states the
+    // direct hooks exist to surface were the ones going unnamed.
+    try std.testing.expectEqualStrings("Agent failed", flockSemanticLabel(.failed));
+    try std.testing.expectEqualStrings("Agent reading", flockSemanticLabel(.review));
+    try std.testing.expectEqualStrings("Agent blocked", flockSemanticLabel(.waiting));
+    try std.testing.expectEqualStrings("Agent working", flockSemanticLabel(.running));
+    try std.testing.expectEqualStrings("Agent idle", flockSemanticLabel(.idle));
+}
+
+test "a body earns the marker when a human has to act" {
+    try std.testing.expect(flockNeedsAttention(.waiting));
+    try std.testing.expect(flockNeedsAttention(.failed));
+    try std.testing.expect(!flockNeedsAttention(.running));
+    try std.testing.expect(!flockNeedsAttention(.idle));
+    try std.testing.expect(!flockNeedsAttention(.review));
+}
+
 test "flock states that must look different get different image slots" {
     // Bodies render stills from separate slots, so two agents in
     // different states cannot collapse onto the same artwork.
-    try std.testing.expect(flockImageId(.waiting) != flockImageId(.running));
-    try std.testing.expect(flockImageId(.waiting) != flockImageId(.idle));
-    try std.testing.expect(flockImageId(.running) != flockImageId(.idle));
+    const flock_states = [_]State{ .waiting, .running, .idle, .failed, .review };
+    for (flock_states, 0..) |a, i| {
+        for (flock_states[i + 1 ..]) |b| {
+            try std.testing.expect(flockImageId(a) != flockImageId(b));
+        }
+    }
     // And they must not collide with the slots the rest of the app owns.
-    for ([_]u64{ flockImageId(.waiting), flockImageId(.running), flockImageId(.idle) }) |id| {
+    for (flock_states) |state| {
+        const id = flockImageId(state);
         try std.testing.expect(id != sheet_image_id);
         try std.testing.expect(id != agent_icon_atlas_id);
         try std.testing.expect(id != avatar_image_id);
         try std.testing.expect(id != tail_image_id);
         try std.testing.expect(id > cols);
+        // The registry caps at 16 slots and these are the last free ones.
+        try std.testing.expect(id <= 16);
     }
 }
 

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -922,7 +922,7 @@ const auth_token_key: u64 = 43;
 const auth_library_key: u64 = 44;
 const auth_avatar_key: u64 = 45;
 const auth_preview_key: u64 = 46;
-const auth_keychain_save_keys = [_]u64{ auth_keychain_save_key, 47, 48 };
+const auth_keychain_save_keys = [_]u64{ auth_keychain_save_key, 47, 48, 49, 50 };
 const update_boot_delay_ms: u32 = 5000;
 const update_background_interval_ms: i64 = 24 * 60 * 60 * 1000;
 const update_settings_interval_ms: i64 = 5 * 60 * 1000;
@@ -935,12 +935,14 @@ fn loadAuthSession(model: *Model, fx: *Effects) void {
     const argv = [_][]const u8{
         "/bin/sh",
         "-c",
-        "petdex_legacy=$(/usr/bin/security find-generic-password -a \"$1\" -s \"$5\" -w 2>/dev/null) && { printf '%s' \"$petdex_legacy\"; exit 0; }; for petdex_account in \"$2\" \"$3\" \"$4\"; do petdex_part=$(/usr/bin/security find-generic-password -a \"$petdex_account\" -s \"$5\" -w 2>/dev/null) || exit 1; printf '%s' \"$petdex_part\"; done",
+        "petdex_legacy=$(/usr/bin/security find-generic-password -a \"$1\" -s \"$7\" -w 2>/dev/null) && { printf '%s' \"$petdex_legacy\"; exit 0; }; for petdex_account in \"$2\" \"$3\" \"$4\" \"$5\" \"$6\"; do petdex_part=$(/usr/bin/security find-generic-password -a \"$petdex_account\" -s \"$7\" -w 2>/dev/null) || exit 1; printf '%s' \"$petdex_part\"; done",
         "petdex-keychain",
         desktop_auth.account,
         desktop_auth.keychain_accounts[0],
         desktop_auth.keychain_accounts[1],
         desktop_auth.keychain_accounts[2],
+        desktop_auth.keychain_accounts[3],
+        desktop_auth.keychain_accounts[4],
         desktop_auth.service,
     };
     fx.spawn(.{
@@ -953,7 +955,8 @@ fn loadAuthSession(model: *Model, fx: *Effects) void {
 
 fn saveAuthSession(model: *const Model, fx: *Effects) void {
     if (!desktop_auth.available) return;
-    const token = model.auth.refreshToken();
+    var session_buf: [17000]u8 = undefined;
+    const token = desktop_auth.storedTokens(&model.auth, &session_buf) orelse return;
     for (desktop_auth.keychain_accounts, auth_keychain_save_keys, 0..) |account_name, effect_key, index| {
         const chunk = desktop_auth.keychainChunk(token, index) orelse return;
         const argv = [_][]const u8{
@@ -2571,12 +2574,14 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             const argv = [_][]const u8{
                 "/bin/sh",
                 "-c",
-                "for petdex_account in \"$1\" \"$2\" \"$3\" \"$4\"; do /usr/bin/security delete-generic-password -a \"$petdex_account\" -s \"$5\" >/dev/null 2>&1 || true; done",
+                "for petdex_account in \"$1\" \"$2\" \"$3\" \"$4\" \"$5\" \"$6\"; do /usr/bin/security delete-generic-password -a \"$petdex_account\" -s \"$7\" >/dev/null 2>&1 || true; done",
                 "petdex-keychain",
                 desktop_auth.account,
                 desktop_auth.keychain_accounts[0],
                 desktop_auth.keychain_accounts[1],
                 desktop_auth.keychain_accounts[2],
+                desktop_auth.keychain_accounts[3],
+                desktop_auth.keychain_accounts[4],
                 desktop_auth.service,
             };
             fx.spawn(.{

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -1992,7 +1992,13 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             applyState(model, model.state.next(), 0, fx);
         },
         .toggle_pets_expanded => model.pets_expanded = !model.pets_expanded,
-        .toggle_flock_window => model.flock.open = !model.flock.open,
+        .toggle_flock_window => {
+            model.flock.open = !model.flock.open;
+            // Badges read from the shared agent strip. It loads at boot,
+            // but a theme flip since then would leave it in the wrong
+            // palette; this reloads only when that happened.
+            if (model.flock.open) loadAgentsAtlas(model.dark, fx);
+        },
         .dismiss_install_error => model.install.error_len = 0,
         .install_first_pet => {
             // A fresh install has no pets, so the pet window renders an
@@ -4046,8 +4052,11 @@ fn bubbleView(ui: *AppUi, model: *const Model) AppUi.Node {
 
 const flock_window_label = "flock";
 const flock_canvas_label = "flock-canvas";
-/// Room under the grid for one row of agent labels.
-const flock_label_h: f32 = 18;
+/// Room under each body for its agent badge, plus the gap above it.
+const flock_badge_px: f32 = 18;
+/// Badge, the gap above it, and breathing room below: at exactly badge +
+/// gap the badge lands flush on the window edge and reads as clipped.
+const flock_label_h: f32 = flock_badge_px + 8;
 const flock_max_columns: usize = 4;
 /// Bodies render smaller than the solo pet: the point of the window is
 /// the whole set at a glance, not one mascot at full size.
@@ -4109,10 +4118,39 @@ fn flockMember(ui: *AppUi, model: *const Model, index: usize, spec: flock_mod.La
     });
     body.widget.image_fit = .stretch;
     body.widget.image_sampling = .nearest;
-    return ui.column(.{ .cross = .center }, .{
+    return ui.column(.{ .cross = .center, .gap = 2 }, .{
         body,
-        ui.text(.{ .size = .sm, .text_alignment = .center }, member.labelSlice()),
+        flockBadge(ui, member),
     });
+}
+
+/// Which agent this body belongs to. The logo reads faster than the name
+/// at this size and survives a narrow cell, and the strip it comes from
+/// is already compiled into the binary for the bubbles. The name stays as
+/// the accessibility label, so screen readers and the automation snapshot
+/// still get it.
+fn flockBadge(ui: *AppUi, member: *const flock_mod.Member) AppUi.Node {
+    const name = member.labelSlice();
+    const identity = if (agents_icons_ready and name.len != 0) blk: {
+        var badge = ui.image(.{
+            .width = flock_badge_px,
+            .height = flock_badge_px,
+            .image = agent_icon_atlas_id,
+            .semantics = .{ .label = name },
+        });
+        badge.widget.image_src = agentIconRect(agentIconIndex(name));
+        badge.widget.image_fit = .contain;
+        break :blk badge;
+    } else ui.text(.{ .size = .sm, .text_alignment = .center }, name);
+
+    // An agent that needs the human is the one thing worth spotting from
+    // across the room, and the resting poses of waiting and idle are too
+    // close to carry that on their own. Same amber marker the bubble
+    // already uses for the same meaning.
+    if (member.state != .waiting) return identity;
+    var marker = ui.text(.{ .size = .sm }, "!");
+    marker.widget.style.foreground = canvas.Color.rgb8(250, 170, 48);
+    return ui.row(.{ .cross = .center, .gap = 3 }, .{ identity, marker });
 }
 
 const settings_window_label = "settings";
@@ -4468,6 +4506,29 @@ test "transparent surfaces clear independently from settings" {
     model.dark = false;
     try std.testing.expectEqual(@as(f32, 0), petdexTokens(&model).colors.background.a);
     try std.testing.expectEqual(settings_alpha, settingsBackground(&model).a);
+}
+
+test "a flock body reserves more than its badge is tall" {
+    // At exactly badge + gap the badge landed flush on the window edge
+    // and read as clipped, which only the screenshot showed: the
+    // snapshot bounds looked correct.
+    try std.testing.expect(flock_label_h > flock_badge_px + 2);
+}
+
+test "flock states that must look different get different image slots" {
+    // Bodies render stills from separate slots, so two agents in
+    // different states cannot collapse onto the same artwork.
+    try std.testing.expect(flockImageId(.waiting) != flockImageId(.running));
+    try std.testing.expect(flockImageId(.waiting) != flockImageId(.idle));
+    try std.testing.expect(flockImageId(.running) != flockImageId(.idle));
+    // And they must not collide with the slots the rest of the app owns.
+    for ([_]u64{ flockImageId(.waiting), flockImageId(.running), flockImageId(.idle) }) |id| {
+        try std.testing.expect(id != sheet_image_id);
+        try std.testing.expect(id != agent_icon_atlas_id);
+        try std.testing.expect(id != avatar_image_id);
+        try std.testing.expect(id != tail_image_id);
+        try std.testing.expect(id > cols);
+    }
 }
 
 test "one image slot covers every agent" {

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -922,6 +922,7 @@ const auth_token_key: u64 = 43;
 const auth_library_key: u64 = 44;
 const auth_avatar_key: u64 = 45;
 const auth_preview_key: u64 = 46;
+const auth_keychain_save_keys = [_]u64{ auth_keychain_save_key, 47, 48 };
 const update_boot_delay_ms: u32 = 5000;
 const update_background_interval_ms: i64 = 24 * 60 * 60 * 1000;
 const update_settings_interval_ms: i64 = 5 * 60 * 1000;
@@ -931,7 +932,17 @@ const homebrew_timeout_ms: u64 = 8000;
 fn loadAuthSession(model: *Model, fx: *Effects) void {
     if (!desktop_auth.available) return;
     model.auth.phase = .loading;
-    const argv = [_][]const u8{ "/usr/bin/security", "find-generic-password", "-a", desktop_auth.account, "-s", desktop_auth.service, "-w" };
+    const argv = [_][]const u8{
+        "/bin/sh",
+        "-c",
+        "petdex_legacy=$(/usr/bin/security find-generic-password -a \"$1\" -s \"$5\" -w 2>/dev/null) && { printf '%s' \"$petdex_legacy\"; exit 0; }; for petdex_account in \"$2\" \"$3\" \"$4\"; do petdex_part=$(/usr/bin/security find-generic-password -a \"$petdex_account\" -s \"$5\" -w 2>/dev/null) || exit 1; printf '%s' \"$petdex_part\"; done",
+        "petdex-keychain",
+        desktop_auth.account,
+        desktop_auth.keychain_accounts[0],
+        desktop_auth.keychain_accounts[1],
+        desktop_auth.keychain_accounts[2],
+        desktop_auth.service,
+    };
     fx.spawn(.{
         .key = auth_keychain_load_key,
         .argv = &argv,
@@ -942,23 +953,25 @@ fn loadAuthSession(model: *Model, fx: *Effects) void {
 
 fn saveAuthSession(model: *const Model, fx: *Effects) void {
     if (!desktop_auth.available) return;
-    var json_buf: [4096]u8 = undefined;
-    const json = desktop_auth.storedTokens(&model.auth, &json_buf) orelse return;
-    const argv = [_][]const u8{
-        "/bin/sh",
-        "-c",
-        "IFS= read -r petdex_secret; printf '%s\\n%s\\n' \"$petdex_secret\" \"$petdex_secret\" | /usr/bin/security add-generic-password -U -a \"$1\" -s \"$2\" -w",
-        "petdex-keychain",
-        desktop_auth.account,
-        desktop_auth.service,
-    };
-    fx.spawn(.{
-        .key = auth_keychain_save_key,
-        .argv = &argv,
-        .stdin = json,
-        .output = .collect,
-        .on_exit = Effects.exitMsg(.auth_keychain_saved),
-    });
+    const token = model.auth.refreshToken();
+    for (desktop_auth.keychain_accounts, auth_keychain_save_keys, 0..) |account_name, effect_key, index| {
+        const chunk = desktop_auth.keychainChunk(token, index) orelse return;
+        const argv = [_][]const u8{
+            "/bin/sh",
+            "-c",
+            "IFS= read -r petdex_secret; printf '%s\\n%s\\n' \"$petdex_secret\" \"$petdex_secret\" | /usr/bin/security add-generic-password -U -a \"$1\" -s \"$2\" -w",
+            "petdex-keychain",
+            account_name,
+            desktop_auth.service,
+        };
+        fx.spawn(.{
+            .key = effect_key,
+            .argv = &argv,
+            .stdin = chunk,
+            .output = .collect,
+            .on_exit = Effects.exitMsg(.auth_keychain_saved),
+        });
+    }
 }
 
 fn fetchAuthLibrary(model: *Model, fx: *Effects) void {
@@ -2555,7 +2568,17 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             auth_avatar_ready = false;
             model.auth_preview_ready = @splat(false);
             if (!desktop_auth.available) return;
-            const argv = [_][]const u8{ "/usr/bin/security", "delete-generic-password", "-a", desktop_auth.account, "-s", desktop_auth.service };
+            const argv = [_][]const u8{
+                "/bin/sh",
+                "-c",
+                "for petdex_account in \"$1\" \"$2\" \"$3\" \"$4\"; do /usr/bin/security delete-generic-password -a \"$petdex_account\" -s \"$5\" >/dev/null 2>&1 || true; done",
+                "petdex-keychain",
+                desktop_auth.account,
+                desktop_auth.keychain_accounts[0],
+                desktop_auth.keychain_accounts[1],
+                desktop_auth.keychain_accounts[2],
+                desktop_auth.service,
+            };
             fx.spawn(.{
                 .key = auth_keychain_delete_key,
                 .argv = &argv,

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -28,6 +28,7 @@ const remote_ssh = @import("remote_ssh.zig");
 const remote_writeback = @import("remote_writeback.zig");
 const remote_runtime = @import("remote_runtime.zig");
 const herdr_status = @import("herdr_status.zig");
+const flock_mod = @import("flock.zig");
 pub const updates = @import("updates.zig");
 
 pub const panic = std.debug.FullPanic(native_sdk.debug.capturePanic);
@@ -115,6 +116,7 @@ pub const Msg = union(enum) {
     dsh_remove_done: native_sdk.EffectExit,
     pet_filter: canvas.TextInputEvent,
     toggle_pets_expanded,
+    toggle_flock_window,
     manifest_done: native_sdk.EffectExit,
     pet_json_done: native_sdk.EffectExit,
     spritesheet_done: native_sdk.EffectExit,
@@ -313,6 +315,10 @@ pub const Model = struct {
     pet_filter: [48]u8 = @splat(0),
     pet_filter_len: usize = 0,
     pets_expanded: bool = false,
+    /// One body per live agent. Derived from the same bubbles the
+    /// mailbox already keys by session, so the set exists whether or
+    /// not the window is open.
+    flock: flock_mod.Model = .{},
     install: InstallState = .{},
     remotes: [remote_runtime.max_remotes]remote_runtime.Slot = .{ .{}, .{}, .{}, .{}, .{}, .{}, .{}, .{} },
     remote_count: usize = 0,
@@ -1935,6 +1941,7 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             applyState(model, model.state.next(), 0, fx);
         },
         .toggle_pets_expanded => model.pets_expanded = !model.pets_expanded,
+        .toggle_flock_window => model.flock.open = !model.flock.open,
         .dismiss_install_error => model.install.error_len = 0,
         .install_first_pet => {
             // A fresh install has no pets, so the pet window renders an
@@ -2645,6 +2652,10 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
                     @memcpy(model.bubbles[0..count], drained[0..count]);
                     for (count..hook_server.max_bubbles) |i| model.bubbles[i] = .{};
                     model.bubbles_len = count;
+                    // The flock reads the same live set, one body per
+                    // session, instead of the single aggregate state the
+                    // pet window shows.
+                    flock_mod.reconcile(&model.flock, model.bubbles[0..count]);
                     syncBubbleDeadlines(model, previous[0..previous_len], previous_deadlines[0..previous_len], now);
                     if (newestBubble(model)) |newest| {
                         loadAgentAvatar(newest.agent[0..newest.agent_len], model.dark, fx);
@@ -2714,6 +2725,7 @@ pub fn onCommand(name: []const u8) ?Msg {
     if (std.mem.eql(u8, name, "petdex.quit")) return .quit_app;
     if (std.mem.eql(u8, name, "petdex.focus")) return .toggle_focus_mode;
     if (std.mem.eql(u8, name, "petdex.shuffle")) return .shuffle_pet;
+    if (std.mem.eql(u8, name, "petdex.flock")) return .toggle_flock_window;
     return null;
 }
 
@@ -3978,6 +3990,71 @@ fn bubbleView(ui: *AppUi, model: *const Model) AppUi.Node {
 
 // --------------------------------------------------------- settings window
 
+// ------------------------------------------------------------- flock
+
+const flock_window_label = "flock";
+const flock_canvas_label = "flock-canvas";
+/// Room under the grid for one row of agent labels.
+const flock_label_h: f32 = 18;
+const flock_max_columns: usize = 4;
+/// Bodies render smaller than the solo pet: the point of the window is
+/// the whole set at a glance, not one mascot at full size.
+const flock_pet_scale: f32 = 0.6;
+
+fn flockLayout(model: *const Model) flock_mod.LayoutSpec {
+    _ = model;
+    return .{
+        .cell_w = frame_w * flock_pet_scale,
+        .cell_h = frame_h * flock_pet_scale,
+        .gap = 8,
+        .columns = flock_max_columns,
+        .label_h = flock_label_h,
+    };
+}
+
+/// One body per live agent, laid out in a grid. V1 draws every member
+/// with the active pet's current frame: the bodies are separate, the
+/// artwork is not yet. V3 gives each session its own pet.
+fn flockView(ui: *AppUi, model: *const Model) AppUi.Node {
+    if (model.flock.len == 0 or !model.sheet_loaded) {
+        return ui.column(.{ .grow = 1, .main = .center, .cross = .center, .window_drag = true }, .{
+            ui.text(.{ .size = .sm, .text_alignment = .center }, "No agents running"),
+        });
+    }
+    const spec = flockLayout(model);
+    const columns = flock_mod.columnsFor(model.flock.len, flock_max_columns);
+    var rows: [flock_mod.max_members]AppUi.Node = undefined;
+    var row_count: usize = 0;
+    var index: usize = 0;
+    while (index < model.flock.len) {
+        var cells: [flock_max_columns]AppUi.Node = undefined;
+        var cell_count: usize = 0;
+        while (cell_count < columns and index < model.flock.len) : (index += 1) {
+            cells[cell_count] = flockMember(ui, model, index, spec);
+            cell_count += 1;
+        }
+        rows[row_count] = ui.row(.{ .gap = spec.gap, .cross = .end }, cells[0..cell_count]);
+        row_count += 1;
+    }
+    return ui.column(.{ .grow = 1, .main = .center, .cross = .center, .gap = spec.gap, .window_drag = true }, rows[0..row_count]);
+}
+
+fn flockMember(ui: *AppUi, model: *const Model, index: usize, spec: flock_mod.LayoutSpec) AppUi.Node {
+    const member = &model.flock.members[index];
+    var body = ui.image(.{
+        .width = spec.cell_w,
+        .height = spec.cell_h,
+        .image = @intCast(model.frame_index + 1),
+        .semantics = .{ .label = "Petdex agent" },
+    });
+    body.widget.image_fit = .stretch;
+    body.widget.image_sampling = .nearest;
+    return ui.column(.{ .cross = .center }, .{
+        body,
+        ui.text(.{ .size = .sm, .text_alignment = .center }, member.labelSlice()),
+    });
+}
+
 const settings_window_label = "settings";
 const settings_canvas_label = "settings-canvas";
 
@@ -4025,6 +4102,22 @@ fn petdexWindows(model: *const Model, scratch: *PetdexApp.WindowsScratch) []cons
         }
         count += 1;
     }
+    if (model.flock.open) {
+        const size = flock_mod.windowSize(model.flock.len, flockLayout(model));
+        scratch.windows[count] = .{
+            .label = flock_window_label,
+            .canvas_label = flock_canvas_label,
+            .title = "Petdex Flock",
+            .width = size.w,
+            .height = size.h,
+            .resizable = false,
+            .titlebar = .chromeless,
+            .floating = true,
+            .transparent = true,
+            .on_close = .toggle_flock_window,
+        };
+        count += 1;
+    }
     if (model.settings_open) {
         scratch.windows[count] = .{
             .label = settings_window_label,
@@ -4042,6 +4135,7 @@ fn petdexWindows(model: *const Model, scratch: *PetdexApp.WindowsScratch) []cons
 
 fn petdexWindowView(ui: *PetdexApp.Ui, model: *const Model, window_label: []const u8) PetdexApp.Ui.Node {
     if (std.mem.eql(u8, window_label, "bubble")) return bubbleView(ui, model);
+    if (std.mem.eql(u8, window_label, flock_window_label)) return flockView(ui, model);
     std.debug.assert(std.mem.eql(u8, window_label, settings_window_label));
     return settings_view.settingsView(ui, model, .{
         .ready = agents_icons_ready,
@@ -4099,9 +4193,14 @@ fn petdexStatusItem(model: *const Model, scratch: *PetdexApp.StatusItemScratch) 
         .command = "petdex.focus",
     };
     scratch.items[2] = .{ .id = 3, .label = "Shuffle Pet", .command = "petdex.shuffle" };
-    scratch.items[3] = .{ .id = 4, .separator = true };
-    scratch.items[4] = .{ .id = 5, .label = "Quit Petdex", .command = "petdex.quit" };
-    return .{ .items = scratch.items[0..5] };
+    scratch.items[3] = .{
+        .id = 4,
+        .label = if (model.flock.open) "Hide Flock" else "Show Flock",
+        .command = "petdex.flock",
+    };
+    scratch.items[4] = .{ .id = 5, .separator = true };
+    scratch.items[5] = .{ .id = 6, .label = "Quit Petdex", .command = "petdex.quit" };
+    return .{ .items = scratch.items[0..6] };
 }
 
 /// The menu-bar button icon: the brand mark's silhouette with the face

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -1601,20 +1601,31 @@ fn registerStateFrames(state: State, fx: *Effects) void {
 /// per state is enough to tell them apart at a glance, and it fits the
 /// registry's remaining budget where eight animated frames per body would
 /// not.
-const flock_waiting_image_id: u64 = 10;
-const flock_running_image_id: u64 = 11;
-const flock_idle_image_id: u64 = 12;
-const flock_failed_image_id: u64 = 15;
-const flock_review_image_id: u64 = 16;
+const flock_atlas_image_id: u64 = 10;
+const flock_states = [_]State{ .waiting, .running, .idle, .failed, .review };
 
 pub fn flockImageId(state: State) u64 {
+    _ = state;
+    return flock_atlas_image_id;
+}
+
+fn flockFrameIndex(state: State) usize {
     return switch (state) {
-        .waiting => flock_waiting_image_id,
-        .running, .@"running-right", .@"running-left" => flock_running_image_id,
-        .failed => flock_failed_image_id,
-        .review => flock_review_image_id,
-        else => flock_idle_image_id,
+        .waiting => 0,
+        .running, .@"running-right", .@"running-left" => 1,
+        .failed => 3,
+        .review => 4,
+        else => 2,
     };
+}
+
+fn flockImageRect(state: State) geometry.RectF {
+    return geometry.RectF.init(
+        @as(f32, @floatFromInt(flockFrameIndex(state))) * frame_w,
+        0,
+        frame_w,
+        frame_h,
+    );
 }
 
 /// Register one representative still per flock state. Called when the
@@ -1623,32 +1634,23 @@ fn registerFlockFrames(fx: *Effects) void {
     if (sheet.pixels.len == 0) return;
     const fw = sheet.width / cols;
     const fh = sheet.height / sheet.rows;
-    var scratch = boot_allocator.alloc(u8, fw * fh * 4) catch return;
+    const atlas_w = fw * flock_states.len;
+    var scratch = boot_allocator.alloc(u8, atlas_w * fh * 4) catch return;
     defer boot_allocator.free(scratch);
-    // Five stills fill the registry to its 16-slot cap alongside the pet
-    // window's eight frames, the agent strip, the avatar and the tail.
-    // Nothing else may claim a slot without freeing one here.
-    const entries = [_]struct { state: State, id: u64 }{
-        .{ .state = .waiting, .id = flock_waiting_image_id },
-        .{ .state = .running, .id = flock_running_image_id },
-        .{ .state = .idle, .id = flock_idle_image_id },
-        .{ .state = .failed, .id = flock_failed_image_id },
-        .{ .state = .review, .id = flock_review_image_id },
-    };
-    for (entries) |entry| {
-        const def = stateDef(entry.state);
-        // The first frame is each state's resting pose.
+    for (flock_states, 0..) |state, index| {
+        const def = stateDef(state);
         const src_x = def.frames[0].col * fw;
         const src_y = def.row * fh;
         for (0..fh) |y| {
             const src_off = ((src_y + y) * sheet.width + src_x) * 4;
-            @memcpy(scratch[y * fw * 4 ..][0 .. fw * 4], sheet.pixels[src_off..][0 .. fw * 4]);
+            const dst_off = (y * atlas_w + index * fw) * 4;
+            @memcpy(scratch[dst_off..][0 .. fw * 4], sheet.pixels[src_off..][0 .. fw * 4]);
         }
-        fx.registerImage(entry.id, fw, fh, scratch) catch |err| {
-            std.debug.print("petdex: flock frame register failed ({s})\n", .{@errorName(err)});
-            return;
-        };
     }
+    fx.registerImage(flock_atlas_image_id, atlas_w, fh, scratch) catch |err| {
+        std.debug.print("petdex: flock frame register failed ({s})\n", .{@errorName(err)});
+        return;
+    };
 }
 
 const poll_timer_key: u64 = 2;
@@ -2813,8 +2815,18 @@ pub const AppUi = canvas.Ui(Msg);
 
 const pet_menu = [_]AppUi.ContextMenuItem{
     .{ .label = "Open Settings", .msg = .open_settings },
+    .{ .label = "Open Flock", .msg = .toggle_flock_window },
     .{ .label = "Close Pet", .msg = .close_pet },
 };
+
+test "pet context menu opens the flock" {
+    try std.testing.expectEqualStrings("Open Flock", pet_menu[1].label);
+    const msg = pet_menu[1].msg orelse return error.TestUnexpectedResult;
+    switch (msg) {
+        .toggle_flock_window => {},
+        else => return error.TestUnexpectedResult,
+    }
+}
 
 // The visible card remains intrinsic and grows only with the text it actually
 // contains. These values size the surrounding transparent canvas generously
@@ -4072,6 +4084,7 @@ fn bubbleView(ui: *AppUi, model: *const Model) AppUi.Node {
 
 const flock_window_label = "flock";
 const flock_canvas_label = "flock-canvas";
+pub const companion_header_h: f32 = 28;
 /// Room under each body for its agent badge, plus the gap above it.
 const flock_badge_px: f32 = 18;
 /// Badge, the gap above it, and breathing room below: at exactly badge +
@@ -4098,9 +4111,14 @@ fn flockLayout(model: *const Model) flock_mod.LayoutSpec {
 /// artwork is not yet. V3 gives each session its own pet.
 fn flockView(ui: *AppUi, model: *const Model) AppUi.Node {
     if (model.flock.len == 0 or !model.sheet_loaded) {
-        return ui.column(.{ .grow = 1, .main = .center, .cross = .center, .window_drag = true }, .{
-            ui.text(.{ .size = .sm, .text_alignment = .center }, "No agents running"),
+        var root = ui.column(.{ .grow = 1 }, .{
+            ui.el(.stack, .{ .height = companion_header_h, .window_drag = true }, .{}),
+            ui.column(.{ .grow = 1, .main = .center, .cross = .center }, .{
+                ui.text(.{ .size = .sm, .text_alignment = .center }, "No agents running"),
+            }),
         });
+        root.widget.style.background = settingsBackground(model);
+        return root;
     }
     const spec = flockLayout(model);
     const columns = flock_mod.columnsFor(model.flock.len, flock_max_columns);
@@ -4117,7 +4135,12 @@ fn flockView(ui: *AppUi, model: *const Model) AppUi.Node {
         rows[row_count] = ui.row(.{ .gap = spec.gap, .cross = .end }, cells[0..cell_count]);
         row_count += 1;
     }
-    return ui.column(.{ .grow = 1, .main = .center, .cross = .center, .gap = spec.gap, .window_drag = true }, rows[0..row_count]);
+    var root = ui.column(.{ .grow = 1 }, .{
+        ui.el(.stack, .{ .height = companion_header_h, .window_drag = true }, .{}),
+        ui.column(.{ .grow = 1, .main = .center, .cross = .center, .gap = spec.gap }, rows[0..row_count]),
+    });
+    root.widget.style.background = settingsBackground(model);
+    return root;
 }
 
 fn flockSemanticLabel(state: State) []const u8 {
@@ -4149,6 +4172,7 @@ fn flockMember(ui: *AppUi, model: *const Model, index: usize, spec: flock_mod.La
     });
     body.widget.image_fit = .stretch;
     body.widget.image_sampling = .nearest;
+    body.widget.image_src = flockImageRect(member.state);
     // Whole cell, not just the sprite: a 115px target beats a 18px one,
     // and the badge is part of the same body. A member with no pane (a
     // direct hook outside Herdr) stays inert rather than offering a jump
@@ -4247,11 +4271,9 @@ fn petdexWindows(model: *const Model, scratch: *PetdexApp.WindowsScratch) []cons
             .canvas_label = flock_canvas_label,
             .title = "Petdex Flock",
             .width = size.w,
-            .height = size.h,
+            .height = size.h + companion_header_h,
             .resizable = false,
-            .titlebar = .chromeless,
-            .floating = true,
-            .transparent = true,
+            .titlebar = .hidden_inset,
             .on_close = .toggle_flock_window,
         };
         count += 1;
@@ -4264,11 +4286,29 @@ fn petdexWindows(model: *const Model, scratch: *PetdexApp.WindowsScratch) []cons
             .width = 420,
             .height = 680,
             .resizable = false,
+            .titlebar = .hidden_inset,
             .on_close = .settings_closed,
         };
         count += 1;
     }
     return scratch.windows[0..count];
+}
+
+test "companion windows use the unified opaque shell" {
+    var model: Model = .{};
+    model.flock.open = true;
+    model.settings_open = true;
+    var scratch: PetdexApp.WindowsScratch = undefined;
+    const windows = petdexWindows(&model, &scratch);
+    try std.testing.expectEqual(@as(usize, 2), windows.len);
+    try std.testing.expectEqualStrings(flock_window_label, windows[0].label);
+    try std.testing.expectEqual(.hidden_inset, windows[0].titlebar);
+    try std.testing.expect(!windows[0].transparent);
+    try std.testing.expect(!windows[0].floating);
+    try std.testing.expectEqualStrings(settings_window_label, windows[1].label);
+    try std.testing.expectEqual(.hidden_inset, windows[1].titlebar);
+    try std.testing.expect(!windows[1].transparent);
+    try std.testing.expect(!windows[1].floating);
 }
 
 fn petdexWindowView(ui: *PetdexApp.Ui, model: *const Model, window_label: []const u8) PetdexApp.Ui.Node {
@@ -4574,26 +4614,16 @@ test "a body earns the marker when a human has to act" {
     try std.testing.expect(!flockNeedsAttention(.review));
 }
 
-test "flock states that must look different get different image slots" {
-    // Bodies render stills from separate slots, so two agents in
-    // different states cannot collapse onto the same artwork.
-    const flock_states = [_]State{ .waiting, .running, .idle, .failed, .review };
-    for (flock_states, 0..) |a, i| {
-        for (flock_states[i + 1 ..]) |b| {
-            try std.testing.expect(flockImageId(a) != flockImageId(b));
-        }
+test "flock states use distinct cells in one atlas" {
+    for (flock_states, 0..) |state, index| {
+        try std.testing.expectEqual(flock_atlas_image_id, flockImageId(state));
+        try std.testing.expectEqual(@as(f32, @floatFromInt(index)) * frame_w, flockImageRect(state).x);
     }
-    // And they must not collide with the slots the rest of the app owns.
-    for (flock_states) |state| {
-        const id = flockImageId(state);
-        try std.testing.expect(id != sheet_image_id);
-        try std.testing.expect(id != agent_icon_atlas_id);
-        try std.testing.expect(id != avatar_image_id);
-        try std.testing.expect(id != tail_image_id);
-        try std.testing.expect(id > cols);
-        // The registry caps at 16 slots and these are the last free ones.
-        try std.testing.expect(id <= 16);
-    }
+    try std.testing.expect(flock_atlas_image_id != sheet_image_id);
+    try std.testing.expect(flock_atlas_image_id != agent_icon_atlas_id);
+    try std.testing.expect(flock_atlas_image_id != thumb_atlas_id);
+    try std.testing.expect(flock_atlas_image_id != avatar_image_id);
+    try std.testing.expect(flock_atlas_image_id != tail_image_id);
 }
 
 test "one image slot covers every agent" {

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -153,16 +153,13 @@ pub const Msg = union(enum) {
     auth_open_community,
     set_pet_source: u32,
     settings_scrolled: canvas.ScrollState,
-    auth_keychain_loaded: native_sdk.EffectExit,
-    auth_keychain_saved: native_sdk.EffectExit,
-    auth_keychain_deleted: native_sdk.EffectExit,
     auth_token_response: native_sdk.EffectResponse,
     auth_avatar_response: native_sdk.EffectResponse,
     auth_preview_response: native_sdk.EffectResponse,
     auth_library_done: native_sdk.EffectExit,
     noop,
 
-    pub const view_unbound = .{ "frame_tick", "poll_tick", "physics_tick", "frame_clock", "cycle_state", "native_drag_watchdog", "chime_done", "quit_app", "toggle_focus_mode", "shuffle_pet", "dsh_install_done", "dsh_remove_done", "remote_line", "remote_done", "remote_backoff", "update_boot_check", "update_response", "homebrew_done", "homebrew_timeout", "brew_command_copied", "auth_keychain_loaded", "auth_keychain_saved", "auth_keychain_deleted", "auth_token_response", "auth_avatar_response", "auth_preview_response", "auth_library_done" };
+    pub const view_unbound = .{ "frame_tick", "poll_tick", "physics_tick", "frame_clock", "cycle_state", "native_drag_watchdog", "chime_done", "quit_app", "toggle_focus_mode", "shuffle_pet", "dsh_install_done", "dsh_remove_done", "remote_line", "remote_done", "remote_backoff", "update_boot_check", "update_response", "homebrew_done", "homebrew_timeout", "brew_command_copied", "auth_token_response", "auth_avatar_response", "auth_preview_response", "auth_library_done" };
 };
 
 pub const Model = struct {
@@ -915,14 +912,10 @@ const update_boot_timer_key: u64 = 33;
 const homebrew_timeout_timer_key: u64 = 34;
 const dsh_install_key: u64 = 35;
 const dsh_remove_key: u64 = 36;
-const auth_keychain_load_key: u64 = 40;
-const auth_keychain_save_key: u64 = 41;
-const auth_keychain_delete_key: u64 = 42;
 const auth_token_key: u64 = 43;
 const auth_library_key: u64 = 44;
 const auth_avatar_key: u64 = 45;
 const auth_preview_key: u64 = 46;
-const auth_keychain_save_keys = [_]u64{ auth_keychain_save_key, 47, 48, 49, 50 };
 const update_boot_delay_ms: u32 = 5000;
 const update_background_interval_ms: i64 = 24 * 60 * 60 * 1000;
 const update_settings_interval_ms: i64 = 5 * 60 * 1000;
@@ -932,49 +925,24 @@ const homebrew_timeout_ms: u64 = 8000;
 fn loadAuthSession(model: *Model, fx: *Effects) void {
     if (!desktop_auth.available) return;
     model.auth.phase = .loading;
-    const argv = [_][]const u8{
-        "/bin/sh",
-        "-c",
-        "petdex_legacy=$(/usr/bin/security find-generic-password -a \"$1\" -s \"$7\" -w 2>/dev/null) && { printf '%s' \"$petdex_legacy\"; exit 0; }; for petdex_account in \"$2\" \"$3\" \"$4\" \"$5\" \"$6\"; do petdex_part=$(/usr/bin/security find-generic-password -a \"$petdex_account\" -s \"$7\" -w 2>/dev/null) || exit 1; printf '%s' \"$petdex_part\"; done",
-        "petdex-keychain",
-        desktop_auth.account,
-        desktop_auth.keychain_accounts[0],
-        desktop_auth.keychain_accounts[1],
-        desktop_auth.keychain_accounts[2],
-        desktop_auth.keychain_accounts[3],
-        desktop_auth.keychain_accounts[4],
-        desktop_auth.service,
+    var stored_buf: [17000]u8 = undefined;
+    const stored = desktop_auth.loadStoredSession(&stored_buf) orelse {
+        model.auth.clearSession();
+        return;
     };
-    fx.spawn(.{
-        .key = auth_keychain_load_key,
-        .argv = &argv,
-        .output = .collect,
-        .on_exit = Effects.exitMsg(.auth_keychain_loaded),
-    });
+    if (!desktop_auth.applyStoredTokens(&model.auth, boot_allocator, stored)) {
+        model.auth.clearSession();
+        return;
+    }
+    fetchAuthLibrary(model, fx);
 }
 
 fn saveAuthSession(model: *const Model, fx: *Effects) void {
+    _ = fx;
     if (!desktop_auth.available) return;
     var session_buf: [17000]u8 = undefined;
     const token = desktop_auth.storedTokens(&model.auth, &session_buf) orelse return;
-    for (desktop_auth.keychain_accounts, auth_keychain_save_keys, 0..) |account_name, effect_key, index| {
-        const chunk = desktop_auth.keychainChunk(token, index) orelse return;
-        const argv = [_][]const u8{
-            "/bin/sh",
-            "-c",
-            "IFS= read -r petdex_secret; printf '%s\\n%s\\n' \"$petdex_secret\" \"$petdex_secret\" | /usr/bin/security add-generic-password -U -a \"$1\" -s \"$2\" -w",
-            "petdex-keychain",
-            account_name,
-            desktop_auth.service,
-        };
-        fx.spawn(.{
-            .key = effect_key,
-            .argv = &argv,
-            .stdin = chunk,
-            .output = .collect,
-            .on_exit = Effects.exitMsg(.auth_keychain_saved),
-        });
-    }
+    if (!desktop_auth.saveStoredSession(token)) std.debug.print("petdex: macOS Keychain could not save the session\n", .{});
 }
 
 fn fetchAuthLibrary(model: *Model, fx: *Effects) void {
@@ -2570,26 +2538,7 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             model.pet_source = .installed;
             auth_avatar_ready = false;
             model.auth_preview_ready = @splat(false);
-            if (!desktop_auth.available) return;
-            const argv = [_][]const u8{
-                "/bin/sh",
-                "-c",
-                "for petdex_account in \"$1\" \"$2\" \"$3\" \"$4\" \"$5\" \"$6\"; do /usr/bin/security delete-generic-password -a \"$petdex_account\" -s \"$7\" >/dev/null 2>&1 || true; done",
-                "petdex-keychain",
-                desktop_auth.account,
-                desktop_auth.keychain_accounts[0],
-                desktop_auth.keychain_accounts[1],
-                desktop_auth.keychain_accounts[2],
-                desktop_auth.keychain_accounts[3],
-                desktop_auth.keychain_accounts[4],
-                desktop_auth.service,
-            };
-            fx.spawn(.{
-                .key = auth_keychain_delete_key,
-                .argv = &argv,
-                .output = .collect,
-                .on_exit = Effects.exitMsg(.auth_keychain_deleted),
-            });
+            if (desktop_auth.available and !desktop_auth.deleteStoredSession()) std.debug.print("petdex: macOS Keychain could not delete the session\n", .{});
         },
         .auth_install_pet => |cloud_id| {
             const caught = cloud_id >= desktop_auth.max_pets;
@@ -2642,19 +2591,6 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             model.settings_scroll = 0;
         },
         .settings_scrolled => |state| model.settings_scroll = state.offset,
-        .auth_keychain_loaded => |exit| {
-            if (exit.reason != .exited or exit.code != 0 or exit.output_truncated or !desktop_auth.applyStoredTokens(&model.auth, boot_allocator, exit.output)) {
-                model.auth.clearSession();
-                return;
-            }
-            fetchAuthLibrary(model, fx);
-        },
-        .auth_keychain_saved => |exit| {
-            if (exit.reason != .exited or exit.code != 0) {
-                std.debug.print("petdex: macOS Keychain could not save the session\n", .{});
-            }
-        },
-        .auth_keychain_deleted => {},
         .auth_token_response => |response| {
             if (response.outcome != .ok or response.status != 200 or response.truncated or !desktop_auth.applyTokenResponse(&model.auth, boot_allocator, response.body)) {
                 model.auth.refreshing = false;

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -5426,12 +5426,12 @@ test "cached update versions restore the correct phase" {
     var model: Model = .{};
     updateCachePhase(&model);
     try std.testing.expectEqual(updates.Phase.idle, model.update_phase);
-    @memcpy(model.latest_version[0.."0.9.0".len], "0.9.0");
-    model.latest_version_len = "0.9.0".len;
+    @memcpy(model.latest_version[0.."0.10.0".len], "0.10.0");
+    model.latest_version_len = "0.10.0".len;
     updateCachePhase(&model);
     try std.testing.expectEqual(updates.Phase.available, model.update_phase);
-    @memcpy(model.latest_version[0.."0.8.0".len], "0.8.0");
-    model.latest_version_len = "0.8.0".len;
+    @memcpy(model.latest_version[0.."0.9.0".len], "0.9.0");
+    model.latest_version_len = "0.9.0".len;
     updateCachePhase(&model);
     try std.testing.expectEqual(updates.Phase.current, model.update_phase);
 }
@@ -5451,10 +5451,10 @@ test "tray exposes website active pet and updater commands" {
     try std.testing.expect(std.mem.startsWith(u8, state.items[8].label, "Check for Updates"));
 
     model.update_phase = .available;
-    @memcpy(model.latest_version[0.."0.9.0".len], "0.9.0");
-    model.latest_version_len = "0.9.0".len;
+    @memcpy(model.latest_version[0.."0.10.0".len], "0.10.0");
+    model.latest_version_len = "0.10.0".len;
     state = petdexStatusItem(&model, &scratch);
-    try std.testing.expectEqualStrings("Update to Petdex 0.9.0…", state.items[8].label);
+    try std.testing.expectEqualStrings("Update to Petdex 0.10.0…", state.items[8].label);
 }
 
 test "bubble text default is its own value, not the range floor" {

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -28,6 +28,7 @@ const remote_ssh = @import("remote_ssh.zig");
 const remote_writeback = @import("remote_writeback.zig");
 const remote_runtime = @import("remote_runtime.zig");
 const herdr_status = @import("herdr_status.zig");
+pub const desktop_auth = @import("desktop_auth.zig");
 pub const updates = @import("updates.zig");
 
 pub const panic = std.debug.FullPanic(native_sdk.debug.capturePanic);
@@ -96,6 +97,8 @@ pub const Msg = union(enum) {
     set_scale: f32,
     open_pets_folder,
     open_pet_page: u32,
+    open_active_pet_page,
+    open_website,
     appearance: native_sdk.platform.Appearance,
     toggle_bubbles,
     toggle_bubbles_per_conversation,
@@ -138,9 +141,25 @@ pub const Msg = union(enum) {
     download_update,
     copy_brew_command,
     brew_command_copied: native_sdk.EffectClipboardResult,
+    auth_sign_in,
+    auth_refresh,
+    auth_sign_out,
+    auth_install_pet: u32,
+    auth_open_pet: u32,
+    auth_open_library,
+    auth_open_community,
+    set_pet_source: u32,
+    settings_scrolled: canvas.ScrollState,
+    auth_keychain_loaded: native_sdk.EffectExit,
+    auth_keychain_saved: native_sdk.EffectExit,
+    auth_keychain_deleted: native_sdk.EffectExit,
+    auth_token_response: native_sdk.EffectResponse,
+    auth_avatar_response: native_sdk.EffectResponse,
+    auth_preview_response: native_sdk.EffectResponse,
+    auth_library_done: native_sdk.EffectExit,
     noop,
 
-    pub const view_unbound = .{ "frame_tick", "poll_tick", "physics_tick", "frame_clock", "cycle_state", "native_drag_watchdog", "chime_done", "quit_app", "toggle_focus_mode", "shuffle_pet", "dsh_install_done", "dsh_remove_done", "remote_line", "remote_done", "remote_backoff", "update_boot_check", "update_response", "homebrew_done", "homebrew_timeout", "brew_command_copied" };
+    pub const view_unbound = .{ "frame_tick", "poll_tick", "physics_tick", "frame_clock", "cycle_state", "native_drag_watchdog", "chime_done", "quit_app", "toggle_focus_mode", "shuffle_pet", "dsh_install_done", "dsh_remove_done", "remote_line", "remote_done", "remote_backoff", "update_boot_check", "update_response", "homebrew_done", "homebrew_timeout", "brew_command_copied", "auth_keychain_loaded", "auth_keychain_saved", "auth_keychain_deleted", "auth_token_response", "auth_avatar_response", "auth_preview_response", "auth_library_done" };
 };
 
 pub const Model = struct {
@@ -331,6 +350,11 @@ pub const Model = struct {
     dark: bool = true,
     high_contrast: bool = false,
     reduce_motion: bool = false,
+    auth: desktop_auth.State = .{},
+    pet_source: desktop_auth.LibraryView = .installed,
+    settings_scroll: f32 = 0,
+    auth_preview_next: usize = 0,
+    auth_preview_ready: [12]bool = @splat(false),
 };
 
 /// Petdex web tokens (globals.css) translated from OKLCH: brand purple
@@ -884,11 +908,178 @@ const update_boot_timer_key: u64 = 33;
 const homebrew_timeout_timer_key: u64 = 34;
 const dsh_install_key: u64 = 35;
 const dsh_remove_key: u64 = 36;
+const auth_keychain_load_key: u64 = 40;
+const auth_keychain_save_key: u64 = 41;
+const auth_keychain_delete_key: u64 = 42;
+const auth_token_key: u64 = 43;
+const auth_library_key: u64 = 44;
+const auth_avatar_key: u64 = 45;
+const auth_preview_key: u64 = 46;
 const update_boot_delay_ms: u32 = 5000;
 const update_background_interval_ms: i64 = 24 * 60 * 60 * 1000;
 const update_settings_interval_ms: i64 = 5 * 60 * 1000;
 const update_failure_retry_ms: u64 = 60 * 60 * 1000;
 const homebrew_timeout_ms: u64 = 8000;
+
+fn loadAuthSession(model: *Model, fx: *Effects) void {
+    if (!desktop_auth.available) return;
+    model.auth.phase = .loading;
+    const argv = [_][]const u8{ "/usr/bin/security", "find-generic-password", "-a", desktop_auth.account, "-s", desktop_auth.service, "-w" };
+    fx.spawn(.{
+        .key = auth_keychain_load_key,
+        .argv = &argv,
+        .output = .collect,
+        .on_exit = Effects.exitMsg(.auth_keychain_loaded),
+    });
+}
+
+fn saveAuthSession(model: *const Model, fx: *Effects) void {
+    if (!desktop_auth.available) return;
+    var json_buf: [4096]u8 = undefined;
+    const json = desktop_auth.storedTokens(&model.auth, &json_buf) orelse return;
+    const argv = [_][]const u8{
+        "/bin/sh",
+        "-c",
+        "IFS= read -r petdex_secret; printf '%s\\n%s\\n' \"$petdex_secret\" \"$petdex_secret\" | /usr/bin/security add-generic-password -U -a \"$1\" -s \"$2\" -w",
+        "petdex-keychain",
+        desktop_auth.account,
+        desktop_auth.service,
+    };
+    fx.spawn(.{
+        .key = auth_keychain_save_key,
+        .argv = &argv,
+        .stdin = json,
+        .output = .collect,
+        .on_exit = Effects.exitMsg(.auth_keychain_saved),
+    });
+}
+
+fn fetchAuthLibrary(model: *Model, fx: *Effects) void {
+    if (model.auth.access_token_len == 0) {
+        model.auth.setError("Your Petdex session is missing an access token");
+        return;
+    }
+    model.auth.phase = .syncing;
+    var config_buf: [9000]u8 = undefined;
+    const config = std.fmt.bufPrint(&config_buf, "url = \"{s}\"\nheader = \"Authorization: Bearer {s}\"\nsilent\nshow-error\nwrite-out = \"\\n%{{http_code}}\"\n", .{ env_auth_library_url, model.auth.accessToken() }) catch {
+        model.auth.setError("Your Petdex session token is too large");
+        return;
+    };
+    const argv = [_][]const u8{ "/usr/bin/curl", "--max-time", "15", "--config", "-" };
+    fx.spawn(.{
+        .key = auth_library_key,
+        .argv = &argv,
+        .stdin = config,
+        .output = .collect,
+        .on_exit = Effects.exitMsg(.auth_library_done),
+    });
+}
+
+fn requestAuthTokens(model: *Model, code: ?[]const u8, fx: *Effects) void {
+    var body_buf: [10000]u8 = undefined;
+    const body = if (code) |value| desktop_auth.tokenBody(&model.auth, value, &body_buf) else desktop_auth.refreshBody(&model.auth, &body_buf);
+    const payload = body orelse {
+        model.auth.setError("Could not prepare the Petdex sign-in request");
+        return;
+    };
+    model.auth.refreshing = code == null;
+    model.auth.phase = .exchanging;
+    const headers = [_]std.http.Header{.{ .name = "content-type", .value = "application/x-www-form-urlencoded" }};
+    fx.fetch(.{
+        .key = auth_token_key,
+        .method = .POST,
+        .url = desktop_auth.issuer ++ "/oauth/token",
+        .headers = &headers,
+        .body = payload,
+        .timeout_ms = 15000,
+        .on_response = Effects.responseMsg(.auth_token_response),
+    });
+}
+
+fn authPetForCell(model: *const Model, cell: usize) ?*const desktop_auth.Pet {
+    if (cell < 6) {
+        if (cell >= model.auth.owned_len) return null;
+        return &model.auth.owned[cell];
+    }
+    const index = cell - 6;
+    if (index >= model.auth.caught_len) return null;
+    return &model.auth.caught[index];
+}
+
+fn fetchNextAuthPreview(model: *Model, fx: *Effects) void {
+    while (model.auth_preview_next < auth_preview_count) {
+        const cell = model.auth_preview_next;
+        model.auth_preview_next += 1;
+        const pet = authPetForCell(model, cell) orelse continue;
+        if (pet.thumbnail_url_len == 0) continue;
+        fx.fetch(.{
+            .key = auth_preview_key,
+            .url = pet.thumbnailUrl(),
+            .timeout_ms = 10000,
+            .on_response = Effects.responseMsg(.auth_preview_response),
+        });
+        return;
+    }
+}
+
+fn startAuthImages(model: *Model, fx: *Effects) void {
+    auth_avatar_ready = false;
+    model.auth_preview_next = 0;
+    model.auth_preview_ready = @splat(false);
+    if (auth_preview_pixels.len == 0) {
+        auth_preview_pixels = boot_allocator.alloc(u8, auth_preview_columns * auth_preview_cell * 2 * auth_preview_cell * 4) catch return;
+    }
+    @memset(auth_preview_pixels, 0);
+    if (model.auth.avatar_url_len > 0) {
+        fx.fetch(.{
+            .key = auth_avatar_key,
+            .url = model.auth.avatarUrl(),
+            .timeout_ms = 10000,
+            .on_response = Effects.responseMsg(.auth_avatar_response),
+        });
+    }
+    fetchNextAuthPreview(model, fx);
+}
+
+fn registerAuthPreview(model: *Model, response: native_sdk.EffectResponse, fx: *Effects) void {
+    const cell = model.auth_preview_next -| 1;
+    if (cell >= auth_preview_count or response.outcome != .ok or response.status != 200 or response.truncated) {
+        fetchNextAuthPreview(model, fx);
+        return;
+    }
+    const services = fx.services orelse {
+        fetchNextAuthPreview(model, fx);
+        return;
+    };
+    const scratch = boot_allocator.alloc(u8, 512 * 512 * 4) catch {
+        fetchNextAuthPreview(model, fx);
+        return;
+    };
+    defer boot_allocator.free(scratch);
+    const decoded = services.decodeImage(response.body, scratch) catch {
+        fetchNextAuthPreview(model, fx);
+        return;
+    };
+    if (decoded.width == 0 or decoded.height == 0) {
+        fetchNextAuthPreview(model, fx);
+        return;
+    }
+    const atlas_width = auth_preview_columns * auth_preview_cell;
+    const cell_x = (cell % auth_preview_columns) * auth_preview_cell;
+    const cell_y = (cell / auth_preview_columns) * auth_preview_cell;
+    for (0..auth_preview_cell) |y| {
+        const src_y = y * decoded.height / auth_preview_cell;
+        for (0..auth_preview_cell) |x| {
+            const src_x = x * decoded.width / auth_preview_cell;
+            const src_off = (src_y * decoded.width + src_x) * 4;
+            const dst_off = ((cell_y + y) * atlas_width + cell_x + x) * 4;
+            @memcpy(auth_preview_pixels[dst_off..][0..4], scratch[src_off..][0..4]);
+        }
+    }
+    model.auth_preview_ready[cell] = true;
+    fx.registerImage(auth_preview_atlas_id, atlas_width, auth_preview_cell * 2, auth_preview_pixels) catch {};
+    fetchNextAuthPreview(model, fx);
+}
 
 fn updateCachePhase(model: *Model) void {
     if (model.latest_version_len == 0) {
@@ -1011,6 +1202,7 @@ var sheet: Sheet = .{};
 /// global getenv; env rides std.process.Init).
 var env_home: ?[]const u8 = null;
 var env_wanted_pet: ?[]const u8 = null;
+var env_auth_library_url: []const u8 = desktop_auth.library_url;
 
 fn readFileAbsolute(io: std.Io, allocator: std.mem.Allocator, path: []const u8, max: usize) ![]u8 {
     var file = try std.Io.Dir.openFileAbsolute(io, path, .{});
@@ -1328,6 +1520,13 @@ var initial_pet_y: ?f64 = null;
 // assets/agents/, re-registered only when the agent changes.
 const avatar_image_id: u64 = 13;
 const tail_image_id: u64 = 14;
+const auth_avatar_image_id: u64 = 15;
+const auth_preview_atlas_id: u64 = 16;
+const auth_preview_cell: usize = 48;
+const auth_preview_columns: usize = 6;
+const auth_preview_count: usize = 12;
+var auth_avatar_ready: bool = false;
+var auth_preview_pixels: []u8 = &.{};
 // One slot for every agent logo plus fallback, packed side by side and read back with
 // `image_src` (the thumbnail atlas above does the same). Previously each
 // agent held its own registry id, which ran the app into the SDK's
@@ -1896,6 +2095,7 @@ pub fn boot(model: *Model, fx: *Effects) void {
         };
         startRemotes(model, fx);
     }
+    loadAuthSession(model, fx);
     fx.startTimer(.{
         .key = poll_timer_key,
         .interval_ms = poll_interval_ms,
@@ -2246,11 +2446,144 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             }
             model.settings_open = true;
         },
+        .auth_sign_in => {
+            if (!desktop_auth.available or model.auth.phase == .authorizing or model.auth.phase == .exchanging) return;
+            var url_buf: [1024]u8 = undefined;
+            const url = desktop_auth.begin(&model.auth, &url_buf) orelse {
+                model.auth.setError("Could not start Petdex sign-in");
+                return;
+            };
+            plat.openExternal(url);
+        },
+        .auth_refresh => {
+            if (model.auth.phase != .signed_in and model.auth.phase != .failed) return;
+            if (model.auth.access_token_len > 0) {
+                fetchAuthLibrary(model, fx);
+            } else {
+                requestAuthTokens(model, null, fx);
+            }
+        },
+        .auth_sign_out => {
+            model.auth.clearSession();
+            model.pet_source = .installed;
+            auth_avatar_ready = false;
+            model.auth_preview_ready = @splat(false);
+            if (!desktop_auth.available) return;
+            const argv = [_][]const u8{ "/usr/bin/security", "delete-generic-password", "-a", desktop_auth.account, "-s", desktop_auth.service };
+            fx.spawn(.{
+                .key = auth_keychain_delete_key,
+                .argv = &argv,
+                .output = .collect,
+                .on_exit = Effects.exitMsg(.auth_keychain_deleted),
+            });
+        },
+        .auth_install_pet => |cloud_id| {
+            const caught = cloud_id >= desktop_auth.max_pets;
+            const index: usize = if (caught) cloud_id - desktop_auth.max_pets else cloud_id;
+            const pet = if (caught) blk: {
+                if (index >= model.auth.caught_len) return;
+                break :blk &model.auth.caught[index];
+            } else blk: {
+                if (index >= model.auth.owned_len) return;
+                break :blk &model.auth.owned[index];
+            };
+            if (pet.status != .approved and pet.status != .caught) return;
+            if (catalogIndexOf(pet.slugSlice())) |catalog_index| {
+                update(model, .{ .select_pet = @intCast(catalog_index) }, fx);
+                return;
+            }
+            if (model.install.busy()) return;
+            model.install.error_len = 0;
+            _ = model.install.enqueueRequest(pet.slugSlice(), true);
+            startInstallQueue(model, fx);
+        },
+        .auth_open_pet => |cloud_id| {
+            const caught = cloud_id >= desktop_auth.max_pets;
+            const index: usize = if (caught) cloud_id - desktop_auth.max_pets else cloud_id;
+            const pet = if (caught) blk: {
+                if (index >= model.auth.caught_len) return;
+                break :blk &model.auth.caught[index];
+            } else blk: {
+                if (index >= model.auth.owned_len) return;
+                break :blk &model.auth.owned[index];
+            };
+            if (pet.status != .approved and pet.status != .caught) {
+                plat.openExternal("https://petdex.dev/my-pets");
+                return;
+            }
+            var url: [256]u8 = undefined;
+            const value = std.fmt.bufPrint(&url, "https://petdex.dev/pets/{s}", .{pet.slugSlice()}) catch return;
+            plat.openExternal(value);
+        },
+        .auth_open_library => plat.openExternal("https://petdex.dev/my-pets"),
+        .auth_open_community => plat.openExternal("https://petdex.dev"),
+        .set_pet_source => |source| {
+            model.pet_source = switch (source) {
+                0 => .installed,
+                1 => .yours,
+                2 => .caught,
+                else => return,
+            };
+            model.pets_expanded = false;
+            model.settings_scroll = 0;
+        },
+        .settings_scrolled => |state| model.settings_scroll = state.offset,
+        .auth_keychain_loaded => |exit| {
+            if (exit.reason != .exited or exit.code != 0 or exit.output_truncated or !desktop_auth.applyStoredTokens(&model.auth, boot_allocator, exit.output)) {
+                model.auth.clearSession();
+                return;
+            }
+            fetchAuthLibrary(model, fx);
+        },
+        .auth_keychain_saved => |exit| {
+            if (exit.reason != .exited or exit.code != 0) {
+                std.debug.print("petdex: macOS Keychain could not save the session\n", .{});
+            }
+        },
+        .auth_keychain_deleted => {},
+        .auth_token_response => |response| {
+            if (response.outcome != .ok or response.status != 200 or response.truncated or !desktop_auth.applyTokenResponse(&model.auth, boot_allocator, response.body)) {
+                model.auth.refreshing = false;
+                model.auth.setError("Petdex sign-in could not complete");
+                return;
+            }
+            saveAuthSession(model, fx);
+            fetchAuthLibrary(model, fx);
+        },
+        .auth_avatar_response => |response| {
+            if (response.outcome != .ok or response.status != 200 or response.truncated) return;
+            _ = fx.registerImageBytes(auth_avatar_image_id, response.body) catch return;
+            auth_avatar_ready = true;
+        },
+        .auth_preview_response => |response| registerAuthPreview(model, response, fx),
+        .auth_library_done => |exit| {
+            const output = std.mem.trimEnd(u8, exit.output, "\r\n");
+            const newline = std.mem.lastIndexOfScalar(u8, output, '\n');
+            const status = if (newline) |at| std.fmt.parseInt(u16, output[at + 1 ..], 10) catch 0 else 0;
+            const body = if (newline) |at| output[0..at] else "";
+            if (exit.reason == .exited and exit.code == 0 and status == 401 and model.auth.refresh_token_len > 0 and !model.auth.refreshing) {
+                requestAuthTokens(model, null, fx);
+                return;
+            }
+            if (exit.reason != .exited or exit.code != 0 or exit.output_truncated or status != 200 or !desktop_auth.applyLibrary(&model.auth, boot_allocator, body)) {
+                model.auth.refreshing = false;
+                model.auth.setError("Could not sync your My Petdex library");
+                return;
+            }
+            model.auth.refreshing = false;
+            startAuthImages(model, fx);
+        },
         .settings_closed => model.settings_open = false,
         .update_boot_check => |timer| {
             if (timer.outcome == .fired and model.update_checks_enabled) startUpdateCheck(model, false, fx);
         },
-        .check_updates => startUpdateCheck(model, true, fx),
+        .check_updates => {
+            if (model.update_phase == .available) {
+                plat.openExternal(updates.downloadUrl());
+            } else {
+                startUpdateCheck(model, true, fx);
+            }
+        },
         .toggle_update_checks => {
             model.update_checks_enabled = !model.update_checks_enabled;
             if (!model.update_checks_enabled) {
@@ -2502,6 +2835,13 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             const url = std.fmt.bufPrint(&buf, "https://petdex.dev/pets/{s}", .{catalog[index].slice()}) catch return;
             plat.openExternal(url);
         },
+        .open_active_pet_page => {
+            if (model.active_pet >= catalog_mod.catalog_len) return;
+            var buf: [256]u8 = undefined;
+            const url = std.fmt.bufPrint(&buf, "https://petdex.dev/pets/{s}", .{catalog[model.active_pet].slice()}) catch return;
+            plat.openExternal(url);
+        },
+        .open_website => plat.openExternal("https://petdex.dev"),
         .appearance => |a| {
             model.dark = a.color_scheme == .dark;
             if (newestBubble(model)) |newest| {
@@ -2751,6 +3091,19 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
         },
         .poll_tick => |timer| {
             if (timer.outcome != .fired) return;
+            if (hook_server.auth_mailbox.take()) |callback| {
+                if (model.auth.phase == .authorizing) {
+                    if (!std.mem.eql(u8, callback.stateSlice(), model.auth.oauthState())) {
+                        model.auth.setError("Petdex rejected the sign-in callback");
+                    } else if (callback.error_len > 0) {
+                        model.auth.setError(callback.errorSlice());
+                    } else if (callback.code_len > 0) {
+                        requestAuthTokens(model, callback.codeSlice(), fx);
+                    } else {
+                        model.auth.setError("Petdex rejected the sign-in callback");
+                    }
+                }
+            }
             // Ahead of the sheet guard on purpose: a machine with no pet
             // installed has no sheet, and that is precisely when a
             // `petdex://<slug>` link has work to do.
@@ -2866,6 +3219,9 @@ pub fn onCommand(name: []const u8) ?Msg {
     if (std.mem.eql(u8, name, "petdex.quit")) return .quit_app;
     if (std.mem.eql(u8, name, "petdex.focus")) return .toggle_focus_mode;
     if (std.mem.eql(u8, name, "petdex.shuffle")) return .shuffle_pet;
+    if (std.mem.eql(u8, name, "petdex.website")) return .open_website;
+    if (std.mem.eql(u8, name, "petdex.pet-page")) return .open_active_pet_page;
+    if (std.mem.eql(u8, name, "petdex.updates")) return .check_updates;
     return null;
 }
 
@@ -2876,6 +3232,7 @@ pub const AppUi = canvas.Ui(Msg);
 const pet_menu = [_]AppUi.ContextMenuItem{
     .{ .label = "Open Settings", .msg = .open_settings },
     .{ .label = "Close Pet", .msg = .close_pet },
+    .{ .label = "View Pet on Petdex", .msg = .open_active_pet_page },
 };
 
 // The visible card remains intrinsic and grows only with the text it actually
@@ -4303,6 +4660,13 @@ fn petdexWindowView(ui: *PetdexApp.Ui, model: *const Model, window_label: []cons
         .ready = &thumbs_ready,
         .cell_w = @floatFromInt(thumb_w),
         .cell_h = @floatFromInt(thumb_h),
+    }, .{
+        .avatar_ready = auth_avatar_ready,
+        .avatar_image = auth_avatar_image_id,
+        .preview_image = auth_preview_atlas_id,
+        .preview_ready = &model.auth_preview_ready,
+        .preview_cell = @floatFromInt(auth_preview_cell),
+        .preview_columns = auth_preview_columns,
     });
 }
 
@@ -4343,16 +4707,27 @@ fn refreshHookEntry(argv0: []const u8) void {
 /// Model-derived (the `status_item_fn` shape) so Focus Mode can show
 /// its state in the label; the static options keep icon and tooltip.
 fn petdexStatusItem(model: *const Model, scratch: *PetdexApp.StatusItemScratch) PetdexApp.StatusItemState {
+    const update_label = switch (model.update_phase) {
+        .checking => "Checking for Updates…",
+        .available => std.fmt.bufPrint(&scratch.title_buffer, "Update to Petdex {s}…", .{model.latest_version[0..model.latest_version_len]}) catch "Update Petdex…",
+        .current => std.fmt.bufPrint(&scratch.title_buffer, "Petdex is up to date · {s}", .{updates.current_version}) catch "Petdex is up to date",
+        .idle, .failed => std.fmt.bufPrint(&scratch.title_buffer, "Check for Updates… · {s}", .{updates.current_version}) catch "Check for Updates…",
+    };
     scratch.items[0] = .{ .id = 1, .label = "Open Settings", .command = "petdex.settings" };
-    scratch.items[1] = .{
-        .id = 2,
+    scratch.items[1] = .{ .id = 2, .label = "Open petdex.dev", .command = "petdex.website" };
+    scratch.items[2] = .{ .id = 3, .separator = true };
+    scratch.items[3] = .{
+        .id = 4,
         .label = if (model.focus_mode) "Focus Mode: On" else "Focus Mode: Off",
         .command = "petdex.focus",
     };
-    scratch.items[2] = .{ .id = 3, .label = "Shuffle Pet", .command = "petdex.shuffle" };
-    scratch.items[3] = .{ .id = 4, .separator = true };
-    scratch.items[4] = .{ .id = 5, .label = "Quit Petdex", .command = "petdex.quit" };
-    return .{ .items = scratch.items[0..5] };
+    scratch.items[4] = .{ .id = 5, .label = "Shuffle Pet", .command = "petdex.shuffle" };
+    scratch.items[5] = .{ .id = 6, .label = "View Pet on Petdex", .command = "petdex.pet-page" };
+    scratch.items[6] = .{ .id = 7, .separator = true };
+    scratch.items[7] = .{ .id = 8, .label = update_label, .command = "petdex.updates", .enabled = model.update_phase != .checking };
+    scratch.items[8] = .{ .id = 9, .separator = true };
+    scratch.items[9] = .{ .id = 10, .label = "Quit Petdex", .command = "petdex.quit" };
+    return .{ .items = scratch.items[0..10] };
 }
 
 /// The menu-bar button icon: the brand mark's silhouette with the face
@@ -4397,6 +4772,7 @@ pub fn main(init: std.process.Init) !void {
     // %USERPROFILE%\.petdex\pets. HOME still wins where it exists, so a
     // POSIX user pointing it elsewhere keeps that.
     env_home = init.environ_map.get("HOME") orelse init.environ_map.get("USERPROFILE");
+    env_auth_library_url = init.environ_map.get("PETDEX_LIBRARY_URL") orelse desktop_auth.library_url;
     // Claude Code honors CLAUDE_CONFIG_DIR for fully isolated installs;
     // wiring hooks into ~/.claude for those users writes a settings.json
     // their Claude Code never reads, and detection shows them as
@@ -4743,6 +5119,26 @@ test "cached update versions restore the correct phase" {
     model.latest_version_len = "0.8.0".len;
     updateCachePhase(&model);
     try std.testing.expectEqual(updates.Phase.current, model.update_phase);
+}
+
+test "tray exposes website active pet and updater commands" {
+    try std.testing.expectEqual(std.meta.Tag(Msg).open_website, std.meta.activeTag(onCommand("petdex.website").?));
+    try std.testing.expectEqual(std.meta.Tag(Msg).open_active_pet_page, std.meta.activeTag(onCommand("petdex.pet-page").?));
+    try std.testing.expectEqual(std.meta.Tag(Msg).check_updates, std.meta.activeTag(onCommand("petdex.updates").?));
+
+    var model: Model = .{};
+    var scratch: PetdexApp.StatusItemScratch = .{};
+    var state = petdexStatusItem(&model, &scratch);
+    try std.testing.expectEqual(@as(usize, 10), state.items.len);
+    try std.testing.expectEqualStrings("Open petdex.dev", state.items[1].label);
+    try std.testing.expectEqualStrings("View Pet on Petdex", state.items[5].label);
+    try std.testing.expect(std.mem.startsWith(u8, state.items[7].label, "Check for Updates"));
+
+    model.update_phase = .available;
+    @memcpy(model.latest_version[0.."0.9.0".len], "0.9.0");
+    model.latest_version_len = "0.9.0".len;
+    state = petdexStatusItem(&model, &scratch);
+    try std.testing.expectEqualStrings("Update to Petdex 0.9.0…", state.items[7].label);
 }
 
 test "bubble text default is its own value, not the range floor" {

--- a/packages/petdex-desktop-native/src/main.zig
+++ b/packages/petdex-desktop-native/src/main.zig
@@ -1594,6 +1594,53 @@ fn registerStateFrames(state: State, fx: *Effects) void {
     }
 }
 
+/// Slots for the flock's per-state stills. The pet window animates one
+/// state at a time through slots 1..8; a flock shows several states at
+/// once, so each body needs a frame of its own state resident. One still
+/// per state is enough to tell them apart at a glance, and it fits the
+/// registry's remaining budget where eight animated frames per body would
+/// not.
+const flock_waiting_image_id: u64 = 10;
+const flock_running_image_id: u64 = 11;
+const flock_idle_image_id: u64 = 12;
+
+pub fn flockImageId(state: State) u64 {
+    return switch (state) {
+        .waiting => flock_waiting_image_id,
+        .running, .@"running-right", .@"running-left" => flock_running_image_id,
+        else => flock_idle_image_id,
+    };
+}
+
+/// Register one representative still per flock state. Called when the
+/// sheet loads, so the bodies have artwork before the window opens.
+fn registerFlockFrames(fx: *Effects) void {
+    if (sheet.pixels.len == 0) return;
+    const fw = sheet.width / cols;
+    const fh = sheet.height / sheet.rows;
+    var scratch = boot_allocator.alloc(u8, fw * fh * 4) catch return;
+    defer boot_allocator.free(scratch);
+    const entries = [_]struct { state: State, id: u64 }{
+        .{ .state = .waiting, .id = flock_waiting_image_id },
+        .{ .state = .running, .id = flock_running_image_id },
+        .{ .state = .idle, .id = flock_idle_image_id },
+    };
+    for (entries) |entry| {
+        const def = stateDef(entry.state);
+        // The first frame is each state's resting pose.
+        const src_x = def.frames[0].col * fw;
+        const src_y = def.row * fh;
+        for (0..fh) |y| {
+            const src_off = ((src_y + y) * sheet.width + src_x) * 4;
+            @memcpy(scratch[y * fw * 4 ..][0 .. fw * 4], sheet.pixels[src_off..][0 .. fw * 4]);
+        }
+        fx.registerImage(entry.id, fw, fh, scratch) catch |err| {
+            std.debug.print("petdex: flock frame register failed ({s})\n", .{@errorName(err)});
+            return;
+        };
+    }
+}
+
 const poll_timer_key: u64 = 2;
 const poll_interval_ms: u32 = 100;
 const min_dwell_ms: u32 = 250;
@@ -1875,6 +1922,10 @@ pub fn boot(model: *Model, fx: *Effects) void {
     // draw.
     pet_display_name = catalog[active].slice();
     registerStateFrames(model.state, fx);
+    // The flock draws several states at once, so its stills are resident
+    // from the moment the sheet is: a body must not wait for its own
+    // state to become the pet window's.
+    registerFlockFrames(fx);
     model.sheet_loaded = true;
     const n = @min(pet_display_name.len, model.pet_name.len);
     @memcpy(model.pet_name[0..n], pet_display_name[0..n]);
@@ -2237,6 +2288,7 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             // the next day.
             model.rotation_day = dayFromWallMs(fx.wallMs());
             registerStateFrames(model.state, fx);
+            registerFlockFrames(fx);
             armFrameTimer(model, fx);
             saveSettings(model);
         },
@@ -4039,13 +4091,21 @@ fn flockView(ui: *AppUi, model: *const Model) AppUi.Node {
     return ui.column(.{ .grow = 1, .main = .center, .cross = .center, .gap = spec.gap, .window_drag = true }, rows[0..row_count]);
 }
 
+fn flockSemanticLabel(state: State) []const u8 {
+    return switch (state) {
+        .waiting => "Agent blocked",
+        .running, .@"running-right", .@"running-left" => "Agent working",
+        else => "Agent idle",
+    };
+}
+
 fn flockMember(ui: *AppUi, model: *const Model, index: usize, spec: flock_mod.LayoutSpec) AppUi.Node {
     const member = &model.flock.members[index];
     var body = ui.image(.{
         .width = spec.cell_w,
         .height = spec.cell_h,
-        .image = @intCast(model.frame_index + 1),
-        .semantics = .{ .label = "Petdex agent" },
+        .image = @intCast(flockImageId(member.state)),
+        .semantics = .{ .label = flockSemanticLabel(member.state) },
     });
     body.widget.image_fit = .stretch;
     body.widget.image_sampling = .nearest;

--- a/packages/petdex-desktop-native/src/settings_view.zig
+++ b/packages/petdex-desktop-native/src/settings_view.zig
@@ -34,6 +34,7 @@ const max_catalog = catalog_mod.max_catalog;
 const agent_hooks = @import("agent_hooks.zig");
 const remote_runtime = @import("remote_runtime.zig");
 const settingsBackground = app.settingsBackground;
+const companion_header_h = app.companion_header_h;
 
 /// Where the agent logos are, handed in so this file does not reach into
 /// main.zig's registration state.
@@ -600,7 +601,10 @@ pub fn settingsView(ui: *AppUi, model: *const Model, icons: IconAtlas, thumbs: T
         // of the scroll extent, so the last card needs explicit air.
         ui.el(.stack, .{ .height = 8 }, .{}),
     })});
-    var root = ui.el(.panel, .{ .grow = 1 }, .{page});
+    var root = ui.column(.{ .grow = 1 }, .{
+        ui.el(.stack, .{ .height = companion_header_h, .window_drag = true }, .{}),
+        page,
+    });
     root.widget.style.background = settingsBackground(model);
     return root;
 }

--- a/packages/petdex-desktop-native/src/settings_view.zig
+++ b/packages/petdex-desktop-native/src/settings_view.zig
@@ -53,6 +53,15 @@ pub const ThumbAtlas = struct {
     cell_h: f32,
 };
 
+pub const CloudImages = struct {
+    avatar_ready: bool,
+    avatar_image: u64,
+    preview_image: u64,
+    preview_ready: []const bool,
+    preview_cell: f32,
+    preview_columns: usize,
+};
+
 /// Secondary copy in a settings row. A plain `ui.text` leaf is always
 /// single-line and elides when the trailing control narrows its column.
 /// Span paragraphs word-wrap and make the row reserve the resulting
@@ -332,79 +341,217 @@ fn updatesSection(ui: *AppUi, model: *const Model) AppUi.Node {
     });
 }
 
-pub fn settingsView(ui: *AppUi, model: *const Model, icons: IconAtlas, thumbs: ThumbAtlas) AppUi.Node {
+fn cloudStatus(status: app.desktop_auth.PetStatus) []const u8 {
+    return switch (status) {
+        .pending => "Pending review",
+        .approved => "Yours",
+        .rejected => "Needs changes",
+        .caught => "Caught",
+    };
+}
+
+fn cloudPetRow(ui: *AppUi, pet: *const app.desktop_auth.Pet, cloud_id: u32, preview_cell: ?usize, images: CloudImages) AppUi.Node {
+    const installed = catalog_mod.catalogIndexOf(pet.slugSlice()) != null;
+    const usable = pet.status == .approved or pet.status == .caught;
+    const action = if (!usable)
+        ui.button(.{ .size = .sm, .width = 64, .variant = .secondary, .disabled = true }, "Review")
+    else if (installed)
+        ui.button(.{ .size = .sm, .width = 64, .variant = .primary, .on_press = Msg{ .auth_install_pet = cloud_id } }, "Select")
+    else
+        ui.button(.{ .size = .sm, .width = 64, .variant = .primary, .on_press = Msg{ .auth_install_pet = cloud_id } }, "Install");
+    const cell = preview_cell orelse images.preview_ready.len;
+    var thumb = ui.image(.{
+        .width = 40,
+        .height = 44,
+        .image = if (cell < images.preview_ready.len and images.preview_ready[cell]) images.preview_image else 0,
+        .semantics = .{ .label = pet.displayName() },
+    });
+    if (cell < images.preview_ready.len) {
+        thumb.widget.image_src = geometry.RectF.init(
+            @as(f32, @floatFromInt(cell % images.preview_columns)) * images.preview_cell,
+            @as(f32, @floatFromInt(cell / images.preview_columns)) * images.preview_cell,
+            images.preview_cell,
+            images.preview_cell,
+        );
+    }
+    thumb.widget.image_fit = .contain;
+    thumb.widget.image_sampling = .nearest;
+    return ui.el(.list_item, .{
+        .height = 56,
+        .padding = 8,
+        .gap = 12,
+        .cross = .center,
+        .style_tokens = .{ .background = .surface, .radius = .md },
+        .semantics = .{ .label = pet.displayName() },
+    }, .{
+        thumb,
+        ui.column(.{ .width = 150, .main = .center }, .{
+            ui.text(.{}, pet.displayName()),
+            mutedParagraph(ui, cloudStatus(pet.status)),
+        }),
+        action,
+        ui.button(.{ .size = .sm, .width = 54, .variant = .secondary, .on_press = Msg{ .auth_open_pet = cloud_id } }, "Open"),
+    });
+}
+
+fn cloudLibrarySection(ui: *AppUi, model: *const Model, images: CloudImages) AppUi.Node {
+    const auth = &model.auth;
+    const action = switch (auth.phase) {
+        .signed_out, .failed => ui.button(.{ .size = .sm, .variant = .primary, .on_press = .auth_sign_in }, if (auth.phase == .failed) "Try again" else "Sign in"),
+        .signed_in => ui.row(.{ .gap = 8 }, .{
+            ui.button(.{ .size = .sm, .variant = .secondary, .on_press = .auth_refresh }, "Sync"),
+            ui.button(.{ .size = .sm, .variant = .secondary, .on_press = .auth_sign_out }, "Sign out"),
+        }),
+        .loading, .authorizing, .exchanging, .syncing => ui.el(.spinner, .{ .width = 18, .height = 18, .semantics = .{ .label = "Working" } }, .{}),
+        .unavailable => ui.button(.{ .size = .sm, .variant = .secondary, .disabled = true }, "macOS only"),
+    };
+    const title = if (auth.phase == .signed_in and auth.name_len > 0) auth.nameSlice() else "My Petdex";
+    const caption = switch (auth.phase) {
+        .signed_out => "See pets you created and caught",
+        .loading => "Checking for a saved Petdex session",
+        .authorizing => "Finish signing in in your browser",
+        .exchanging => "Completing secure sign-in",
+        .syncing => "Syncing your Petdex library",
+        .signed_in => if (auth.email_len > 0) auth.emailSlice() else "Your cloud pet library",
+        .failed => if (auth.error_len > 0) auth.errorSlice() else "Petdex sign-in failed",
+        .unavailable => "Account sync currently uses macOS Keychain",
+    };
+    var avatar = ui.image(.{
+        .width = 36,
+        .height = 36,
+        .image = if (auth.phase == .signed_in and images.avatar_ready) images.avatar_image else 0,
+        .semantics = .{ .label = "Profile photo" },
+    });
+    avatar.widget.image_fit = .cover;
+    avatar.widget.style.radius = 18;
+    return ui.el(.panel, .{ .style_tokens = .{ .background = .surface, .radius = .md } }, .{
+        ui.row(.{ .padding = 12, .cross = .center, .gap = 12 }, .{
+            if (auth.phase == .signed_in) avatar else ui.el(.stack, .{}, .{}),
+            ui.column(.{ .grow = 1 }, .{
+                ui.text(.{}, title),
+                mutedParagraph(ui, caption),
+            }),
+            action,
+        }),
+    });
+}
+
+fn petsTop(ui: *AppUi, model: *const Model, filter: []const u8) AppUi.Node {
+    const search = ui.el(.search_field, .{
+        .height = 34,
+        .text = filter,
+        .on_input = AppUi.inputMsg(.pet_filter),
+        .placeholder = "Search pets",
+        .semantics = .{ .label = "Search pets" },
+    }, .{});
+    const filters = ui.row(.{ .gap = 6 }, .{
+        ui.button(.{ .size = .sm, .variant = if (model.pet_source == .installed) .primary else .secondary, .on_press = Msg{ .set_pet_source = @intFromEnum(app.desktop_auth.LibraryView.installed) } }, "Installed"),
+        ui.button(.{ .size = .sm, .variant = if (model.pet_source == .yours) .primary else .secondary, .disabled = model.auth.phase != .signed_in, .on_press = Msg{ .set_pet_source = @intFromEnum(app.desktop_auth.LibraryView.yours) } }, "Yours"),
+        ui.button(.{ .size = .sm, .variant = if (model.pet_source == .caught) .primary else .secondary, .disabled = model.auth.phase != .signed_in, .on_press = Msg{ .set_pet_source = @intFromEnum(app.desktop_auth.LibraryView.caught) } }, "Caught"),
+        ui.button(.{ .size = .sm, .variant = .secondary, .on_press = .auth_open_community }, "Community"),
+    });
+    if (model.install.busy() or model.install.error_len > 0) {
+        return ui.column(.{ .gap = 8 }, .{
+            ui.text(.{ .size = .lg }, "Pets"),
+            filters,
+            installBanner(ui, model),
+            search,
+        });
+    }
+    return ui.column(.{ .gap = 8 }, .{
+        ui.text(.{ .size = .lg }, "Pets"),
+        filters,
+        search,
+    });
+}
+
+pub fn settingsView(ui: *AppUi, model: *const Model, icons: IconAtlas, thumbs: ThumbAtlas, cloud_images: CloudImages) AppUi.Node {
     var rows: [max_catalog]AppUi.Node = undefined;
     var shown: usize = 0;
     var matches: usize = 0;
-    const max_visible: usize = if (model.pets_expanded) max_catalog else 6;
+    const max_visible: usize = if (model.pet_source == .installed and model.pets_expanded) max_catalog else 6;
     const filter = model.pet_filter[0..model.pet_filter_len];
-    for (catalog[0..@min(catalog_mod.catalog_len, max_catalog)], 0..) |*entry, i| {
-        if (!petMatchesFilter(entry.slice(), filter)) continue;
-        matches += 1;
-        if (shown >= max_visible) continue;
-        const active = i == model.active_pet;
-        var thumb = ui.image(.{
-            .width = 40,
-            .height = 44,
-            .image = if (thumbs.ready[i]) thumbs.image else 0,
-            .semantics = .{ .label = entry.slice() },
-        });
-        thumb.widget.image_src = geometry.RectF.init(
-            @as(f32, @floatFromInt(i)) * thumbs.cell_w,
-            0,
-            thumbs.cell_w,
-            thumbs.cell_h,
-        );
-        thumb.widget.image_fit = .contain;
-        thumb.widget.image_sampling = .nearest;
-        rows[shown] = ui.el(.list_item, .{
-            .height = 56,
-            .padding = 8,
-            .gap = 12,
-            .cross = .center,
-            .on_press = Msg{ .select_pet = @intCast(i) },
-            .selected = active,
-            .style_tokens = .{ .background = .surface, .radius = .md },
-            .semantics = .{ .label = entry.slice() },
-        }, .{
-            thumb,
-            ui.column(.{ .grow = 1, .main = .center }, .{
-                ui.text(.{}, entry.slice()),
-                ui.text(.{ .size = .sm, .style_tokens = .{ .foreground = .text_muted } }, entry.rootSlice()),
-            }),
-            if (active)
-                ui.button(.{ .size = .sm, .width = 64, .variant = .primary, .disabled = true }, "Active")
-            else
-                ui.button(.{ .size = .sm, .width = 64, .variant = .primary, .on_press = Msg{ .select_pet = @intCast(i) } }, "Select"),
-            ui.button(.{ .size = .sm, .variant = .secondary, .on_press = Msg{ .open_pet_page = @intCast(i) } }, "Open"),
-        });
-        shown += 1;
+    if (model.pet_source == .installed) {
+        for (catalog[0..@min(catalog_mod.catalog_len, max_catalog)], 0..) |*entry, i| {
+            if (!petMatchesFilter(entry.slice(), filter)) continue;
+            matches += 1;
+            if (shown >= max_visible) continue;
+            const active = i == model.active_pet;
+            var thumb = ui.image(.{
+                .width = 40,
+                .height = 44,
+                .image = if (thumbs.ready[i]) thumbs.image else 0,
+                .semantics = .{ .label = entry.slice() },
+            });
+            thumb.widget.image_src = geometry.RectF.init(
+                @as(f32, @floatFromInt(i)) * thumbs.cell_w,
+                0,
+                thumbs.cell_w,
+                thumbs.cell_h,
+            );
+            thumb.widget.image_fit = .contain;
+            thumb.widget.image_sampling = .nearest;
+            rows[shown] = ui.el(.list_item, .{
+                .height = 56,
+                .padding = 8,
+                .gap = 12,
+                .cross = .center,
+                .on_press = Msg{ .select_pet = @intCast(i) },
+                .selected = active,
+                .style_tokens = .{ .background = .surface, .radius = .md },
+                .semantics = .{ .label = entry.slice() },
+            }, .{
+                thumb,
+                ui.column(.{ .grow = 1, .main = .center }, .{
+                    ui.text(.{}, entry.slice()),
+                    ui.text(.{ .size = .sm, .style_tokens = .{ .foreground = .text_muted } }, entry.rootSlice()),
+                }),
+                if (active)
+                    ui.button(.{ .size = .sm, .width = 64, .variant = .primary, .disabled = true }, "Active")
+                else
+                    ui.button(.{ .size = .sm, .width = 64, .variant = .primary, .on_press = Msg{ .select_pet = @intCast(i) } }, "Select"),
+                ui.button(.{ .size = .sm, .variant = .secondary, .on_press = Msg{ .open_pet_page = @intCast(i) } }, "Open"),
+            });
+            shown += 1;
+        }
+    } else {
+        const pets = if (model.pet_source == .yours) model.auth.owned[0..model.auth.owned_len] else model.auth.caught[0..model.auth.caught_len];
+        for (pets, 0..) |*pet, i| {
+            if (!petMatchesFilter(pet.displayName(), filter) and !petMatchesFilter(pet.slugSlice(), filter)) continue;
+            matches += 1;
+            if (shown >= max_visible) continue;
+            const caught_offset: usize = if (model.pet_source == .caught) app.desktop_auth.max_pets else 0;
+            const preview_offset: usize = if (model.pet_source == .caught) 6 else 0;
+            rows[shown] = cloudPetRow(
+                ui,
+                pet,
+                @intCast(caught_offset + i),
+                if (i < 6) preview_offset + i else null,
+                cloud_images,
+            );
+            shown += 1;
+        }
     }
     const scale_fraction: f32 = (model.scale - 0.4) / 0.8;
     const bubble_text_fraction: f32 = (model.bubble_text_px - bubble_text_min_px) / (bubble_text_max_px - bubble_text_min_px);
     // One scrollable page: the root scroll takes the window frame and
     // everything - full pet catalog included - flows inside it. No
     // more per-section band budgets.
-    const page = ui.scroll(.{ .grow = 1 }, .{ui.column(.{ .padding = 16, .gap = 12 }, .{
-        ui.text(.{ .size = .lg }, "Pets"),
-        installBanner(ui, model),
-        ui.el(.search_field, .{
-            .height = 34,
-            .text = filter,
-            .on_input = AppUi.inputMsg(.pet_filter),
-            .placeholder = "Search pets",
-            .semantics = .{ .label = "Search pets" },
-        }, .{}),
+    const page = ui.scroll(.{ .grow = 1, .value = model.settings_scroll, .on_scroll = AppUi.scrollMsg(.settings_scrolled) }, .{ui.column(.{ .padding = 12, .gap = 10 }, .{
+        cloudLibrarySection(ui, model, cloud_images),
+        petsTop(ui, model, filter),
         // Search-first catalog: six rows collapsed, the whole catalog
         // expanded - the page itself scrolls, so no nested scroll and
         // the extent stays exact.
         ui.column(.{ .gap = 6 }, @as([]const AppUi.Node, rows[0..shown])),
-        if (matches > shown)
+        if (model.pet_source == .installed and matches > shown)
             ui.button(.{ .size = .sm, .variant = .secondary, .on_press = .toggle_pets_expanded }, moreLabel(matches))
-        else if (model.pets_expanded and matches > 6)
+        else if (model.pet_source == .installed and model.pets_expanded and matches > 6)
             ui.button(.{ .size = .sm, .variant = .secondary, .on_press = .toggle_pets_expanded }, "Show less")
+        else if (model.pet_source != .installed and matches > shown)
+            ui.button(.{ .size = .sm, .variant = .secondary, .on_press = .auth_open_library }, "Open all on Petdex")
         else if (matches == 0)
-            ui.text(.{ .size = .sm, .style_tokens = .{ .foreground = .text_muted } }, "No pets match your search")
+            ui.text(.{ .size = .sm, .style_tokens = .{ .foreground = .text_muted } }, if (model.pet_source == .installed) "No installed pets match your search" else "No pets match your search")
         else
             ui.el(.stack, .{}, .{}),
         ui.el(.stack, .{ .height = 10 }, .{}),

--- a/packages/petdex-desktop-native/src/updates.zig
+++ b/packages/petdex-desktop-native/src/updates.zig
@@ -4,7 +4,7 @@ const builtin = @import("builtin");
 pub const endpoint = "https://petdex.crafter.run/api/desktop/latest-release?format=json";
 pub const release_page = "https://github.com/crafter-station/petdex/releases";
 pub const brew_command = "brew upgrade --cask petdex";
-pub const current_version = "0.8.0";
+pub const current_version = "0.9.0";
 
 pub const Phase = enum { idle, checking, current, available, failed };
 pub const InstallSource = enum { unknown, checking, direct, homebrew };

--- a/src/app/api/desktop/library/route.test.ts
+++ b/src/app/api/desktop/library/route.test.ts
@@ -1,0 +1,100 @@
+import * as BunTest from "bun:test";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+const testMock = (
+  BunTest as typeof BunTest & {
+    mock: { module: (specifier: string, factory: () => object) => void };
+  }
+).mock;
+
+const requestedUsers: string[] = [];
+let limited = false;
+
+testMock.module("@/lib/cli-auth", () => ({
+  verifyCliBearer: async (header: string | null) =>
+    header === "Bearer valid"
+      ? {
+          userId: "user_owner",
+          email: "owner@petdex.dev",
+          username: "owner",
+          imageUrl: "https://img.clerk.com/owner.png",
+          firstName: "Pet",
+          lastName: "Owner",
+        }
+      : null,
+}));
+
+testMock.module("@/lib/desktop-library", () => ({
+  getDesktopLibrary: async (userId: string) => {
+    requestedUsers.push(userId);
+    return {
+      owned: [
+        {
+          id: "pet_1",
+          slug: "boba",
+          displayName: "Boba",
+          status: "approved",
+          thumbnailUrl: "https://assets.petdex.dev/pets/boba/thumb.webp",
+        },
+      ],
+      caught: [
+        {
+          slug: "droid",
+          displayName: "Droid",
+          status: "caught",
+          thumbnailUrl: "https://assets.petdex.dev/pets/droid/thumb.webp",
+        },
+      ],
+    };
+  },
+}));
+
+testMock.module("@/lib/ratelimit", () => ({
+  cliVerifyRatelimit: {
+    limit: async () => ({ success: !limited }),
+  },
+}));
+
+function request(authorization = "Bearer valid") {
+  return new Request("https://petdex.dev/api/desktop/library", {
+    headers: { authorization },
+  });
+}
+
+describe("GET /api/desktop/library", () => {
+  beforeEach(() => {
+    requestedUsers.length = 0;
+    limited = false;
+  });
+
+  it("returns the authenticated user's cloud library", async () => {
+    const { GET } = await import("./route");
+    const response = await GET(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(requestedUsers).toEqual(["user_owner"]);
+    expect(body.user.username).toBe("owner");
+    expect(body.owned[0].slug).toBe("boba");
+    expect(body.owned[0].thumbnailUrl).toContain("boba/thumb.webp");
+    expect(body.caught[0].slug).toBe("droid");
+  });
+
+  it("rejects invalid bearer credentials", async () => {
+    const { GET } = await import("./route");
+    const response = await GET(request("Bearer invalid"));
+
+    expect(response.status).toBe(401);
+    expect(requestedUsers).toHaveLength(0);
+  });
+
+  it("rate limits before verifying the bearer", async () => {
+    limited = true;
+    const { GET } = await import("./route");
+    const response = await GET(request());
+
+    expect(response.status).toBe(429);
+    expect(requestedUsers).toHaveLength(0);
+  });
+});

--- a/src/app/api/desktop/library/route.ts
+++ b/src/app/api/desktop/library/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+
+import { verifyCliBearer } from "@/lib/cli-auth";
+import { getDesktopLibrary } from "@/lib/desktop-library";
+import { cliVerifyRatelimit } from "@/lib/ratelimit";
+
+export const runtime = "nodejs";
+
+function clientIp(req: Request): string {
+  const forwarded = req.headers.get("x-forwarded-for") ?? "";
+  return forwarded.split(",")[0]?.trim() || "anon";
+}
+
+export async function GET(req: Request): Promise<Response> {
+  const limit = await cliVerifyRatelimit.limit(clientIp(req));
+  if (!limit.success) {
+    return NextResponse.json({ error: "rate_limited" }, { status: 429 });
+  }
+
+  const principal = await verifyCliBearer(req.headers.get("authorization"));
+  if (!principal) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const library = await getDesktopLibrary(principal.userId);
+  return NextResponse.json(
+    {
+      user: {
+        id: principal.userId,
+        email: principal.email,
+        username: principal.username,
+        imageUrl: principal.imageUrl,
+        firstName: principal.firstName,
+        lastName: principal.lastName,
+      },
+      ...library,
+    },
+    { headers: { "Cache-Control": "private, no-store" } },
+  );
+}

--- a/src/lib/desktop-library.ts
+++ b/src/lib/desktop-library.ts
@@ -1,0 +1,71 @@
+import { and, desc, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/db/client";
+import { petThumbnailUrlForSource } from "@/lib/pet-thumbnail";
+
+export type DesktopLibraryPet = {
+  id?: string;
+  slug: string;
+  displayName: string;
+  status: "pending" | "approved" | "rejected" | "caught";
+  thumbnailUrl?: string;
+};
+
+const desktopLibraryLimit = 64;
+
+export async function getDesktopLibrary(userId: string): Promise<{
+  owned: DesktopLibraryPet[];
+  caught: DesktopLibraryPet[];
+}> {
+  const [owned, caught] = await Promise.all([
+    db
+      .select({
+        id: schema.submittedPets.id,
+        slug: schema.submittedPets.slug,
+        displayName: schema.submittedPets.displayName,
+        status: schema.submittedPets.status,
+        spritesheetUrl: schema.submittedPets.spritesheetUrl,
+      })
+      .from(schema.submittedPets)
+      .where(eq(schema.submittedPets.ownerId, userId))
+      .orderBy(desc(schema.submittedPets.createdAt))
+      .limit(desktopLibraryLimit),
+    db
+      .select({
+        slug: schema.submittedPets.slug,
+        displayName: schema.submittedPets.displayName,
+        spritesheetUrl: schema.submittedPets.spritesheetUrl,
+      })
+      .from(schema.petLikes)
+      .innerJoin(
+        schema.submittedPets,
+        eq(schema.submittedPets.slug, schema.petLikes.petSlug),
+      )
+      .where(
+        and(
+          eq(schema.petLikes.userId, userId),
+          eq(schema.submittedPets.status, "approved"),
+        ),
+      )
+      .orderBy(desc(schema.petLikes.createdAt))
+      .limit(desktopLibraryLimit),
+  ]);
+
+  return {
+    owned: owned.map(({ spritesheetUrl, ...pet }) => ({
+      ...pet,
+      ...(pet.status === "approved"
+        ? {
+            thumbnailUrl:
+              petThumbnailUrlForSource(pet.slug, spritesheetUrl) ?? undefined,
+          }
+        : {}),
+    })),
+    caught: caught.map(({ spritesheetUrl, ...pet }) => ({
+      ...pet,
+      status: "caught" as const,
+      thumbnailUrl:
+        petThumbnailUrlForSource(pet.slug, spritesheetUrl) ?? undefined,
+    })),
+  };
+}


### PR DESCRIPTION
## Summary

- add the native Flock window for live agents
- sync the signed-in Petdex library with avatar and web pet previews
- unify Installed, Yours, Caught, and Community pet browsing
- add native menu shortcuts for updates, petdex.dev, and the active pet page
- persist the OAuth session in the macOS Keychain

## Validation

- `bun test` (529 passed)
- `bun run check`
- `bun run i18n:check`
- `bunx tsc --noEmit`
- production Next.js build with `.env.mock`
- native SDK tests (263 passed)
- Herdr bridge tests (13 passed)
- packaged macOS app, real OAuth login, restart persistence, avatar/library previews, tray and context menu automation