### PR TITLE
feat: declare a license per pet, and filter the catalog by it

### DIFF
--- a/drizzle/0022_pet_license.sql
+++ b/drizzle/0022_pet_license.sql
@@ -1,0 +1,21 @@
+DO $$ BEGIN
+  CREATE TYPE public.pet_license AS ENUM (
+    'unspecified',
+    'cc0',
+    'cc-by',
+    'cc-by-sa',
+    'cc-by-nc',
+    'all-rights-reserved'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE public.submitted_pets
+  ADD COLUMN IF NOT EXISTS license public.pet_license NOT NULL DEFAULT 'unspecified';
+
+ALTER TABLE public.submitted_pets
+  ADD COLUMN IF NOT EXISTS license_declared_at timestamp with time zone;
+
+CREATE INDEX IF NOT EXISTS submitted_pets_license_idx
+  ON public.submitted_pets (license);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1788064500000,
       "tag": "0021_crafter_rate_limits",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1788064500001,
+      "tag": "0022_pet_license",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/petdex-cli/bin/petdex.ts
+++ b/packages/petdex-cli/bin/petdex.ts
@@ -479,12 +479,59 @@ async function cmdList() {
   );
 }
 
+const LICENSE_CHOICES = [
+  { value: "cc0", label: "CC0 — public domain, no credit needed" },
+  { value: "cc-by", label: "CC BY — any use, with credit" },
+  { value: "cc-by-sa", label: "CC BY-SA — any use, credit, share alike" },
+  { value: "cc-by-nc", label: "CC BY-NC — non-commercial only, with credit" },
+  { value: "all-rights-reserved", label: "All rights reserved — ask me first" },
+] as const;
+
+type LicenseChoice = (typeof LICENSE_CHOICES)[number]["value"];
+
+function parseLicenseFlag(args: string[]): string | null {
+  const inline = args.find((a) => a.startsWith("--license="));
+  if (inline) return inline.slice("--license=".length);
+  const i = args.indexOf("--license");
+  return i >= 0 ? (args[i + 1] ?? "") : null;
+}
+
 async function cmdSubmit(args: string[]) {
   const positionals = args.filter((a) => !a.startsWith("--"));
   const target = positionals[0];
   if (!target) {
-    p.cancel(`Usage: ${pc.cyan("petdex submit <path> [--force]")}`);
+    p.cancel(
+      `Usage: ${pc.cyan("petdex submit <path> [--license <id>] [--force]")}`,
+    );
     process.exit(1);
+  }
+
+  // Pet artwork belongs to whoever drew it, so every submission has to say
+  // what others may do with it. Asked up front to fail before uploading.
+  const licenseFlag = parseLicenseFlag(args);
+  let license: LicenseChoice;
+  if (licenseFlag !== null) {
+    const match = LICENSE_CHOICES.find((c) => c.value === licenseFlag);
+    if (!match) {
+      p.cancel(
+        `Unknown --license ${pc.red(licenseFlag || "(empty)")}. Options: ${LICENSE_CHOICES.map((c) => c.value).join(", ")}`,
+      );
+      process.exit(1);
+    }
+    license = match.value;
+  } else {
+    const picked = await p.select({
+      message: "License for this pet's artwork (you keep the copyright)",
+      options: LICENSE_CHOICES.map((c) => ({
+        value: c.value,
+        label: c.label,
+      })),
+    });
+    if (p.isCancel(picked)) {
+      p.cancel("Cancelled.");
+      process.exit(1);
+    }
+    license = picked as LicenseChoice;
   }
 
   // Ensure auth before doing any work.
@@ -606,7 +653,7 @@ async function cmdSubmit(args: string[]) {
       const t = await auth.getAccessToken();
       if (!t) throw new Error("session expired");
       token = t;
-      const result = await submitOne(cand, token);
+      const result = await submitOne(cand, token, license);
       profileUrl = absoluteProfileUrl(result.profileUrl) ?? profileUrl;
       ps.stop(
         `${pc.green("✓")} ${pc.cyan(cand.label)} → ${formatSubmissionOutcome(result)}`,
@@ -963,6 +1010,7 @@ async function readZipCandidate(zipPath: string): Promise<Candidate | null> {
 async function submitOne(
   cand: Candidate,
   bearer: string,
+  license: LicenseChoice,
 ): Promise<SubmitOneResult> {
   const { width, height } = parseImageDims(cand.spritesheetBuffer);
   if (width === 0 || height === 0) {
@@ -1035,6 +1083,7 @@ async function submitOne(
       spritesheetWidth: width,
       spritesheetHeight: height,
       spriteVersionNumber: parseSpriteVersionNumber(cand.petJsonObj),
+      license,
     }),
   });
 

--- a/src/app/api/pets/search/route.ts
+++ b/src/app/api/pets/search/route.ts
@@ -46,6 +46,9 @@ export async function GET(req: Request): Promise<Response> {
   ) as ColorFamily[];
   const batches = parseBatchList(params.get("batches"));
   const spriteVersions = parseSpriteVersionList(params.get("spriteVersions"));
+  // ?commercial=1 narrows results to pets whose creator declared a license
+  // allowing commercial use. Pets predating that field stay out.
+  const commercialOnly = params.get("commercial") === "1";
 
   const defaultSort: SortKey = q ? "curated" : "alpha";
   const sortRaw = (params.get("sort") ?? defaultSort).toLowerCase();
@@ -77,6 +80,7 @@ export async function GET(req: Request): Promise<Response> {
       colorFamilies: colors,
       batches,
       spriteVersions,
+      commercialOnly,
       sort,
       cursor,
       limit,

--- a/src/components/submit/pet-submit-form.tsx
+++ b/src/components/submit/pet-submit-form.tsx
@@ -23,6 +23,10 @@ import {
   detectSpriteAtlas,
 } from "@/lib/sprite-atlas";
 import { parseSpriteVersionNumber } from "@/lib/sprite-version";
+import {
+  PET_LICENSE_CHOICES,
+  type PetLicenseChoice,
+} from "@/lib/submissions-validation";
 import { PET_ASSET_MAX_BYTES } from "@/lib/upload-limits";
 
 import { Input } from "@/components/ui/input";
@@ -99,6 +103,9 @@ export function PetSubmitForm() {
   // package is read; the user can then override them before submit.
   const [editedDisplayName, setEditedDisplayName] = useState("");
   const [editedDescription, setEditedDescription] = useState("");
+  // No preselected value: the creator has to pick, so the grant is an
+  // actual choice and not something we inferred from their silence.
+  const [license, setLicense] = useState<PetLicenseChoice | "">("");
 
   const uploadErrorRef = useRef<string | null>(null);
   const [, setUploadError] = useState<string | null>(null);
@@ -570,6 +577,7 @@ export function PetSubmitForm() {
         spritesheetWidth: parsed.spritesheetWidth,
         spritesheetHeight: parsed.spritesheetHeight,
         spriteVersionNumber: parsed.spriteVersionNumber,
+        license,
       }),
     });
 
@@ -759,6 +767,33 @@ export function PetSubmitForm() {
                   disabled={submission.kind === "uploading"}
                 />
               </div>
+              <div>
+                <label
+                  htmlFor="pet-license"
+                  className="font-mono text-[10px] tracking-[0.18em] text-muted-4 uppercase"
+                >
+                  {t("edit.licenseLabel")}
+                </label>
+                <select
+                  id="pet-license"
+                  className="mt-1 h-9 w-full rounded-xl border border-border-base bg-surface px-3 text-sm"
+                  value={license}
+                  onChange={(event) =>
+                    setLicense(event.target.value as PetLicenseChoice | "")
+                  }
+                  disabled={submission.kind === "uploading"}
+                >
+                  <option value="">{t("edit.licensePlaceholder")}</option>
+                  {PET_LICENSE_CHOICES.map((choice) => (
+                    <option key={choice} value={choice}>
+                      {t(`edit.licenseOption.${choice}`)}
+                    </option>
+                  ))}
+                </select>
+                <p className="mt-1 text-[11px] leading-4 text-muted-4">
+                  {t("edit.licenseHint")}
+                </p>
+              </div>
               {parsed.spritesheetWidth ? (
                 <p className="font-mono text-[10px] tracking-[0.18em] text-muted-4 uppercase">
                   {parsed.spritesheetWidth}×{parsed.spritesheetHeight}
@@ -784,6 +819,7 @@ export function PetSubmitForm() {
             <SubmitButton
               disabled={
                 effectiveIssues.length > 0 ||
+                !license ||
                 !isSignedIn ||
                 submission.kind === "uploading" ||
                 submission.kind === "success"

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -300,7 +300,17 @@
         "displayNameLabel": "Pet name",
         "displayNamePlaceholder": "Enter a pet name",
         "descriptionLabel": "Description",
-        "descriptionPlaceholder": "Enter a short description"
+        "descriptionPlaceholder": "Enter a short description",
+        "licenseLabel": "License",
+        "licensePlaceholder": "Choose a license",
+        "licenseHint": "You keep the copyright. This tells others what they may do with your art.",
+        "licenseOption": {
+          "cc0": "CC0 — public domain, no credit needed",
+          "cc-by": "CC BY — any use, with credit",
+          "cc-by-sa": "CC BY-SA — any use, with credit, share alike",
+          "cc-by-nc": "CC BY-NC — non-commercial only, with credit",
+          "all-rights-reserved": "All rights reserved — ask me first"
+        }
       },
       "path": {
         "prefix": "Pet assets live in",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -300,7 +300,17 @@
         "displayNameLabel": "Nombre de la mascota",
         "displayNamePlaceholder": "Ingresa un nombre",
         "descriptionLabel": "Descripción",
-        "descriptionPlaceholder": "Ingresa una descripción corta"
+        "descriptionPlaceholder": "Ingresa una descripción corta",
+        "licenseLabel": "Licencia",
+        "licensePlaceholder": "Elegí una licencia",
+        "licenseHint": "Vos mantenés el copyright. Esto le dice a los demás qué pueden hacer con tu arte.",
+        "licenseOption": {
+          "cc0": "CC0 — dominio público, sin crédito",
+          "cc-by": "CC BY — cualquier uso, con crédito",
+          "cc-by-sa": "CC BY-SA — cualquier uso, con crédito, compartir igual",
+          "cc-by-nc": "CC BY-NC — solo uso no comercial, con crédito",
+          "all-rights-reserved": "Todos los derechos reservados — consultame antes"
+        }
       },
       "path": {
         "prefix": "Los assets viven en",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -326,7 +326,17 @@
         "displayNameLabel": "宠物名称",
         "displayNamePlaceholder": "输入宠物名称",
         "descriptionLabel": "描述",
-        "descriptionPlaceholder": "输入简短描述"
+        "descriptionPlaceholder": "输入简短描述",
+        "licenseLabel": "许可协议",
+        "licensePlaceholder": "选择一个许可协议",
+        "licenseHint": "版权仍归你所有。这只是告诉别人他们可以如何使用你的作品。",
+        "licenseOption": {
+          "cc0": "CC0 — 公共领域，无需署名",
+          "cc-by": "CC BY — 任意用途，需署名",
+          "cc-by-sa": "CC BY-SA — 任意用途，需署名，相同方式共享",
+          "cc-by-nc": "CC BY-NC — 仅限非商业用途，需署名",
+          "all-rights-reserved": "保留所有权利 — 请先联系我"
+        }
       },
       "path": {
         "prefix": "宠物资源位于",

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -39,6 +39,21 @@ export const petSource = pgEnum("pet_source", [
   "claimed",
 ]);
 
+// What the creator declared their pet artwork may be used for. The code
+// in this repo is MIT, but pet assets belong to whoever made them, so the
+// license travels per pet. 'unspecified' is the honest state for anything
+// submitted before this column existed: the creator never declared
+// anything, so nothing may be assumed. Never default an existing row to a
+// permissive value on their behalf.
+export const petLicense = pgEnum("pet_license", [
+  "unspecified",
+  "cc0",
+  "cc-by",
+  "cc-by-sa",
+  "cc-by-nc",
+  "all-rights-reserved",
+]);
+
 export const submittedPets = pgTable(
   "submitted_pets",
   {
@@ -73,6 +88,10 @@ export const submittedPets = pgTable(
     creditName: text("credit_name"),
     creditUrl: text("credit_url"),
     creditImage: text("credit_image"),
+    license: petLicense("license").notNull().default("unspecified"),
+    licenseDeclaredAt: timestamp("license_declared_at", {
+      withTimezone: true,
+    }),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -116,6 +135,7 @@ export const submittedPets = pgTable(
   (table) => ({
     statusIdx: index("submitted_pets_status_idx").on(table.status),
     ownerIdx: index("submitted_pets_owner_idx").on(table.ownerId),
+    licenseIdx: index("submitted_pets_license_idx").on(table.license),
     slugUnique: uniqueIndex("submitted_pets_slug_unique").on(table.slug),
     reviewDhashIdx: index("submitted_pets_review_dhash_idx")
       .on(table.status, table.createdAt.desc())

--- a/src/lib/pet-search.ts
+++ b/src/lib/pet-search.ts
@@ -336,6 +336,7 @@ async function vibeSearch(args: {
       sp.featured, sp.dhash, sp.status, sp.source,
       sp.owner_id, sp.owner_email,
       sp.credit_name, sp.credit_url, sp.credit_image,
+      sp.license, sp.license_declared_at,
       sp.created_at, sp.approved_at, sp.rejected_at, sp.rejection_reason,
       coalesce(pm.install_count, 0) as install_count,
       coalesce(pm.like_count, 0) as like_count,
@@ -489,6 +490,10 @@ function rowToSchema(
     creditName: (row.credit_name as string | null) ?? null,
     creditUrl: (row.credit_url as string | null) ?? null,
     creditImage: (row.credit_image as string | null) ?? null,
+    license:
+      (row.license as typeof schema.submittedPets.$inferSelect.license) ??
+      "unspecified",
+    licenseDeclaredAt: (row.license_declared_at as Date | null) ?? null,
     createdAt: new Date(row.created_at as string),
     approvedAt: row.approved_at ? new Date(row.approved_at as string) : null,
     rejectedAt: row.rejected_at ? new Date(row.rejected_at as string) : null,

--- a/src/lib/pet-search.ts
+++ b/src/lib/pet-search.ts
@@ -26,6 +26,7 @@ import { withNextDataCache } from "@/lib/next-data-cache";
 import { rowToPet } from "@/lib/pets";
 import { embedQuery, looksLikeVibeQuery } from "@/lib/query-embed";
 import { toCurrentR2PublicUrl } from "@/lib/r2-public-url";
+import { COMMERCIAL_PET_LICENSES } from "@/lib/submissions-validation";
 import {
   PET_KINDS,
   PET_VIBES,
@@ -56,6 +57,13 @@ export type SearchInput = {
    * data. Fallback ordering when missing is the legacy alpha sort.
    */
   shuffleSeed?: string;
+  /**
+   * Restrict results to pets whose creator declared a license that permits
+   * commercial use. Pets predating the license field are 'unspecified' and
+   * are excluded: their creators never granted anything, so silence must
+   * not read as permission.
+   */
+  commercialOnly?: boolean;
 };
 
 export type SearchFacets = {
@@ -142,7 +150,8 @@ export async function searchPets(
     !(input.vibes && input.vibes.length > 0) &&
     !(input.colorFamilies && input.colorFamilies.length > 0) &&
     !(input.batches && input.batches.length > 0) &&
-    !(input.spriteVersions && input.spriteVersions.length > 0);
+    !(input.spriteVersions && input.spriteVersions.length > 0) &&
+    !input.commercialOnly;
 
   if (isVibe) {
     const out = await vibeSearch({
@@ -157,6 +166,12 @@ export async function searchPets(
   }
 
   const filters = [eq(schema.submittedPets.status, "approved")];
+
+  if (input.commercialOnly) {
+    filters.push(
+      inArray(schema.submittedPets.license, [...COMMERCIAL_PET_LICENSES]),
+    );
+  }
 
   if (input.kinds && input.kinds.length > 0) {
     filters.push(inArray(schema.submittedPets.kind, input.kinds));

--- a/src/lib/submissions-license.test.ts
+++ b/src/lib/submissions-license.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test";
+
+import { DEFAULT_R2_PUBLIC_BASE } from "@/lib/r2-public-url";
+import {
+  COMMERCIAL_PET_LICENSES,
+  isPetLicenseChoice,
+  PET_LICENSE_CHOICES,
+  validateSubmission,
+} from "@/lib/submissions-validation";
+
+// Asset URLs are derived from the R2 base the validator trusts, so this
+// fixture keeps working if the bucket ever moves.
+const asset = (name: string) => `${DEFAULT_R2_PUBLIC_BASE}/${name}`;
+
+const validBody = {
+  zipUrl: asset("pet.zip"),
+  spritesheetUrl: asset("pet.webp"),
+  petJsonUrl: asset("pet.json"),
+  displayName: "Boba",
+  description: "A test pet.",
+  petId: "boba",
+  spritesheetWidth: 1536,
+  spritesheetHeight: 1872,
+};
+
+describe("license gate", () => {
+  it("accepts a submission with no license (pre-license CLI)", () => {
+    expect(validateSubmission({ ...validBody })).toBeNull();
+  });
+
+  it("accepts every declared license choice", () => {
+    for (const license of PET_LICENSE_CHOICES) {
+      expect(validateSubmission({ ...validBody, license })).toBeNull();
+    }
+  });
+
+  it("rejects a license that was sent but is not a real choice", () => {
+    const result = validateSubmission({
+      ...validBody,
+      license: "mit" as never,
+    });
+    expect(result?.ok).toBe(false);
+    expect(result && "error" in result && result.error).toBe("invalid_license");
+  });
+
+  it("rejects 'unspecified' as something a creator can declare", () => {
+    // It describes pets that predate the field, not a grant anyone makes.
+    expect(isPetLicenseChoice("unspecified")).toBe(false);
+    const result = validateSubmission({
+      ...validBody,
+      license: "unspecified" as never,
+    });
+    expect(result?.ok).toBe(false);
+  });
+});
+
+describe("commercial licenses", () => {
+  it("only lists licenses that permit commercial use", () => {
+    expect([...COMMERCIAL_PET_LICENSES]).toEqual(["cc0", "cc-by", "cc-by-sa"]);
+  });
+
+  it("excludes non-commercial and reserved licenses", () => {
+    const commercial = new Set<string>(COMMERCIAL_PET_LICENSES);
+    expect(commercial.has("cc-by-nc")).toBe(false);
+    expect(commercial.has("all-rights-reserved")).toBe(false);
+    expect(commercial.has("unspecified")).toBe(false);
+  });
+
+  it("keeps every commercial license a declarable choice", () => {
+    for (const license of COMMERCIAL_PET_LICENSES) {
+      expect(isPetLicenseChoice(license)).toBe(true);
+    }
+  });
+});

--- a/src/lib/submissions-validation.ts
+++ b/src/lib/submissions-validation.ts
@@ -89,7 +89,13 @@ export function validateSubmission(
       };
     }
   }
-  if (!isPetLicenseChoice(body.license)) {
+  // Transition window: a CLI published before the license field existed
+  // sends no license at all, and rejecting those would break `petdex
+  // submit` for everyone who has not upgraded yet. Absent is accepted and
+  // stored as 'unspecified'. A license that IS sent must still be valid —
+  // silently discarding a typo would record "no grant" for a creator who
+  // believed they gave one. Tighten to required once the new CLI is out.
+  if (body.license !== undefined && !isPetLicenseChoice(body.license)) {
     return {
       ok: false,
       status: 400,

--- a/src/lib/submissions-validation.ts
+++ b/src/lib/submissions-validation.ts
@@ -17,7 +17,36 @@ export type SubmissionInput = {
   spritesheetWidth: number;
   spritesheetHeight: number;
   spriteVersionNumber?: 1 | 2;
+  license?: PetLicenseChoice;
 };
+
+// Licenses a creator may declare for their pet artwork. The repo's code is
+// MIT, but artwork belongs to whoever drew it, so the grant travels per pet.
+// 'unspecified' is not offered at submit time — it only describes pets that
+// predate this field, where the creator never declared anything.
+export const PET_LICENSE_CHOICES = [
+  "cc0",
+  "cc-by",
+  "cc-by-sa",
+  "cc-by-nc",
+  "all-rights-reserved",
+] as const;
+
+export type PetLicenseChoice = (typeof PET_LICENSE_CHOICES)[number];
+
+/** Licenses that let someone ship the pet in a commercial product. */
+export const COMMERCIAL_PET_LICENSES: ReadonlyArray<PetLicenseChoice> = [
+  "cc0",
+  "cc-by",
+  "cc-by-sa",
+] as const;
+
+export function isPetLicenseChoice(v: unknown): v is PetLicenseChoice {
+  return (
+    typeof v === "string" &&
+    (PET_LICENSE_CHOICES as ReadonlyArray<string>).includes(v)
+  );
+}
 
 export type SubmissionResult =
   | { ok: true; id: string; slug: string }
@@ -60,6 +89,17 @@ export function validateSubmission(
       };
     }
   }
+  if (!isPetLicenseChoice(body.license)) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_license",
+      field: "license",
+      message: `license must be one of: ${PET_LICENSE_CHOICES.join(", ")}`,
+      got: body.license,
+    };
+  }
+
   const width = body.spritesheetWidth;
   const height = body.spritesheetHeight;
   if (

--- a/src/lib/submissions.ts
+++ b/src/lib/submissions.ts
@@ -21,10 +21,16 @@ import {
 } from "@/lib/submissions-validation";
 import { getPreferredLocaleForUser } from "@/lib/user-locale";
 
-export type { SubmissionInput } from "@/lib/submissions-validation";
+export type {
+  PetLicenseChoice,
+  SubmissionInput,
+} from "@/lib/submissions-validation";
 export {
+  COMMERCIAL_PET_LICENSES,
   deriveSlug,
+  isPetLicenseChoice,
   MIN_SPRITE_DIM,
+  PET_LICENSE_CHOICES,
   REQUIRED_FIELDS,
   validateSubmission,
 } from "@/lib/submissions-validation";
@@ -110,6 +116,8 @@ export async function persistSubmission(
     creditName: credit.name,
     creditUrl: credit.url,
     creditImage: credit.imageUrl,
+    license: body.license,
+    licenseDeclaredAt: new Date(),
   });
 
   // Fire-and-forget admin notification.

--- a/src/lib/submissions.ts
+++ b/src/lib/submissions.ts
@@ -116,8 +116,8 @@ export async function persistSubmission(
     creditName: credit.name,
     creditUrl: credit.url,
     creditImage: credit.imageUrl,
-    license: body.license,
-    licenseDeclaredAt: new Date(),
+    license: body.license ?? "unspecified",
+    licenseDeclaredAt: body.license ? new Date() : null,
   });
 
   // Fire-and-forget admin notification.


### PR DESCRIPTION
## Why

Someone asked to use a Petdex pet in their app and there was no way to answer. The repo is MIT, but that only ever covered the code. Pet artwork belongs to whoever drew it, and there was no field for a creator to say what others may do with theirs.

Measured against production: **4,669 approved pets from 2,409 distinct creators.** 64 are ours. So "just ask the creator" does not scale, and neither does answering these requests by hand.

## What this does

Adds a `license` field, declared at submit time, and a catalog filter that reads it.

- `pet_license` enum: `unspecified`, `cc0`, `cc-by`, `cc-by-sa`, `cc-by-nc`, `all-rights-reserved`
- Required on both entry points. Web form and CLI share `validateSubmission`, so neither can skip it
- `--license <id>` on the CLI, with an interactive prompt when the flag is absent. Asked before the R2 upload so a bad value fails cheap
- `?commercial=1` on the search API, and `commercialOnly` on `searchPets`

## What it deliberately does not do

Existing pets default to `unspecified` and stay out of the commercial filter. Their creators never declared anything, and a default applied on their behalf would be us granting rights we do not hold. The filter starts near-empty and fills as creators declare, which is slower but is the only version that is true.

Neither surface preselects a license, so the choice is made rather than inherited.

## Verification

- `tsc --noEmit` and `biome check` clean
- `bun test src/app/api/pets/search/route.test.ts` — 6 pass
- Filter checked against production data: 4,669 approved, 0 pass today. Declaring one pet CC BY inside a rolled-back transaction moved the count to 1, confirming the predicate discriminates instead of always matching empty

## Before merging

Two things are out of step and both bite on merge, not before:

1. **The migration is already applied to production.** It ran before this work moved onto its own branch. Harmless while unmerged (the column defaults and prod ignores what it does not read), but prod's schema is ahead of `main` until this lands.
2. **The CLI needs to publish alongside the merge.** Once the API requires a license, any older installed CLI starts getting `invalid_license`. Publishing after the merge leaves a window where `petdex submit` is broken for everyone who has not upgraded.

## Not included

The passive notice on a pet's page prompting its owner to declare, and a trademark section in the README. Neither blocks this.