### PR TITLE
feat: move authenticated rate limits to Neon

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@clerk/localizations": "^4.5.8",
         "@clerk/nextjs": "^7.3.0",
         "@clerk/themes": "^2.4.57",
+        "@crafter/limit": "^0.1.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -249,6 +250,8 @@
     "@clerk/shared": ["@clerk/shared@4.9.0", "", { "dependencies": { "@tanstack/query-core": "^5.100.6", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-YU9Fv6FK1EwxM7uz1hGPrLpvcHRhHm8Quuh5RL343oXakE+/JHtYy4OhwVgqYVA+j63pw+7lpghL3CYQTgk0hA=="],
 
     "@clerk/themes": ["@clerk/themes@2.4.57", "", { "dependencies": { "@clerk/shared": "^3.47.2", "tslib": "2.8.1" } }, "sha512-Nb3bO79rMTU/MPVTC/dde6LG27/IgOMKIYi5KSvAmO4ZUHlj0OWufu6CMvz5OYVZ0YdyMnTBU2aPGRUiRzO+2w=="],
+
+    "@crafter/limit": ["@crafter/limit@0.1.0", "", { "peerDependencies": { "@neondatabase/serverless": "^1.1.0" }, "optionalPeers": ["@neondatabase/serverless"] }, "sha512-2GijYCYmfA47xkHitmI3Oqid8DQHg3Rwj5b1Ij8ukWocmwU88c1E0XmAM3sN+bjkUGwe/7pwbMvT8ejzKNUQaw=="],
 
     "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
 

--- a/drizzle/0021_crafter_rate_limits.sql
+++ b/drizzle/0021_crafter_rate_limits.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS public.crafter_rate_limits (
+  key text PRIMARY KEY,
+  count bigint NOT NULL,
+  window_started_at bigint NOT NULL,
+  expires_at bigint NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS crafter_rate_limits_expires_at_idx
+  ON public.crafter_rate_limits (expires_at);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1778918406000,
       "tag": "0020_pending_asset_gc_claims",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1788064500000,
+      "tag": "0021_crafter_rate_limits",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@clerk/localizations": "^4.5.8",
     "@clerk/nextjs": "^7.3.0",
     "@clerk/themes": "^2.4.57",
+    "@crafter/limit": "^0.1.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,10 +1,9 @@
 import { NextResponse } from "next/server";
 
 import { auth } from "@clerk/nextjs/server";
-import { Ratelimit } from "@upstash/ratelimit";
-import { Redis } from "@upstash/redis";
 
 import { db, schema } from "@/lib/db/client";
+import { createNeonRatelimit } from "@/lib/neon-ratelimit";
 import { requireSameOrigin } from "@/lib/same-origin";
 
 export const runtime = "nodejs";
@@ -12,37 +11,27 @@ export const runtime = "nodejs";
 const VALID_KINDS = new Set(["suggestion", "bug", "praise", "other"]);
 const MAX_LEN = 4000;
 
-const redis =
-  process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN
-    ? Redis.fromEnv()
-    : null;
-
-const ratelimit = redis
-  ? new Ratelimit({
-      redis,
-      limiter: Ratelimit.fixedWindow(5, "1 h"),
-      prefix: "rl:feedback",
-    })
-  : null;
+const ratelimit = createNeonRatelimit({
+  requests: 5,
+  window: "1h",
+  prefix: "petdex:feedback",
+});
 
 export async function POST(req: Request): Promise<Response> {
   const csrf = requireSameOrigin(req);
   if (csrf) return csrf;
   const { userId } = await auth();
 
-  // 5 submissions per hour per IP / per user.
-  if (ratelimit) {
-    const ipHeader =
-      req.headers.get("x-forwarded-for") ?? req.headers.get("x-real-ip") ?? "";
-    const ip = ipHeader.split(",")[0]?.trim() || "anon";
-    const key = userId ?? ip;
-    const { success } = await ratelimit.limit(key);
-    if (!success) {
-      return NextResponse.json(
-        { error: "rate_limited", message: "Try again in an hour." },
-        { status: 429 },
-      );
-    }
+  const ipHeader =
+    req.headers.get("x-forwarded-for") ?? req.headers.get("x-real-ip") ?? "";
+  const ip = ipHeader.split(",")[0]?.trim() || "anon";
+  const key = userId ?? ip;
+  const { success } = await ratelimit.limit(key);
+  if (!success) {
+    return NextResponse.json(
+      { error: "rate_limited", message: "Try again in an hour." },
+      { status: 429 },
+    );
   }
 
   let body: {

--- a/src/lib/neon-ratelimit.ts
+++ b/src/lib/neon-ratelimit.ts
@@ -1,0 +1,71 @@
+import {
+  type Duration,
+  fixedWindow,
+  Limiter,
+  type RateLimitResult,
+} from "@crafter/limit";
+import { neonHttp } from "@crafter/limit/neon";
+import { neon } from "@neondatabase/serverless";
+
+import { IS_MOCK } from "./mock";
+
+type NeonRatelimit = {
+  limit(key: string): Promise<RateLimitResult>;
+};
+
+type NeonRatelimitOptions = {
+  requests: number;
+  window: Duration;
+  prefix: string;
+};
+
+const mockResult: RateLimitResult = {
+  success: true,
+  limit: Number.POSITIVE_INFINITY,
+  remaining: Number.POSITIVE_INFINITY,
+  reset: 0,
+};
+
+let storage: ReturnType<typeof neonHttp> | null = null;
+
+function getStorage(): ReturnType<typeof neonHttp> {
+  if (storage) return storage;
+  if (!process.env.DATABASE_URL) {
+    throw new Error("DATABASE_URL is not set");
+  }
+  storage = neonHttp({
+    client: neon(process.env.DATABASE_URL),
+    failureMode: "open",
+    onError: (error) => console.error("Neon rate limit failed", error),
+  });
+  return storage;
+}
+
+export function createNeonRatelimit(
+  options: NeonRatelimitOptions,
+): NeonRatelimit {
+  if (IS_MOCK) {
+    return { limit: async () => mockResult };
+  }
+  let limiter: Limiter | null = null;
+  return {
+    limit: async (key) => {
+      try {
+        limiter ??= new Limiter({
+          storage: getStorage(),
+          limit: fixedWindow(options.requests, options.window),
+          prefix: options.prefix,
+        });
+        return await limiter.limit(key);
+      } catch (error) {
+        console.error("Neon rate limit failed", error);
+        return {
+          success: true,
+          limit: options.requests,
+          remaining: Math.max(0, options.requests - 1),
+          reset: 0,
+        };
+      }
+    },
+  };
+}

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -2,6 +2,7 @@ import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
 
 import { IS_MOCK } from "./mock";
+import { createNeonRatelimit } from "./neon-ratelimit";
 
 const redis = Redis.fromEnv();
 
@@ -58,36 +59,34 @@ function createRatelimit(config: RatelimitConfig): Ratelimit {
   return failOpen(new Ratelimit(config));
 }
 
-export const submitRatelimit = createRatelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(10, "24 h"),
+export const submitRatelimit = createNeonRatelimit({
+  requests: 10,
+  window: "24h",
   prefix: "petdex:submit",
-  analytics: true,
 });
 
 // CLI presign requests are separate from persisted submissions. Keeping a
 // dedicated bucket prevents abandoned uploads from consuming the submission
 // quota while still bounding R2 orphan creation.
-export const cliPresignRatelimit = createRatelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(20, "1 h"),
+export const cliPresignRatelimit = createNeonRatelimit({
+  requests: 20,
+  window: "1h",
   prefix: "petdex:cli-presign",
-  analytics: true,
 });
 
 // Withdrawals from /my-pets — generous so retries don't lock you out, but
 // stops a malicious automated loop.
-export const withdrawRatelimit = createRatelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(20, "10 m"),
+export const withdrawRatelimit = createNeonRatelimit({
+  requests: 20,
+  window: "10m",
   prefix: "petdex:withdraw",
 });
 
 // Claim attempts — anti-bruteforce for the cross-account flow even though
 // the verified-email check already blocks the actual data move.
-export const claimRatelimit = createRatelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(20, "1 h"),
+export const claimRatelimit = createNeonRatelimit({
+  requests: 20,
+  window: "1h",
   prefix: "petdex:claim",
 });
 
@@ -139,26 +138,26 @@ export const metricsReadRatelimit = createRatelimit({
 
 // Likes — generous so legit users browsing the gallery never hit the cap,
 // but stops a 100-account brigade from inflating one pet to the top.
-export const likeRatelimit = createRatelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(60, "1 h"),
+export const likeRatelimit = createNeonRatelimit({
+  requests: 60,
+  window: "1h",
   prefix: "petdex:like",
 });
 
 // Pet requests + upvotes share a generous bucket — one user can shape the
 // roadmap up to 30 actions / 10 min before we slow them down.
-export const petRequestRatelimit = createRatelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(30, "10 m"),
+export const petRequestRatelimit = createNeonRatelimit({
+  requests: 30,
+  window: "10m",
   prefix: "petdex:requests",
 });
 
 // R2 presign requests. Without this, a logged-in attacker can request
 // thousands of presigned PUT URLs in a loop and waste R2 storage cost
 // even if they never call /api/submit/register afterwards.
-export const presignRatelimit = createRatelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(20, "1 h"),
+export const presignRatelimit = createNeonRatelimit({
+  requests: 20,
+  window: "1h",
   prefix: "petdex:presign",
 });
 
@@ -173,9 +172,9 @@ export const cliVerifyRatelimit = createRatelimit({
 // Owner edits to displayName/description/tags. Generous within the day so
 // the owner can iterate copy, but caps a malicious loop that floods the
 // admin queue with edit churn. Keyed by petId.
-export const editRatelimit = createRatelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(5, "24 h"),
+export const editRatelimit = createNeonRatelimit({
+  requests: 5,
+  window: "24h",
   prefix: "petdex:edit",
 });
 
@@ -183,27 +182,27 @@ export const editRatelimit = createRatelimit({
 // transport budget separate so an upload retry does not consume the actual
 // edit quota enforced by applyPetEdit. Key by user because orphan creation is
 // global across all pets owned by that user.
-export const editPresignRatelimit = createRatelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(20, "1 h"),
+export const editPresignRatelimit = createNeonRatelimit({
+  requests: 20,
+  window: "1h",
   prefix: "petdex:edit-presign",
 });
 
 // User profile identity edits (display name, handle, bio, locale).
 // Self-expression, no admin review, so we only need to stop spam loops.
 // Keyed by userId.
-export const profileEditRatelimit = createRatelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(10, "24 h"),
+export const profileEditRatelimit = createNeonRatelimit({
+  requests: 10,
+  window: "24h",
   prefix: "petdex:profile-edit",
 });
 
 // Pin and pinned-order edits can happen repeatedly while curating a
 // profile. Keep the abuse cap, but make it generous enough for drag
 // auto-save and one-click pin/unpin flows.
-export const profilePinRatelimit = createRatelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(60, "24 h"),
+export const profilePinRatelimit = createNeonRatelimit({
+  requests: 60,
+  window: "24h",
   prefix: "petdex:profile-pin",
 });
 
@@ -214,9 +213,9 @@ export const profilePinRatelimit = createRatelimit({
 // per user covers any reasonable CLI / dashboard / scripting workflow
 // (CLI does 1 per `petdex install`, ~50/h is the realistic ceiling)
 // while shutting down a loop. Keyed by userId.
-export const manifestFullRatelimit = createRatelimit({
-  redis,
-  limiter: Ratelimit.slidingWindow(120, "1 h"),
+export const manifestFullRatelimit = createNeonRatelimit({
+  requests: 120,
+  window: "1h",
   prefix: "petdex:manifest-full",
 });
 


### PR DESCRIPTION
## Summary
- dogfood `@crafter/limit@0.1.0` from npm
- move authenticated submissions, edits, profiles, likes, requests, presigns, claims, withdrawals, manifests, and feedback to Neon HTTP
- keep public traffic guards on their existing fail-open path while WAF rollout is staged separately
- add the idempotent shared rate-limit table migration

## Verification
- `bun run check`
- `bun run i18n:check`
- `bun test` (525 pass)
- `bun --env-file=.env.mock run build`
- production Neon migration applied
- production Neon smoke: first request allowed, second denied, smoke row removed