### PR TITLE
Adopt Crafter action button for pending withdrawals

### DIFF
--- a/docs/crafter-ui-adoption.md
+++ b/docs/crafter-ui-adoption.md
@@ -1,0 +1,9 @@
+# Crafter UI adoption
+
+Source: https://ui.crafter.run/r/action-button.json, from the production ZIP downloaded on 2026-09-07 (Crafter UI b3a5bc5). Editable source is owned by this repository.
+
+Adopted ActionButton and Spinner into src/components/ui. The existing Petdex Button and global theme are retained. Spinner's cn import uses Petdex's existing utility instead of adding the cn package. Biome formatting follows this repository.
+
+SubmissionCard now passes its existing withdrawal transition to ActionButton's pending and pendingLabel props. The component centralizes disabling, the pending label, spinner, and aria-busy. The existing handler, destructive confirmation, backend mutation, and class names remain in place.
+
+Validation: focused server-render tests pass (2 tests, 8 assertions); whole-project TypeScript check passes. No production submission was withdrawn to exercise this UI change.

--- a/src/components/profile/my-pets-view.tsx
+++ b/src/components/profile/my-pets-view.tsx
@@ -33,6 +33,7 @@ import {
   ProfileCard,
   type ProfileData,
 } from "@/components/profile/profile-card";
+import { ActionButton } from "@/components/ui/action-button";
 
 type Submission = {
   id: string;
@@ -473,15 +474,17 @@ export function SubmissionCard({ submission }: { submission: Submission }) {
               Submit a new version
             </Link>
           ) : (
-            <button
+            <ActionButton
               type="button"
+              variant="outline"
               onClick={handleWithdraw}
-              disabled={isPending}
+              pending={isPending}
+              pendingLabel="Withdrawing…"
               className="inline-flex h-9 items-center justify-center gap-1.5 rounded-full border border-rose-200 bg-rose-50 px-3 text-xs font-medium text-rose-800 transition hover:border-rose-300 hover:bg-rose-100 disabled:opacity-50 dark:border-rose-800/60 dark:bg-rose-950/40 dark:text-rose-300 dark:hover:border-rose-700 dark:hover:bg-rose-900/40"
             >
               <Trash2 className="size-3.5" />
-              {isPending ? "Withdrawing…" : "Withdraw"}
-            </button>
+              Withdraw
+            </ActionButton>
           )}
         </div>
 

--- a/src/components/ui/action-button.test.tsx
+++ b/src/components/ui/action-button.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ActionButton } from "./action-button";
+
+describe("Crafter action button", () => {
+  test("pending disables withdrawal and exposes its progress", () => {
+    const html = renderToStaticMarkup(
+      <ActionButton pending pendingLabel="Withdrawing…">
+        Withdraw
+      </ActionButton>,
+    );
+    expect(html).toContain("disabled");
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain("Withdrawing…");
+    expect(html).toContain('aria-label="Loading"');
+  });
+
+  test("settled actions preserve content and caller disabled state", () => {
+    const enabled = renderToStaticMarkup(<ActionButton>Withdraw</ActionButton>);
+    const disabled = renderToStaticMarkup(
+      <ActionButton disabled>Withdraw</ActionButton>,
+    );
+    expect(enabled).toContain("Withdraw");
+    expect(enabled).not.toContain('aria-busy="true"');
+    expect(enabled).not.toContain('disabled=""');
+    expect(disabled).toContain('disabled=""');
+  });
+});

--- a/src/components/ui/action-button.tsx
+++ b/src/components/ui/action-button.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import type { ComponentProps } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+
+type ActionButtonProps = ComponentProps<typeof Button> & {
+  pending?: boolean;
+  pendingLabel?: string;
+};
+
+export function ActionButton({
+  pending = false,
+  pendingLabel = "Working…",
+  children,
+  disabled,
+  ...props
+}: ActionButtonProps) {
+  return (
+    <Button {...props} disabled={disabled || pending} aria-busy={pending}>
+      {pending && <Spinner data-icon="inline-start" />}
+      {pending ? pendingLabel : children}
+    </Button>
+  );
+}

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,17 @@
+import { Loader2Icon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+  return (
+    <Loader2Icon
+      data-slot="spinner"
+      role="status"
+      aria-label="Loading"
+      className={cn("size-4 animate-spin", className)}
+      {...props}
+    />
+  );
+}
+
+export { Spinner };


### PR DESCRIPTION
The pending withdrawal button repeats disabled state and label switching. Adopt Crafter UI's ActionButton so the same pending state also provides a spinner and aria-busy, while preserving Petdex's existing Button, styles, withdrawal handler, and confirmation flow.

The two source components come from Crafter UI's production registry ZIP. Spinner uses Petdex's existing cn utility, so no dependency or theme migration is needed. Provenance is documented in docs/crafter-ui-adoption.md.

Validation: focused component rendering tests pass (2 tests, 8 assertions), whole-project TypeScript passes, and Biome passes on changed files. No production submission was withdrawn for testing.
